### PR TITLE
AGNTLOG-217 - fix panic during write failures in logs tcp destination

### DIFF
--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -114,6 +114,9 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 				continue
 			}
 			d.incrementErrors(true)
+			d.updateRetryState(nil, isRetrying)
+			log.Debugf("Resetting TCP connection following write error: %s", err)
+			return
 		}
 
 		d.updateRetryState(nil, isRetrying)

--- a/releasenotes/notes/tcp-destination-panic-85598c9c9884c5a3.yaml
+++ b/releasenotes/notes/tcp-destination-panic-85598c9c9884c5a3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a rare panic that can occur when a log is unable to be written to a TCP-based unreliable endpoint.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
A panic has been detected within the TCP destination entity of the logs agent. This panic is strictly scoped:
1. the destination must be established on an unreliable endpoint (aka has retry disabled) and 
2. a write failure must occur on a successfully established connection that is old enough to be reset

In order to resolve this case moving forward, we will preemptively exit the send loop on write failure without attempting a connection reset.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
An additional unit test has been drafted would catch the panic in the original code

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->