### PR TITLE
[CWS] support parsing all 6 arguments in on demand events

### DIFF
--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -33,6 +33,7 @@ typedef unsigned long long ctx_t;
 #define CTX_PARM3(ctx) (u64)(ctx[2])
 #define CTX_PARM4(ctx) (u64)(ctx[3])
 #define CTX_PARM5(ctx) (u64)(ctx[4])
+#define CTX_PARM6(ctx) (u64)(ctx[5])
 
 u64 __attribute__((always_inline)) CTX_PARMRET(ctx_t *ctx) {
 	u64 argc;
@@ -87,6 +88,7 @@ typedef struct pt_regs ctx_t;
 #define CTX_PARM3(ctx) PT_REGS_PARM3(ctx)
 #define CTX_PARM4(ctx) PT_REGS_PARM4(ctx)
 #define CTX_PARM5(ctx) PT_REGS_PARM5(ctx)
+#define CTX_PARM6(ctx) PT_REGS_PARM6(ctx)
 
 u64 __attribute__((always_inline)) CTX_PARMRET(ctx_t *ctx) {
     return PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -469,6 +469,8 @@ struct chdir_event_t {
     struct file_t file;
 };
 
+#define ON_DEMAND_PER_ARG_SIZE 64
+
 struct on_demand_event_t {
     struct kevent_t event;
     struct process_context_t process;
@@ -476,7 +478,7 @@ struct on_demand_event_t {
     struct container_context_t container;
 
     u32 synth_id;
-    char data[256];
+    char data[ON_DEMAND_PER_ARG_SIZE * 6];
 };
 
 struct raw_packet_event_t {

--- a/pkg/security/ebpf/c/include/hooks/on_demand.h
+++ b/pkg/security/ebpf/c/include/hooks/on_demand.h
@@ -1,8 +1,6 @@
 #ifndef _HOOKS_ON_DEMAND_H_
 #define _HOOKS_ON_DEMAND_H_
 
-#define PER_ARG_SIZE 64
-
 enum param_kind_t {
 	PARAM_NO_ACTION,
 	PARAM_KIND_INTEGER,
@@ -16,12 +14,12 @@ enum param_kind_t {
 	switch (param##idx##kind) { \
 	case PARAM_KIND_INTEGER: \
 		value = CTX_PARM##idx(ctx); \
-		bpf_probe_read(&event.data[(idx - 1) * PER_ARG_SIZE], sizeof(value), &value); \
+		bpf_probe_read(&event.data[(idx - 1) * ON_DEMAND_PER_ARG_SIZE], sizeof(value), &value); \
 		break; \
 	case PARAM_KIND_NULL_STR: \
-		buf = &event.data[(idx - 1) * PER_ARG_SIZE]; \
+		buf = &event.data[(idx - 1) * ON_DEMAND_PER_ARG_SIZE]; \
 		path = (char *)CTX_PARM##idx(ctx); \
-		bpf_probe_read_str(buf, PER_ARG_SIZE, path); \
+		bpf_probe_read_str(buf, ON_DEMAND_PER_ARG_SIZE, path); \
 		break; \
 	}
 
@@ -34,12 +32,12 @@ enum param_kind_t {
                                              \
 	switch (param##idx##kind) { \
 	case PARAM_KIND_INTEGER: \
-		bpf_probe_read(&event.data[(idx - 1) * PER_ARG_SIZE], sizeof(arg##idx), &arg##idx); \
+		bpf_probe_read(&event.data[(idx - 1) * ON_DEMAND_PER_ARG_SIZE], sizeof(arg##idx), &arg##idx); \
 		break; \
 	case PARAM_KIND_NULL_STR: \
-		buf = &event.data[(idx - 1) * PER_ARG_SIZE]; \
+		buf = &event.data[(idx - 1) * ON_DEMAND_PER_ARG_SIZE]; \
 		path = (char *)arg##idx; \
-		bpf_probe_read_str(buf, PER_ARG_SIZE, path); \
+		bpf_probe_read_str(buf, ON_DEMAND_PER_ARG_SIZE, path); \
 		break; \
 	}
 
@@ -66,6 +64,8 @@ int hook_on_demand(ctx_t *ctx) {
 	param_parsing_regular(2);
 	param_parsing_regular(3);
 	param_parsing_regular(4);
+	param_parsing_regular(5);
+	param_parsing_regular(6);
 
 	send_event(ctx, EVENT_ON_DEMAND, event);
 
@@ -95,6 +95,8 @@ int hook_on_demand_syscall(ctx_t *ptctx) {
 	param_parsing_syscall(2);
 	param_parsing_syscall(3);
 	param_parsing_syscall(4);
+	param_parsing_syscall(5);
+	param_parsing_syscall(6);
 
 	send_event(ptctx, EVENT_ON_DEMAND, event);
 

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -117,6 +117,7 @@ BPF_PERCPU_ARRAY_MAP(network_flow_monitor_event_gen, struct network_flow_monitor
 BPF_PERCPU_ARRAY_MAP(active_flows_gen, struct active_flows_t, 1)
 BPF_PERCPU_ARRAY_MAP(raw_packet_enabled, u32, 1)
 BPF_PERCPU_ARRAY_MAP(sysctl_event_gen, struct sysctl_event_t, 1)
+BPF_PERCPU_ARRAY_MAP(on_demand_event_gen, struct on_demand_event_t, 1)
 
 BPF_PROG_ARRAY(args_envs_progs, 3)
 BPF_PROG_ARRAY(dentry_resolver_kprobe_or_fentry_callbacks, EVENT_MAX)

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -685,52 +685,83 @@ func (fh *EBPFFieldHandlers) ResolveOnDemandName(_ *model.Event, e *model.OnDema
 	return fh.onDemand.getHookNameFromID(int(e.ID))
 }
 
+func resolveOnDemandArgStr(e *model.OnDemandEvent, index int) string {
+	if !(1 <= index && index <= 6) {
+		panic("index must be between 1 and 6")
+	}
+
+	start := (index - 1) * model.OnDemandPerArgSize
+	data := e.Data[start : start+model.OnDemandPerArgSize]
+	return model.NullTerminatedString(data)
+}
+
+func resolveOnDemandArgUint(e *model.OnDemandEvent, index int) int {
+	if !(1 <= index && index <= 6) {
+		panic("index must be between 1 and 6")
+	}
+
+	start := (index - 1) * model.OnDemandPerArgSize
+	return int(binary.NativeEndian.Uint64(e.Data[start : start+8]))
+}
+
 // ResolveOnDemandArg1Str resolves the string value of the first argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg1Str(_ *model.Event, e *model.OnDemandEvent) string {
-	data := e.Data[0:64]
-	s := model.NullTerminatedString(data)
-	return s
+	return resolveOnDemandArgStr(e, 1)
 }
 
 // ResolveOnDemandArg1Uint resolves the uint value of the first argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg1Uint(_ *model.Event, e *model.OnDemandEvent) int {
-	return int(binary.NativeEndian.Uint64(e.Data[0:8]))
+	return resolveOnDemandArgUint(e, 1)
 }
 
 // ResolveOnDemandArg2Str resolves the string value of the second argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg2Str(_ *model.Event, e *model.OnDemandEvent) string {
-	data := e.Data[64:128]
-	s := model.NullTerminatedString(data)
-	return s
+	return resolveOnDemandArgStr(e, 2)
 }
 
 // ResolveOnDemandArg2Uint resolves the uint value of the second argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg2Uint(_ *model.Event, e *model.OnDemandEvent) int {
-	return int(binary.NativeEndian.Uint64(e.Data[64 : 64+8]))
+	return resolveOnDemandArgUint(e, 2)
 }
 
 // ResolveOnDemandArg3Str resolves the string value of the third argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg3Str(_ *model.Event, e *model.OnDemandEvent) string {
-	data := e.Data[128:192]
-	s := model.NullTerminatedString(data)
-	return s
+	return resolveOnDemandArgStr(e, 3)
 }
 
 // ResolveOnDemandArg3Uint resolves the uint value of the third argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg3Uint(_ *model.Event, e *model.OnDemandEvent) int {
-	return int(binary.NativeEndian.Uint64(e.Data[128 : 128+8]))
+	return resolveOnDemandArgUint(e, 3)
 }
 
 // ResolveOnDemandArg4Str resolves the string value of the fourth argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg4Str(_ *model.Event, e *model.OnDemandEvent) string {
-	data := e.Data[192:256]
-	s := model.NullTerminatedString(data)
-	return s
+	return resolveOnDemandArgStr(e, 4)
 }
 
 // ResolveOnDemandArg4Uint resolves the uint value of the fourth argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg4Uint(_ *model.Event, e *model.OnDemandEvent) int {
-	return int(binary.NativeEndian.Uint64(e.Data[192 : 192+8]))
+	return resolveOnDemandArgUint(e, 4)
+}
+
+// ResolveOnDemandArg5Str resolves the string value of the fifth argument of hooked function
+func (fh *EBPFFieldHandlers) ResolveOnDemandArg5Str(_ *model.Event, e *model.OnDemandEvent) string {
+	return resolveOnDemandArgStr(e, 5)
+}
+
+// ResolveOnDemandArg5Uint resolves the uint value of the fifth argument of hooked function
+func (fh *EBPFFieldHandlers) ResolveOnDemandArg5Uint(_ *model.Event, e *model.OnDemandEvent) int {
+	return resolveOnDemandArgUint(e, 5)
+}
+
+// ResolveOnDemandArg6Str resolves the string value of the sixth argument of hooked function
+func (fh *EBPFFieldHandlers) ResolveOnDemandArg6Str(_ *model.Event, e *model.OnDemandEvent) string {
+	return resolveOnDemandArgStr(e, 6)
+}
+
+// ResolveOnDemandArg6Uint resolves the uint value of the sixth argument of hooked function
+func (fh *EBPFFieldHandlers) ResolveOnDemandArg6Uint(_ *model.Event, e *model.OnDemandEvent) int {
+	return resolveOnDemandArgUint(e, 6)
 }
 
 // ResolveProcessNSID resolves the process namespace ID

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -10,6 +10,7 @@ package probe
 
 import (
 	"encoding/binary"
+	"fmt"
 	"path"
 	"strings"
 	"syscall"
@@ -686,8 +687,8 @@ func (fh *EBPFFieldHandlers) ResolveOnDemandName(_ *model.Event, e *model.OnDema
 }
 
 func resolveOnDemandArgStr(e *model.OnDemandEvent, index int) string {
-	if !(1 <= index && index <= 6) {
-		panic("index must be between 1 and 6")
+	if !(1 <= index && index <= model.OnDemandParsedArgsCount) {
+		panic(fmt.Sprintf("index must be between 1 and %d", model.OnDemandParsedArgsCount))
 	}
 
 	start := (index - 1) * model.OnDemandPerArgSize
@@ -696,8 +697,8 @@ func resolveOnDemandArgStr(e *model.OnDemandEvent, index int) string {
 }
 
 func resolveOnDemandArgUint(e *model.OnDemandEvent, index int) int {
-	if !(1 <= index && index <= 6) {
-		panic("index must be between 1 and 6")
+	if !(1 <= index && index <= model.OnDemandParsedArgsCount) {
+		panic(fmt.Sprintf("index must be between 1 and %d", model.OnDemandParsedArgsCount))
 	}
 
 	start := (index - 1) * model.OnDemandPerArgSize

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -469,3 +469,23 @@ func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg4Str(_ *model.Event, _ *model
 func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg4Uint(_ *model.Event, _ *model.OnDemandEvent) int {
 	return 0
 }
+
+// ResolveOnDemandArg5Str resolves the string value of the fifth argument of hooked function
+func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg5Str(_ *model.Event, _ *model.OnDemandEvent) string {
+	return ""
+}
+
+// ResolveOnDemandArg5Uint resolves the uint value of the fifth argument of hooked function
+func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg5Uint(_ *model.Event, _ *model.OnDemandEvent) int {
+	return 0
+}
+
+// ResolveOnDemandArg6Str resolves the string value of the sixth argument of hooked function
+func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg6Str(_ *model.Event, _ *model.OnDemandEvent) string {
+	return ""
+}
+
+// ResolveOnDemandArg6Uint resolves the uint value of the sixth argument of hooked function
+func (fh *EBPFLessFieldHandlers) ResolveOnDemandArg6Uint(_ *model.Event, _ *model.OnDemandEvent) int {
+	return 0
+}

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -5669,6 +5669,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.HandlerWeight,
 			Offset: offset,
 		}, nil
+	case "ondemand.arg5.str":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveOnDemandArg5Str(ev, &ev.OnDemand)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ondemand.arg5.uint":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveOnDemandArg5Uint(ev, &ev.OnDemand))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ondemand.arg6.str":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveOnDemandArg6Str(ev, &ev.OnDemand)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ondemand.arg6.uint":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.FieldHandlers.ResolveOnDemandArg6Uint(ev, &ev.OnDemand))
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
 	case "ondemand.name":
 		return &eval.StringEvaluator{
 			OpOverrides: OnDemandNameOverrides,
@@ -22860,6 +22904,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"ondemand.arg3.uint",
 		"ondemand.arg4.str",
 		"ondemand.arg4.uint",
+		"ondemand.arg5.str",
+		"ondemand.arg5.uint",
+		"ondemand.arg6.str",
+		"ondemand.arg6.uint",
 		"ondemand.name",
 		"open.file.change_time",
 		"open.file.destination.mode",
@@ -24796,6 +24844,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "ondemand.arg4.str":
 		return "ondemand", reflect.String, "string", nil
 	case "ondemand.arg4.uint":
+		return "ondemand", reflect.Int, "int", nil
+	case "ondemand.arg5.str":
+		return "ondemand", reflect.String, "string", nil
+	case "ondemand.arg5.uint":
+		return "ondemand", reflect.Int, "int", nil
+	case "ondemand.arg6.str":
+		return "ondemand", reflect.String, "string", nil
+	case "ondemand.arg6.uint":
 		return "ondemand", reflect.Int, "int", nil
 	case "ondemand.name":
 		return "ondemand", reflect.String, "string", nil
@@ -30844,6 +30900,34 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "ondemand.arg4.uint"}
 		}
 		ev.OnDemand.Arg4Uint = uint64(rv)
+		return nil
+	case "ondemand.arg5.str":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ondemand.arg5.str"}
+		}
+		ev.OnDemand.Arg5Str = rv
+		return nil
+	case "ondemand.arg5.uint":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ondemand.arg5.uint"}
+		}
+		ev.OnDemand.Arg5Uint = uint64(rv)
+		return nil
+	case "ondemand.arg6.str":
+		rv, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ondemand.arg6.str"}
+		}
+		ev.OnDemand.Arg6Str = rv
+		return nil
+	case "ondemand.arg6.uint":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ondemand.arg6.uint"}
+		}
+		ev.OnDemand.Arg6Uint = uint64(rv)
 		return nil
 	case "ondemand.name":
 		rv, ok := value.(string)

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -66,6 +66,7 @@ var bpfMapNames = []string{
 	"netns_cache",
 	"network_flow_mo",
 	"ns_flow_to_netw",
+	"on_demand_event",
 	"open_flags_appr",
 	"packets",
 	"path_id",

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -576,6 +576,10 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveOnDemandArg3Uint(ev, &ev.OnDemand)
 		_ = ev.FieldHandlers.ResolveOnDemandArg4Str(ev, &ev.OnDemand)
 		_ = ev.FieldHandlers.ResolveOnDemandArg4Uint(ev, &ev.OnDemand)
+		_ = ev.FieldHandlers.ResolveOnDemandArg5Str(ev, &ev.OnDemand)
+		_ = ev.FieldHandlers.ResolveOnDemandArg5Uint(ev, &ev.OnDemand)
+		_ = ev.FieldHandlers.ResolveOnDemandArg6Str(ev, &ev.OnDemand)
+		_ = ev.FieldHandlers.ResolveOnDemandArg6Uint(ev, &ev.OnDemand)
 	case "open":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Open.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Open.File.FileFields)
@@ -1162,6 +1166,10 @@ type FieldHandlers interface {
 	ResolveOnDemandArg3Uint(ev *Event, e *OnDemandEvent) int
 	ResolveOnDemandArg4Str(ev *Event, e *OnDemandEvent) string
 	ResolveOnDemandArg4Uint(ev *Event, e *OnDemandEvent) int
+	ResolveOnDemandArg5Str(ev *Event, e *OnDemandEvent) string
+	ResolveOnDemandArg5Uint(ev *Event, e *OnDemandEvent) int
+	ResolveOnDemandArg6Str(ev *Event, e *OnDemandEvent) string
+	ResolveOnDemandArg6Uint(ev *Event, e *OnDemandEvent) int
 	ResolveOnDemandName(ev *Event, e *OnDemandEvent) string
 	ResolvePackageName(ev *Event, e *FileEvent) string
 	ResolvePackageSourceVersion(ev *Event, e *FileEvent) string
@@ -1312,6 +1320,18 @@ func (dfh *FakeFieldHandlers) ResolveOnDemandArg4Str(ev *Event, e *OnDemandEvent
 }
 func (dfh *FakeFieldHandlers) ResolveOnDemandArg4Uint(ev *Event, e *OnDemandEvent) int {
 	return int(e.Arg4Uint)
+}
+func (dfh *FakeFieldHandlers) ResolveOnDemandArg5Str(ev *Event, e *OnDemandEvent) string {
+	return string(e.Arg5Str)
+}
+func (dfh *FakeFieldHandlers) ResolveOnDemandArg5Uint(ev *Event, e *OnDemandEvent) int {
+	return int(e.Arg5Uint)
+}
+func (dfh *FakeFieldHandlers) ResolveOnDemandArg6Str(ev *Event, e *OnDemandEvent) string {
+	return string(e.Arg6Str)
+}
+func (dfh *FakeFieldHandlers) ResolveOnDemandArg6Uint(ev *Event, e *OnDemandEvent) int {
+	return int(e.Arg6Uint)
 }
 func (dfh *FakeFieldHandlers) ResolveOnDemandName(ev *Event, e *OnDemandEvent) string {
 	return string(e.Name)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -824,19 +824,26 @@ type PathKey struct {
 	PathID  uint32 `field:"-"`
 }
 
+// OnDemandPerArgSize is the size of each argument in Data in the on-demand event
+const OnDemandPerArgSize = 64
+
 // OnDemandEvent identifies an on-demand event generated from on-demand probes
 type OnDemandEvent struct {
-	ID       uint32    `field:"-"`
-	Name     string    `field:"name,handler:ResolveOnDemandName" op_override:"OnDemandNameOverrides"`
-	Data     [256]byte `field:"-"`
-	Arg1Str  string    `field:"arg1.str,handler:ResolveOnDemandArg1Str"`
-	Arg1Uint uint64    `field:"arg1.uint,handler:ResolveOnDemandArg1Uint"`
-	Arg2Str  string    `field:"arg2.str,handler:ResolveOnDemandArg2Str"`
-	Arg2Uint uint64    `field:"arg2.uint,handler:ResolveOnDemandArg2Uint"`
-	Arg3Str  string    `field:"arg3.str,handler:ResolveOnDemandArg3Str"`
-	Arg3Uint uint64    `field:"arg3.uint,handler:ResolveOnDemandArg3Uint"`
-	Arg4Str  string    `field:"arg4.str,handler:ResolveOnDemandArg4Str"`
-	Arg4Uint uint64    `field:"arg4.uint,handler:ResolveOnDemandArg4Uint"`
+	ID       uint32                       `field:"-"`
+	Name     string                       `field:"name,handler:ResolveOnDemandName" op_override:"OnDemandNameOverrides"`
+	Data     [6 * OnDemandPerArgSize]byte `field:"-"`
+	Arg1Str  string                       `field:"arg1.str,handler:ResolveOnDemandArg1Str"`
+	Arg1Uint uint64                       `field:"arg1.uint,handler:ResolveOnDemandArg1Uint"`
+	Arg2Str  string                       `field:"arg2.str,handler:ResolveOnDemandArg2Str"`
+	Arg2Uint uint64                       `field:"arg2.uint,handler:ResolveOnDemandArg2Uint"`
+	Arg3Str  string                       `field:"arg3.str,handler:ResolveOnDemandArg3Str"`
+	Arg3Uint uint64                       `field:"arg3.uint,handler:ResolveOnDemandArg3Uint"`
+	Arg4Str  string                       `field:"arg4.str,handler:ResolveOnDemandArg4Str"`
+	Arg4Uint uint64                       `field:"arg4.uint,handler:ResolveOnDemandArg4Uint"`
+	Arg5Str  string                       `field:"arg5.str,handler:ResolveOnDemandArg5Str"`
+	Arg5Uint uint64                       `field:"arg5.uint,handler:ResolveOnDemandArg5Uint"`
+	Arg6Str  string                       `field:"arg5.str,handler:ResolveOnDemandArg5Str"`
+	Arg6Uint uint64                       `field:"arg5.uint,handler:ResolveOnDemandArg5Uint"`
 }
 
 // LoginUIDWriteEvent is used to propagate login UID updates to user space

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -827,23 +827,26 @@ type PathKey struct {
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event
 const OnDemandPerArgSize = 64
 
+// OnDemandParsedArgsCount is the number of parsed arguments in the on-demand event
+const OnDemandParsedArgsCount = 6
+
 // OnDemandEvent identifies an on-demand event generated from on-demand probes
 type OnDemandEvent struct {
-	ID       uint32                       `field:"-"`
-	Name     string                       `field:"name,handler:ResolveOnDemandName" op_override:"OnDemandNameOverrides"`
-	Data     [6 * OnDemandPerArgSize]byte `field:"-"`
-	Arg1Str  string                       `field:"arg1.str,handler:ResolveOnDemandArg1Str"`
-	Arg1Uint uint64                       `field:"arg1.uint,handler:ResolveOnDemandArg1Uint"`
-	Arg2Str  string                       `field:"arg2.str,handler:ResolveOnDemandArg2Str"`
-	Arg2Uint uint64                       `field:"arg2.uint,handler:ResolveOnDemandArg2Uint"`
-	Arg3Str  string                       `field:"arg3.str,handler:ResolveOnDemandArg3Str"`
-	Arg3Uint uint64                       `field:"arg3.uint,handler:ResolveOnDemandArg3Uint"`
-	Arg4Str  string                       `field:"arg4.str,handler:ResolveOnDemandArg4Str"`
-	Arg4Uint uint64                       `field:"arg4.uint,handler:ResolveOnDemandArg4Uint"`
-	Arg5Str  string                       `field:"arg5.str,handler:ResolveOnDemandArg5Str"`
-	Arg5Uint uint64                       `field:"arg5.uint,handler:ResolveOnDemandArg5Uint"`
-	Arg6Str  string                       `field:"arg5.str,handler:ResolveOnDemandArg5Str"`
-	Arg6Uint uint64                       `field:"arg5.uint,handler:ResolveOnDemandArg5Uint"`
+	ID       uint32                                             `field:"-"`
+	Name     string                                             `field:"name,handler:ResolveOnDemandName" op_override:"OnDemandNameOverrides"`
+	Data     [OnDemandParsedArgsCount * OnDemandPerArgSize]byte `field:"-"`
+	Arg1Str  string                                             `field:"arg1.str,handler:ResolveOnDemandArg1Str"`
+	Arg1Uint uint64                                             `field:"arg1.uint,handler:ResolveOnDemandArg1Uint"`
+	Arg2Str  string                                             `field:"arg2.str,handler:ResolveOnDemandArg2Str"`
+	Arg2Uint uint64                                             `field:"arg2.uint,handler:ResolveOnDemandArg2Uint"`
+	Arg3Str  string                                             `field:"arg3.str,handler:ResolveOnDemandArg3Str"`
+	Arg3Uint uint64                                             `field:"arg3.uint,handler:ResolveOnDemandArg3Uint"`
+	Arg4Str  string                                             `field:"arg4.str,handler:ResolveOnDemandArg4Str"`
+	Arg4Uint uint64                                             `field:"arg4.uint,handler:ResolveOnDemandArg4Uint"`
+	Arg5Str  string                                             `field:"arg5.str,handler:ResolveOnDemandArg5Str"`
+	Arg5Uint uint64                                             `field:"arg5.uint,handler:ResolveOnDemandArg5Uint"`
+	Arg6Str  string                                             `field:"arg6.str,handler:ResolveOnDemandArg6Str"`
+	Arg6Uint uint64                                             `field:"arg6.uint,handler:ResolveOnDemandArg6Uint"`
 }
 
 // LoginUIDWriteEvent is used to propagate login UID updates to user space

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1359,13 +1359,14 @@ func (e *SyscallsEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *OnDemandEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 260 {
+	const eventSize = 4 + 6*OnDemandPerArgSize
+	if len(data) < eventSize {
 		return 0, ErrNotEnoughData
 	}
 
 	e.ID = binary.NativeEndian.Uint32(data[0:4])
-	SliceToArray(data[4:260], e.Data[:])
-	return 260, nil
+	SliceToArray(data[4:eventSize], e.Data[:])
+	return eventSize, nil
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1359,7 +1359,7 @@ func (e *SyscallsEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *OnDemandEvent) UnmarshalBinary(data []byte) (int, error) {
-	const eventSize = 4 + 6*OnDemandPerArgSize
+	const eventSize = 4 + OnDemandParsedArgsCount*OnDemandPerArgSize
 	if len(data) < eventSize {
 		return 0, ErrNotEnoughData
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support for parsing arguments 5 and 6 in the on-demand code.
In order to do that, this PR refactors a bit the code to try to make sure we use common code as much as possible (shared constants, shared unmarshalling functions).
This increase in the event size also requires the event to be stored in a per-cpu map instead of the stack.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->