### PR TITLE
[CWS] nslookup `one.one.one.one` instead of `foo.bar`

### DIFF
--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -249,7 +249,7 @@ func TestActivityDumps(t *testing.T) {
 		defer dockerInstance.stop()
 
 		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -268,7 +268,7 @@ func TestActivityDumps(t *testing.T) {
 			}
 			for _, node := range nodes {
 				for name := range node.DNSNames {
-					if name == "foo.bar" {
+					if name == "one.one.one.one" {
 						return true
 					}
 				}
@@ -533,7 +533,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 		},
 		{
 			ID:         "test_autosuppression_dns",
-			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
+			Expression: `dns.question.type == A && dns.question.name == "one.one.one.one"`,
 			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 	}
@@ -584,7 +584,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 	t.Run("auto-suppression-dns-suppression", func(t *testing.T) {
 		// check we autosuppress signals during the activity dump duration
 		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
@@ -630,7 +630,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 		},
 		{
 			ID:         "test_autosuppression_dns",
-			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
+			Expression: `dns.question.type == A && dns.question.name == "one.one.one.one"`,
 			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 	}
@@ -693,7 +693,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 	t.Run("auto-suppression-dns-suppression", func(t *testing.T) {
 		// check we autosuppress signals during the activity dump duration
 		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance2.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := dockerInstance2.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1348,7 +1348,7 @@ func (tm *testModule) addAllEventTypesOnDump(dockerInstance *dockerCmdWrapper, s
 	_, _ = cmd.CombinedOutput()
 
 	// dns
-	cmd = dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+	cmd = dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 	_, _ = cmd.CombinedOutput()
 
 	// bind

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -173,7 +173,7 @@ func TestSecurityProfile(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -197,7 +197,7 @@ func TestSecurityProfile(t *testing.T) {
 					t.Fatalf("Found %d nodes, expected only one.", len(nodes))
 				}
 				for name := range nodes[0].DNSNames {
-					if name == "foo.bar" {
+					if name == "one.one.one.one" {
 						return true
 					}
 				}
@@ -326,7 +326,7 @@ func TestAnomalyDetection(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -362,7 +362,7 @@ func TestAnomalyDetection(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -458,7 +458,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 
 	t.Run("anomaly-detection-warmup-1", func(t *testing.T) {
 		test.GetCustomEventSent(t, func() error {
-			cmd := testDockerInstance1.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := testDockerInstance1.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
@@ -469,7 +469,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 
 	t.Run("anomaly-detection-warmed-up-autolearned-1", func(t *testing.T) {
 		test.GetCustomEventSent(t, func() error {
-			cmd := testDockerInstance1.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := testDockerInstance1.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
@@ -512,7 +512,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 
 	t.Run("anomaly-detection-warmed-up-autolearned-2", func(t *testing.T) {
 		test.GetCustomEventSent(t, func() error {
-			cmd := testDockerInstance2.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := testDockerInstance2.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
@@ -633,7 +633,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -700,7 +700,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 		}
 		defer dockerInstance.stop()
 
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -762,7 +762,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 		},
 		{
 			ID:         "test_autosuppression_dns",
-			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
+			Expression: `dns.question.type == A && dns.question.name == "one.one.one.one"`,
 			Tags:       map[string]string{"allow_autosuppression": "true"},
 		},
 		{
@@ -829,7 +829,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 	t.Run("auto-suppression-dns-signal", func(t *testing.T) {
 		// check that we generate an event during profile learning phase
 		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(rule *rules.Rule, event *model.Event) bool {
@@ -869,7 +869,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 	t.Run("auto-suppression-dns-suppression", func(t *testing.T) {
 		// check we autosuppress signals
 		err = test.GetEventSent(t, func() error {
-			cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+			cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -42,7 +42,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		},
 		{
 			ID:         "tag_rule_threat_score_dns",
-			Expression: `dns.question.name == "foo.bar" && process.file.name == "nslookup"`,
+			Expression: `dns.question.name == "one.one.one.one" && process.file.name == "nslookup"`,
 			Tags:       map[string]string{"threat_score": "9"},
 			Version:    "4.5.6",
 		},
@@ -143,7 +143,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		defer dockerInstance.stop()
 
 		time.Sleep(time.Second * 1) // to ensure we did not get ratelimited
-		cmd := dockerInstance.Command("nslookup", []string{"foo.bar"}, []string{})
+		cmd := dockerInstance.Command("nslookup", []string{"one.one.one.one"}, []string{})
 		_, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Fatal(err)
@@ -163,7 +163,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 			node := nodes[0]
 
 			for dnsName, dnsReq := range node.DNSNames {
-				if dnsName == "foo.bar" {
+				if dnsName == "one.one.one.one" {
 					if len(dnsReq.MatchedRules) != 1 ||
 						dnsReq.MatchedRules[0].RuleID != "tag_rule_threat_score_dns" ||
 						dnsReq.MatchedRules[0].RuleVersion != "4.5.6" {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently in activity dumps' tests we do some `nslookup foo.bar` that started failing recently. This PR migrates to a more well known/stable DNS instead, `one.one.one.one`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->