### PR TITLE
fix bug in admission controller config webhook

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -63,9 +63,10 @@ const (
 type csiInjectionType string
 
 const (
-	csiAPMSocket               csiInjectionType = "APMSocket"
-	csiDSDSocket               csiInjectionType = "DSDSocket"
-	csiDatadogSocketsDirectory csiInjectionType = "DatadogSocketsDirectory"
+	csiAPMSocket          csiInjectionType = "APMSocket"
+	csiAPMSocketDirectory csiInjectionType = "APMSocketDirectory"
+	csiDSDSocket          csiInjectionType = "DSDSocket"
+	csiDSDSocketDirectory csiInjectionType = "DSDSocketDirectory"
 )
 
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -368,7 +368,7 @@ func TestInjectSocket(t *testing.T) {
 							ReadOnly: pointer.Ptr(true),
 							Driver:   "k8s.csi.datadoghq.com",
 							VolumeAttributes: map[string]string{
-								"type": string(csiDatadogSocketsDirectory),
+								"type": string(csiDSDSocketDirectory),
 							},
 						},
 					},

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -196,7 +196,9 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod, withCSI bool) bool {
 		var volume corev1.Volume
 		var volumeMount corev1.VolumeMount
 		if withCSI {
-			volume, volumeMount = buildCSIVolume(DatadogVolumeName, i.config.socketPath, csiDatadogSocketsDirectory, true, i.config.csiDriver)
+			// csiDSDSocketDirectory is used because we can't mount two different volumes at the same mount path
+			// this is a limitation in the configuration of the admission controller
+			volume, volumeMount = buildCSIVolume(DatadogVolumeName, i.config.socketPath, csiDSDSocketDirectory, true, i.config.csiDriver)
 		} else {
 			volume, volumeMount = buildHostPathVolume(
 				DatadogVolumeName,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes bug in config webhook of the admission controller resulting from an oversight in a previous PR that update the webhook based on the new csi driver volume schema.

### Motivation

Fix the bug.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

- Unit tests updated. 
- Run e2e after the fix:
```
ubuntu@ip-10-1-57-231:~$ kubectl get namespaces
NAME                             STATUS   AGE
datadog                          Active   2m47s
datadog-csi                      Active   2m47s
default                          Active   3m12s
dogstatsd-standalone             Active   2m47s
etcd                             Active   2m47s
kube-node-lease                  Active   3m12s
kube-public                      Active   3m12s
kube-system                      Active   3m12s
local-path-storage               Active   3m8s
workload-cpustress               Active   2m47s
workload-dogstatsd               Active   101s
workload-dogstatsd-standalone    Active   101s
workload-mutated                 Active   101s
workload-mutated-lib-injection   Active   101s
workload-nginx                   Active   101s
workload-prometheus              Active   2m47s
workload-redis                   Active   101s
workload-tracegen                Active   2m47s
ubuntu@ip-10-1-57-231:~$ kubectl get pods -n workload-dogstatsd
NAME                                                READY   STATUS    RESTARTS   AGE
dogstatsd-udp-6dbdd97bb8-lhf2d                      1/1     Running   0          109s
dogstatsd-udp-contname-injected-56c6849b4f-wqxw9    1/1     Running   0          110s
dogstatsd-udp-external-data-only-69b984d86d-rjbld   1/1     Running   0          109s
dogstatsd-udp-origin-detection-7ddb67bdb8-9chmj     1/1     Running   0          109s
dogstatsd-uds-77b5b6b567-h4hzq                      1/1     Running   0          110s
dogstatsd-uds-with-csi-56747cbb74-bc422             1/1     Running   0          109s
```

You can see all pods are running now. 

Note: e2e tests are not yet merged, but were used here for validation. E2E tests will be added in a subsequent PR.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->