### PR TITLE
[CWS] do not report `test_events` in self test events

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -30,7 +30,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
@@ -195,7 +194,7 @@ func (c *CWSConsumer) Start() error {
 	seclog.Infof("runtime security started")
 
 	// we can now wait for self test events
-	cb := func(success []eval.RuleID, fails []eval.RuleID, testEvents map[eval.RuleID]*serializers.EventSerializer) {
+	cb := func(success []eval.RuleID, fails []eval.RuleID) {
 		c.selfTestCount++
 
 		seclog.Debugf("self-test results : success : %v, failed : %v, run %d", success, fails, c.selfTestCount)
@@ -206,11 +205,11 @@ func (c *CWSConsumer) Start() error {
 		}
 
 		if !c.selfTestPassed && c.selfTestCount == selftestMaxRetry {
-			c.reportSelfTest(success, fails, testEvents)
+			c.reportSelfTest(success, fails)
 		} else if len(fails) == 0 {
 			c.selfTestPassed = true
 
-			c.reportSelfTest(success, fails, testEvents)
+			c.reportSelfTest(success, fails)
 		}
 
 		if _, err := c.RunSelfTest(false); err != nil {
@@ -269,7 +268,7 @@ func (c *CWSConsumer) RunSelfTest(gRPC bool) (bool, error) {
 	return true, nil
 }
 
-func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID, testEvents map[eval.RuleID]*serializers.EventSerializer) {
+func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID) {
 	if !c.config.SelfTestSendReport {
 		return
 	}
@@ -287,7 +286,7 @@ func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID,
 	}
 
 	// send the custom event with the list of succeed and failed self tests
-	rule, event := selftests.NewSelfTestEvent(c.probe.GetAgentContainerContext(), success, fails, testEvents)
+	rule, event := selftests.NewSelfTestEvent(c.probe.GetAgentContainerContext(), success, fails)
 	c.SendEvent(rule, event, nil, "")
 }
 

--- a/pkg/security/probe/selftests/self_tests.go
+++ b/pkg/security/probe/selftests/self_tests.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 )
 
 const (
@@ -33,9 +32,8 @@ const (
 // SelfTestEvent is used to report a self test result
 type SelfTestEvent struct {
 	events.CustomEventCommonFields
-	Success    []eval.RuleID                                `json:"succeeded_tests"`
-	Fails      []eval.RuleID                                `json:"failed_tests"`
-	TestEvents map[eval.RuleID]*serializers.EventSerializer `json:"test_events"`
+	Success []eval.RuleID `json:"succeeded_tests"`
+	Fails   []eval.RuleID `json:"failed_tests"`
 }
 
 // ToJSON marshal using json format
@@ -52,11 +50,10 @@ func (t SelfTestEvent) ToJSON() ([]byte, error) {
 }
 
 // NewSelfTestEvent returns the rule and the result of the self test
-func NewSelfTestEvent(acc *events.AgentContainerContext, success []eval.RuleID, fails []eval.RuleID, testEvents map[eval.RuleID]*serializers.EventSerializer) (*rules.Rule, *events.CustomEvent) {
+func NewSelfTestEvent(acc *events.AgentContainerContext, success []eval.RuleID, fails []eval.RuleID) (*rules.Rule, *events.CustomEvent) {
 	evt := SelfTestEvent{
-		Success:    success,
-		Fails:      fails,
-		TestEvents: testEvents,
+		Success: success,
+		Fails:   fails,
 	}
 	evt.FillCustomEventCommonFields(acc)
 

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -102,7 +102,7 @@ func CreateTargetDir() (string, error) {
 }
 
 // WaitForResult wait for self test results
-func (t *SelfTester) WaitForResult(cb func(success []eval.RuleID, fails []eval.RuleID, events map[eval.RuleID]*serializers.EventSerializer)) {
+func (t *SelfTester) WaitForResult(cb func(success []eval.RuleID, fails []eval.RuleID)) {
 	for timeout := range t.selfTestRunning {
 		timer := time.After(timeout)
 
@@ -153,7 +153,7 @@ func (t *SelfTester) WaitForResult(cb func(success []eval.RuleID, fails []eval.R
 		t.success, t.fails, t.lastTimestamp = success, fails, time.Now()
 		t.Unlock()
 
-		cb(success, fails, events)
+		cb(success, fails)
 
 		t.endSelfTests()
 	}

--- a/pkg/security/secl/schemas/self_test_schema.json
+++ b/pkg/security/secl/schemas/self_test_schema.json
@@ -44,23 +44,6 @@
         },
         "title": {
             "type": "string"
-        },
-        "test_events": {
-            "type": "object",
-            "properties": {
-                "datadog_agent_cws_self_test_rule_open": {
-                    "$ref": "open.schema.json"
-                },
-                "datadog_agent_cws_self_test_rule_chmod": {
-                    "$ref": "chmod.schema.json"
-                },
-                "datadog_agent_cws_self_test_rule_chown": {
-                    "$ref": "chown.schema.json"
-                },
-                "datadog_agent_cws_self_test_rule_exec": {
-                    "$ref": "exec.schema.json"
-                }
-            }
         }
     },
     "required": [
@@ -70,8 +53,7 @@
         "service",
         "status",
         "timestamp",
-        "title",
-        "test_events"
+        "title"
     ],
     "oneOf": [
         {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Events listed in self test `test_events` are only reported if they are from a successful event, making them basically useless, in addition to making the self test event super big (regular event size * amount of self tests (3 currently on linux)). This PR removes this reporting.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->