### PR TITLE
[CWS] Fix pausing AD kernel events collection

### DIFF
--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -327,7 +327,7 @@ func (m *Manager) pauseKernelEventCollection(ad *dump.ActivityDump) error {
 	newLoadConfig := *ad.LoadConfig.Load()
 	newLoadConfig.Paused = 1
 	ad.LoadConfig.Store(&newLoadConfig)
-	if err := m.activityDumpsConfigMap.Put(ad.Cookie, newLoadConfig); err != nil {
+	if err := m.activityDumpsConfigMap.Put(ad.Cookie, &newLoadConfig); err != nil {
 		return fmt.Errorf("failed to pause activity dump [%s]: %w", ad.Profile.Metadata.ContainerID, err)
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This fixes pausing AD kernel events collection.
The `activity_dumps_config` map was directly given a `ActivityDumpLoadConfig` struct instead of a pointer, causing serialization to fail because the type wasn't implementing the `encoding.BinaryMarshaler` interface.

### Motivation

Fix a regression introduced in https://github.com/DataDog/datadog-agent/pull/33877.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->