### PR TITLE
[draft] Add grpc endpoint to stream config updates for `RemoteAgent` service

### DIFF
--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -198,4 +198,8 @@ service RemoteAgent {
 
   // Gets the telemetry data of a remote agent.
   rpc GetTelemetry(datadog.remoteagent.GetTelemetryRequest) returns (datadog.remoteagent.GetTelemetryResponse);
+
+
+  // Streams config updates to the remote agent.
+  rpc StreamConfigUpdates(stream datadog.remoteagent.PushedConfig) returns (google.protobuf.Empty);
 }

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -200,6 +200,6 @@ service RemoteAgent {
   rpc GetTelemetry(datadog.remoteagent.GetTelemetryRequest) returns (datadog.remoteagent.GetTelemetryResponse);
 
 
-  // Streams config updates to the remote agent.
-  rpc StreamConfigUpdates(stream datadog.remoteagent.ConfigUpdate) returns (google.protobuf.Empty);
+  // Streams config events to the remote agent.
+  rpc StreamConfigEvents(stream datadog.remoteagent.ConfigEvent) returns (google.protobuf.Empty);
 }

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -201,5 +201,5 @@ service RemoteAgent {
 
 
   // Streams config updates to the remote agent.
-  rpc StreamConfigUpdates(stream datadog.remoteagent.PushedConfig) returns (google.protobuf.Empty);
+  rpc StreamConfigUpdates(stream datadog.remoteagent.ConfigUpdate) returns (google.protobuf.Empty);
 }

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -84,3 +84,8 @@ message GetTelemetryResponse {
     string prom_text = 1;
   }
 }
+
+message PushedConfig {
+  // Config payload.
+  bytes payload = 1;
+}

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package datadog.remoteagent;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
 
 option go_package = "pkg/proto/pbgo/core"; // golang
 
@@ -86,8 +88,25 @@ message GetTelemetryResponse {
     string prom_text = 1;
   }
 }
