### PR TITLE
[EBPF] gpu: add MIG devices to the mocks


### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -34,7 +34,7 @@ func TestPull(t *testing.T) {
 	c.Pull(context.Background())
 
 	gpus := wmetaMock.ListGPUs()
-	require.Equal(t, len(testutil.GPUUUIDs), len(gpus))
+	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 	var expectedActivePIDs []int
 	for _, proc := range testutil.DefaultProcessInfo {
 		expectedActivePIDs = append(expectedActivePIDs, int(proc.Pid))
@@ -43,14 +43,21 @@ func TestPull(t *testing.T) {
 	foundIDs := make(map[string]bool)
 	for _, gpu := range gpus {
 		foundIDs[gpu.ID] = true
+		var expectedName string
+		if gpu.DeviceType == workloadmeta.GPUDeviceTypeMIG {
+			expectedName = "MIG " + testutil.DefaultGPUName
+		} else if gpu.DeviceType == workloadmeta.GPUDeviceTypePhysical {
+			expectedName = testutil.DefaultGPUName
+			//for now, we test totalMemory only for physical devices
+			require.Equal(t, testutil.DefaultTotalMemory, gpu.TotalMemory, "unexpected device memory for device %s", gpu.ID)
+		}
 		require.Equal(t, testutil.DefaultNvidiaDriverVersion, gpu.DriverVersion)
 		require.Equal(t, nvidiaVendor, gpu.Vendor)
-		require.Equal(t, testutil.DefaultGPUName, gpu.Name)
-		require.Equal(t, testutil.DefaultGPUName, gpu.Device)
+		require.Equal(t, expectedName, gpu.Name)
+		require.Equal(t, expectedName, gpu.Device)
 		require.Equal(t, "hopper", gpu.Architecture)
 		require.Equal(t, testutil.DefaultGPUComputeCapMajor, gpu.ComputeCapability.Major)
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
-		require.Equal(t, testutil.DefaultTotalMemory, gpu.TotalMemory)
 		require.Equal(t, testutil.DefaultMaxClockRates[workloadmeta.GPUSM], gpu.MaxClockRates[workloadmeta.GPUSM])
 		require.Equal(t, testutil.DefaultMaxClockRates[workloadmeta.GPUMemory], gpu.MaxClockRates[workloadmeta.GPUMemory])
 		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)
@@ -94,7 +101,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 	c.Pull(context.Background())
 
 	gpus := wmetaMock.ListGPUs()
-	require.Equal(t, len(testutil.GPUUUIDs), len(gpus))
+	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	var expectedActivePIDs []int
 	for _, proc := range testutil.DefaultProcessInfo {
@@ -119,7 +126,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 
 	c.Pull(context.Background())
 	gpus = wmetaMock.ListGPUs()
-	require.Equal(t, len(testutil.GPUUUIDs), len(gpus))
+	require.Equal(t, testutil.GetTotalExpectedDevices(), len(gpus))
 
 	for _, gpu := range gpus {
 		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -36,7 +36,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 
-	nvmlMock := testutil.GetBasicNvmlMock()
+	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache, err := ddnvml.NewDeviceCache()
 	require.NoError(t, err)

--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestConsumerCanStartAndStop(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	handler := ddebpf.NewRingBufferHandler(consumerChannelSize)
 	cfg := config.New()
 	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
@@ -39,7 +39,7 @@ func TestConsumerCanStartAndStop(t *testing.T) {
 }
 
 func TestGetStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
 	cfg := config.New()
 	handlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), cfg)
@@ -122,7 +122,7 @@ func BenchmarkConsumer(b *testing.B) {
 			name = "fatbinParsingEnabled"
 		}
 		b.Run(name, func(b *testing.B) {
-			ddnvml.WithMockNVML(b, testutil.GetBasicNvmlMock())
+			ddnvml.WithMockNVML(b, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 			ctx, err := getSystemContext(
 				withProcRoot(kernel.ProcFSRoot()),
 				withWorkloadMeta(testutil.GetWorkloadMetaMock(b)),

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -270,7 +270,7 @@ func (ctx *systemContext) getCurrentActiveGpuDevice(pid int, tid int, containerI
 	}
 
 	if selectedDeviceIndex < 0 || selectedDeviceIndex >= int32(len(visibleDevices)) {
-		return nil, fmt.Errorf("device index %d is out of range", selectedDeviceIndex)
+		return nil, fmt.Errorf("device index %d is out of range for visible devices %+v", selectedDeviceIndex, visibleDevices)
 	}
 
 	return visibleDevices[selectedDeviceIndex], nil

--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -39,7 +39,7 @@ func getTestSystemContext(t *testing.T, extraOpts ...systemContextOption) *syste
 }
 
 func TestFilterDevicesForContainer(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	wmetaMock := testutil.GetWorkloadMetaMock(t)
 	sysCtx := getTestSystemContext(t, withWorkloadMeta(wmetaMock))
 
@@ -138,7 +138,8 @@ func TestGetCurrentActiveGpuDevice(t *testing.T) {
 		{Pid: uint32(pidNoContainerButEnv), Env: map[string]string{"CUDA_VISIBLE_DEVICES": envVisibleDevicesValue}},
 	})
 
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	// MIG makes the device selection more complex, so we disable it for these tests
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	wmetaMock := testutil.GetWorkloadMetaMock(t)
 	sysCtx := getTestSystemContext(t, withProcRoot(procFs), withWorkloadMeta(wmetaMock))
 

--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -45,7 +45,7 @@ func injectEventsToConsumer(tb testing.TB, consumer *cudaEventConsumer, events *
 func TestPytorchBatchedKernels(t *testing.T) {
 	cfg := config.New()
 	telemetryMock := testutil.GetTelemetryMock(t)
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	ctx, err := getSystemContext(
 		withProcRoot(kernel.ProcFSRoot()),
 		withWorkloadMeta(testutil.GetWorkloadMetaMock(t)),

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -50,7 +50,7 @@ func (s *probeTestSuite) getProbe() *Probe {
 	// Enable fatbin parsing in tests so we can validate it runs
 	cfg.EnableFatbinParsing = true
 
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	deps := ProbeDependencies{
 		ProcessMonitor: consumerstestutil.NewTestProcessConsumer(t),
 		WorkloadMeta:   testutil.GetWorkloadMetaMock(t),

--- a/pkg/gpu/safenvml/cache_test.go
+++ b/pkg/gpu/safenvml/cache_test.go
@@ -20,6 +20,7 @@ func TestDeviceCache(t *testing.T) {
 	// Create mock with all symbols available
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithMIGDisabled(),
 	)
 
 	// Use WithMockNVML to set the mock
@@ -48,6 +49,7 @@ func TestDeviceCachePartialFailure(t *testing.T) {
 	// Create custom mock with specific config
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithMIGDisabled(),
 	)
 
 	// Override device count and get by index funcs
@@ -81,6 +83,7 @@ func TestDeviceCacheGetByIndex(t *testing.T) {
 	// Create mock with all symbols available
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithMIGDisabled(),
 	)
 
 	// Use WithMockNVML to set the mock
@@ -111,6 +114,7 @@ func TestDeviceCacheSMVersionSet(t *testing.T) {
 	// Create mock with all symbols available
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithMIGDisabled(),
 	)
 
 	// Use WithMockNVML to set the mock
@@ -131,7 +135,7 @@ func TestDeviceCacheSMVersionSet(t *testing.T) {
 func TestDeviceCacheAll(t *testing.T) {
 	// Create mock with all symbols available
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
-		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithSymbolsMock(allSymbols), // Default mock, MIG enabled for configured devices
 	)
 
 	// Use WithMockNVML to set the mock
@@ -142,21 +146,20 @@ func TestDeviceCacheAll(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cache)
 
-	// Test get all devices
-	devices := cache.All()
-	require.Len(t, devices, len(testutil.GPUUUIDs))
+	// cache.Count() should *only* counts physical devices
+	require.Equal(t, len(testutil.GPUUUIDs), cache.Count(), "Didn't find expected number of physical devices in cache")
 
-	for i, device := range devices {
-		require.Equal(t, testutil.GPUUUIDs[i], device.GetDeviceInfo().UUID)
-		require.Equal(t, testutil.GPUCores[i], device.GetDeviceInfo().CoreCount)
-		require.Equal(t, i, device.GetDeviceInfo().Index)
-	}
+	// cache.All() includes all physical and MIG devices
+	allDevices := cache.All()
+	expectedTotalDevices := testutil.GetTotalExpectedDevices()
+	require.Len(t, allDevices, expectedTotalDevices, "Cache is not filled correctly, some devices are missing")
 }
 
 func TestDeviceCacheCores(t *testing.T) {
 	// Create mock with all symbols available
 	mockNvml := testutil.GetBasicNvmlMockWithOptions(
 		testutil.WithSymbolsMock(allSymbols),
+		testutil.WithMIGDisabled(),
 	)
 
 	// Use WithMockNVML to set the mock
@@ -176,4 +179,50 @@ func TestDeviceCacheCores(t *testing.T) {
 	_, err = cache.Cores("non-existent-uuid")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "device non-existent-uuid not found")
+}
+
+func TestDeviceCacheAllPhysicalDevices(t *testing.T) {
+	// Test with MIG enabled
+	mockNvml := testutil.GetBasicNvmlMockWithOptions(
+		testutil.WithSymbolsMock(allSymbols),
+	)
+	WithMockNVML(t, mockNvml)
+
+	cache, err := NewDeviceCache()
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	// Test get all devices
+	physicalDevices := cache.AllPhysicalDevices()
+	require.Len(t, physicalDevices, len(testutil.GPUUUIDs))
+
+	for i, device := range physicalDevices {
+		require.Equal(t, testutil.GPUUUIDs[i], device.GetDeviceInfo().UUID)
+		require.Equal(t, testutil.GPUCores[i], device.GetDeviceInfo().CoreCount)
+		require.Equal(t, i, device.GetDeviceInfo().Index)
+	}
+}
+
+func TestDeviceCacheAllMigDevices(t *testing.T) {
+	// Test with MIG enabled
+	mockNvml := testutil.GetBasicNvmlMockWithOptions(
+		testutil.WithSymbolsMock(allSymbols),
+	)
+	WithMockNVML(t, mockNvml)
+
+	cache, err := NewDeviceCache()
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	migDevices := cache.AllMigDevices()
+	// Calculate expected number of MIG devices from testutil
+	expectedTotalMigCount := testutil.GetTotalExpectedDevices() - len(testutil.GPUUUIDs)
+	require.Len(t, migDevices, expectedTotalMigCount, "AllMigDevices should return all and only configured MIG instances")
+
+	for _, migDevice := range migDevices {
+		// Verify that the device is identified as a MIG device handle
+		isMig, err := migDevice.IsMigDeviceHandle()
+		require.NoError(t, err)
+		require.True(t, isMig, "Device %s from AllMigDevices should be identified as a MIG device handle", migDevice.GetDeviceInfo().UUID)
+	}
 }

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -32,7 +32,7 @@ func getMetricsEntry(key model.StatsKey, stats *model.GPUStats) *model.Utilizati
 }
 
 func getStatsGeneratorForTest(t *testing.T) (*statsGenerator, *streamCollection, int64) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	sysCtx := getTestSystemContext(t)
 
 	ktime, err := ddebpf.NowNanoseconds()

--- a/pkg/gpu/stream_collection_test.go
+++ b/pkg/gpu/stream_collection_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	ctx := getTestSystemContext(t)
 	handlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), config.New())
 
@@ -86,7 +86,7 @@ func TestStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
 }
 
 func TestStreamCollectionCleanRemovesInactiveStreams(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	ctx := getTestSystemContext(t)
 	cfg := config.New()
 	cfg.MaxStreamInactivity = 1 * time.Second // Set inactivity threshold to 1 second

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestKernelLaunchesHandled(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	streamTelemetry := newStreamTelemetry(testutil.GetTelemetryMock(t))
 	stream, err := newStreamHandler(streamMetadata{}, getTestSystemContext(t), getStreamLimits(config.New()), streamTelemetry)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestKernelLaunchesHandled(t *testing.T) {
 }
 
 func TestMemoryAllocationsHandled(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	streamTelemetry := newStreamTelemetry(testutil.GetTelemetryMock(t))
 	stream, err := newStreamHandler(streamMetadata{}, getTestSystemContext(t), getStreamLimits(config.New()), streamTelemetry)
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestMemoryAllocationsHandled(t *testing.T) {
 }
 
 func TestMemoryAllocationsDetectLeaks(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	streamTelemetry := newStreamTelemetry(testutil.GetTelemetryMock(t))
 	stream, err := newStreamHandler(streamMetadata{}, getTestSystemContext(t), getStreamLimits(config.New()), streamTelemetry)
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestMemoryAllocationsDetectLeaks(t *testing.T) {
 }
 
 func TestMemoryAllocationsNoCrashOnInvalidFree(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	streamTelemetry := newStreamTelemetry(testutil.GetTelemetryMock(t))
 	stream, err := newStreamHandler(streamMetadata{}, getTestSystemContext(t), getStreamLimits(config.New()), streamTelemetry)
 	require.NoError(t, err)
@@ -235,7 +235,7 @@ func TestMemoryAllocationsNoCrashOnInvalidFree(t *testing.T) {
 }
 
 func TestMemoryAllocationsMultipleAllocsHandled(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	streamTelemetry := newStreamTelemetry(testutil.GetTelemetryMock(t))
 	stream, err := newStreamHandler(streamMetadata{}, getTestSystemContext(t), getStreamLimits(config.New()), streamTelemetry)
 	require.NoError(t, err)
@@ -336,7 +336,7 @@ func TestKernelLaunchEnrichment(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			proc := kernel.ProcFSRoot()
-			ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+			ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 			sysCtx := getTestSystemContext(t, withFatbinParsingEnabled(fatbinParsingEnabled), withProcRoot(proc))
 
 			if fatbinParsingEnabled {
@@ -454,7 +454,7 @@ func TestKernelLaunchEnrichment(t *testing.T) {
 }
 
 func TestKernelLaunchTriggersSyncIfLimitReached(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	telemetryMock := testutil.GetTelemetryMock(t)
 	streamTelemetry := newStreamTelemetry(telemetryMock)
 	limits := streamLimits{
@@ -491,7 +491,7 @@ func TestKernelLaunchTriggersSyncIfLimitReached(t *testing.T) {
 }
 
 func TestKernelLaunchWithManualSyncsAndLimitsReached(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	telemetryMock := testutil.GetTelemetryMock(t)
 	streamTelemetry := newStreamTelemetry(telemetryMock)
 	limits := streamLimits{
@@ -570,7 +570,7 @@ func TestKernelLaunchWithManualSyncsAndLimitsReached(t *testing.T) {
 }
 
 func TestMemoryAllocationEviction(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	telemetryMock := testutil.GetTelemetryMock(t)
 	streamTelemetry := newStreamTelemetry(telemetryMock)
 	limits := streamLimits{
@@ -609,7 +609,7 @@ func TestMemoryAllocationEviction(t *testing.T) {
 }
 
 func TestMemoryAllocationEvictionAndFrees(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	telemetryMock := testutil.GetTelemetryMock(t)
 	streamTelemetry := newStreamTelemetry(telemetryMock)
 	limits := streamLimits{
@@ -685,7 +685,7 @@ func TestMemoryAllocationEvictionAndFrees(t *testing.T) {
 }
 
 func TestStreamHandlerIsInactive(t *testing.T) {
-	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	limits := streamLimits{
 		maxKernelLaunches: 5,
 		maxAllocEvents:    5,

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -199,6 +199,7 @@ func GetMIGDeviceMock(deviceIdx int, migDeviceIdx int, opts ...func(*nvmlmock.De
 			}
 
 			// core count and total memory - equally distribute between all mig devices
+			// in the future, we might want to make this more sophisticated, to support more complex scenarios in our UTs
 			parentTotalCores := GPUCores[deviceIdx]
 			coresPerMigDevice := parentTotalCores / numMigChildrenForParent
 			memoryPerMigDevice := DefaultTotalMemory / uint64(numMigChildrenForParent)

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -79,7 +79,7 @@ var DefaultProcessInfo = []nvml.ProcessInfo{
 }
 
 // DefaultTotalMemory is the total memory for the default device returned by the mock
-var DefaultTotalMemory = uint64(1000)
+var DefaultTotalMemory = uint64(1024 * 1024 * 1024)
 
 // DefaultMaxClockRates is an array of Max SM clock and Max Mem Clock rates for the default device
 var DefaultMaxClockRates = [2]uint32{1000, 2000}
@@ -205,7 +205,7 @@ func GetMIGDeviceMock(deviceIdx int, migDeviceIdx int, opts ...func(*nvmlmock.De
 
 			migSpecificAttributes := nvml.DeviceAttributes{
 				MultiprocessorCount: uint32(coresPerMigDevice),
-				MemorySizeMB:        memoryPerMigDevice,
+				MemorySizeMB:        memoryPerMigDevice / (1024 * 1024),
 			}
 
 			return migSpecificAttributes, nvml.SUCCESS

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -167,6 +167,7 @@ func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Devi
 	return mock
 }
 
+// GetMIGDeviceMock returns a mock of the MIG Device.
 func GetMIGDeviceMock(deviceIdx int, migDeviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Device {
 	// Take the original mock and override only the relevant functions to make it a MIG device.
 	prepareMigDevice := func(d *nvmlmock.Device) {
@@ -221,9 +222,10 @@ type nvmlMockOptions struct {
 	extensionsFunc func() nvml.ExtendedInterface
 }
 
-type nvmlMockOption func(*nvmlMockOptions)
+type NvmlMockOption func(*nvmlMockOptions)
 
-func WithMIGDisabled() nvmlMockOption {
+// WithMIGDisabled disables MIG support for the nvml mock.
+func WithMIGDisabled() NvmlMockOption {
 	return func(o *nvmlMockOptions) {
 		o.deviceOptions = append(o.deviceOptions, func(d *nvmlmock.Device) {
 			d.GetMigModeFunc = func() (int, int, nvml.Return) {
@@ -242,7 +244,7 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 // GetBasicNvmlMockWithOptions returns a mock of the nvml.Interface with a single device with 10 cores,
 // allowing additional configuration through functional options.
 // It's ideal for tests that need custom NVML behavior beyond the defaults.
-func GetBasicNvmlMockWithOptions(options ...nvmlMockOption) *nvmlmock.Interface {
+func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface {
 	if len(GPUUUIDs) != len(GPUCores) {
 		// Make it really easy to spot errors if we change any of the arrays.
 		panic("GPUUUIDs and GPUCores must have the same length, please fix it")
@@ -272,7 +274,7 @@ func GetBasicNvmlMockWithOptions(options ...nvmlMockOption) *nvmlmock.Interface 
 // WithSymbolsMock returns an option that configures the mock NVML interface with the given symbols available.
 // It takes a map of symbols that should be considered available in the mock.
 // Any symbol not in the map will return an error when looked up.
-func WithSymbolsMock(availableSymbols map[string]struct{}) nvmlMockOption {
+func WithSymbolsMock(availableSymbols map[string]struct{}) NvmlMockOption {
 	return func(o *nvmlMockOptions) {
 		o.extensionsFunc = func() nvml.ExtendedInterface {
 			return &nvmlmock.ExtendedInterface{

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -222,6 +222,7 @@ type nvmlMockOptions struct {
 	extensionsFunc func() nvml.ExtendedInterface
 }
 
+// NvmlMockOption is a functional option for configuring the nvml mock.
 type NvmlMockOption func(*nvmlMockOptions)
 
 // WithMIGDisabled disables MIG support for the nvml mock.


### PR DESCRIPTION
### What does this PR do?

Adds MIG devices to the nvml mocks
updates `deviceCache` UTs to test MIG scenarios as well

### Motivation

cover code flows introduced by MIG support [PR](https://github.com/DataDog/datadog-agent/pull/36377)
avoid regressions - see this [PR](https://github.com/DataDog/datadog-agent/pull/37225) for reference

### Describe how you validated your changes

Updated deviceCache UTs to include MIG devices scenarios and ensured all UTs are passing

### Possible Drawbacks / Trade-offs

### Additional Notes