### PR TITLE
[AGTMETRICS-233] Fix formatting of remote agent's main section in RAR status output

### DIFF
--- a/comp/core/remoteagentregistry/status/status_templates/remote_agents.tmpl
+++ b/comp/core/remoteagentregistry/status/status_templates/remote_agents.tmpl
@@ -20,7 +20,7 @@ No remote agents registered
 {{ .FailureReason }}
 {{ end }}
 {{- if .MainSection }}
-{{- range $key, $value := .MainSection }}
+{{ range $key, $value := .MainSection -}}
 {{ $key }}: {{ $value }}
 {{ end }}
 {{- end }}

--- a/internal/remote-agent/main.go
+++ b/internal/remote-agent/main.go
@@ -40,6 +40,7 @@ func (s *remoteAgentServer) GetStatusDetails(_ context.Context, req *pbcore.GetS
 
 	fields := make(map[string]string)
 	fields["Started"] = s.started.Format(time.RFC3339)
+	fields["Version"] = "1.0.0"
 
 	return &pbcore.GetStatusDetailsResponse{
 		MainSection: &pbcore.StatusSection{


### PR DESCRIPTION
### What does this PR do?

Updates the status template used by the Remote Agent Registry in order to improve the formatted status output.

### Motivation

Prior to this PR, the status template added some extra whitespace between fields in the "main" section of a registered remote agent's status, like so:

```
================
agent-data-plane
================

Architecture: x86_64-unknown-linux-gnu

Git Commit: 44e7bc8

Started: 2025-05-23T13:37:57.900504090+00:00

Version: 0.1.0

...
```

After this change, it now has a properly condensed format:

```
================
agent-data-plane
================

Architecture: x86_64-unknown-linux-gnu
Git Commit: 44e7bc8
Started: 2025-05-23T13:37:57.900504090+00:00
Version: 0.1.0

...
```

### Describe how you validated your changes

Built and ran the Agent, and registered a test remote agent (`dda inv agent.build-remote-agent`) to simulate a registered remote agent. Verified the formatting change had the intended effect.

### Possible Drawbacks / Trade-offs

### Additional Notes
