### PR TITLE
[EBPF] added gpu tags to gpu.device.total metric

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -41,7 +41,6 @@ const (
 	metricNameCoreLimit   = gpuMetricsNs + "core.limit"
 	metricNameMemoryUsage = gpuMetricsNs + "memory.usage"
 	metricNameMemoryLimit = gpuMetricsNs + "memory.limit"
-	metricNameDeviceTotal = gpuMetricsNs + "device.total"
 )
 
 // Check represents the GPU check that will be periodically executed via the Run() function

--- a/pkg/collector/corechecks/gpu/nvidia/device.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device.go
@@ -238,7 +238,7 @@ func getTotalEnergyConsumption(dev ddnvml.SafeDevice) (float64, error) {
 func getDeviceCount(dev ddnvml.SafeDevice) (float64, error) {
 	r, err := dev.IsMigDeviceHandle()
 	if r || err != nil {
-		return float64(0), nil
+		return float64(0), err
 	}
 	return float64(1), nil
 }

--- a/pkg/collector/corechecks/gpu/nvidia/device.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device.go
@@ -40,6 +40,7 @@ var allDeviceMetrics = []deviceMetric{
 	{"temperature", getTemperature, metrics.GaugeType},
 	{"total_energy_consumption", getTotalEnergyConsumption, metrics.CountType},
 	{"sm_active", getSMActive, metrics.GaugeType},
+	{"device.total", getDeviceCount, metrics.GaugeType},
 }
 
 type deviceCollector struct {
@@ -232,4 +233,12 @@ func getTotalEnergyConsumption(dev ddnvml.SafeDevice) (float64, error) {
 	// returns energy in millijoules
 	energy, err := dev.GetTotalEnergyConsumption()
 	return float64(energy), err
+}
+
+func getDeviceCount(dev ddnvml.SafeDevice) (float64, error) {
+	r, err := dev.IsMigDeviceHandle()
+	if r || err != nil {
+		return float64(0), nil
+	}
+	return float64(1), nil
 }

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -81,6 +81,8 @@ type SafeDevice interface {
 	GetUUID() (string, error)
 	// GetUtilizationRates returns the utilization rates for the device
 	GetUtilizationRates() (nvml.Utilization, error)
+	// IsMigDeviceHandle returns true if the device is a MIG device or false for a physical device
+	IsMigDeviceHandle() (bool, error)
 }
 
 // DeviceInfo holds common cached properties for a GPU device

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -275,3 +275,11 @@ func (d *safeDeviceImpl) GetUtilizationRates() (nvml.Utilization, error) {
 	utilization, ret := d.nvmlDevice.GetUtilizationRates()
 	return utilization, NewNvmlAPIErrorOrNil("GetUtilizationRates", ret)
 }
+
+func (d *safeDeviceImpl) IsMigDeviceHandle() (bool, error) {
+	if err := d.lib.lookup(toNativeName("IsMigDeviceHandle")); err != nil {
+		return false, err
+	}
+	isMig, ret := d.nvmlDevice.IsMigDeviceHandle()
+	return isMig, NewNvmlAPIErrorOrNil("IsMigDeviceHandle", ret)
+}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -68,6 +68,7 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetTemperature"),
 		toNativeName("GetTotalEnergyConsumption"),
 		toNativeName("GetUtilizationRates"),
+		toNativeName("IsMigDeviceHandle"),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Changed gpu.device.total to be emitted per GPU device to allow GPU tags

### Motivation

Allow grouping number of device by type or other gpu tags

### Describe how you validated your changes

existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
we count only non mig devices