### PR TITLE
APM: Update usage of rand in unit tests to unflake

### DIFF
--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -30,8 +30,8 @@ func getTestErrorsSampler(tps float64) *ErrorsSampler {
 	return NewErrorsSampler(conf)
 }
 
-func getTestTrace() (pb.Trace, *pb.Span) {
-	tID := randomTraceID(rand.NewSource(time.Now().UnixNano()))
+func getTestTrace(rnd rand.Source) (pb.Trace, *pb.Span) {
+	tID := randomTraceID(rnd)
 	trace := pb.Trace{
 		&pb.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: "mcnulty", Type: "web"},
 		&pb.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: "mcnulty", Type: "sql"},
@@ -43,7 +43,7 @@ func TestExtraSampleRate(t *testing.T) {
 	assert := assert.New(t)
 
 	s := getTestErrorsSampler(10)
-	trace, root := getTestTrace()
+	trace, root := getTestTrace(rand.NewSource(3))
 	signature := testComputeSignature(trace, "")
 
 	testTime := time.Now()
@@ -70,7 +70,7 @@ func TestShrink(t *testing.T) {
 
 	sigs := []Signature{}
 	for i := 1; i < 3*shrinkCardinality; i++ {
-		trace, root := getTestTrace()
+		trace, root := getTestTrace(rand.NewSource(3))
 		sigs = append(sigs, computeSignatureWithRootAndEnv(trace, root, ""))
 
 		trace[1].Service = strconv.FormatInt(int64(i+1000), 10)
@@ -94,7 +94,7 @@ func TestDisable(t *testing.T) {
 	assert := assert.New(t)
 
 	s := getTestErrorsSampler(0)
-	trace, root := getTestTrace()
+	trace, root := getTestTrace(rand.NewSource(3))
 	for i := 0; i < int(1e2); i++ {
 		assert.False(s.Sample(time.Now(), trace, root, defaultEnv))
 	}
@@ -121,7 +121,7 @@ func TestTargetTPS(t *testing.T) {
 	for period := 0; period < initPeriods+periods; period++ {
 		testTime = testTime.Add(bucketDuration)
 		for i := 0; i < int(tracesPerPeriod); i++ {
-			trace, root := getTestTrace()
+			trace, root := getTestTrace(rand.NewSource(int64(i)))
 			sampled := s.Sample(testTime, trace, root, defaultEnv)
 			// Once we got into the "supposed-to-be" stable "regime", count the samples
 			if period > initPeriods && sampled {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
These tests previously relied on rand.Seed to ensure they did not flake here. Returning to the original behavior here by explicitly using a seeded random source

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran these tests locally to ensure they are no longer flaking

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->