### PR TITLE
[CSPM] Qualify the "running check" log as a debug log

### DIFF
--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -36,7 +36,7 @@ func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchm
 		return nil
 	}
 
-	log.Infof("running rego check for rule=%s", rule.ID)
+	log.Debugf("running rego check for rule=%s", rule.ID)
 	log.Tracef("building rego modules for rule=%s", rule.ID)
 	modules, err := buildRegoModules(benchmark.dirname, rule)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Mark the "running rego check" log as a debug log.

### Motivation

The log is too spammy and should be qualified as a debug one.
