### PR TITLE
[EBPF]: added gpu tags to gpu.device.total metric

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/global.go
+++ b/pkg/collector/corechecks/gpu/nvidia/global.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// globalCollector is responsible for emitting global metrics (like device.total)
+// but in the context of a specific device for tagging purposes.
+type globalCollector struct {
+	deviceUUID       string
+	totalDeviceCount int
+}
+
+// newGlobalCollector creates a new collector that reports the total device count,
+// associated with a specific deviceUUID for tagging.
+func newGlobalCollector(deviceUUID string, totalDeviceCount int) (Collector, error) {
+	return &globalCollector{
+		deviceUUID:       deviceUUID,
+		totalDeviceCount: totalDeviceCount,
+	}, nil
+}
+
+// Name returns the name of the collector.
+func (c *globalCollector) Name() CollectorName {
+	return global // Use the constant 'global' defined in collector.go
+}
+
+// DeviceUUID returns the UUID of the device this collector is associated with for tagging.
+func (c *globalCollector) DeviceUUID() string {
+	return c.deviceUUID
+}
+
+// Collect emits the "device.total" metric.
+func (c *globalCollector) Collect() ([]Metric, error) {
+	return []Metric{
+		{
+			Name:  "device.total",
+			Value: float64(c.totalDeviceCount),
+			Type:  metrics.GaugeType,
+		},
+	}, nil
+}

--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -19,7 +19,7 @@ type DeviceCache interface {
 	GetByUUID(uuid string) (Device, bool)
 	// GetByIndex returns a device by its index
 	GetByIndex(index int) (Device, error)
-	// Count returns the number of devices in the cache
+	// Count returns the number of physical devices in the cache
 	Count() int
 	// SMVersionSet returns a set of all SM versions in the cache
 	SMVersionSet() map[uint32]struct{}
@@ -109,9 +109,9 @@ func (c *deviceCache) GetByIndex(index int) (Device, error) {
 	return c.allDevices[index], nil
 }
 
-// Count returns the number of devices in the cache
+// Count returns the number of physical devices in the cache
 func (c *deviceCache) Count() int {
-	return len(c.allDevices)
+	return len(c.allPhysicalDevices)
 }
 
 // SMVersionSet returns a set of all SM versions in the cache


### PR DESCRIPTION
### What does this PR do?

Changed gpu.device.total to be emitted per gpu device.
- Introduced globalCollector to match current core-check design that will emit the metric. 
- Fixes the collectors creation flow to accumulate errors and emit one multi-error at the end

### Motivation

Add gpu tags to the metric

### Describe how you validated your changes

existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes