### PR TITLE
(fleet) improve user creation logic

### DIFF
--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -10,30 +10,64 @@ package user
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"os/user"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // EnsureAgentUserAndGroup ensures that the user and group required by the agent are present on the system.
 func EnsureAgentUserAndGroup(ctx context.Context, installPath string) error {
-	if _, err := user.LookupGroup("dd-agent"); err == nil {
+	if err := ensureGroup(ctx, "dd-agent"); err != nil {
+		return fmt.Errorf("error ensuring dd-agent group: %w", err)
+	}
+	if err := ensureUser(ctx, "dd-agent", installPath); err != nil {
+		return fmt.Errorf("error ensuring dd-agent user: %w", err)
+	}
+	if err := ensureUserInGroup(ctx, "dd-agent", "dd-agent"); err != nil {
+		return fmt.Errorf("error ensuring dd-agent user in dd-agent group: %w", err)
+	}
+	return nil
+}
+
+func ensureGroup(ctx context.Context, groupName string) error {
+	_, err := user.LookupGroup(groupName)
+	if err == nil {
 		return nil
 	}
-	err := exec.CommandContext(ctx, "groupadd", "--system", "dd-agent").Run()
+	var unknownGroupError *user.UnknownGroupError
+	if !errors.As(err, &unknownGroupError) {
+		log.Warnf("error looking up %s group: %w", groupName, err)
+	}
+	err = exec.CommandContext(ctx, "groupadd", "--system", groupName).Run()
 	if err != nil {
-		return fmt.Errorf("error creating dd-agent group: %w", err)
+		return fmt.Errorf("error creating %s group: %w", groupName, err)
 	}
-	if _, err := user.Lookup("dd-agent"); err == nil {
+	return nil
+}
+
+func ensureUser(ctx context.Context, userName string, installPath string) error {
+	_, err := user.Lookup(userName)
+	if err == nil {
 		return nil
+	}
+	var unknownUserError *user.UnknownUserError
+	if !errors.As(err, &unknownUserError) {
+		log.Warnf("error looking up %s user: %w", userName, err)
 	}
 	err = exec.CommandContext(ctx, "useradd", "--system", "--shell", "/usr/sbin/nologin", "--home", installPath, "--no-create-home", "--no-user-group", "-g", "dd-agent", "dd-agent").Run()
 	if err != nil {
-		return fmt.Errorf("error creating dd-agent user: %w", err)
+		return fmt.Errorf("error creating %s user: %w", userName, err)
 	}
-	err = exec.CommandContext(ctx, "usermod", "-g", "dd-agent", "dd-agent").Run()
+	return nil
+}
+
+func ensureUserInGroup(ctx context.Context, userName string, groupName string) error {
+	err := exec.CommandContext(ctx, "usermod", "-g", groupName, userName).Run()
 	if err != nil {
-		return fmt.Errorf("error adding dd-agent user to dd-agent group: %w", err)
+		return fmt.Errorf("error adding %s user to %s group: %w", userName, groupName, err)
 	}
 	return nil
 }

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -39,7 +39,7 @@ func ensureGroup(ctx context.Context, groupName string) error {
 	}
 	var unknownGroupError *user.UnknownGroupError
 	if !errors.As(err, &unknownGroupError) {
-		log.Warnf("error looking up %s group: %w", groupName, err)
+		log.Warnf("error looking up %s group: %v", groupName, err)
 	}
 	err = exec.CommandContext(ctx, "groupadd", "--force", "--system", groupName).Run()
 	if err != nil {
@@ -55,7 +55,7 @@ func ensureUser(ctx context.Context, userName string, installPath string) error 
 	}
 	var unknownUserError *user.UnknownUserError
 	if !errors.As(err, &unknownUserError) {
-		log.Warnf("error looking up %s user: %w", userName, err)
+		log.Warnf("error looking up %s user: %v", userName, err)
 	}
 	err = exec.CommandContext(ctx, "useradd", "--system", "--shell", "/usr/sbin/nologin", "--home", installPath, "--no-create-home", "--no-user-group", "-g", "dd-agent", "dd-agent").Run()
 	if err != nil {

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -41,7 +41,7 @@ func ensureGroup(ctx context.Context, groupName string) error {
 	if !errors.As(err, &unknownGroupError) {
 		log.Warnf("error looking up %s group: %w", groupName, err)
 	}
-	err = exec.CommandContext(ctx, "groupadd", "--system", groupName).Run()
+	err = exec.CommandContext(ctx, "groupadd", "--force", "--system", groupName).Run()
 	if err != nil {
 		return fmt.Errorf("error creating %s group: %w", groupName, err)
 	}


### PR DESCRIPTION
We noticed a few errors during the agent postinst where:
- The group was created previously but not the user, leading to a skip of the user creation
- The group was somehow not seen as created but `groupadd` would still fail with error 9 meaning it already existed

This PR fixes both.
