### PR TITLE
Update devcontainer

### DIFF
--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -33,18 +33,17 @@ jobs:
       with:
         features: legacy-tasks
 
-    - name: Build image
-      run: |
-        git clone https://github.com/DataDog/datadog-agent-buildimages.git
-        cd datadog-agent-buildimages
-        dda run build devcontainer legacy-devenv
-
     - name: Create Dev Container config
-      run: dda inv -- devcontainer.setup --image legacy-devenv
+      run: dda inv -- devcontainer.setup
 
     - name: Ensure mount paths exist
       run: |
         mkdir -p ~/.ssh
+
+    - name: Free up some disk space
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
 
     - name: Install Dev Container CLI
       run: npm install -g @devcontainers/cli

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -23,7 +23,7 @@ from tasks.libs.common.utils import is_installed
 DEVCONTAINER_DIR = ".devcontainer"
 DEVCONTAINER_FILE = "devcontainer.json"
 DEVCONTAINER_NAME = "datadog_agent_devcontainer"
-DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
+DEVCONTAINER_IMAGE = "datadog/agent-dev-env-linux"
 
 
 class SkaffoldProfile(Enum):
@@ -40,7 +40,7 @@ def setup(
     build_exclude=None,
     skaffoldProfile=None,
     flavor=AgentFlavor.base.name,
-    image='',
+    image=DEVCONTAINER_IMAGE,
 ):
     """
     Generate or Modify devcontainer settings file for this project.
@@ -71,6 +71,9 @@ def setup(
 
     local_build_tags = ",".join(use_tags)
 
+    # Remove explicitly for out of date devcontainer.json files using the latest developer image
+    devcontainer.pop("remoteUser", None)
+
     devcontainer["name"] = "Datadog-Agent-DevEnv"
     if image:
         devcontainer["image"] = image
@@ -92,11 +95,17 @@ def setup(
         "--name",
         "datadog_agent_devcontainer",
     ]
+    if sys.platform != "win32":
+        # Save the current user's UID and GID to a local `.env` file
+        with open(os.path.join(DEVCONTAINER_DIR, ".env"), "w") as f:
+            f.write(f"UID={os.getuid()}\n")
+            f.write(f"GID={os.getgid()}\n")
+        devcontainer["runArgs"].append("--env-file=.env")
+
     devcontainer["features"] = {}
-    devcontainer["remoteUser"] = "datadog"
     devcontainer["mounts"] = [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
     ]
     devcontainer["customizations"] = {
         "vscode": {
@@ -125,11 +134,18 @@ def setup(
     # onCreateCommond runs the install-tools and deps tasks only when the devcontainer is created and not each time
     # the container is started
     devcontainer["onCreateCommand"] = (
-        f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && dda inv -- -e install-tools && dda inv -- -e deps"
+        # SSH is used by default in other circumstances to access private repositories
+        # https://github.com/DataDog/datadog-agent-buildimages/blob/e15e4d4d7e71272c2e338260f5e7b0cdf552d72b/dev-envs/linux/ssh.sh#L31
+        f"git config --global --unset url.ssh://git@github.com/.insteadOf && "
+        f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && "
+        f"dda inv -- -e install-tools && "
+        f"dda inv -- -e deps"
     )
 
     devcontainer["containerEnv"] = {
         "GITLAB_TOKEN": "${localEnv:GITLAB_TOKEN}",
+        "HOST_UID": "${localEnv:UID}",
+        "HOST_GID": "${localEnv:GID}",
     }
 
     configure_skaffold(devcontainer, SkaffoldProfile(skaffoldProfile))


### PR DESCRIPTION
### What does this PR do?

- Update the image used by the devcontainer tooling to the modern developer image `datadog/agent-dev-env-linux` found here: https://github.com/DataDog/datadog-agent-buildimages/tree/main/dev-envs/linux
- Support Windows by properly referencing the home environment variable

### Motivation

Consolidate developer images to only one per platform

### Describe how you validated your changes

Example run: https://github.com/DataDog/datadog-agent/actions/runs/15308606394

And locally:

```
devcontainer up --workspace-folder .
```