### PR TITLE
[CWS] allow to remove rule with approver from the discarder discovery

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -105,7 +105,7 @@ func EvalRule(evalArgs EvalRuleParams) error {
 	}
 
 	if !evalArgs.UseWindowsModel {
-		approvers, _, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
+		approvers, _, _, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
 		if err != nil {
 			report.Error = err
 		} else {

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -293,7 +293,7 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 		}
 
 		if len(basenameRules) > 0 {
-			if isDiscarder, _, _ := rules.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
+			if isDiscarder, _, _ := rs.IsDiscarder(id.evalCtx, basenameField, basenameRules); !isDiscarder {
 				return false, true, nil
 			}
 		}

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -362,10 +362,16 @@ func TestIsDiscarderOverride(t *testing.T) {
 		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields)
 
+	supportedDiscarders := map[eval.Field]bool{
+		eval.Field("process.file.path"): true,
+		eval.Field("unlink.file.path"):  true,
+	}
+
 	var opts rules.Opts
 	opts.
 		WithEventTypeEnabled(enabled).
-		WithLogger(seclog.DefaultLogger)
+		WithLogger(seclog.DefaultLogger).
+		WithSupportedDiscarders(supportedDiscarders)
 
 	var listener testEventListener
 

--- a/pkg/security/probe/kfilters/approvers_test.go
+++ b/pkg/security/probe/kfilters/approvers_test.go
@@ -34,7 +34,7 @@ func TestApproverAncestors1(t *testing.T) {
 		t.Fatal("no capabilities for open")
 	}
 
-	approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestApproverAncestors2(t *testing.T) {
 	if !exists {
 		t.Fatal("no capabilities for open")
 	}
-	approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestApproverGlob(t *testing.T) {
 	if !exists {
 		t.Fatal("no capabilities for open")
 	}
-	approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestApproverFlags(t *testing.T) {
 	if !exists {
 		t.Fatal("no capabilities for open")
 	}
-	approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestApproverWildcardBasename(t *testing.T) {
 	if !exists {
 		t.Fatal("no capabilities for open")
 	}
-	approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+	approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestApproverAUIDRange(t *testing.T) {
 		if !exists {
 			t.Fatal("no capabilities for open")
 		}
-		approvers, _, err := rs.GetEventTypeApprovers("open", capabilities)
+		approvers, _, _, err := rs.GetEventTypeApprovers("open", capabilities)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/security/probe/kfilters/capabilities.go
+++ b/pkg/security/probe/kfilters/capabilities.go
@@ -11,10 +11,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+type Capababilities map[eval.EventType]rules.FieldCapabilities
+
 // allCapabilities hold all the supported filtering capabilities
-var allCapabilities = make(map[eval.EventType]rules.FieldCapabilities)
+var allCapabilities = make(Capababilities)
 
 // GetCapababilities returns all the filtering capabilities
-func GetCapababilities() map[eval.EventType]rules.FieldCapabilities {
+func GetCapababilities() Capababilities {
 	return allCapabilities
+}
+
+// Clone returns a copy of the Capababilities
+func (c *Capababilities) Clone() Capababilities {
+	clone := make(Capababilities, len(*c))
+	for k, v := range *c {
+		clone[k] = v.Clone()
+	}
+	return clone
 }

--- a/pkg/security/probe/kfilters/capabilities.go
+++ b/pkg/security/probe/kfilters/capabilities.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+// Capababilities is a map of event types to field capabilities
 type Capababilities map[eval.EventType]rules.FieldCapabilities
 
 // allCapabilities hold all the supported filtering capabilities

--- a/pkg/security/probe/kfilters/open.go
+++ b/pkg/security/probe/kfilters/open.go
@@ -24,7 +24,7 @@ var openCapabilities = mergeCapabilities(
 			Field:        "open.file.path",
 			TypeBitmask:  eval.ScalarValueType | eval.PatternValueType | eval.GlobValueType,
 			ValidateFnc:  validateBasenameFilter,
-			FilterWeight: 15,
+			FilterWeight: 300,
 		},
 		{
 			Field:        "open.file.name",

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -141,8 +141,14 @@ func ComputeFilters(config *config.Config, rs *rules.RuleSet) (*FilterReport, er
 		return approverReports, discarderReport, nil
 	}
 
+	var (
+		approverReports map[eval.EventType]*ApproverReport
+		discarderReport *rules.DiscardersReport
+		err             error
+	)
+
 	// first attempt to compute the approvers and discarders
-	approverReports, discarderReport, err := computeFilters(rs, allCapabilities)
+	approverReports, discarderReport, err = computeFilters(rs, allCapabilities)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -191,6 +191,8 @@ func ComputeFilters(config *config.Config, rs *rules.RuleSet) (*FilterReport, er
 				}
 			}
 		}
+	} else {
+		return &FilterReport{ApproverReports: approverReports, DiscardersReport: discarderReport}, nil
 	}
 
 	// no improvement, return the initial report

--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -8,6 +8,7 @@ package kfilters
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -24,6 +25,7 @@ type ApproverReport struct {
 	Mode            PolicyMode       `json:"mode"`
 	Approvers       rules.Approvers  `json:"approvers,omitempty"`
 	AcceptModeRules []AcceptModeRule `json:"accept_mode_rules,omitempty"`
+	ApproversOnly   []eval.Field     `json:"approvers_only,omitempty"`
 }
 
 // FilterReport describes the event types and their associated policy policies
@@ -64,16 +66,16 @@ func (r *FilterReport) String() string {
 	return string(content)
 }
 
-func getApproverReports(config *config.Config, rs *rules.RuleSet) (map[eval.EventType]*ApproverReport, error) {
+func computeApprovers(config *config.Config, rs *rules.RuleSet, capabilities map[eval.EventType]rules.FieldCapabilities) (map[eval.EventType]*ApproverReport, []*rules.Rule, error) {
 	approverReports := make(map[eval.EventType]*ApproverReport)
 
-	// We need to call the approver detection even when approvers aren't enabled as it may have impact on some rule flags and
-	// the discarder mechanism, see ruleset.go
-	approvers, rules, err := rs.GetApprovers(GetCapababilities())
+	// get the approvers and accept mode rules
+	approvers, acceptModeRules, noDiscarderRules, err := rs.GetApprovers(capabilities)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	// generate the approver reports
 	for _, eventType := range rs.GetEventTypes() {
 		report := &ApproverReport{Mode: PolicyModeDeny}
 		approverReports[eventType] = report
@@ -95,9 +97,15 @@ func getApproverReports(config *config.Config, rs *rules.RuleSet) (map[eval.Even
 
 		if values, exists := approvers[eventType]; exists {
 			report.Approvers = values
+
+			for _, evtCapability := range capabilities[eventType] {
+				if evtCapability.FilterMode == rules.ApproverOnlyMode {
+					report.ApproversOnly = append(report.ApproversOnly, evtCapability.Field)
+				}
+			}
 		} else {
 			report.Mode = PolicyModeAccept
-			if rule := rules[eventType]; rule != nil {
+			if rule := acceptModeRules[eventType]; rule != nil {
 				report.AcceptModeRules = append(report.AcceptModeRules, AcceptModeRule{
 					RuleID: rule.ID,
 				})
@@ -105,17 +113,82 @@ func getApproverReports(config *config.Config, rs *rules.RuleSet) (map[eval.Even
 		}
 	}
 
-	return approverReports, nil
+	return approverReports, noDiscarderRules, nil
+}
+
+func ruleListToMap(rules []*rules.Rule) map[eval.RuleID]bool {
+	m := make(map[eval.RuleID]bool, len(rules))
+	for _, rule := range rules {
+		m[rule.ID] = true
+	}
+	return m
 }
 
 // ComputeFilters computes the approver and discarder and returns a FilterReport
 func ComputeFilters(config *config.Config, rs *rules.RuleSet) (*FilterReport, error) {
-	approverReports, err := getApproverReports(config, rs)
+	computeFilters := func(rs *rules.RuleSet, capabilities map[eval.EventType]rules.FieldCapabilities) (map[eval.EventType]*ApproverReport, *rules.DiscardersReport, error) {
+		approverReports, noDiscarderRules, err := computeApprovers(config, rs, capabilities)
+		if err != nil {
+			return nil, nil, err
+		}
+		rs.WithExcludedRuleFromDiscarders(ruleListToMap(noDiscarderRules))
+
+		discarderReport, err := rs.GetDiscardersReport()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return approverReports, discarderReport, nil
+	}
+
+	// first attempt to compute the approvers and discarders
+	approverReports, discarderReport, err := computeFilters(rs, allCapabilities)
 	if err != nil {
 		return nil, err
 	}
 
-	discarderReport, err := rs.GetDiscardersReport()
+	// if some invalid discarders, try to improve putting some approvers in ApproverOnly mode
+	if len(discarderReport.Invalid) > 0 {
+		event := rs.NewEvent()
+
+		for _, invalid := range discarderReport.Invalid {
+			eventType, _, _, err := event.GetFieldMetadata(invalid.Field)
+			if err != nil {
+				return nil, err
+			}
+
+			capabilities := allCapabilities.Clone()
+
+			evtCapabilities, ok := capabilities[eventType]
+			if !ok {
+				continue
+			}
+
+			// try to convert the most efficient approver so that weak approvers are still backed by a discarder
+			sort.Slice(evtCapabilities, func(i, j int) bool {
+				return evtCapabilities[i].FilterWeight > evtCapabilities[j].FilterWeight
+			})
+
+			for _, evtCapability := range evtCapabilities {
+				evtCapability.FilterMode = rules.ApproverOnlyMode
+
+				approverReports, discarderReport, err = computeFilters(rs, capabilities)
+				if err != nil {
+					return nil, err
+				}
+
+				// revert the capability
+				evtCapability.FilterMode = rules.DefaultMode
+
+				if len(discarderReport.Invalid) == 0 {
+					return &FilterReport{ApproverReports: approverReports, DiscardersReport: discarderReport}, nil
+				}
+			}
+		}
+	}
+
+	// no improvement, return the initial report
+	approverReports, discarderReport, err = computeFilters(rs, allCapabilities)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/kfilters/report_test.go
+++ b/pkg/security/probe/kfilters/report_test.go
@@ -43,11 +43,40 @@ func TestDiscarderReport(t *testing.T) {
 			t.Errorf("expected 1 supported discarder, got %d", len(report.DiscardersReport.Supported))
 		}
 	})
-
-	t.Run("two-field-ko", func(t *testing.T) {
+	t.Run("no-discarder-ok", func(t *testing.T) {
 		rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-		rules.AddTestRuleExpr(t, rs, `open.file.path == "/etc/passwd"`)
+
+		// The first rule can generate a discarder, the second one can't
+		// As the second can be in approver only, we can generate discarders for the first one
+		// if we convert the second one to approver only
+		rules.AddTestRuleExpr(t, rs, `open.file.path =~ "/etc/**" && open.file.name == "cron"`)
 		rules.AddTestRuleExpr(t, rs, `open.file.name == "group"`)
+
+		report, err := ComputeFilters(cfg, rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(report.DiscardersReport.Supported) != 1 {
+			t.Errorf("expected 1 supported discarder, got %d", len(report.DiscardersReport.Supported))
+		}
+
+		if len(report.DiscardersReport.Invalid) != 0 {
+			t.Errorf("expected 0 invalid discarder, got %d", len(report.DiscardersReport.Invalid))
+		}
+
+		if len(report.ApproverReports["open"].ApproversOnly) != 2 {
+			t.Errorf("expected 0 approvers only, got %+v", report.ApproverReports["open"].ApproversOnly)
+		}
+	})
+
+	t.Run("no-discarder-ko", func(t *testing.T) {
+		rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+
+		// The first rule can generate a discarder, the second one can't
+		// As the second can't be in approver only, we can't generate discarders
+		rules.AddTestRuleExpr(t, rs, `open.file.path == "/etc/passwd"`)
+		rules.AddTestRuleExpr(t, rs, `open.mode == 0444`)
 
 		report, err := ComputeFilters(cfg, rs)
 		if err != nil {
@@ -58,8 +87,12 @@ func TestDiscarderReport(t *testing.T) {
 			t.Errorf("expected 0 supported discarder, got %d", len(report.DiscardersReport.Supported))
 		}
 
-		if len(report.DiscardersReport.Invalid) != 1 {
+		if len(report.DiscardersReport.Invalid) == 0 {
 			t.Errorf("expected 1 invalid discarder, got %d", len(report.DiscardersReport.Invalid))
+		}
+
+		if len(report.ApproverReports["open"].ApproversOnly) != 0 {
+			t.Errorf("expected 0 approvers only, got %+v", report.ApproverReports["open"].ApproversOnly)
 		}
 	})
 }

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -577,6 +577,29 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityProbeKfilters1
 				}
 				in.Delim(']')
 			}
+		case "approvers_only":
+			if in.IsNull() {
+				in.Skip()
+				out.ApproversOnly = nil
+			} else {
+				in.Delim('[')
+				if out.ApproversOnly == nil {
+					if !in.IsDelim(']') {
+						out.ApproversOnly = make([]string, 0, 4)
+					} else {
+						out.ApproversOnly = []string{}
+					}
+				} else {
+					out.ApproversOnly = (out.ApproversOnly)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v15 string
+					v15 = string(in.String())
+					out.ApproversOnly = append(out.ApproversOnly, v15)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -601,24 +624,24 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityProbeKfilters1
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v15First := true
-			for v15Name, v15Value := range in.Approvers {
-				if v15First {
-					v15First = false
+			v16First := true
+			for v16Name, v16Value := range in.Approvers {
+				if v16First {
+					v16First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v15Name))
+				out.String(string(v16Name))
 				out.RawByte(':')
-				if v15Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v16Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v16, v17 := range v15Value {
-						if v16 > 0 {
+					for v17, v18 := range v16Value {
+						if v17 > 0 {
 							out.RawByte(',')
 						}
-						easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecuritySeclRules2(out, v17)
+						easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecuritySeclRules2(out, v18)
 					}
 					out.RawByte(']')
 				}
@@ -631,11 +654,25 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityProbeKfilters1
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v18, v19 := range in.AcceptModeRules {
-				if v18 > 0 {
+			for v19, v20 := range in.AcceptModeRules {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityProbeKfilters2(out, v19)
+				easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityProbeKfilters2(out, v20)
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.ApproversOnly) != 0 {
+		const prefix string = ",\"approvers_only\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v21, v22 := range in.ApproversOnly {
+				if v21 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v22))
 			}
 			out.RawByte(']')
 		}
@@ -801,9 +838,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v20 string
-					v20 = string(in.String())
-					(out.Tags)[key] = v20
+					var v23 string
+					v23 = string(in.String())
+					(out.Tags)[key] = v23
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -824,9 +861,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.ProductTags = (out.ProductTags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v21 string
-					v21 = string(in.String())
-					out.ProductTags = append(out.ProductTags, v21)
+					var v24 string
+					v24 = string(in.String())
+					out.ProductTags = append(out.ProductTags, v24)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -847,9 +884,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v22 RuleAction
-					(v22).UnmarshalEasyJSON(in)
-					out.Actions = append(out.Actions, v22)
+					var v25 RuleAction
+					(v25).UnmarshalEasyJSON(in)
+					out.Actions = append(out.Actions, v25)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -870,17 +907,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.ModifiedBy = (out.ModifiedBy)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v23 *PolicyState
+					var v26 *PolicyState
 					if in.IsNull() {
 						in.Skip()
-						v23 = nil
+						v26 = nil
 					} else {
-						if v23 == nil {
-							v23 = new(PolicyState)
+						if v26 == nil {
+							v26 = new(PolicyState)
 						}
-						(*v23).UnmarshalEasyJSON(in)
+						(*v26).UnmarshalEasyJSON(in)
 					}
-					out.ModifiedBy = append(out.ModifiedBy, v23)
+					out.ModifiedBy = append(out.ModifiedBy, v26)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -929,16 +966,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v24First := true
-			for v24Name, v24Value := range in.Tags {
-				if v24First {
-					v24First = false
+			v27First := true
+			for v27Name, v27Value := range in.Tags {
+				if v27First {
+					v27First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v24Name))
+				out.String(string(v27Name))
 				out.RawByte(':')
-				out.String(string(v24Value))
+				out.String(string(v27Value))
 			}
 			out.RawByte('}')
 		}
@@ -948,11 +985,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v25, v26 := range in.ProductTags {
-				if v25 > 0 {
+			for v28, v29 := range in.ProductTags {
+				if v28 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v26))
+				out.String(string(v29))
 			}
 			out.RawByte(']')
 		}
@@ -962,11 +999,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v27, v28 := range in.Actions {
-				if v27 > 0 {
+			for v30, v31 := range in.Actions {
+				if v30 > 0 {
 					out.RawByte(',')
 				}
-				(v28).MarshalEasyJSON(out)
+				(v31).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -976,14 +1013,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v29, v30 := range in.ModifiedBy {
-				if v29 > 0 {
+			for v32, v33 := range in.ModifiedBy {
+				if v32 > 0 {
 					out.RawByte(',')
 				}
-				if v30 == nil {
+				if v33 == nil {
 					out.RawString("null")
 				} else {
-					(*v30).MarshalEasyJSON(out)
+					(*v33).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -1441,17 +1478,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 					out.Rules = (out.Rules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 *RuleState
+					var v34 *RuleState
 					if in.IsNull() {
 						in.Skip()
-						v31 = nil
+						v34 = nil
 					} else {
-						if v31 == nil {
-							v31 = new(RuleState)
+						if v34 == nil {
+							v34 = new(RuleState)
 						}
-						(*v31).UnmarshalEasyJSON(in)
+						(*v34).UnmarshalEasyJSON(in)
 					}
-					out.Rules = append(out.Rules, v31)
+					out.Rules = append(out.Rules, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1492,14 +1529,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.Rules {
-				if v32 > 0 {
+			for v35, v36 := range in.Rules {
+				if v35 > 0 {
 					out.RawByte(',')
 				}
-				if v33 == nil {
+				if v36 == nil {
 					out.RawString("null")
 				} else {
-					(*v33).MarshalEasyJSON(out)
+					(*v36).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')

--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -27,7 +27,7 @@ func partialEval(event eval.Event, ctx *eval.Context, rule *Rule, field eval.Fie
 	return rule.PartialEval(ctx, field)
 }
 
-func isAnIntLesserEqualThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap FieldCapability, value interface{}) (bool, interface{}, error) {
+func isAnIntLesserEqualThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap *FieldCapability, value interface{}) (bool, interface{}, error) {
 	min := math.MinInt
 	if fieldCap.RangeFilterValue != nil {
 		min = fieldCap.RangeFilterValue.Min
@@ -45,7 +45,7 @@ func isAnIntLesserEqualThanApprover(event eval.Event, ctx *eval.Context, rule *R
 	return !result, RangeFilterValue{Min: min, Max: value.(int)}, err
 }
 
-func isAnIntLesserThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap FieldCapability, value interface{}) (bool, interface{}, error) {
+func isAnIntLesserThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap *FieldCapability, value interface{}) (bool, interface{}, error) {
 	min := math.MinInt
 	if fieldCap.RangeFilterValue != nil {
 		min = fieldCap.RangeFilterValue.Min
@@ -63,7 +63,7 @@ func isAnIntLesserThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, 
 	return !result, RangeFilterValue{Min: min, Max: value.(int) - 1}, err
 }
 
-func isAnIntGreaterEqualThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap FieldCapability, value interface{}) (bool, interface{}, error) {
+func isAnIntGreaterEqualThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap *FieldCapability, value interface{}) (bool, interface{}, error) {
 	max := math.MaxInt
 	if fieldCap.RangeFilterValue != nil {
 		max = fieldCap.RangeFilterValue.Max
@@ -81,7 +81,7 @@ func isAnIntGreaterEqualThanApprover(event eval.Event, ctx *eval.Context, rule *
 	return !result, RangeFilterValue{Min: value.(int), Max: max}, err
 }
 
-func isAnIntGreaterThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap FieldCapability, value interface{}) (bool, interface{}, error) {
+func isAnIntGreaterThanApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap *FieldCapability, value interface{}) (bool, interface{}, error) {
 	max := math.MaxInt
 	if fieldCap.RangeFilterValue != nil {
 		max = fieldCap.RangeFilterValue.Max
@@ -100,7 +100,7 @@ func isAnIntGreaterThanApprover(event eval.Event, ctx *eval.Context, rule *Rule,
 }
 
 // isAnApprover returns whether the given value is an approver for the given rule
-func isAnApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap FieldCapability, fieldValueType eval.FieldValueType, value interface{}) (bool, eval.FieldValueType, interface{}, error) {
+func isAnApprover(event eval.Event, ctx *eval.Context, rule *Rule, fieldCap *FieldCapability, fieldValueType eval.FieldValueType, value interface{}) (bool, eval.FieldValueType, interface{}, error) {
 	if fieldValueType == eval.RangeValueType {
 		isAnApprover, approverValue, err := isAnIntLesserEqualThanApprover(event, ctx, rule, fieldCap, value)
 		if isAnApprover || err != nil {
@@ -204,10 +204,12 @@ func bitmaskCombinations(bitmasks []int) []int {
 //     * open.file.name in ["123", "456"] && open.file.name != "4.*" && open.file.name != "888"
 //     reason:
 //     * event will be approved kernel side and will be rejected userspace side
-func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) (Approvers, *Rule, error) {
-	approvers := make(Approvers)
-
-	ctx := eval.NewContext(event)
+func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) (Approvers, *Rule, []*Rule, error) {
+	var (
+		approvers        = make(Approvers)
+		ctx              = eval.NewContext(event)
+		noDiscarderRules []*Rule
+	)
 
 	for _, rule := range rules {
 		var (
@@ -238,7 +240,7 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 				case eval.ScalarValueType, eval.PatternValueType, eval.GlobValueType, eval.RangeValueType:
 					isAnApprover, approverValueType, approverValue, err := isAnApprover(event, ctx, rule, fieldCap, value.Type, value.Value)
 					if err != nil {
-						return nil, rule, err
+						return nil, rule, nil, err
 					}
 					if isAnApprover {
 						filterValue := FilterValue{Field: field, Value: approverValue, Type: approverValueType, Mode: fieldCap.FilterMode}
@@ -255,7 +257,7 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 			for _, bitmask := range bitmaskCombinations(bitmasks) {
 				isAnApprover, _, _, err := isAnApprover(event, ctx, rule, fieldCap, eval.BitmaskValueType, bitmask)
 				if err != nil {
-					return nil, rule, err
+					return nil, rule, nil, err
 				}
 
 				if isAnApprover {
@@ -281,20 +283,20 @@ func getApprovers(rules []*Rule, event eval.Event, fieldCaps FieldCapabilities) 
 
 		// no filter value for a rule thus no approver for the event type
 		if bestFilterValues == nil {
-			return nil, rule, nil
+			return nil, rule, nil, nil
 		}
 
-		// this rule as an approver in ApproverOnly mode. Disable the rule from being used by the discarder mechanism.
+		// this rule as an approver in ApproverOnly mode. Report the rule so that it can excluded from being used by the discarder mechanism.
 		// the goal is to have approvers that are good enough to filter properly the events used by rule that would break the
 		// discarder discovery.
 		// ex: open.file.name != "" && process.auid == 1000 # this rule avoid open.file.path discarder discovery, but with a ApproverOnly on process.auid the problem disappear
 		//     open.file.filename == "/etc/passwd"
 		if bestFilterMode == ApproverOnlyMode {
-			rule.NoDiscarder = true
+			noDiscarderRules = append(noDiscarderRules, rule)
 		}
 
 		approvers[bestFilterField] = approvers[bestFilterField].Merge(bestFilterValues...)
 	}
 
-	return approvers, nil, nil
+	return approvers, nil, noDiscarderRules, nil
 }

--- a/pkg/security/secl/rules/capabilities.go
+++ b/pkg/security/secl/rules/capabilities.go
@@ -14,14 +14,14 @@ import (
 type FilterMode int
 
 const (
-	// NormalMode enabled approver and discarder
-	NormalMode FilterMode = iota
+	// DefaultMode enabled approver and discarder
+	DefaultMode FilterMode = iota
 	// ApproverOnlyMode not used to generate a discarder
 	ApproverOnlyMode
 )
 
 // FieldCapabilities holds a list of field capabilities
-type FieldCapabilities []FieldCapability
+type FieldCapabilities []*FieldCapability
 
 // FieldCapability represents a field and the type of its value (scalar, pattern, bitmask, ...)
 type FieldCapability struct {
@@ -61,4 +61,11 @@ func (fcs FieldCapabilities) GetFields() []eval.Field {
 		fields = append(fields, fc.Field)
 	}
 	return fields
+}
+
+// Clone returns a copy of the FieldCapabilities
+func (fcs *FieldCapabilities) Clone() FieldCapabilities {
+	clone := make(FieldCapabilities, len(*fcs))
+	copy(clone, *fcs)
+	return clone
 }

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -27,13 +27,14 @@ type RuleActionPerformedCb func(r *Rule, action *ActionDefinition)
 
 // Opts defines rules set options
 type Opts struct {
-	SupportedDiscarders      map[eval.Field]bool
-	SupportedMultiDiscarders []*MultiDiscarder
-	ReservedRuleIDs          []RuleID
-	EventTypeEnabled         map[eval.EventType]bool
-	StateScopes              map[Scope]VariableProviderFactory
-	Logger                   log.Logger
-	ruleActionPerformedCb    RuleActionPerformedCb
+	SupportedDiscarders        map[eval.Field]bool
+	SupportedMultiDiscarders   []*MultiDiscarder
+	ExcludedRuleFromDiscarders map[eval.RuleID]bool
+	ReservedRuleIDs            []RuleID
+	EventTypeEnabled           map[eval.EventType]bool
+	StateScopes                map[Scope]VariableProviderFactory
+	Logger                     log.Logger
+	ruleActionPerformedCb      RuleActionPerformedCb
 }
 
 // WithSupportedDiscarders set supported discarders
@@ -45,6 +46,12 @@ func (o *Opts) WithSupportedDiscarders(discarders map[eval.Field]bool) *Opts {
 // WithSupportedMultiDiscarder set supported multi discarders
 func (o *Opts) WithSupportedMultiDiscarder(discarders []*MultiDiscarder) *Opts {
 	o.SupportedMultiDiscarders = discarders
+	return o
+}
+
+// WithExcludedRuleFromDiscarders set excluded rule from discarders
+func (o *Opts) WithExcludedRuleFromDiscarders(excludedRuleFromDiscarders map[eval.RuleID]bool) *Opts {
+	o.ExcludedRuleFromDiscarders = excludedRuleFromDiscarders
 	return o
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -32,7 +32,6 @@ import (
 type Rule struct {
 	*PolicyRule
 	*eval.Rule
-	NoDiscarder bool
 }
 
 // DiscarderInvalidReport is a report of an invalid discarder
@@ -311,7 +310,7 @@ func (rs *RuleSet) GetDiscardersReport() (*DiscardersReport, error) {
 			continue
 		}
 
-		_, rule, err := IsDiscarder(ctx, field, bucket.GetRules())
+		_, rule, err := rs.IsDiscarder(ctx, field, bucket.GetRules())
 		if err != nil {
 			if errors.As(err, &errFieldNotFound) {
 				report.Invalid = append(report.Invalid, DiscarderInvalidReport{
@@ -498,6 +497,11 @@ func GetRuleEventType(rule *eval.Rule) (eval.EventType, error) {
 	return eventType, nil
 }
 
+// WithExcludedRuleFromDiscarders set excluded rule from discarders
+func (rs *RuleSet) WithExcludedRuleFromDiscarders(excludedRuleFromDiscarders map[eval.RuleID]bool) {
+	rs.opts.ExcludedRuleFromDiscarders = excludedRuleFromDiscarders
+}
+
 func (rs *RuleSet) isActionAvailable(eventType eval.EventType, action *Action) bool {
 	if action.Def.Name() == HashAction && eventType != model.FileOpenEventType.String() && eventType != model.ExecEventType.String() {
 		return false
@@ -679,9 +683,12 @@ func (rs *RuleSet) GetBucket(eventType eval.EventType) *RuleBucket {
 }
 
 // GetApprovers returns all approvers
-func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) (map[eval.EventType]Approvers, map[eval.EventType]*Rule, error) {
-	approvers := make(map[eval.EventType]Approvers)
-	rules := make(map[eval.EventType]*Rule)
+func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) (map[eval.EventType]Approvers, map[eval.EventType]*Rule, []*Rule, error) {
+	var (
+		approvers        = make(map[eval.EventType]Approvers)
+		acceptModeRules  = make(map[eval.EventType]*Rule)
+		noDiscarderRules []*Rule
+	)
 
 	for _, eventType := range rs.GetEventTypes() {
 		caps, exists := fieldCaps[eventType]
@@ -689,23 +696,24 @@ func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) 
 			continue
 		}
 
-		eventTypeApprovers, rule, err := rs.GetEventTypeApprovers(eventType, caps)
-		if err != nil || len(eventTypeApprovers) == 0 {
+		evtApprovers, rule, evtNoDiscarderRules, err := rs.GetEventTypeApprovers(eventType, caps)
+		if err != nil || len(evtApprovers) == 0 {
 			// report the first rule avoiding to generate an approver
-			rules[eventType] = rule
+			acceptModeRules[eventType] = rule
 			continue
 		}
-		approvers[eventType] = eventTypeApprovers
+		approvers[eventType] = evtApprovers
+		noDiscarderRules = append(noDiscarderRules, evtNoDiscarderRules...)
 	}
 
-	return approvers, rules, nil
+	return approvers, acceptModeRules, noDiscarderRules, nil
 }
 
-// GetEventTypeApprovers returns approvers for the given event type and the fields
-func (rs *RuleSet) GetEventTypeApprovers(eventType eval.EventType, fieldCaps FieldCapabilities) (Approvers, *Rule, error) {
+// GetevtApprovers returns approvers for the given event type and the fields
+func (rs *RuleSet) GetEventTypeApprovers(eventType eval.EventType, fieldCaps FieldCapabilities) (Approvers, *Rule, []*Rule, error) {
 	bucket, exists := rs.eventRuleBuckets[eventType]
 	if !exists {
-		return nil, nil, ErrNoEventTypeBucket{EventType: eventType}
+		return nil, nil, nil, ErrNoEventTypeBucket{EventType: eventType}
 	}
 
 	// all the rules needs to be of the same type
@@ -727,12 +735,12 @@ func (rs *RuleSet) GetFieldValues(field eval.Field) []eval.FieldValue {
 }
 
 // IsDiscarder partially evaluates an Event against a field
-func IsDiscarder(ctx *eval.Context, field eval.Field, rules []*Rule) (bool, *Rule, error) {
+func (rs *RuleSet) IsDiscarder(ctx *eval.Context, field eval.Field, rules []*Rule) (bool, *Rule, error) {
 	var isDiscarder bool
 
 	for _, rule := range rules {
 		// ignore rule that can't generate discarders
-		if rule.NoDiscarder {
+		if _, exists := rs.opts.ExcludedRuleFromDiscarders[rule.ID]; exists {
 			continue
 		}
 
@@ -917,13 +925,11 @@ func (rs *RuleSet) EvaluateDiscarders(event eval.Event) {
 			}
 		}
 
-		if rs.opts.SupportedDiscarders != nil {
-			if _, exists := rs.opts.SupportedDiscarders[field]; !exists {
-				continue
-			}
+		if _, exists := rs.opts.SupportedDiscarders[field]; !exists {
+			continue
 		}
 
-		if isDiscarder, _, _ := IsDiscarder(ctx, field, bucket.rules); isDiscarder {
+		if isDiscarder, _, _ := rs.IsDiscarder(ctx, field, bucket.rules); isDiscarder {
 			rs.NotifyDiscarderFound(event, field, eventType)
 		}
 	}
@@ -943,7 +949,7 @@ func (rs *RuleSet) EvaluateDiscarders(event eval.Event) {
 				break
 			}
 
-			if isDiscarder, _, _ := IsDiscarder(dctx, entry.Field, bucket.rules); !isDiscarder {
+			if isDiscarder, _, _ := rs.IsDiscarder(dctx, entry.Field, bucket.rules); !isDiscarder {
 				isMultiDiscarder = false
 				break
 			}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -709,7 +709,7 @@ func (rs *RuleSet) GetApprovers(fieldCaps map[eval.EventType]FieldCapabilities) 
 	return approvers, acceptModeRules, noDiscarderRules, nil
 }
 
-// GetevtApprovers returns approvers for the given event type and the fields
+// GetEventTypeApprovers returns approvers for the given event type and the fields
 func (rs *RuleSet) GetEventTypeApprovers(eventType eval.EventType, fieldCaps FieldCapabilities) (Approvers, *Rule, []*Rule, error) {
 	bucket, exists := rs.eventRuleBuckets[eventType]
 	if !exists {

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -73,6 +73,13 @@ func newFakeEvent() eval.Event {
 
 func newRuleSet() *RuleSet {
 	ruleOpts, evalOpts := NewBothOpts(map[eval.EventType]bool{"*": true})
+
+	ruleOpts.WithSupportedDiscarders(map[eval.Field]bool{
+		"open.file.path":  true,
+		"mkdir.file.path": true,
+		"process.uid":     true,
+	})
+
 	return NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 }
 
@@ -177,7 +184,7 @@ func TestRuleSetApprovers1(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("should get an approver")
 	}
@@ -201,7 +208,7 @@ func TestRuleSetApprovers1(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ = rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ = rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("should get an approver")
 	}
@@ -227,7 +234,7 @@ func TestRuleSetApprovers2(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get any approver")
 	}
@@ -245,7 +252,7 @@ func TestRuleSetApprovers2(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ = rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ = rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 2 {
 		t.Fatal("should get 2 field approvers")
 	}
@@ -270,7 +277,7 @@ func TestRuleSetApprovers3(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 {
 		t.Fatal("should get only one field approver")
 	}
@@ -291,7 +298,7 @@ func TestRuleSetApprovers4(t *testing.T) {
 		},
 	}
 
-	if approvers, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) != 0 {
+	if approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) != 0 {
 		t.Fatalf("shouldn't get any approver, got: %+v", approvers)
 	}
 
@@ -302,7 +309,7 @@ func TestRuleSetApprovers4(t *testing.T) {
 		},
 	}
 
-	if approvers, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) == 0 {
+	if approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
 }
@@ -318,7 +325,7 @@ func TestRuleSetApprovers5(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
@@ -344,7 +351,7 @@ func TestRuleSetApprovers6(t *testing.T) {
 		},
 	}
 
-	if approvers, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) == 0 {
+	if approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
 
@@ -358,7 +365,7 @@ func TestRuleSetApprovers6(t *testing.T) {
 		},
 	}
 
-	if approvers, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) > 0 {
+	if approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps); len(approvers) > 0 {
 		t.Fatal("shouldn't get any approver")
 	}
 }
@@ -374,7 +381,7 @@ func TestRuleSetApprovers7(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
@@ -400,7 +407,7 @@ func TestRuleSetApprovers8(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
@@ -430,7 +437,7 @@ func TestRuleSetApprovers9(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
@@ -456,7 +463,7 @@ func TestRuleSetApprovers10(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver for `open.file.path`")
 	}
@@ -474,7 +481,7 @@ func TestRuleSetApprovers11(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) == 0 {
 		t.Fatal("expected approver not found")
 	}
@@ -497,7 +504,7 @@ func TestRuleSetApprovers12(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver for `open.file.path`")
 	}
@@ -514,7 +521,7 @@ func TestRuleSetApprovers13(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver for `open.file.flags`")
 	}
@@ -537,7 +544,7 @@ func TestRuleSetApprovers14(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.path"]) != 2 {
 		t.Fatalf("should get an approver for `open.file.path`: %v", approvers)
 	}
@@ -559,10 +566,18 @@ func TestRuleSetApprovers15(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.name"]) != 1 {
 		t.Fatalf("should get an approver for `open.file.name`: %v", approvers)
 	}
+}
+
+func ruleListToMap(rules []*Rule) map[eval.RuleID]bool {
+	m := make(map[eval.RuleID]bool, len(rules))
+	for _, rule := range rules {
+		m[rule.ID] = true
+	}
+	return m
 }
 
 func TestRuleSetApprovers16(t *testing.T) {
@@ -588,7 +603,7 @@ func TestRuleSetApprovers16(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver")
 	}
@@ -605,7 +620,7 @@ func TestRuleSetApprovers16(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ = rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ = rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver")
 	}
@@ -637,10 +652,12 @@ func TestRuleSetApprovers16(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ = rs.GetEventTypeApprovers("open", caps)
+	approvers, _, noDiscarderRules, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 2 || len(approvers["open.file.path"]) != 1 || len(approvers["process.auid"]) != 1 {
 		t.Fatalf("should get an approver`: %v", approvers)
 	}
+
+	rs.WithExcludedRuleFromDiscarders(ruleListToMap(noDiscarderRules))
 
 	if !rs.Evaluate(ev) {
 		rs.EvaluateDiscarders(ev)
@@ -668,7 +685,7 @@ func TestRuleSetApprovers17(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.path"]) != 3 {
 		t.Fatalf("should get an approver for `open.file.path`: %v", approvers)
 	}
@@ -695,7 +712,7 @@ func TestRuleSetApprovers18(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 2 || len(approvers["open.file.path"]) != 2 || len(approvers["open.flags"]) != 1 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -718,7 +735,7 @@ func TestRuleSetApprovers19(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatal("shouldn't get an approver")
 	}
@@ -741,7 +758,7 @@ func TestRuleSetApprovers20(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 || len(approvers["open.file.path"]) != 2 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -763,7 +780,7 @@ func TestRuleSetApprovers21(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -785,7 +802,7 @@ func TestRuleSetApprovers22(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatalf("shouldn't get approvers: %v", approvers)
 	}
@@ -807,7 +824,7 @@ func TestRuleSetApprovers23(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -829,7 +846,7 @@ func TestRuleSetApprovers24(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 0 {
 		t.Fatalf("shouldn't get approvers: %v", approvers)
 	}
@@ -851,7 +868,7 @@ func TestRuleSetApprovers25(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -873,7 +890,7 @@ func TestRuleSetApprovers26(t *testing.T) {
 		},
 	}
 
-	approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+	approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 	if len(approvers) != 1 {
 		t.Fatalf("should get approvers: %v", approvers)
 	}
@@ -919,7 +936,7 @@ func TestRuleSetAUDApprovers(t *testing.T) {
 
 		AddTestRuleExpr(t, rs, exprs...)
 
-		approvers, _, _ := rs.GetEventTypeApprovers("open", caps)
+		approvers, _, _, _ := rs.GetEventTypeApprovers("open", caps)
 		return approvers
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

```
open.file.path =~ "/etc/*" && open.flags & O_CREAT > 0
open.file.name == "group"
```

* Without the PR:
Approvers for `group` & `O_CREAT` but no discarders

* With the PR:
Approvers for `group` & `O_CREAT` & discarders for `open.file.path`


### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->