### PR TITLE
Fixing log to say secret_refresh_interval instead of secret_refresh interval

### DIFF
--- a/comp/core/secrets/secretsimpl/info_nix_test.go
+++ b/comp/core/secrets/secretsimpl/info_nix_test.go
@@ -113,7 +113,7 @@ Secrets handle resolved:
 - 'pass3':
 	used in 'test2' configuration in entry 'instances/0/password'
 
-'secret_refresh interval' is disabled
+'secret_refresh_interval' is disabled
 `
 
 	assert.Equal(t, expectedResult, buffer.String())
@@ -158,7 +158,7 @@ Secrets handle resolved:
 - 'pass3':
 	used in 'test2' configuration in entry 'instances/0/password'
 
-'secret_refresh interval' is disabled
+'secret_refresh_interval' is disabled
 `
 
 	assert.Equal(t, expectedResult, buffer.String())

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -707,9 +707,9 @@ func (r *secretResolver) GetDebugInfo(w io.Writer) {
 
 	fmt.Fprintf(w, "\n")
 	if r.refreshInterval > 0 {
-		fmt.Fprintf(w, "'secret_refresh interval' is enabled: the first refresh will happen %s after startup and then every %s\n", r.scatterDuration, r.refreshInterval)
+		fmt.Fprintf(w, "'secret_refresh_interval' is enabled: the first refresh will happen %s after startup and then every %s\n", r.scatterDuration, r.refreshInterval)
 	} else {
-		fmt.Fprintf(w, "'secret_refresh interval' is disabled\n")
+		fmt.Fprintf(w, "'secret_refresh_interval' is disabled\n")
 	}
 
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The name of the config options is `secret_refresh_interval`, not `secret_refresh interval`. Since the pr that [caused this issue](https://github.com/DataDog/datadog-agent/pull/37017) is in 7.67, and this log appears in the output of the agent status command, this change needs to be backported as well.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->