### PR TITLE
[EBPF]: fixed GPU DeviceCache.Count API to consider only physical devices

### DIFF
--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -19,7 +19,7 @@ type DeviceCache interface {
 	GetByUUID(uuid string) (Device, bool)
 	// GetByIndex returns a device by its index
 	GetByIndex(index int) (Device, error)
-	// Count returns the number of devices in the cache
+	// Count returns the number of physical devices in the cache
 	Count() int
 	// SMVersionSet returns a set of all SM versions in the cache
 	SMVersionSet() map[uint32]struct{}
@@ -109,9 +109,9 @@ func (c *deviceCache) GetByIndex(index int) (Device, error) {
 	return c.allDevices[index], nil
 }
 
-// Count returns the number of devices in the cache
+// Count returns the number of physical devices in the cache
 func (c *deviceCache) Count() int {
-	return len(c.allDevices)
+	return len(c.allPhysicalDevices)
 }
 
 // SMVersionSet returns a set of all SM versions in the cache


### PR DESCRIPTION
### What does this PR do?

[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-748)

Returns the number of physical GPU devices when calling the `Count` API as it was before adding support to the MIG devices

### Motivation

this API is used to emit gpu.device.total metric which should count **only** physical GPU devices, with the introduction of MIG support, the API returned a total number of devices, including the MIG devices

### Describe how you validated your changes
existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
our current nvml mocks used for UTs, don't cover MIG devices. refactor of the testutil will be performed in a separate PR

We should backport this PR to 7.67, as currently the gpu.device.total metric shows an incorrect value