### PR TITLE
[orchestrator] fix buffered manifest tag collection

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
@@ -99,6 +99,7 @@ func (cb *ManifestBuffer) flushManifest(sender sender.Sender) {
 				MaxWeightPerMessageBytes: cb.Cfg.MaxWeightPerMessageBytes,
 				ExtraTags:                cb.Cfg.ExtraTags,
 			},
+			ExtraTags: cb.Cfg.ExtraTags,
 			ClusterID: cb.Cfg.ClusterID,
 		},
 	}


### PR DESCRIPTION
This back port pulls in the key fix from this PR
https://github.com/DataDog/datadog-agent/pull/37117

but does not extend functionality to include more tags.

----

To validate - deploy build as DCA & Node Agent. Confirm `k8s_pods`, `k8ds_deployments` and `k8s_namespaces` have the configured extraTags within REDAPL/DDSQL.