### PR TITLE
[EBPF]: reduce gpu probe log verbosity

### DIFF
--- a/pkg/gpu/eventcollector.go
+++ b/pkg/gpu/eventcollector.go
@@ -46,7 +46,9 @@ func (c *eventCollector) tryRecordEvent(event any) {
 
 	marshaled, err := json.Marshal(event)
 	if err != nil {
-		log.Warnf("Failed to marshal event: %v", err)
+		if logLimitProbe.ShouldLog() {
+			log.Warnf("Failed to marshal event: %v", err)
+		}
 		return
 	}
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -35,6 +35,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// logLimitProbe is used to limit the number of times we log messages about streams and cuda events, as that can be very verbose
+var logLimitProbe = log.NewLogLimit(20, 10*time.Minute)
+
 const (
 	// consumerChannelSize controls the size of the go channel that buffers ringbuffer
 	// events (*ddebpf.RingBufferHandler).

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -182,7 +182,9 @@ func (sc *streamCollection) createStreamHandler(header *gpuebpf.CudaEventHeader,
 		var err error
 		device, err = sc.sysCtx.getCurrentActiveGpuDevice(int(pid), int(tid), containerIDFunc)
 		if err != nil {
-			log.Warnf("error getting GPU device for process %d: %s", pid, err)
+			if logLimitProbe.ShouldLog() {
+				log.Warnf("error getting GPU device for process %d: %s", pid, err)
+			}
 			sc.telemetry.missingDevices.Inc()
 			return nil, err
 		}
@@ -201,7 +203,9 @@ func (sc *streamCollection) memoizedContainerID(header *gpuebpf.CudaEventHeader)
 		cgroup := unix.ByteSliceToString(header.Cgroup[:])
 		containerID, err := cgroups.ContainerFilter("", cgroup)
 		if err != nil {
-			log.Warnf("error getting container ID for cgroup %s: %s", cgroup, err)
+			if logLimitProbe.ShouldLog() {
+				log.Warnf("error getting container ID for cgroup %s: %s", cgroup, err)
+			}
 
 			sc.telemetry.missingContainers.Inc("error")
 			return ""


### PR DESCRIPTION
### What does this PR do?

- changes some gpu probe log messages to `warn` from `error`
- wraps the logging with the log limiter to avoid spamming

### Motivation

avoid sending [huge amounts](https://app.datadoghq.com/logs?query=service%3Asystem-probe%20%22Error%20processing%20CUDA%20event%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1747773871033&to_ts=1747816517560&live=false) of logs

### Describe how you validated your changes

existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
we have also telemetry counter for those errors, so limiting the log messages makes total sense