### PR TITLE
remove package version sanity check

### DIFF
--- a/test/new-e2e/tests/installer/windows/agent_package.go
+++ b/test/new-e2e/tests/installer/windows/agent_package.go
@@ -30,14 +30,9 @@ func NewAgentVersionManager(versionStr, packageVersionStr string, ociPackage Tes
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse version %s: %w", versionStr, err)
 	}
-	// sanity check format of packageVersionStr
-	// NOTE: we don't use the struct result, GetNumberAndPre() does not work on
-	//       url-safe package strings because its regex expects a `+` character,
-	//       which is not present in the url-safe package version string.
-	_, err = agentVersion.New(packageVersionStr, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse package version %s: %w", packageVersionStr, err)
-	}
+	// TODO: sanity check package version
+	//       had to remove original check because it was failing on release pipeline builds
+	//       Example: 7.66.0.git.0.8005fe1.pipeline.65816352-1
 	return &AgentVersionManager{
 		version:        version,
 		packageVersion: packageVersionStr,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
remove installer e2e test package version sanity check

### Motivation
unblock release pipeline
failing on release pipeline version of the form
```
7.66.0.git.0.8005fe1.pipeline.65816352-1
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
We should consider a longer term fix, like generating a valid semver for release pipeline branches

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The tests use the string as a whole, not the parts, the sanity check was just that, to ensure the version looked well formatted, which should only be relevant when running the test locally.