### PR TITLE
[Serverless] Increase serverless perf test cold start threshold to 70ms

### DIFF
--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-STARTUP_TIME_THRESHOLD=55
+STARTUP_TIME_THRESHOLD=70
 
 # If OVERRIDE_STARTUP_TIME_THRESHOLD is set, use it as the threshold
 if [ -n "$OVERRIDE_STARTUP_TIME_THRESHOLD" ]; then


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increase the threshold for failure in cold start performance test from 55ms to 70ms.

### Motivation

Flaky failures as cold start time slowly drifts up.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->