### PR TITLE
[autodiscovery] Delete Start/Stop from interface

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -47,10 +47,5 @@ func LoadComponents(_ secrets.Component, wmeta workloadmeta.Component, ac autodi
 		"",
 	}
 
-	// TODO: (components) - This is a temporary fix to start the autodiscovery component in CLI mode (agent flare and diagnose in forcelocal checks)
-	// because the autodiscovery component is not started by the agent automatically. Probably we can start it inside
-	// fx lifecycle and remove this call.
-	ac.Start()
-
 	setupAutoDiscovery(confSearchPaths, wmeta, ac)
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -257,7 +257,7 @@ func (suite *AutoConfigTestSuite) TestStop() {
 	listeners.Register("mock", ml.fakeFactory, ac.serviceListenerFactories)
 	ac.AddListeners([]pkgconfigsetup.Listeners{mockListenenerConfig})
 
-	ac.Stop()
+	ac.stop()
 
 	assert.True(suite.T(), ml.stopReceived)
 }

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -33,9 +33,6 @@ type Component interface {
 	GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet
 	GetProviderCatalog() map[string]providers.ConfigProviderFactory
 	GetTelemetryStore() *telemetry.Store
-	// TODO (component): deprecate start/stop methods
-	Start()
-	Stop()
 	// TODO (component): once cluster agent uses the API component remove this function
 	GetConfigCheck() integration.ConfigCheckResponse
 }

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -69,10 +69,6 @@ func (n *noopAutoConfig) GetTelemetryStore() *telemetry.Store {
 	return nil
 }
 
-func (n *noopAutoConfig) Start() {}
-
-func (n *noopAutoConfig) Stop() {}
-
 func (n *noopAutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
 	return integration.ConfigCheckResponse{}
 }


### PR DESCRIPTION
### What does this PR do?

Deletes the `Start` and `Stop` functions from the autodiscovery interface.

The `Stop` function is never called, and `Start` is only invoked from `LoadComponents()` in `cmd/agent/common/loader.go`. However, the function that instantiates autodiscovery already defines fx lifecycle hooks that call `Start`, making the call in `LoadComponents()` unnecessary.

### Describe how you validated your changes
CI.

I also manually ran the commands that call `LoadComponents()` to confirm they still work.