+message ConfigSnapshot {
+  message SettingSnapshot {
+    string key = 1;
+    string value = 2;
+  }
 
-message ConfigUpdate {
-  // Config payload.
-  google.protobuf.Struct payload = 1;
+  repeated SettingSnapshot settings = 1;
+}
+
+message SingleUpdate {
+  string key = 1;
+  google.protobuf.Timestamp updated_at = 2;
+  string previous_value = 3;
+  string new_value = 4;
+}
+
+message ConfigEvent {
+  oneof event {
+    ConfigSnapshot snapshot = 1;
+    SingleUpdate update = 2;
+  }
 }

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -89,19 +89,24 @@ message GetTelemetryResponse {
   }
 }
 message ConfigSnapshot {
-  message SettingSnapshot {
+message SettingSnapshot {
     string key = 1;
-    string value = 2;
+    google.protobuf.Value value = 2;
   }
 
   repeated SettingSnapshot settings = 1;
+
 }
 
 message SingleUpdate {
   string key = 1;
+  // Timestamp indicating when the update was processed.
+  // Remote agents may choose how to handle updates with an earlier timestamp
+  // than one they have already seen.
   google.protobuf.Timestamp updated_at = 2;
-  string previous_value = 3;
-  string new_value = 4;
+  google.protobuf.Value previous_value = 3;
+  google.protobuf.Value new_value = 4;
+
 }
 
 message ConfigEvent {

--- a/pkg/proto/datadog/remoteagent/remoteagent.proto
+++ b/pkg/proto/datadog/remoteagent/remoteagent.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package datadog.remoteagent;
 
+import "google/protobuf/struct.proto";
+
 option go_package = "pkg/proto/pbgo/core"; // golang
 
 message StatusSection {
@@ -85,7 +87,7 @@ message GetTelemetryResponse {
   }
 }
 
-message PushedConfig {
+message ConfigUpdate {
   // Config payload.
-  bytes payload = 1;
+  google.protobuf.Struct payload = 1;
 }

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -51,7 +51,7 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x10GetStatusDetails\x12,.datadog.remoteagent.GetStatusDetailsRequest\x1a-.datadog.remoteagent.GetStatusDetailsResponse\x12f\n" +
 	"\rGetFlareFiles\x12).datadog.remoteagent.GetFlareFilesRequest\x1a*.datadog.remoteagent.GetFlareFilesResponse\x12c\n" +
 	"\fGetTelemetry\x12(.datadog.remoteagent.GetTelemetryRequest\x1a).datadog.remoteagent.GetTelemetryResponse\x12R\n" +
-	"\x13StreamConfigUpdates\x12!.datadog.remoteagent.PushedConfig\x1a\x16.google.protobuf.Empty(\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\x13StreamConfigUpdates\x12!.datadog.remoteagent.ConfigUpdate\x1a\x16.google.protobuf.Empty(\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*HostnameRequest)(nil),                           // 0: datadog.model.v1.HostnameRequest
@@ -68,7 +68,7 @@ var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*GetStatusDetailsRequest)(nil),                   // 11: datadog.remoteagent.GetStatusDetailsRequest
 	(*GetFlareFilesRequest)(nil),                      // 12: datadog.remoteagent.GetFlareFilesRequest
 	(*GetTelemetryRequest)(nil),                       // 13: datadog.remoteagent.GetTelemetryRequest
-	(*PushedConfig)(nil),                              // 14: datadog.remoteagent.PushedConfig
+	(*ConfigUpdate)(nil),                              // 14: datadog.remoteagent.ConfigUpdate
 	(*HostnameReply)(nil),                             // 15: datadog.model.v1.HostnameReply
 	(*StreamTagsResponse)(nil),                        // 16: datadog.model.v1.StreamTagsResponse
 	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 17: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
@@ -103,7 +103,7 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	11, // 14: datadog.api.v1.RemoteAgent.GetStatusDetails:input_type -> datadog.remoteagent.GetStatusDetailsRequest
 	12, // 15: datadog.api.v1.RemoteAgent.GetFlareFiles:input_type -> datadog.remoteagent.GetFlareFilesRequest
 	13, // 16: datadog.api.v1.RemoteAgent.GetTelemetry:input_type -> datadog.remoteagent.GetTelemetryRequest
-	14, // 17: datadog.api.v1.RemoteAgent.StreamConfigUpdates:input_type -> datadog.remoteagent.PushedConfig
+	14, // 17: datadog.api.v1.RemoteAgent.StreamConfigUpdates:input_type -> datadog.remoteagent.ConfigUpdate
 	15, // 18: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
 	16, // 19: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
 	17, // 20: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
@@ -1048,7 +1048,7 @@ func (c *remoteAgentClient) StreamConfigUpdates(ctx context.Context, opts ...grp
 }
 
 type RemoteAgent_StreamConfigUpdatesClient interface {
-	Send(*PushedConfig) error
+	Send(*ConfigUpdate) error
 	CloseAndRecv() (*empty.Empty, error)
 	grpc.ClientStream
 }
@@ -1057,7 +1057,7 @@ type remoteAgentStreamConfigUpdatesClient struct {
 	grpc.ClientStream
 }
 
-func (x *remoteAgentStreamConfigUpdatesClient) Send(m *PushedConfig) error {
+func (x *remoteAgentStreamConfigUpdatesClient) Send(m *ConfigUpdate) error {
 	return x.ClientStream.SendMsg(m)
 }
 
@@ -1165,7 +1165,7 @@ func _RemoteAgent_StreamConfigUpdates_Handler(srv interface{}, stream grpc.Serve
 
 type RemoteAgent_StreamConfigUpdatesServer interface {
 	SendAndClose(*empty.Empty) error
-	Recv() (*PushedConfig, error)
+	Recv() (*ConfigUpdate, error)
 	grpc.ServerStream
 }
 
@@ -1177,8 +1177,8 @@ func (x *remoteAgentStreamConfigUpdatesServer) SendAndClose(m *empty.Empty) erro
 	return x.ServerStream.SendMsg(m)
 }
 
-func (x *remoteAgentStreamConfigUpdatesServer) Recv() (*PushedConfig, error) {
-	m := new(PushedConfig)
+func (x *remoteAgentStreamConfigUpdatesServer) Recv() (*ConfigUpdate, error) {
+	m := new(ConfigUpdate)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -46,11 +46,12 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x1aWorkloadmetaStreamEntities\x12/.datadog.workloadmeta.WorkloadmetaStreamRequest\x1a0.datadog.workloadmeta.WorkloadmetaStreamResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/grpc/workloadmeta/stream_entities0\x01\x12\xaf\x01\n" +
 	"\x13RegisterRemoteAgent\x12/.datadog.remoteagent.RegisterRemoteAgentRequest\x1a0.datadog.remoteagent.RegisterRemoteAgentResponse\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/grpc/remoteagent/register_remote_agent\x12\x9b\x01\n" +
 	"\x19AutodiscoveryStreamConfig\x12\x16.google.protobuf.Empty\x1a2.datadog.autodiscovery.AutodiscoveryStreamResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/grpc/autodiscovery/stream_configs0\x01\x12k\n" +
-	"\vGetHostTags\x12 .datadog.model.v1.HostTagRequest\x1a\x1e.datadog.model.v1.HostTagReply\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/grpc/host_tags2\xcb\x02\n" +
+	"\vGetHostTags\x12 .datadog.model.v1.HostTagRequest\x1a\x1e.datadog.model.v1.HostTagReply\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/grpc/host_tags2\x9f\x03\n" +
 	"\vRemoteAgent\x12o\n" +
 	"\x10GetStatusDetails\x12,.datadog.remoteagent.GetStatusDetailsRequest\x1a-.datadog.remoteagent.GetStatusDetailsResponse\x12f\n" +
 	"\rGetFlareFiles\x12).datadog.remoteagent.GetFlareFilesRequest\x1a*.datadog.remoteagent.GetFlareFilesResponse\x12c\n" +
-	"\fGetTelemetry\x12(.datadog.remoteagent.GetTelemetryRequest\x1a).datadog.remoteagent.GetTelemetryResponseB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\fGetTelemetry\x12(.datadog.remoteagent.GetTelemetryRequest\x1a).datadog.remoteagent.GetTelemetryResponse\x12R\n" +
+	"\x13StreamConfigUpdates\x12!.datadog.remoteagent.PushedConfig\x1a\x16.google.protobuf.Empty(\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*HostnameRequest)(nil),                           // 0: datadog.model.v1.HostnameRequest
@@ -67,21 +68,22 @@ var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*GetStatusDetailsRequest)(nil),                   // 11: datadog.remoteagent.GetStatusDetailsRequest
 	(*GetFlareFilesRequest)(nil),                      // 12: datadog.remoteagent.GetFlareFilesRequest
 	(*GetTelemetryRequest)(nil),                       // 13: datadog.remoteagent.GetTelemetryRequest
-	(*HostnameReply)(nil),                             // 14: datadog.model.v1.HostnameReply
-	(*StreamTagsResponse)(nil),                        // 15: datadog.model.v1.StreamTagsResponse
-	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 16: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	(*FetchEntityResponse)(nil),                       // 17: datadog.model.v1.FetchEntityResponse
-	(*CaptureTriggerResponse)(nil),                    // 18: datadog.model.v1.CaptureTriggerResponse
-	(*TaggerStateResponse)(nil),                       // 19: datadog.model.v1.TaggerStateResponse
-	(*ClientGetConfigsResponse)(nil),                  // 20: datadog.config.ClientGetConfigsResponse
-	(*GetStateConfigResponse)(nil),                    // 21: datadog.config.GetStateConfigResponse
-	(*WorkloadmetaStreamResponse)(nil),                // 22: datadog.workloadmeta.WorkloadmetaStreamResponse
-	(*RegisterRemoteAgentResponse)(nil),               // 23: datadog.remoteagent.RegisterRemoteAgentResponse
-	(*AutodiscoveryStreamResponse)(nil),               // 24: datadog.autodiscovery.AutodiscoveryStreamResponse
-	(*HostTagReply)(nil),                              // 25: datadog.model.v1.HostTagReply
-	(*GetStatusDetailsResponse)(nil),                  // 26: datadog.remoteagent.GetStatusDetailsResponse
-	(*GetFlareFilesResponse)(nil),                     // 27: datadog.remoteagent.GetFlareFilesResponse
-	(*GetTelemetryResponse)(nil),                      // 28: datadog.remoteagent.GetTelemetryResponse
+	(*PushedConfig)(nil),                              // 14: datadog.remoteagent.PushedConfig
+	(*HostnameReply)(nil),                             // 15: datadog.model.v1.HostnameReply
+	(*StreamTagsResponse)(nil),                        // 16: datadog.model.v1.StreamTagsResponse
+	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 17: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	(*FetchEntityResponse)(nil),                       // 18: datadog.model.v1.FetchEntityResponse
+	(*CaptureTriggerResponse)(nil),                    // 19: datadog.model.v1.CaptureTriggerResponse
+	(*TaggerStateResponse)(nil),                       // 20: datadog.model.v1.TaggerStateResponse
+	(*ClientGetConfigsResponse)(nil),                  // 21: datadog.config.ClientGetConfigsResponse
+	(*GetStateConfigResponse)(nil),                    // 22: datadog.config.GetStateConfigResponse
+	(*WorkloadmetaStreamResponse)(nil),                // 23: datadog.workloadmeta.WorkloadmetaStreamResponse
+	(*RegisterRemoteAgentResponse)(nil),               // 24: datadog.remoteagent.RegisterRemoteAgentResponse
+	(*AutodiscoveryStreamResponse)(nil),               // 25: datadog.autodiscovery.AutodiscoveryStreamResponse
+	(*HostTagReply)(nil),                              // 26: datadog.model.v1.HostTagReply
+	(*GetStatusDetailsResponse)(nil),                  // 27: datadog.remoteagent.GetStatusDetailsResponse
+	(*GetFlareFilesResponse)(nil),                     // 28: datadog.remoteagent.GetFlareFilesResponse
+	(*GetTelemetryResponse)(nil),                      // 29: datadog.remoteagent.GetTelemetryResponse
 }
 var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	0,  // 0: datadog.api.v1.Agent.GetHostname:input_type -> datadog.model.v1.HostnameRequest
@@ -101,25 +103,27 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	11, // 14: datadog.api.v1.RemoteAgent.GetStatusDetails:input_type -> datadog.remoteagent.GetStatusDetailsRequest
 	12, // 15: datadog.api.v1.RemoteAgent.GetFlareFiles:input_type -> datadog.remoteagent.GetFlareFilesRequest
 	13, // 16: datadog.api.v1.RemoteAgent.GetTelemetry:input_type -> datadog.remoteagent.GetTelemetryRequest
-	14, // 17: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
-	15, // 18: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
-	16, // 19: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
-	17, // 20: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
-	18, // 21: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
-	19, // 22: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
-	20, // 23: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
-	21, // 24: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
-	20, // 25: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
-	21, // 26: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
-	22, // 27: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
-	23, // 28: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.RegisterRemoteAgentResponse
-	24, // 29: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
-	25, // 30: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
-	26, // 31: datadog.api.v1.RemoteAgent.GetStatusDetails:output_type -> datadog.remoteagent.GetStatusDetailsResponse
-	27, // 32: datadog.api.v1.RemoteAgent.GetFlareFiles:output_type -> datadog.remoteagent.GetFlareFilesResponse
-	28, // 33: datadog.api.v1.RemoteAgent.GetTelemetry:output_type -> datadog.remoteagent.GetTelemetryResponse
-	17, // [17:34] is the sub-list for method output_type
-	0,  // [0:17] is the sub-list for method input_type
+	14, // 17: datadog.api.v1.RemoteAgent.StreamConfigUpdates:input_type -> datadog.remoteagent.PushedConfig
+	15, // 18: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
+	16, // 19: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
+	17, // 20: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
+	18, // 21: datadog.api.v1.AgentSecure.TaggerFetchEntity:output_type -> datadog.model.v1.FetchEntityResponse
+	19, // 22: datadog.api.v1.AgentSecure.DogstatsdCaptureTrigger:output_type -> datadog.model.v1.CaptureTriggerResponse
+	20, // 23: datadog.api.v1.AgentSecure.DogstatsdSetTaggerState:output_type -> datadog.model.v1.TaggerStateResponse
+	21, // 24: datadog.api.v1.AgentSecure.ClientGetConfigs:output_type -> datadog.config.ClientGetConfigsResponse
+	22, // 25: datadog.api.v1.AgentSecure.GetConfigState:output_type -> datadog.config.GetStateConfigResponse
+	21, // 26: datadog.api.v1.AgentSecure.ClientGetConfigsHA:output_type -> datadog.config.ClientGetConfigsResponse
+	22, // 27: datadog.api.v1.AgentSecure.GetConfigStateHA:output_type -> datadog.config.GetStateConfigResponse
+	23, // 28: datadog.api.v1.AgentSecure.WorkloadmetaStreamEntities:output_type -> datadog.workloadmeta.WorkloadmetaStreamResponse
+	24, // 29: datadog.api.v1.AgentSecure.RegisterRemoteAgent:output_type -> datadog.remoteagent.RegisterRemoteAgentResponse
+	25, // 30: datadog.api.v1.AgentSecure.AutodiscoveryStreamConfig:output_type -> datadog.autodiscovery.AutodiscoveryStreamResponse
+	26, // 31: datadog.api.v1.AgentSecure.GetHostTags:output_type -> datadog.model.v1.HostTagReply
+	27, // 32: datadog.api.v1.RemoteAgent.GetStatusDetails:output_type -> datadog.remoteagent.GetStatusDetailsResponse
+	28, // 33: datadog.api.v1.RemoteAgent.GetFlareFiles:output_type -> datadog.remoteagent.GetFlareFilesResponse
+	29, // 34: datadog.api.v1.RemoteAgent.GetTelemetry:output_type -> datadog.remoteagent.GetTelemetryResponse
+	7,  // 35: datadog.api.v1.RemoteAgent.StreamConfigUpdates:output_type -> google.protobuf.Empty
+	18, // [18:36] is the sub-list for method output_type
+	0,  // [0:18] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name
@@ -995,6 +999,8 @@ type RemoteAgentClient interface {
 	GetFlareFiles(ctx context.Context, in *GetFlareFilesRequest, opts ...grpc.CallOption) (*GetFlareFilesResponse, error)
 	// Gets the telemetry data of a remote agent.
 	GetTelemetry(ctx context.Context, in *GetTelemetryRequest, opts ...grpc.CallOption) (*GetTelemetryResponse, error)
+	// Streams config updates to the remote agent.
+	StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigUpdatesClient, error)
 }
 
 type remoteAgentClient struct {
@@ -1032,6 +1038,40 @@ func (c *remoteAgentClient) GetTelemetry(ctx context.Context, in *GetTelemetryRe
 	return out, nil
 }
 
+func (c *remoteAgentClient) StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigUpdatesClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_RemoteAgent_serviceDesc.Streams[0], "/datadog.api.v1.RemoteAgent/StreamConfigUpdates", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &remoteAgentStreamConfigUpdatesClient{stream}
+	return x, nil
+}
+
+type RemoteAgent_StreamConfigUpdatesClient interface {
+	Send(*PushedConfig) error
+	CloseAndRecv() (*empty.Empty, error)
+	grpc.ClientStream
+}
+
+type remoteAgentStreamConfigUpdatesClient struct {
+	grpc.ClientStream
+}
+
+func (x *remoteAgentStreamConfigUpdatesClient) Send(m *PushedConfig) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *remoteAgentStreamConfigUpdatesClient) CloseAndRecv() (*empty.Empty, error) {
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	m := new(empty.Empty)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // RemoteAgentServer is the server API for RemoteAgent service.
 type RemoteAgentServer interface {
 	// Gets the status details of a remote agent.
@@ -1040,6 +1080,8 @@ type RemoteAgentServer interface {
 	GetFlareFiles(context.Context, *GetFlareFilesRequest) (*GetFlareFilesResponse, error)
 	// Gets the telemetry data of a remote agent.
 	GetTelemetry(context.Context, *GetTelemetryRequest) (*GetTelemetryResponse, error)
+	// Streams config updates to the remote agent.
+	StreamConfigUpdates(RemoteAgent_StreamConfigUpdatesServer) error
 }
 
 // UnimplementedRemoteAgentServer can be embedded to have forward compatible implementations.
@@ -1054,6 +1096,9 @@ func (*UnimplementedRemoteAgentServer) GetFlareFiles(context.Context, *GetFlareF
 }
 func (*UnimplementedRemoteAgentServer) GetTelemetry(context.Context, *GetTelemetryRequest) (*GetTelemetryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTelemetry not implemented")
+}
+func (*UnimplementedRemoteAgentServer) StreamConfigUpdates(RemoteAgent_StreamConfigUpdatesServer) error {
+	return status.Errorf(codes.Unimplemented, "method StreamConfigUpdates not implemented")
 }
 
 func RegisterRemoteAgentServer(s *grpc.Server, srv RemoteAgentServer) {
@@ -1114,6 +1159,32 @@ func _RemoteAgent_GetTelemetry_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RemoteAgent_StreamConfigUpdates_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(RemoteAgentServer).StreamConfigUpdates(&remoteAgentStreamConfigUpdatesServer{stream})
+}
+
+type RemoteAgent_StreamConfigUpdatesServer interface {
+	SendAndClose(*empty.Empty) error
+	Recv() (*PushedConfig, error)
+	grpc.ServerStream
+}
+
+type remoteAgentStreamConfigUpdatesServer struct {
+	grpc.ServerStream
+}
+
+func (x *remoteAgentStreamConfigUpdatesServer) SendAndClose(m *empty.Empty) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *remoteAgentStreamConfigUpdatesServer) Recv() (*PushedConfig, error) {
+	m := new(PushedConfig)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 var _RemoteAgent_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "datadog.api.v1.RemoteAgent",
 	HandlerType: (*RemoteAgentServer)(nil),
@@ -1131,6 +1202,12 @@ var _RemoteAgent_serviceDesc = grpc.ServiceDesc{
 			Handler:    _RemoteAgent_GetTelemetry_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "StreamConfigUpdates",
+			Handler:       _RemoteAgent_StreamConfigUpdates_Handler,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "datadog/api/v1/api.proto",
 }

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -46,12 +46,12 @@ const file_datadog_api_v1_api_proto_rawDesc = "" +
 	"\x1aWorkloadmetaStreamEntities\x12/.datadog.workloadmeta.WorkloadmetaStreamRequest\x1a0.datadog.workloadmeta.WorkloadmetaStreamResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/grpc/workloadmeta/stream_entities0\x01\x12\xaf\x01\n" +
 	"\x13RegisterRemoteAgent\x12/.datadog.remoteagent.RegisterRemoteAgentRequest\x1a0.datadog.remoteagent.RegisterRemoteAgentResponse\"5\x82\xd3\xe4\x93\x02/:\x01*\"*/v1/grpc/remoteagent/register_remote_agent\x12\x9b\x01\n" +
 	"\x19AutodiscoveryStreamConfig\x12\x16.google.protobuf.Empty\x1a2.datadog.autodiscovery.AutodiscoveryStreamResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/grpc/autodiscovery/stream_configs0\x01\x12k\n" +
-	"\vGetHostTags\x12 .datadog.model.v1.HostTagRequest\x1a\x1e.datadog.model.v1.HostTagReply\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/grpc/host_tags2\x9f\x03\n" +
+	"\vGetHostTags\x12 .datadog.model.v1.HostTagRequest\x1a\x1e.datadog.model.v1.HostTagReply\"\x1a\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/grpc/host_tags2\x9d\x03\n" +
 	"\vRemoteAgent\x12o\n" +
 	"\x10GetStatusDetails\x12,.datadog.remoteagent.GetStatusDetailsRequest\x1a-.datadog.remoteagent.GetStatusDetailsResponse\x12f\n" +
 	"\rGetFlareFiles\x12).datadog.remoteagent.GetFlareFilesRequest\x1a*.datadog.remoteagent.GetFlareFilesResponse\x12c\n" +
-	"\fGetTelemetry\x12(.datadog.remoteagent.GetTelemetryRequest\x1a).datadog.remoteagent.GetTelemetryResponse\x12R\n" +
-	"\x13StreamConfigUpdates\x12!.datadog.remoteagent.ConfigUpdate\x1a\x16.google.protobuf.Empty(\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\fGetTelemetry\x12(.datadog.remoteagent.GetTelemetryRequest\x1a).datadog.remoteagent.GetTelemetryResponse\x12P\n" +
+	"\x12StreamConfigEvents\x12 .datadog.remoteagent.ConfigEvent\x1a\x16.google.protobuf.Empty(\x01B\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*HostnameRequest)(nil),                           // 0: datadog.model.v1.HostnameRequest
@@ -68,7 +68,7 @@ var file_datadog_api_v1_api_proto_goTypes = []any{
 	(*GetStatusDetailsRequest)(nil),                   // 11: datadog.remoteagent.GetStatusDetailsRequest
 	(*GetFlareFilesRequest)(nil),                      // 12: datadog.remoteagent.GetFlareFilesRequest
 	(*GetTelemetryRequest)(nil),                       // 13: datadog.remoteagent.GetTelemetryRequest
-	(*ConfigUpdate)(nil),                              // 14: datadog.remoteagent.ConfigUpdate
+	(*ConfigEvent)(nil),                               // 14: datadog.remoteagent.ConfigEvent
 	(*HostnameReply)(nil),                             // 15: datadog.model.v1.HostnameReply
 	(*StreamTagsResponse)(nil),                        // 16: datadog.model.v1.StreamTagsResponse
 	(*GenerateContainerIDFromOriginInfoResponse)(nil), // 17: datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
@@ -103,7 +103,7 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	11, // 14: datadog.api.v1.RemoteAgent.GetStatusDetails:input_type -> datadog.remoteagent.GetStatusDetailsRequest
 	12, // 15: datadog.api.v1.RemoteAgent.GetFlareFiles:input_type -> datadog.remoteagent.GetFlareFilesRequest
 	13, // 16: datadog.api.v1.RemoteAgent.GetTelemetry:input_type -> datadog.remoteagent.GetTelemetryRequest
-	14, // 17: datadog.api.v1.RemoteAgent.StreamConfigUpdates:input_type -> datadog.remoteagent.ConfigUpdate
+	14, // 17: datadog.api.v1.RemoteAgent.StreamConfigEvents:input_type -> datadog.remoteagent.ConfigEvent
 	15, // 18: datadog.api.v1.Agent.GetHostname:output_type -> datadog.model.v1.HostnameReply
 	16, // 19: datadog.api.v1.AgentSecure.TaggerStreamEntities:output_type -> datadog.model.v1.StreamTagsResponse
 	17, // 20: datadog.api.v1.AgentSecure.TaggerGenerateContainerIDFromOriginInfo:output_type -> datadog.model.v1.GenerateContainerIDFromOriginInfoResponse
@@ -121,7 +121,7 @@ var file_datadog_api_v1_api_proto_depIdxs = []int32{
 	27, // 32: datadog.api.v1.RemoteAgent.GetStatusDetails:output_type -> datadog.remoteagent.GetStatusDetailsResponse
 	28, // 33: datadog.api.v1.RemoteAgent.GetFlareFiles:output_type -> datadog.remoteagent.GetFlareFilesResponse
 	29, // 34: datadog.api.v1.RemoteAgent.GetTelemetry:output_type -> datadog.remoteagent.GetTelemetryResponse
-	7,  // 35: datadog.api.v1.RemoteAgent.StreamConfigUpdates:output_type -> google.protobuf.Empty
+	7,  // 35: datadog.api.v1.RemoteAgent.StreamConfigEvents:output_type -> google.protobuf.Empty
 	18, // [18:36] is the sub-list for method output_type
 	0,  // [0:18] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
@@ -999,8 +999,8 @@ type RemoteAgentClient interface {
 	GetFlareFiles(ctx context.Context, in *GetFlareFilesRequest, opts ...grpc.CallOption) (*GetFlareFilesResponse, error)
 	// Gets the telemetry data of a remote agent.
 	GetTelemetry(ctx context.Context, in *GetTelemetryRequest, opts ...grpc.CallOption) (*GetTelemetryResponse, error)
-	// Streams config updates to the remote agent.
-	StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigUpdatesClient, error)
+	// Streams config events to the remote agent.
+	StreamConfigEvents(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigEventsClient, error)
 }
 
 type remoteAgentClient struct {
@@ -1038,30 +1038,30 @@ func (c *remoteAgentClient) GetTelemetry(ctx context.Context, in *GetTelemetryRe
 	return out, nil
 }
 
-func (c *remoteAgentClient) StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigUpdatesClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_RemoteAgent_serviceDesc.Streams[0], "/datadog.api.v1.RemoteAgent/StreamConfigUpdates", opts...)
+func (c *remoteAgentClient) StreamConfigEvents(ctx context.Context, opts ...grpc.CallOption) (RemoteAgent_StreamConfigEventsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_RemoteAgent_serviceDesc.Streams[0], "/datadog.api.v1.RemoteAgent/StreamConfigEvents", opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &remoteAgentStreamConfigUpdatesClient{stream}
+	x := &remoteAgentStreamConfigEventsClient{stream}
 	return x, nil
 }
 
-type RemoteAgent_StreamConfigUpdatesClient interface {
-	Send(*ConfigUpdate) error
+type RemoteAgent_StreamConfigEventsClient interface {
+	Send(*ConfigEvent) error
 	CloseAndRecv() (*empty.Empty, error)
 	grpc.ClientStream
 }
 
-type remoteAgentStreamConfigUpdatesClient struct {
+type remoteAgentStreamConfigEventsClient struct {
 	grpc.ClientStream
 }
 
-func (x *remoteAgentStreamConfigUpdatesClient) Send(m *ConfigUpdate) error {
+func (x *remoteAgentStreamConfigEventsClient) Send(m *ConfigEvent) error {
 	return x.ClientStream.SendMsg(m)
 }
 
-func (x *remoteAgentStreamConfigUpdatesClient) CloseAndRecv() (*empty.Empty, error) {
+func (x *remoteAgentStreamConfigEventsClient) CloseAndRecv() (*empty.Empty, error) {
 	if err := x.ClientStream.CloseSend(); err != nil {
 		return nil, err
 	}
@@ -1080,8 +1080,8 @@ type RemoteAgentServer interface {
 	GetFlareFiles(context.Context, *GetFlareFilesRequest) (*GetFlareFilesResponse, error)
 	// Gets the telemetry data of a remote agent.
 	GetTelemetry(context.Context, *GetTelemetryRequest) (*GetTelemetryResponse, error)
-	// Streams config updates to the remote agent.
-	StreamConfigUpdates(RemoteAgent_StreamConfigUpdatesServer) error
+	// Streams config events to the remote agent.
+	StreamConfigEvents(RemoteAgent_StreamConfigEventsServer) error
 }
 
 // UnimplementedRemoteAgentServer can be embedded to have forward compatible implementations.
@@ -1097,8 +1097,8 @@ func (*UnimplementedRemoteAgentServer) GetFlareFiles(context.Context, *GetFlareF
 func (*UnimplementedRemoteAgentServer) GetTelemetry(context.Context, *GetTelemetryRequest) (*GetTelemetryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetTelemetry not implemented")
 }
-func (*UnimplementedRemoteAgentServer) StreamConfigUpdates(RemoteAgent_StreamConfigUpdatesServer) error {
-	return status.Errorf(codes.Unimplemented, "method StreamConfigUpdates not implemented")
+func (*UnimplementedRemoteAgentServer) StreamConfigEvents(RemoteAgent_StreamConfigEventsServer) error {
+	return status.Errorf(codes.Unimplemented, "method StreamConfigEvents not implemented")
 }
 
 func RegisterRemoteAgentServer(s *grpc.Server, srv RemoteAgentServer) {
@@ -1159,26 +1159,26 @@ func _RemoteAgent_GetTelemetry_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
-func _RemoteAgent_StreamConfigUpdates_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(RemoteAgentServer).StreamConfigUpdates(&remoteAgentStreamConfigUpdatesServer{stream})
+func _RemoteAgent_StreamConfigEvents_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(RemoteAgentServer).StreamConfigEvents(&remoteAgentStreamConfigEventsServer{stream})
 }
 
-type RemoteAgent_StreamConfigUpdatesServer interface {
+type RemoteAgent_StreamConfigEventsServer interface {
 	SendAndClose(*empty.Empty) error
-	Recv() (*ConfigUpdate, error)
+	Recv() (*ConfigEvent, error)
 	grpc.ServerStream
 }
 
-type remoteAgentStreamConfigUpdatesServer struct {
+type remoteAgentStreamConfigEventsServer struct {
 	grpc.ServerStream
 }
 
-func (x *remoteAgentStreamConfigUpdatesServer) SendAndClose(m *empty.Empty) error {
+func (x *remoteAgentStreamConfigEventsServer) SendAndClose(m *empty.Empty) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func (x *remoteAgentStreamConfigUpdatesServer) Recv() (*ConfigUpdate, error) {
-	m := new(ConfigUpdate)
+func (x *remoteAgentStreamConfigEventsServer) Recv() (*ConfigEvent, error) {
+	m := new(ConfigEvent)
 	if err := x.ServerStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -1204,8 +1204,8 @@ var _RemoteAgent_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams: []grpc.StreamDesc{
 		{
-			StreamName:    "StreamConfigUpdates",
-			Handler:       _RemoteAgent_StreamConfigUpdates_Handler,
+			StreamName:    "StreamConfigEvents",
+			Handler:       _RemoteAgent_StreamConfigEvents_Handler,
 			ClientStreams: true,
 		},
 	},

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -7,6 +7,7 @@
 package core
 
 import (
+	_struct "github.com/golang/protobuf/ptypes/struct"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -489,28 +490,28 @@ type GetTelemetryResponse_PromText struct {
 
 func (*GetTelemetryResponse_PromText) isGetTelemetryResponse_Payload() {}
 
-type PushedConfig struct {
+type ConfigUpdate struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Config payload.
-	Payload       []byte `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+	Payload       *_struct.Struct `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PushedConfig) Reset() {
-	*x = PushedConfig{}
+func (x *ConfigUpdate) Reset() {
+	*x = ConfigUpdate{}
 	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PushedConfig) String() string {
+func (x *ConfigUpdate) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PushedConfig) ProtoMessage() {}
+func (*ConfigUpdate) ProtoMessage() {}
 
-func (x *PushedConfig) ProtoReflect() protoreflect.Message {
+func (x *ConfigUpdate) ProtoReflect() protoreflect.Message {
 	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -522,12 +523,12 @@ func (x *PushedConfig) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PushedConfig.ProtoReflect.Descriptor instead.
-func (*PushedConfig) Descriptor() ([]byte, []int) {
+// Deprecated: Use ConfigUpdate.ProtoReflect.Descriptor instead.
+func (*ConfigUpdate) Descriptor() ([]byte, []int) {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *PushedConfig) GetPayload() []byte {
+func (x *ConfigUpdate) GetPayload() *_struct.Struct {
 	if x != nil {
 		return x.Payload
 	}
@@ -538,7 +539,7 @@ var File_datadog_remoteagent_remoteagent_proto protoreflect.FileDescriptor
 
 const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\n" +
-	"%datadog/remoteagent/remoteagent.proto\x12\x13datadog.remoteagent\"\x92\x01\n" +
+	"%datadog/remoteagent/remoteagent.proto\x12\x13datadog.remoteagent\x1a\x1cgoogle/protobuf/struct.proto\"\x92\x01\n" +
 	"\rStatusSection\x12F\n" +
 	"\x06fields\x18\x01 \x03(\v2..datadog.remoteagent.StatusSection.FieldsEntryR\x06fields\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
@@ -569,9 +570,9 @@ const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\x13GetTelemetryRequest\"@\n" +
 	"\x14GetTelemetryResponse\x12\x1d\n" +
 	"\tprom_text\x18\x01 \x01(\tH\x00R\bpromTextB\t\n" +
-	"\apayload\"(\n" +
-	"\fPushedConfig\x12\x18\n" +
-	"\apayload\x18\x01 \x01(\fR\apayloadB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\apayload\"A\n" +
+	"\fConfigUpdate\x121\n" +
+	"\apayload\x18\x01 \x01(\v2\x17.google.protobuf.StructR\apayloadB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var (
 	file_datadog_remoteagent_remoteagent_proto_rawDescOnce sync.Once
@@ -596,22 +597,24 @@ var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
 	(*GetFlareFilesResponse)(nil),       // 6: datadog.remoteagent.GetFlareFilesResponse
 	(*GetTelemetryRequest)(nil),         // 7: datadog.remoteagent.GetTelemetryRequest
 	(*GetTelemetryResponse)(nil),        // 8: datadog.remoteagent.GetTelemetryResponse
-	(*PushedConfig)(nil),                // 9: datadog.remoteagent.PushedConfig
+	(*ConfigUpdate)(nil),                // 9: datadog.remoteagent.ConfigUpdate
 	nil,                                 // 10: datadog.remoteagent.StatusSection.FieldsEntry
 	nil,                                 // 11: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
 	nil,                                 // 12: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
+	(*_struct.Struct)(nil),              // 13: google.protobuf.Struct
 }
 var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
 	10, // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
 	0,  // 1: datadog.remoteagent.GetStatusDetailsResponse.main_section:type_name -> datadog.remoteagent.StatusSection
 	11, // 2: datadog.remoteagent.GetStatusDetailsResponse.named_sections:type_name -> datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
 	12, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
-	0,  // 4: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
-	5,  // [5:5] is the sub-list for method output_type
-	5,  // [5:5] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	13, // 4: datadog.remoteagent.ConfigUpdate.payload:type_name -> google.protobuf.Struct
+	0,  // 5: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
+	6,  // [6:6] is the sub-list for method output_type
+	6,  // [6:6] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteagent_remoteagent_proto_init() }

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -489,6 +489,51 @@ type GetTelemetryResponse_PromText struct {
 
 func (*GetTelemetryResponse_PromText) isGetTelemetryResponse_Payload() {}
 
+type PushedConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Config payload.
+	Payload       []byte `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PushedConfig) Reset() {
+	*x = PushedConfig{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PushedConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PushedConfig) ProtoMessage() {}
+
+func (x *PushedConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PushedConfig.ProtoReflect.Descriptor instead.
+func (*PushedConfig) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *PushedConfig) GetPayload() []byte {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
 var File_datadog_remoteagent_remoteagent_proto protoreflect.FileDescriptor
 
 const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
@@ -524,7 +569,9 @@ const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\x13GetTelemetryRequest\"@\n" +
 	"\x14GetTelemetryResponse\x12\x1d\n" +
 	"\tprom_text\x18\x01 \x01(\tH\x00R\bpromTextB\t\n" +
-	"\apayloadB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\apayload\"(\n" +
+	"\fPushedConfig\x12\x18\n" +
+	"\apayload\x18\x01 \x01(\fR\apayloadB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var (
 	file_datadog_remoteagent_remoteagent_proto_rawDescOnce sync.Once
@@ -538,7 +585,7 @@ func file_datadog_remoteagent_remoteagent_proto_rawDescGZIP() []byte {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescData
 }
 
-var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
 	(*StatusSection)(nil),               // 0: datadog.remoteagent.StatusSection
 	(*RegisterRemoteAgentRequest)(nil),  // 1: datadog.remoteagent.RegisterRemoteAgentRequest
@@ -549,15 +596,16 @@ var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
 	(*GetFlareFilesResponse)(nil),       // 6: datadog.remoteagent.GetFlareFilesResponse
 	(*GetTelemetryRequest)(nil),         // 7: datadog.remoteagent.GetTelemetryRequest
 	(*GetTelemetryResponse)(nil),        // 8: datadog.remoteagent.GetTelemetryResponse
-	nil,                                 // 9: datadog.remoteagent.StatusSection.FieldsEntry
-	nil,                                 // 10: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
-	nil,                                 // 11: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
+	(*PushedConfig)(nil),                // 9: datadog.remoteagent.PushedConfig
+	nil,                                 // 10: datadog.remoteagent.StatusSection.FieldsEntry
+	nil,                                 // 11: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
+	nil,                                 // 12: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
 }
 var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
-	9,  // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
+	10, // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
 	0,  // 1: datadog.remoteagent.GetStatusDetailsResponse.main_section:type_name -> datadog.remoteagent.StatusSection
-	10, // 2: datadog.remoteagent.GetStatusDetailsResponse.named_sections:type_name -> datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
-	11, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
+	11, // 2: datadog.remoteagent.GetStatusDetailsResponse.named_sections:type_name -> datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
+	12, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
 	0,  // 4: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
 	5,  // [5:5] is the sub-list for method output_type
 	5,  // [5:5] is the sub-list for method input_type
@@ -580,7 +628,7 @@ func file_datadog_remoteagent_remoteagent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteagent_remoteagent_proto_rawDesc), len(file_datadog_remoteagent_remoteagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -7,7 +7,8 @@
 package core
 
 import (
-	_struct "github.com/golang/protobuf/ptypes/struct"
+	_ "github.com/golang/protobuf/ptypes/struct"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -490,28 +491,27 @@ type GetTelemetryResponse_PromText struct {
 
 func (*GetTelemetryResponse_PromText) isGetTelemetryResponse_Payload() {}
 
-type ConfigUpdate struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Config payload.
-	Payload       *_struct.Struct `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+type ConfigSnapshot struct {
+	state         protoimpl.MessageState            `protogen:"open.v1"`
+	Settings      []*ConfigSnapshot_SettingSnapshot `protobuf:"bytes,1,rep,name=settings,proto3" json:"settings,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ConfigUpdate) Reset() {
-	*x = ConfigUpdate{}
+func (x *ConfigSnapshot) Reset() {
+	*x = ConfigSnapshot{}
 	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ConfigUpdate) String() string {
+func (x *ConfigSnapshot) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ConfigUpdate) ProtoMessage() {}
+func (*ConfigSnapshot) ProtoMessage() {}
 
-func (x *ConfigUpdate) ProtoReflect() protoreflect.Message {
+func (x *ConfigSnapshot) ProtoReflect() protoreflect.Message {
 	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -523,23 +523,225 @@ func (x *ConfigUpdate) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ConfigUpdate.ProtoReflect.Descriptor instead.
-func (*ConfigUpdate) Descriptor() ([]byte, []int) {
+// Deprecated: Use ConfigSnapshot.ProtoReflect.Descriptor instead.
+func (*ConfigSnapshot) Descriptor() ([]byte, []int) {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *ConfigUpdate) GetPayload() *_struct.Struct {
+func (x *ConfigSnapshot) GetSettings() []*ConfigSnapshot_SettingSnapshot {
 	if x != nil {
-		return x.Payload
+		return x.Settings
 	}
 	return nil
+}
+
+type SingleUpdate struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	UpdatedAt     *timestamp.Timestamp   `protobuf:"bytes,2,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	PreviousValue string                 `protobuf:"bytes,3,opt,name=previous_value,json=previousValue,proto3" json:"previous_value,omitempty"`
+	NewValue      string                 `protobuf:"bytes,4,opt,name=new_value,json=newValue,proto3" json:"new_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SingleUpdate) Reset() {
+	*x = SingleUpdate{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SingleUpdate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SingleUpdate) ProtoMessage() {}
+
+func (x *SingleUpdate) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SingleUpdate.ProtoReflect.Descriptor instead.
+func (*SingleUpdate) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *SingleUpdate) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *SingleUpdate) GetUpdatedAt() *timestamp.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+func (x *SingleUpdate) GetPreviousValue() string {
+	if x != nil {
+		return x.PreviousValue
+	}
+	return ""
+}
+
+func (x *SingleUpdate) GetNewValue() string {
+	if x != nil {
+		return x.NewValue
+	}
+	return ""
+}
+
+type ConfigEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Event:
+	//
+	//	*ConfigEvent_Snapshot
+	//	*ConfigEvent_Update
+	Event         isConfigEvent_Event `protobuf_oneof:"event"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigEvent) Reset() {
+	*x = ConfigEvent{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigEvent) ProtoMessage() {}
+
+func (x *ConfigEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigEvent.ProtoReflect.Descriptor instead.
+func (*ConfigEvent) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ConfigEvent) GetEvent() isConfigEvent_Event {
+	if x != nil {
+		return x.Event
+	}
+	return nil
+}
+
+func (x *ConfigEvent) GetSnapshot() *ConfigSnapshot {
+	if x != nil {
+		if x, ok := x.Event.(*ConfigEvent_Snapshot); ok {
+			return x.Snapshot
+		}
+	}
+	return nil
+}
+
+func (x *ConfigEvent) GetUpdate() *SingleUpdate {
+	if x != nil {
+		if x, ok := x.Event.(*ConfigEvent_Update); ok {
+			return x.Update
+		}
+	}
+	return nil
+}
+
+type isConfigEvent_Event interface {
+	isConfigEvent_Event()
+}
+
+type ConfigEvent_Snapshot struct {
+	Snapshot *ConfigSnapshot `protobuf:"bytes,1,opt,name=snapshot,proto3,oneof"`
+}
+
+type ConfigEvent_Update struct {
+	Update *SingleUpdate `protobuf:"bytes,2,opt,name=update,proto3,oneof"`
+}
+
+func (*ConfigEvent_Snapshot) isConfigEvent_Event() {}
+
+func (*ConfigEvent_Update) isConfigEvent_Event() {}
+
+type ConfigSnapshot_SettingSnapshot struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigSnapshot_SettingSnapshot) Reset() {
+	*x = ConfigSnapshot_SettingSnapshot{}
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigSnapshot_SettingSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigSnapshot_SettingSnapshot) ProtoMessage() {}
+
+func (x *ConfigSnapshot_SettingSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_remoteagent_remoteagent_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigSnapshot_SettingSnapshot.ProtoReflect.Descriptor instead.
+func (*ConfigSnapshot_SettingSnapshot) Descriptor() ([]byte, []int) {
+	return file_datadog_remoteagent_remoteagent_proto_rawDescGZIP(), []int{9, 0}
+}
+
+func (x *ConfigSnapshot_SettingSnapshot) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *ConfigSnapshot_SettingSnapshot) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
 }
 
 var File_datadog_remoteagent_remoteagent_proto protoreflect.FileDescriptor
 
 const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\n" +
-	"%datadog/remoteagent/remoteagent.proto\x12\x13datadog.remoteagent\x1a\x1cgoogle/protobuf/struct.proto\"\x92\x01\n" +
+	"%datadog/remoteagent/remoteagent.proto\x12\x13datadog.remoteagent\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x92\x01\n" +
 	"\rStatusSection\x12F\n" +
 	"\x06fields\x18\x01 \x03(\v2..datadog.remoteagent.StatusSection.FieldsEntryR\x06fields\x1a9\n" +
 	"\vFieldsEntry\x12\x10\n" +
@@ -570,9 +772,22 @@ const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\x13GetTelemetryRequest\"@\n" +
 	"\x14GetTelemetryResponse\x12\x1d\n" +
 	"\tprom_text\x18\x01 \x01(\tH\x00R\bpromTextB\t\n" +
-	"\apayload\"A\n" +
-	"\fConfigUpdate\x121\n" +
-	"\apayload\x18\x01 \x01(\v2\x17.google.protobuf.StructR\apayloadB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
+	"\apayload\"\x9c\x01\n" +
+	"\x0eConfigSnapshot\x12O\n" +
+	"\bsettings\x18\x01 \x03(\v23.datadog.remoteagent.ConfigSnapshot.SettingSnapshotR\bsettings\x1a9\n" +
+	"\x0fSettingSnapshot\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\x9f\x01\n" +
+	"\fSingleUpdate\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
+	"\n" +
+	"updated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12%\n" +
+	"\x0eprevious_value\x18\x03 \x01(\tR\rpreviousValue\x12\x1b\n" +
+	"\tnew_value\x18\x04 \x01(\tR\bnewValue\"\x96\x01\n" +
+	"\vConfigEvent\x12A\n" +
+	"\bsnapshot\x18\x01 \x01(\v2#.datadog.remoteagent.ConfigSnapshotH\x00R\bsnapshot\x12;\n" +
+	"\x06update\x18\x02 \x01(\v2!.datadog.remoteagent.SingleUpdateH\x00R\x06updateB\a\n" +
+	"\x05eventB\x15Z\x13pkg/proto/pbgo/coreb\x06proto3"
 
 var (
 	file_datadog_remoteagent_remoteagent_proto_rawDescOnce sync.Once
@@ -586,35 +801,41 @@ func file_datadog_remoteagent_remoteagent_proto_rawDescGZIP() []byte {
 	return file_datadog_remoteagent_remoteagent_proto_rawDescData
 }
 
-var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_datadog_remoteagent_remoteagent_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
-	(*StatusSection)(nil),               // 0: datadog.remoteagent.StatusSection
-	(*RegisterRemoteAgentRequest)(nil),  // 1: datadog.remoteagent.RegisterRemoteAgentRequest
-	(*RegisterRemoteAgentResponse)(nil), // 2: datadog.remoteagent.RegisterRemoteAgentResponse
-	(*GetStatusDetailsRequest)(nil),     // 3: datadog.remoteagent.GetStatusDetailsRequest
-	(*GetStatusDetailsResponse)(nil),    // 4: datadog.remoteagent.GetStatusDetailsResponse
-	(*GetFlareFilesRequest)(nil),        // 5: datadog.remoteagent.GetFlareFilesRequest
-	(*GetFlareFilesResponse)(nil),       // 6: datadog.remoteagent.GetFlareFilesResponse
-	(*GetTelemetryRequest)(nil),         // 7: datadog.remoteagent.GetTelemetryRequest
-	(*GetTelemetryResponse)(nil),        // 8: datadog.remoteagent.GetTelemetryResponse
-	(*ConfigUpdate)(nil),                // 9: datadog.remoteagent.ConfigUpdate
-	nil,                                 // 10: datadog.remoteagent.StatusSection.FieldsEntry
-	nil,                                 // 11: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
-	nil,                                 // 12: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
-	(*_struct.Struct)(nil),              // 13: google.protobuf.Struct
+	(*StatusSection)(nil),                  // 0: datadog.remoteagent.StatusSection
+	(*RegisterRemoteAgentRequest)(nil),     // 1: datadog.remoteagent.RegisterRemoteAgentRequest
+	(*RegisterRemoteAgentResponse)(nil),    // 2: datadog.remoteagent.RegisterRemoteAgentResponse
+	(*GetStatusDetailsRequest)(nil),        // 3: datadog.remoteagent.GetStatusDetailsRequest
+	(*GetStatusDetailsResponse)(nil),       // 4: datadog.remoteagent.GetStatusDetailsResponse
+	(*GetFlareFilesRequest)(nil),           // 5: datadog.remoteagent.GetFlareFilesRequest
+	(*GetFlareFilesResponse)(nil),          // 6: datadog.remoteagent.GetFlareFilesResponse
+	(*GetTelemetryRequest)(nil),            // 7: datadog.remoteagent.GetTelemetryRequest
+	(*GetTelemetryResponse)(nil),           // 8: datadog.remoteagent.GetTelemetryResponse
+	(*ConfigSnapshot)(nil),                 // 9: datadog.remoteagent.ConfigSnapshot
+	(*SingleUpdate)(nil),                   // 10: datadog.remoteagent.SingleUpdate
+	(*ConfigEvent)(nil),                    // 11: datadog.remoteagent.ConfigEvent
+	nil,                                    // 12: datadog.remoteagent.StatusSection.FieldsEntry
+	nil,                                    // 13: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
+	nil,                                    // 14: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
+	(*ConfigSnapshot_SettingSnapshot)(nil), // 15: datadog.remoteagent.ConfigSnapshot.SettingSnapshot
+	(*timestamp.Timestamp)(nil),            // 16: google.protobuf.Timestamp
 }
 var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
-	10, // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
+	12, // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
 	0,  // 1: datadog.remoteagent.GetStatusDetailsResponse.main_section:type_name -> datadog.remoteagent.StatusSection
-	11, // 2: datadog.remoteagent.GetStatusDetailsResponse.named_sections:type_name -> datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
-	12, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
-	13, // 4: datadog.remoteagent.ConfigUpdate.payload:type_name -> google.protobuf.Struct
-	0,  // 5: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
-	6,  // [6:6] is the sub-list for method output_type
-	6,  // [6:6] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	13, // 2: datadog.remoteagent.GetStatusDetailsResponse.named_sections:type_name -> datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry
+	14, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
+	15, // 4: datadog.remoteagent.ConfigSnapshot.settings:type_name -> datadog.remoteagent.ConfigSnapshot.SettingSnapshot
+	16, // 5: datadog.remoteagent.SingleUpdate.updated_at:type_name -> google.protobuf.Timestamp
+	9,  // 6: datadog.remoteagent.ConfigEvent.snapshot:type_name -> datadog.remoteagent.ConfigSnapshot
+	10, // 7: datadog.remoteagent.ConfigEvent.update:type_name -> datadog.remoteagent.SingleUpdate
+	0,  // 8: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
+	9,  // [9:9] is the sub-list for method output_type
+	9,  // [9:9] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteagent_remoteagent_proto_init() }
@@ -625,13 +846,17 @@ func file_datadog_remoteagent_remoteagent_proto_init() {
 	file_datadog_remoteagent_remoteagent_proto_msgTypes[8].OneofWrappers = []any{
 		(*GetTelemetryResponse_PromText)(nil),
 	}
+	file_datadog_remoteagent_remoteagent_proto_msgTypes[11].OneofWrappers = []any{
+		(*ConfigEvent_Snapshot)(nil),
+		(*ConfigEvent_Update)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_remoteagent_remoteagent_proto_rawDesc), len(file_datadog_remoteagent_remoteagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/proto/pbgo/core/remoteagent.pb.go
+++ b/pkg/proto/pbgo/core/remoteagent.pb.go
@@ -7,7 +7,7 @@
 package core
 
 import (
-	_ "github.com/golang/protobuf/ptypes/struct"
+	_struct "github.com/golang/protobuf/ptypes/struct"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -536,11 +536,14 @@ func (x *ConfigSnapshot) GetSettings() []*ConfigSnapshot_SettingSnapshot {
 }
 
 type SingleUpdate struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	UpdatedAt     *timestamp.Timestamp   `protobuf:"bytes,2,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	PreviousValue string                 `protobuf:"bytes,3,opt,name=previous_value,json=previousValue,proto3" json:"previous_value,omitempty"`
-	NewValue      string                 `protobuf:"bytes,4,opt,name=new_value,json=newValue,proto3" json:"new_value,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Timestamp indicating when the update was processed.
+	// Remote agents may choose how to handle updates with an earlier timestamp
+	// than one they have already seen.
+	UpdatedAt     *timestamp.Timestamp `protobuf:"bytes,2,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	PreviousValue *_struct.Value       `protobuf:"bytes,3,opt,name=previous_value,json=previousValue,proto3" json:"previous_value,omitempty"`
+	NewValue      *_struct.Value       `protobuf:"bytes,4,opt,name=new_value,json=newValue,proto3" json:"new_value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -589,18 +592,18 @@ func (x *SingleUpdate) GetUpdatedAt() *timestamp.Timestamp {
 	return nil
 }
 
-func (x *SingleUpdate) GetPreviousValue() string {
+func (x *SingleUpdate) GetPreviousValue() *_struct.Value {
 	if x != nil {
 		return x.PreviousValue
 	}
-	return ""
+	return nil
 }
 
-func (x *SingleUpdate) GetNewValue() string {
+func (x *SingleUpdate) GetNewValue() *_struct.Value {
 	if x != nil {
 		return x.NewValue
 	}
-	return ""
+	return nil
 }
 
 type ConfigEvent struct {
@@ -688,7 +691,7 @@ func (*ConfigEvent_Update) isConfigEvent_Event() {}
 type ConfigSnapshot_SettingSnapshot struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Value         *_struct.Value         `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -730,11 +733,11 @@ func (x *ConfigSnapshot_SettingSnapshot) GetKey() string {
 	return ""
 }
 
-func (x *ConfigSnapshot_SettingSnapshot) GetValue() string {
+func (x *ConfigSnapshot_SettingSnapshot) GetValue() *_struct.Value {
 	if x != nil {
 		return x.Value
 	}
-	return ""
+	return nil
 }
 
 var File_datadog_remoteagent_remoteagent_proto protoreflect.FileDescriptor
@@ -772,18 +775,18 @@ const file_datadog_remoteagent_remoteagent_proto_rawDesc = "" +
 	"\x13GetTelemetryRequest\"@\n" +
 	"\x14GetTelemetryResponse\x12\x1d\n" +
 	"\tprom_text\x18\x01 \x01(\tH\x00R\bpromTextB\t\n" +
-	"\apayload\"\x9c\x01\n" +
+	"\apayload\"\xb4\x01\n" +
 	"\x0eConfigSnapshot\x12O\n" +
-	"\bsettings\x18\x01 \x03(\v23.datadog.remoteagent.ConfigSnapshot.SettingSnapshotR\bsettings\x1a9\n" +
+	"\bsettings\x18\x01 \x03(\v23.datadog.remoteagent.ConfigSnapshot.SettingSnapshotR\bsettings\x1aQ\n" +
 	"\x0fSettingSnapshot\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\x9f\x01\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value\"\xcf\x01\n" +
 	"\fSingleUpdate\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x129\n" +
 	"\n" +
-	"updated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12%\n" +
-	"\x0eprevious_value\x18\x03 \x01(\tR\rpreviousValue\x12\x1b\n" +
-	"\tnew_value\x18\x04 \x01(\tR\bnewValue\"\x96\x01\n" +
+	"updated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12=\n" +
+	"\x0eprevious_value\x18\x03 \x01(\v2\x16.google.protobuf.ValueR\rpreviousValue\x123\n" +
+	"\tnew_value\x18\x04 \x01(\v2\x16.google.protobuf.ValueR\bnewValue\"\x96\x01\n" +
 	"\vConfigEvent\x12A\n" +
 	"\bsnapshot\x18\x01 \x01(\v2#.datadog.remoteagent.ConfigSnapshotH\x00R\bsnapshot\x12;\n" +
 	"\x06update\x18\x02 \x01(\v2!.datadog.remoteagent.SingleUpdateH\x00R\x06updateB\a\n" +
@@ -820,6 +823,7 @@ var file_datadog_remoteagent_remoteagent_proto_goTypes = []any{
 	nil,                                    // 14: datadog.remoteagent.GetFlareFilesResponse.FilesEntry
 	(*ConfigSnapshot_SettingSnapshot)(nil), // 15: datadog.remoteagent.ConfigSnapshot.SettingSnapshot
 	(*timestamp.Timestamp)(nil),            // 16: google.protobuf.Timestamp
+	(*_struct.Value)(nil),                  // 17: google.protobuf.Value
 }
 var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
 	12, // 0: datadog.remoteagent.StatusSection.fields:type_name -> datadog.remoteagent.StatusSection.FieldsEntry
@@ -828,14 +832,17 @@ var file_datadog_remoteagent_remoteagent_proto_depIdxs = []int32{
 	14, // 3: datadog.remoteagent.GetFlareFilesResponse.files:type_name -> datadog.remoteagent.GetFlareFilesResponse.FilesEntry
 	15, // 4: datadog.remoteagent.ConfigSnapshot.settings:type_name -> datadog.remoteagent.ConfigSnapshot.SettingSnapshot
 	16, // 5: datadog.remoteagent.SingleUpdate.updated_at:type_name -> google.protobuf.Timestamp
-	9,  // 6: datadog.remoteagent.ConfigEvent.snapshot:type_name -> datadog.remoteagent.ConfigSnapshot
-	10, // 7: datadog.remoteagent.ConfigEvent.update:type_name -> datadog.remoteagent.SingleUpdate
-	0,  // 8: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	17, // 6: datadog.remoteagent.SingleUpdate.previous_value:type_name -> google.protobuf.Value
+	17, // 7: datadog.remoteagent.SingleUpdate.new_value:type_name -> google.protobuf.Value
+	9,  // 8: datadog.remoteagent.ConfigEvent.snapshot:type_name -> datadog.remoteagent.ConfigSnapshot
+	10, // 9: datadog.remoteagent.ConfigEvent.update:type_name -> datadog.remoteagent.SingleUpdate
+	0,  // 10: datadog.remoteagent.GetStatusDetailsResponse.NamedSectionsEntry.value:type_name -> datadog.remoteagent.StatusSection
+	17, // 11: datadog.remoteagent.ConfigSnapshot.SettingSnapshot.value:type_name -> google.protobuf.Value
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_datadog_remoteagent_remoteagent_proto_init() }

--- a/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
+++ b/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
@@ -1403,51 +1403,51 @@ func (mr *MockRemoteAgentClientMockRecorder) GetTelemetry(ctx, in interface{}, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetry", reflect.TypeOf((*MockRemoteAgentClient)(nil).GetTelemetry), varargs...)
 }
 
-// StreamConfigUpdates mocks base method.
-func (m *MockRemoteAgentClient) StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (core.RemoteAgent_StreamConfigUpdatesClient, error) {
+// StreamConfigEvents mocks base method.
+func (m *MockRemoteAgentClient) StreamConfigEvents(ctx context.Context, opts ...grpc.CallOption) (core.RemoteAgent_StreamConfigEventsClient, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "StreamConfigUpdates", varargs...)
-	ret0, _ := ret[0].(core.RemoteAgent_StreamConfigUpdatesClient)
+	ret := m.ctrl.Call(m, "StreamConfigEvents", varargs...)
+	ret0, _ := ret[0].(core.RemoteAgent_StreamConfigEventsClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StreamConfigUpdates indicates an expected call of StreamConfigUpdates.
-func (mr *MockRemoteAgentClientMockRecorder) StreamConfigUpdates(ctx interface{}, opts ...interface{}) *gomock.Call {
+// StreamConfigEvents indicates an expected call of StreamConfigEvents.
+func (mr *MockRemoteAgentClientMockRecorder) StreamConfigEvents(ctx interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigUpdates", reflect.TypeOf((*MockRemoteAgentClient)(nil).StreamConfigUpdates), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigEvents", reflect.TypeOf((*MockRemoteAgentClient)(nil).StreamConfigEvents), varargs...)
 }
 
-// MockRemoteAgent_StreamConfigUpdatesClient is a mock of RemoteAgent_StreamConfigUpdatesClient interface.
-type MockRemoteAgent_StreamConfigUpdatesClient struct {
+// MockRemoteAgent_StreamConfigEventsClient is a mock of RemoteAgent_StreamConfigEventsClient interface.
+type MockRemoteAgent_StreamConfigEventsClient struct {
 	ctrl     *gomock.Controller
-	recorder *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder
+	recorder *MockRemoteAgent_StreamConfigEventsClientMockRecorder
 }
 
-// MockRemoteAgent_StreamConfigUpdatesClientMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigUpdatesClient.
-type MockRemoteAgent_StreamConfigUpdatesClientMockRecorder struct {
-	mock *MockRemoteAgent_StreamConfigUpdatesClient
+// MockRemoteAgent_StreamConfigEventsClientMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigEventsClient.
+type MockRemoteAgent_StreamConfigEventsClientMockRecorder struct {
+	mock *MockRemoteAgent_StreamConfigEventsClient
 }
 
-// NewMockRemoteAgent_StreamConfigUpdatesClient creates a new mock instance.
-func NewMockRemoteAgent_StreamConfigUpdatesClient(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigUpdatesClient {
-	mock := &MockRemoteAgent_StreamConfigUpdatesClient{ctrl: ctrl}
-	mock.recorder = &MockRemoteAgent_StreamConfigUpdatesClientMockRecorder{mock}
+// NewMockRemoteAgent_StreamConfigEventsClient creates a new mock instance.
+func NewMockRemoteAgent_StreamConfigEventsClient(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigEventsClient {
+	mock := &MockRemoteAgent_StreamConfigEventsClient{ctrl: ctrl}
+	mock.recorder = &MockRemoteAgent_StreamConfigEventsClientMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) EXPECT() *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder {
+func (m *MockRemoteAgent_StreamConfigEventsClient) EXPECT() *MockRemoteAgent_StreamConfigEventsClientMockRecorder {
 	return m.recorder
 }
 
 // CloseAndRecv mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseAndRecv() (*empty.Empty, error) {
+func (m *MockRemoteAgent_StreamConfigEventsClient) CloseAndRecv() (*empty.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloseAndRecv")
 	ret0, _ := ret[0].(*empty.Empty)
@@ -1456,13 +1456,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseAndRecv() (*empty.Empty
 }
 
 // CloseAndRecv indicates an expected call of CloseAndRecv.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) CloseAndRecv() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) CloseAndRecv() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAndRecv", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).CloseAndRecv))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAndRecv", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).CloseAndRecv))
 }
 
 // CloseSend mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseSend() error {
+func (m *MockRemoteAgent_StreamConfigEventsClient) CloseSend() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloseSend")
 	ret0, _ := ret[0].(error)
@@ -1470,13 +1470,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseSend() error {
 }
 
 // CloseSend indicates an expected call of CloseSend.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) CloseSend() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) CloseSend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseSend", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).CloseSend))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseSend", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).CloseSend))
 }
 
 // Context mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) Context() context.Context {
+func (m *MockRemoteAgent_StreamConfigEventsClient) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
@@ -1484,13 +1484,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) Context() context.Context {
 }
 
 // Context indicates an expected call of Context.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Context() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).Context))
 }
 
 // Header mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) Header() (metadata.MD, error) {
+func (m *MockRemoteAgent_StreamConfigEventsClient) Header() (metadata.MD, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Header")
 	ret0, _ := ret[0].(metadata.MD)
@@ -1499,13 +1499,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) Header() (metadata.MD, error
 }
 
 // Header indicates an expected call of Header.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Header() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) Header() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Header))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).Header))
 }
 
 // RecvMsg mocks base method.
-func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) RecvMsg(m any) error {
+func (m_2 *MockRemoteAgent_StreamConfigEventsClient) RecvMsg(m any) error {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
 	ret0, _ := ret[0].(error)
@@ -1513,13 +1513,13 @@ func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) RecvMsg(m any) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) RecvMsg(m interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).RecvMsg), m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).RecvMsg), m)
 }
 
 // Send mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) Send(arg0 *core.ConfigUpdate) error {
+func (m *MockRemoteAgent_StreamConfigEventsClient) Send(arg0 *core.ConfigEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0)
 	ret0, _ := ret[0].(error)
@@ -1527,13 +1527,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) Send(arg0 *core.ConfigUpdate
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Send(arg0 interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) Send(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Send), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).Send), arg0)
 }
 
 // SendMsg mocks base method.
-func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) SendMsg(m any) error {
+func (m_2 *MockRemoteAgent_StreamConfigEventsClient) SendMsg(m any) error {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
 	ret0, _ := ret[0].(error)
@@ -1541,13 +1541,13 @@ func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) SendMsg(m any) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) SendMsg(m interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) SendMsg(m interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).SendMsg), m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).SendMsg), m)
 }
 
 // Trailer mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) Trailer() metadata.MD {
+func (m *MockRemoteAgent_StreamConfigEventsClient) Trailer() metadata.MD {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Trailer")
 	ret0, _ := ret[0].(metadata.MD)
@@ -1555,9 +1555,9 @@ func (m *MockRemoteAgent_StreamConfigUpdatesClient) Trailer() metadata.MD {
 }
 
 // Trailer indicates an expected call of Trailer.
-func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Trailer() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsClientMockRecorder) Trailer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Trailer))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsClient)(nil).Trailer))
 }
 
 // MockRemoteAgentServer is a mock of RemoteAgentServer interface.
@@ -1628,45 +1628,45 @@ func (mr *MockRemoteAgentServerMockRecorder) GetTelemetry(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetry", reflect.TypeOf((*MockRemoteAgentServer)(nil).GetTelemetry), arg0, arg1)
 }
 
-// StreamConfigUpdates mocks base method.
-func (m *MockRemoteAgentServer) StreamConfigUpdates(arg0 core.RemoteAgent_StreamConfigUpdatesServer) error {
+// StreamConfigEvents mocks base method.
+func (m *MockRemoteAgentServer) StreamConfigEvents(arg0 core.RemoteAgent_StreamConfigEventsServer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StreamConfigUpdates", arg0)
+	ret := m.ctrl.Call(m, "StreamConfigEvents", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StreamConfigUpdates indicates an expected call of StreamConfigUpdates.
-func (mr *MockRemoteAgentServerMockRecorder) StreamConfigUpdates(arg0 interface{}) *gomock.Call {
+// StreamConfigEvents indicates an expected call of StreamConfigEvents.
+func (mr *MockRemoteAgentServerMockRecorder) StreamConfigEvents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigUpdates", reflect.TypeOf((*MockRemoteAgentServer)(nil).StreamConfigUpdates), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigEvents", reflect.TypeOf((*MockRemoteAgentServer)(nil).StreamConfigEvents), arg0)
 }
 
-// MockRemoteAgent_StreamConfigUpdatesServer is a mock of RemoteAgent_StreamConfigUpdatesServer interface.
-type MockRemoteAgent_StreamConfigUpdatesServer struct {
+// MockRemoteAgent_StreamConfigEventsServer is a mock of RemoteAgent_StreamConfigEventsServer interface.
+type MockRemoteAgent_StreamConfigEventsServer struct {
 	ctrl     *gomock.Controller
-	recorder *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder
+	recorder *MockRemoteAgent_StreamConfigEventsServerMockRecorder
 }
 
-// MockRemoteAgent_StreamConfigUpdatesServerMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigUpdatesServer.
-type MockRemoteAgent_StreamConfigUpdatesServerMockRecorder struct {
-	mock *MockRemoteAgent_StreamConfigUpdatesServer
+// MockRemoteAgent_StreamConfigEventsServerMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigEventsServer.
+type MockRemoteAgent_StreamConfigEventsServerMockRecorder struct {
+	mock *MockRemoteAgent_StreamConfigEventsServer
 }
 
-// NewMockRemoteAgent_StreamConfigUpdatesServer creates a new mock instance.
-func NewMockRemoteAgent_StreamConfigUpdatesServer(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigUpdatesServer {
-	mock := &MockRemoteAgent_StreamConfigUpdatesServer{ctrl: ctrl}
-	mock.recorder = &MockRemoteAgent_StreamConfigUpdatesServerMockRecorder{mock}
+// NewMockRemoteAgent_StreamConfigEventsServer creates a new mock instance.
+func NewMockRemoteAgent_StreamConfigEventsServer(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigEventsServer {
+	mock := &MockRemoteAgent_StreamConfigEventsServer{ctrl: ctrl}
+	mock.recorder = &MockRemoteAgent_StreamConfigEventsServerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) EXPECT() *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder {
+func (m *MockRemoteAgent_StreamConfigEventsServer) EXPECT() *MockRemoteAgent_StreamConfigEventsServerMockRecorder {
 	return m.recorder
 }
 
 // Context mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) Context() context.Context {
+func (m *MockRemoteAgent_StreamConfigEventsServer) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
@@ -1674,28 +1674,28 @@ func (m *MockRemoteAgent_StreamConfigUpdatesServer) Context() context.Context {
 }
 
 // Context indicates an expected call of Context.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) Context() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).Context))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).Context))
 }
 
 // Recv mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) Recv() (*core.ConfigUpdate, error) {
+func (m *MockRemoteAgent_StreamConfigEventsServer) Recv() (*core.ConfigEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Recv")
-	ret0, _ := ret[0].(*core.ConfigUpdate)
+	ret0, _ := ret[0].(*core.ConfigEvent)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Recv indicates an expected call of Recv.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) Recv() *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) Recv() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).Recv))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).Recv))
 }
 
 // RecvMsg mocks base method.
-func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) RecvMsg(m any) error {
+func (m_2 *MockRemoteAgent_StreamConfigEventsServer) RecvMsg(m any) error {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
 	ret0, _ := ret[0].(error)
@@ -1703,13 +1703,13 @@ func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) RecvMsg(m any) error {
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) RecvMsg(m interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).RecvMsg), m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).RecvMsg), m)
 }
 
 // SendAndClose mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendAndClose(arg0 *empty.Empty) error {
+func (m *MockRemoteAgent_StreamConfigEventsServer) SendAndClose(arg0 *empty.Empty) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendAndClose", arg0)
 	ret0, _ := ret[0].(error)
@@ -1717,13 +1717,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendAndClose(arg0 *empty.Emp
 }
 
 // SendAndClose indicates an expected call of SendAndClose.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendAndClose(arg0 interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) SendAndClose(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAndClose", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendAndClose), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAndClose", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).SendAndClose), arg0)
 }
 
 // SendHeader mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendHeader(arg0 metadata.MD) error {
+func (m *MockRemoteAgent_StreamConfigEventsServer) SendHeader(arg0 metadata.MD) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendHeader", arg0)
 	ret0, _ := ret[0].(error)
@@ -1731,13 +1731,13 @@ func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendHeader(arg0 metadata.MD)
 }
 
 // SendHeader indicates an expected call of SendHeader.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendHeader), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).SendHeader), arg0)
 }
 
 // SendMsg mocks base method.
-func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) SendMsg(m any) error {
+func (m_2 *MockRemoteAgent_StreamConfigEventsServer) SendMsg(m any) error {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
 	ret0, _ := ret[0].(error)
@@ -1745,13 +1745,13 @@ func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) SendMsg(m any) error {
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendMsg(m interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) SendMsg(m interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendMsg), m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).SendMsg), m)
 }
 
 // SetHeader mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) SetHeader(arg0 metadata.MD) error {
+func (m *MockRemoteAgent_StreamConfigEventsServer) SetHeader(arg0 metadata.MD) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHeader", arg0)
 	ret0, _ := ret[0].(error)
@@ -1759,19 +1759,19 @@ func (m *MockRemoteAgent_StreamConfigUpdatesServer) SetHeader(arg0 metadata.MD) 
 }
 
 // SetHeader indicates an expected call of SetHeader.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SetHeader), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).SetHeader), arg0)
 }
 
 // SetTrailer mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) SetTrailer(arg0 metadata.MD) {
+func (m *MockRemoteAgent_StreamConfigEventsServer) SetTrailer(arg0 metadata.MD) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTrailer", arg0)
 }
 
 // SetTrailer indicates an expected call of SetTrailer.
-func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+func (mr *MockRemoteAgent_StreamConfigEventsServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SetTrailer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigEventsServer)(nil).SetTrailer), arg0)
 }

--- a/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
+++ b/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
@@ -1403,6 +1403,163 @@ func (mr *MockRemoteAgentClientMockRecorder) GetTelemetry(ctx, in interface{}, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetry", reflect.TypeOf((*MockRemoteAgentClient)(nil).GetTelemetry), varargs...)
 }
 
+// StreamConfigUpdates mocks base method.
+func (m *MockRemoteAgentClient) StreamConfigUpdates(ctx context.Context, opts ...grpc.CallOption) (core.RemoteAgent_StreamConfigUpdatesClient, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StreamConfigUpdates", varargs...)
+	ret0, _ := ret[0].(core.RemoteAgent_StreamConfigUpdatesClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StreamConfigUpdates indicates an expected call of StreamConfigUpdates.
+func (mr *MockRemoteAgentClientMockRecorder) StreamConfigUpdates(ctx interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigUpdates", reflect.TypeOf((*MockRemoteAgentClient)(nil).StreamConfigUpdates), varargs...)
+}
+
+// MockRemoteAgent_StreamConfigUpdatesClient is a mock of RemoteAgent_StreamConfigUpdatesClient interface.
+type MockRemoteAgent_StreamConfigUpdatesClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder
+}
+
+// MockRemoteAgent_StreamConfigUpdatesClientMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigUpdatesClient.
+type MockRemoteAgent_StreamConfigUpdatesClientMockRecorder struct {
+	mock *MockRemoteAgent_StreamConfigUpdatesClient
+}
+
+// NewMockRemoteAgent_StreamConfigUpdatesClient creates a new mock instance.
+func NewMockRemoteAgent_StreamConfigUpdatesClient(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigUpdatesClient {
+	mock := &MockRemoteAgent_StreamConfigUpdatesClient{ctrl: ctrl}
+	mock.recorder = &MockRemoteAgent_StreamConfigUpdatesClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) EXPECT() *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder {
+	return m.recorder
+}
+
+// CloseAndRecv mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseAndRecv() (*empty.Empty, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseAndRecv")
+	ret0, _ := ret[0].(*empty.Empty)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseAndRecv indicates an expected call of CloseAndRecv.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) CloseAndRecv() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAndRecv", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).CloseAndRecv))
+}
+
+// CloseSend mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) CloseSend() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseSend")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseSend indicates an expected call of CloseSend.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) CloseSend() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseSend", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).CloseSend))
+}
+
+// Context mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Context))
+}
+
+// Header mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) Header() (metadata.MD, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Header")
+	ret0, _ := ret[0].(metadata.MD)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Header indicates an expected call of Header.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Header() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Header))
+}
+
+// RecvMsg mocks base method.
+func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecvMsg indicates an expected call of RecvMsg.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).RecvMsg), m)
+}
+
+// Send mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) Send(arg0 *core.PushedConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Send(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Send), arg0)
+}
+
+// SendMsg mocks base method.
+func (m_2 *MockRemoteAgent_StreamConfigUpdatesClient) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMsg indicates an expected call of SendMsg.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) SendMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).SendMsg), m)
+}
+
+// Trailer mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) Trailer() metadata.MD {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Trailer")
+	ret0, _ := ret[0].(metadata.MD)
+	return ret0
+}
+
+// Trailer indicates an expected call of Trailer.
+func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) Trailer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Trailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesClient)(nil).Trailer))
+}
+
 // MockRemoteAgentServer is a mock of RemoteAgentServer interface.
 type MockRemoteAgentServer struct {
 	ctrl     *gomock.Controller
@@ -1469,4 +1626,152 @@ func (m *MockRemoteAgentServer) GetTelemetry(arg0 context.Context, arg1 *core.Ge
 func (mr *MockRemoteAgentServerMockRecorder) GetTelemetry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetry", reflect.TypeOf((*MockRemoteAgentServer)(nil).GetTelemetry), arg0, arg1)
+}
+
+// StreamConfigUpdates mocks base method.
+func (m *MockRemoteAgentServer) StreamConfigUpdates(arg0 core.RemoteAgent_StreamConfigUpdatesServer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamConfigUpdates", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StreamConfigUpdates indicates an expected call of StreamConfigUpdates.
+func (mr *MockRemoteAgentServerMockRecorder) StreamConfigUpdates(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamConfigUpdates", reflect.TypeOf((*MockRemoteAgentServer)(nil).StreamConfigUpdates), arg0)
+}
+
+// MockRemoteAgent_StreamConfigUpdatesServer is a mock of RemoteAgent_StreamConfigUpdatesServer interface.
+type MockRemoteAgent_StreamConfigUpdatesServer struct {
+	ctrl     *gomock.Controller
+	recorder *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder
+}
+
+// MockRemoteAgent_StreamConfigUpdatesServerMockRecorder is the mock recorder for MockRemoteAgent_StreamConfigUpdatesServer.
+type MockRemoteAgent_StreamConfigUpdatesServerMockRecorder struct {
+	mock *MockRemoteAgent_StreamConfigUpdatesServer
+}
+
+// NewMockRemoteAgent_StreamConfigUpdatesServer creates a new mock instance.
+func NewMockRemoteAgent_StreamConfigUpdatesServer(ctrl *gomock.Controller) *MockRemoteAgent_StreamConfigUpdatesServer {
+	mock := &MockRemoteAgent_StreamConfigUpdatesServer{ctrl: ctrl}
+	mock.recorder = &MockRemoteAgent_StreamConfigUpdatesServerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) EXPECT() *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder {
+	return m.recorder
+}
+
+// Context mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).Context))
+}
+
+// Recv mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) Recv() (*core.PushedConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Recv")
+	ret0, _ := ret[0].(*core.PushedConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Recv indicates an expected call of Recv.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) Recv() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).Recv))
+}
+
+// RecvMsg mocks base method.
+func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecvMsg indicates an expected call of RecvMsg.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) RecvMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).RecvMsg), m)
+}
+
+// SendAndClose mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendAndClose(arg0 *empty.Empty) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendAndClose", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendAndClose indicates an expected call of SendAndClose.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendAndClose(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAndClose", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendAndClose), arg0)
+}
+
+// SendHeader mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) SendHeader(arg0 metadata.MD) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendHeader indicates an expected call of SendHeader.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendHeader), arg0)
+}
+
+// SendMsg mocks base method.
+func (m_2 *MockRemoteAgent_StreamConfigUpdatesServer) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendMsg indicates an expected call of SendMsg.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SendMsg(m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SendMsg), m)
+}
+
+// SetHeader mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) SetHeader(arg0 metadata.MD) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetHeader indicates an expected call of SetHeader.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SetHeader), arg0)
+}
+
+// SetTrailer mocks base method.
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) SetTrailer(arg0 metadata.MD) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTrailer", arg0)
+}
+
+// SetTrailer indicates an expected call of SetTrailer.
+func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockRemoteAgent_StreamConfigUpdatesServer)(nil).SetTrailer), arg0)
 }

--- a/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
+++ b/pkg/proto/pbgo/mocks/core/api_mockgen.pb.go
@@ -1519,7 +1519,7 @@ func (mr *MockRemoteAgent_StreamConfigUpdatesClientMockRecorder) RecvMsg(m inter
 }
 
 // Send mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesClient) Send(arg0 *core.PushedConfig) error {
+func (m *MockRemoteAgent_StreamConfigUpdatesClient) Send(arg0 *core.ConfigUpdate) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0)
 	ret0, _ := ret[0].(error)
@@ -1680,10 +1680,10 @@ func (mr *MockRemoteAgent_StreamConfigUpdatesServerMockRecorder) Context() *gomo
 }
 
 // Recv mocks base method.
-func (m *MockRemoteAgent_StreamConfigUpdatesServer) Recv() (*core.PushedConfig, error) {
+func (m *MockRemoteAgent_StreamConfigUpdatesServer) Recv() (*core.ConfigUpdate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Recv")
-	ret0, _ := ret[0].(*core.PushedConfig)
+	ret0, _ := ret[0].(*core.ConfigUpdate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
[draft] 

This pr adds a grpc endpoint for streaming configuration updates to RemoteAgents.

We establish a stream when a new `RemoteAgent` is registered. When deregistering, we call the cancel func associated with the stream.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
ADP side pr: https://github.com/DataDog/saluki/pull/713