### PR TITLE
[NPM-4440] Move packet capture to separate package, add Sink interface

### DIFF
--- a/pkg/networkpath/traceroute/packets/afpacket_source_linux.go
+++ b/pkg/networkpath/traceroute/packets/afpacket_source_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux
 
-package common
+package packets
 
 import (
 	"fmt"
@@ -22,7 +22,7 @@ type AFPacketSource struct {
 	sock *os.File
 }
 
-var _ PacketSource = &AFPacketSource{}
+var _ Source = &AFPacketSource{}
 
 // ethPAllNetwork is all protocols, in network byte order
 var ethPAllNetwork = htons(uint16(unix.ETH_P_ALL))

--- a/pkg/networkpath/traceroute/packets/afpacket_source_linux.go
+++ b/pkg/networkpath/traceroute/packets/afpacket_source_linux.go
@@ -43,9 +43,18 @@ func (a *AFPacketSource) SetReadDeadline(t time.Time) error {
 	return a.sock.SetReadDeadline(t)
 }
 
-// Read reads a packet (including the ethernet frame)
+// Read reads a packet (starting with the IP frame)
 func (a *AFPacketSource) Read(buf []byte) (int, error) {
-	return a.sock.Read(buf)
+	n, err := a.sock.Read(buf)
+	if err != nil {
+		return n, err
+	}
+	payload, err := stripEthernetHeader(buf[:n])
+	if err != nil {
+		return n, err
+	}
+	copy(buf, payload)
+	return n, nil
 }
 
 // Close closes the socket

--- a/pkg/networkpath/traceroute/packets/attach.go
+++ b/pkg/networkpath/traceroute/packets/attach.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package filter
+package packets
 
 import "errors"
 

--- a/pkg/networkpath/traceroute/packets/attach_linux.go
+++ b/pkg/networkpath/traceroute/packets/attach_linux.go
@@ -5,7 +5,7 @@
 
 //go:build linux
 
-package filter
+package packets
 
 import (
 	"errors"

--- a/pkg/networkpath/traceroute/packets/attach_nolinux.go
+++ b/pkg/networkpath/traceroute/packets/attach_nolinux.go
@@ -5,7 +5,7 @@
 
 //go:build !linux
 
-package filter
+package packets
 
 import (
 	"syscall"

--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -19,32 +19,42 @@ import (
 
 // FrameParser parses traceroute responses using gopacket.
 type FrameParser struct {
-	Ethernet layers.Ethernet
 	IP4      layers.IPv4
 	TCP      layers.TCP
 	ICMP4    layers.ICMPv4
 	Payload  gopacket.Payload
 	Layers   []gopacket.LayerType
-	parser   *gopacket.DecodingLayerParser
+	parserv4 *gopacket.DecodingLayerParser
+	parserv6 *gopacket.DecodingLayerParser
 }
 
 var ignoredLayerErr = &common.ReceiveProbeNoPktError{
-	Err: fmt.Errorf("FrameParser saw an a layer type not used by traceroute (e.g. ARP) and decided to ignore it"),
+	Err: fmt.Errorf("FrameParser saw an a layer type not used by traceroute (e.g. SCTP) and decided to ignore it"),
 }
 
-const expectedLayerCount = 3
+const expectedLayerCount = 2
 
 // NewFrameParser constructs a new FrameParser
 func NewFrameParser() *FrameParser {
 	p := &FrameParser{}
-	p.parser = gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &p.Ethernet, &p.IP4, &p.TCP, &p.ICMP4, &p.Payload)
+	p.parserv4 = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &p.IP4, &p.TCP, &p.ICMP4, &p.Payload)
+	// TODO: IPv6 is not implemented yet
+	p.parserv6 = nil
 
 	return p
 }
 
 // Parse parses an ethernet packet
 func (p *FrameParser) Parse(buffer []byte) error {
-	err := p.parser.DecodeLayers(buffer, &p.Layers)
+	parser, err := p.getParser(buffer)
+	if err != nil {
+		return err
+	}
+	// TODO: currently we don't parse/ignore ipv6
+	if parser == nil {
+		return ignoredLayerErr
+	}
+	err = parser.DecodeLayers(buffer, &p.Layers)
 	var unsupportedErr gopacket.UnsupportedLayerType
 	if errors.As(err, &unsupportedErr) {
 		if len(p.Layers) < expectedLayerCount {
@@ -68,7 +78,7 @@ func (p *FrameParser) GetIPLayer() gopacket.LayerType {
 	if len(p.Layers) < expectedLayerCount {
 		return gopacket.LayerTypeZero
 	}
-	return p.Layers[1]
+	return p.Layers[0]
 }
 
 // GetTransportLayer gets the layer type of the transport layer (e.g. TCP, ICMP)
@@ -76,7 +86,7 @@ func (p *FrameParser) GetTransportLayer() gopacket.LayerType {
 	if len(p.Layers) < expectedLayerCount {
 		return gopacket.LayerTypeZero
 	}
-	return p.Layers[2]
+	return p.Layers[1]
 }
 
 // TODO IPv6
@@ -192,3 +202,34 @@ func (p *FrameParser) GetICMPInfo() (ICMPInfo, error) {
 
 // TTLExceeded4 is the TTL Exceeded ICMP4 TypeCode
 var TTLExceeded4 = layers.CreateICMPv4TypeCode(layers.ICMPv4TypeTimeExceeded, layers.ICMPv4CodeTTLExceeded)
+
+func (p *FrameParser) getParser(buffer []byte) (*gopacket.DecodingLayerParser, error) {
+	if len(buffer) < 1 {
+		return nil, fmt.Errorf("getParser: buffer was empty")
+	}
+	version := buffer[0] >> 4
+	switch version {
+	case 4:
+		return p.parserv4, nil
+	case 6:
+		// this is nil for now
+		// TODO: implement ipv6
+		return p.parserv6, nil
+	default:
+		return nil, fmt.Errorf("unexpected IP version %d", version)
+	}
+}
+
+// removes the preceding ethernet header from the buffer
+func stripEthernetHeader(buf []byte) ([]byte, error) {
+	var eth layers.Ethernet
+	err := (&eth).DecodeFromBytes(buf, gopacket.NilDecodeFeedback)
+	if err != nil {
+		return nil, fmt.Errorf("stripEthernetHeader failed to decode ethernet: %w", err)
+	}
+	// return zero bytes when the it's not an IP packet
+	if eth.EthernetType != layers.EthernetTypeIPv4 && eth.EthernetType != layers.EthernetTypeIPv6 {
+		return nil, nil
+	}
+	return eth.Payload, nil
+}

--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -219,17 +219,3 @@ func (p *FrameParser) getParser(buffer []byte) (*gopacket.DecodingLayerParser, e
 		return nil, fmt.Errorf("unexpected IP version %d", version)
 	}
 }
-
-// removes the preceding ethernet header from the buffer
-func stripEthernetHeader(buf []byte) ([]byte, error) {
-	var eth layers.Ethernet
-	err := (&eth).DecodeFromBytes(buf, gopacket.NilDecodeFeedback)
-	if err != nil {
-		return nil, fmt.Errorf("stripEthernetHeader failed to decode ethernet: %w", err)
-	}
-	// return zero bytes when the it's not an IP packet
-	if eth.EthernetType != layers.EthernetTypeIPv4 && eth.EthernetType != layers.EthernetTypeIPv6 {
-		return nil, nil
-	}
-	return eth.Payload, nil
-}

--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package common
+package packets
 
 import (
 	"encoding/binary"
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"slices"
 
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 )
@@ -27,7 +28,7 @@ type FrameParser struct {
 	parser   *gopacket.DecodingLayerParser
 }
 
-var ignoredLayerErr = &ReceiveProbeNoPktError{
+var ignoredLayerErr = &common.ReceiveProbeNoPktError{
 	Err: fmt.Errorf("FrameParser saw an a layer type not used by traceroute (e.g. ARP) and decided to ignore it"),
 }
 

--- a/pkg/networkpath/traceroute/packets/frame_parser_test.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package common
+package packets
 
 import (
 	"net"

--- a/pkg/networkpath/traceroute/packets/frame_parser_test.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser_test.go
@@ -21,18 +21,12 @@ func clearLayer(layer *layers.BaseLayer) {
 
 // SerializeLayers doesn't populate these fields, so we exclude them from equality comparison
 func clearBuffers(parser *FrameParser) {
-	clearLayer(&parser.Ethernet.BaseLayer)
 	clearLayer(&parser.IP4.BaseLayer)
 	clearLayer(&parser.TCP.BaseLayer)
 	clearLayer(&parser.ICMP4.BaseLayer)
 }
 
 func TestFrameParserTCP(t *testing.T) {
-	eth := &layers.Ethernet{
-		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		EthernetType: layers.EthernetTypeIPv4,
-	}
 	ip4 := &layers.IPv4{
 		Version:  4,
 		TTL:      123,
@@ -60,7 +54,7 @@ func TestFrameParserTCP(t *testing.T) {
 		FixLengths:       true,
 		ComputeChecksums: true,
 	}
-	err = gopacket.SerializeLayers(buf, opts, eth, ip4, tcp, payload)
+	err = gopacket.SerializeLayers(buf, opts, ip4, tcp, payload)
 	require.NoError(t, err)
 
 	parser := NewFrameParser()
@@ -70,7 +64,6 @@ func TestFrameParserTCP(t *testing.T) {
 
 	clearBuffers(parser)
 
-	require.EqualExportedValues(t, eth, &parser.Ethernet)
 	require.EqualExportedValues(t, ip4, &parser.IP4)
 	require.EqualExportedValues(t, tcp, &parser.TCP)
 	require.Equal(t, payload, parser.Payload)
@@ -91,11 +84,6 @@ func TestFrameParserICMP4(t *testing.T) {
 	require.NoError(t, err)
 	tcpBytes := buf.Bytes()[:8]
 
-	eth := &layers.Ethernet{
-		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		EthernetType: layers.EthernetTypeIPv4,
-	}
 	ip4 := &layers.IPv4{
 		Version:  4,
 		TTL:      123,
@@ -114,7 +102,7 @@ func TestFrameParserICMP4(t *testing.T) {
 		FixLengths:       true,
 		ComputeChecksums: true,
 	}
-	err = gopacket.SerializeLayers(buf, opts, eth, ip4, icmp4, payload)
+	err = gopacket.SerializeLayers(buf, opts, ip4, icmp4, payload)
 	require.NoError(t, err)
 
 	parser := NewFrameParser()
@@ -124,7 +112,6 @@ func TestFrameParserICMP4(t *testing.T) {
 
 	clearBuffers(parser)
 
-	require.EqualExportedValues(t, eth, &parser.Ethernet)
 	require.EqualExportedValues(t, ip4, &parser.IP4)
 	require.EqualExportedValues(t, icmp4, &parser.ICMP4)
 
@@ -140,21 +127,26 @@ func TestFrameParserICMP4(t *testing.T) {
 }
 
 func TestFrameParserUnrecognizedPacket(t *testing.T) {
-	eth := &layers.Ethernet{
-		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		EthernetType: layers.EthernetTypeARP,
+	ip4 := &layers.IPv4{
+		Version:  4,
+		TTL:      123,
+		SrcIP:    net.ParseIP("127.0.0.1"),
+		DstIP:    net.ParseIP("127.0.0.2"),
+		Id:       41821,
+		Protocol: layers.IPProtocolSCTP,
 	}
-	arp := &layers.ARP{
-		Protocol: layers.EthernetTypeARP,
+	sctp := &layers.SCTP{
+		SrcPort: 42,
+		DstPort: 123,
 	}
+	payload := gopacket.Payload([]byte{42})
 
 	buf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{
 		FixLengths:       true,
 		ComputeChecksums: true,
 	}
-	err := gopacket.SerializeLayers(buf, opts, eth, arp)
+	err := gopacket.SerializeLayers(buf, opts, ip4, sctp, payload)
 	require.NoError(t, err)
 
 	parser := NewFrameParser()
@@ -165,11 +157,6 @@ func TestFrameParserUnrecognizedPacket(t *testing.T) {
 
 func TestFrameParserTLSPacket(t *testing.T) {
 	// tests a TLS packet which has one extra layer we don't care about
-	eth := &layers.Ethernet{
-		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
-		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
-		EthernetType: layers.EthernetTypeIPv4,
-	}
 	ip4 := &layers.IPv4{
 		Version:  4,
 		TTL:      123,
@@ -198,7 +185,7 @@ func TestFrameParserTLSPacket(t *testing.T) {
 		FixLengths:       true,
 		ComputeChecksums: true,
 	}
-	err = gopacket.SerializeLayers(buf, opts, eth, ip4, tcp, tls)
+	err = gopacket.SerializeLayers(buf, opts, ip4, tcp, tls)
 	require.NoError(t, err)
 
 	parser := NewFrameParser()
@@ -208,7 +195,6 @@ func TestFrameParserTLSPacket(t *testing.T) {
 
 	clearBuffers(parser)
 
-	require.EqualExportedValues(t, eth, &parser.Ethernet)
 	require.EqualExportedValues(t, ip4, &parser.IP4)
 	require.EqualExportedValues(t, tcp, &parser.TCP)
 }

--- a/pkg/networkpath/traceroute/packets/packet_sink.go
+++ b/pkg/networkpath/traceroute/packets/packet_sink.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package packets
+
+import (
+	"net/netip"
+)
+
+// Sink is an interface which sends IP packets
+type Sink interface {
+	// WriteTo writes the given packet (buffer starts at the IP layer) to addrPort.
+	// (the port is required for compatibility with Windows)
+	WriteTo(buf []byte, addrPort netip.AddrPort) error
+	// Close closes the socket
+	Close() error
+}

--- a/pkg/networkpath/traceroute/packets/packet_sink_unix.go
+++ b/pkg/networkpath/traceroute/packets/packet_sink_unix.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build unix || linux
+
+package packets
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// SinkUnix is an implementation of the packet sink interface for unix OSes
+// TODO change to sinkUnix and don't export this?
+type SinkUnix struct {
+	rawConn syscall.RawConn
+}
+
+var _ Sink = &SinkUnix{}
+
+// NewSinkUnix returns a new SinkUnix implementing packet sink
+func NewSinkUnix(addr netip.Addr) (*SinkUnix, error) {
+	if !addr.Is4() {
+		return nil, fmt.Errorf("SinkUnix only supports IPv4 addresses (for now)")
+	}
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW|unix.SOCK_NONBLOCK, unix.IPPROTO_RAW)
+	if err != nil {
+		return nil, fmt.Errorf("NewSinkUnix failed to create socket: %s", err)
+	}
+
+	sock := os.NewFile(uintptr(fd), "")
+	rawConn, err := sock.SyscallConn()
+	if err != nil {
+		sock.Close()
+		return nil, fmt.Errorf("failed to get raw connection: %w", err)
+	}
+
+	return &SinkUnix{
+		rawConn: rawConn,
+	}, nil
+}
+
+// WriteTo writes the given packet (buffer starts at the IP layer) to addrPort.
+func (p *SinkUnix) WriteTo(buf []byte, addrPort netip.AddrPort) error {
+	if !addrPort.Addr().Is4() {
+		return fmt.Errorf("SinkUnix only supports IPv4 addresses (for now)")
+	}
+	sa := &unix.SockaddrInet4{
+		Addr: addrPort.Addr().As4(),
+	}
+
+	var sendtoErr error
+	err := p.rawConn.Write(func(fd uintptr) (done bool) {
+		err := unix.Sendto(int(fd), buf, 0, sa)
+		if err == nil {
+			return true
+		}
+
+		return err == syscall.EAGAIN || err == syscall.EWOULDBLOCK
+	})
+
+	return errors.Join(sendtoErr, err)
+}
+
+// Close closes the socket
+func (p *SinkUnix) Close() error {
+	var closeErr error
+	err := p.rawConn.Control(func(fd uintptr) {
+		closeErr = unix.Close(int(fd))
+	})
+
+	return errors.Join(closeErr, err)
+}

--- a/pkg/networkpath/traceroute/packets/packet_sink_unix.go
+++ b/pkg/networkpath/traceroute/packets/packet_sink_unix.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build unix || linux
+//go:build linux
 
 package packets
 

--- a/pkg/networkpath/traceroute/packets/packet_sink_unix.go
+++ b/pkg/networkpath/traceroute/packets/packet_sink_unix.go
@@ -17,16 +17,15 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// SinkUnix is an implementation of the packet sink interface for unix OSes
-// TODO change to sinkUnix and don't export this?
-type SinkUnix struct {
+// sinkUnix is an implementation of the packet sink interface for unix OSes
+type sinkUnix struct {
 	rawConn syscall.RawConn
 }
 
-var _ Sink = &SinkUnix{}
+var _ Sink = &sinkUnix{}
 
 // NewSinkUnix returns a new SinkUnix implementing packet sink
-func NewSinkUnix(addr netip.Addr) (*SinkUnix, error) {
+func NewSinkUnix(addr netip.Addr) (Sink, error) {
 	if !addr.Is4() {
 		return nil, fmt.Errorf("SinkUnix only supports IPv4 addresses (for now)")
 	}
@@ -42,13 +41,13 @@ func NewSinkUnix(addr netip.Addr) (*SinkUnix, error) {
 		return nil, fmt.Errorf("failed to get raw connection: %w", err)
 	}
 
-	return &SinkUnix{
+	return &sinkUnix{
 		rawConn: rawConn,
 	}, nil
 }
 
 // WriteTo writes the given packet (buffer starts at the IP layer) to addrPort.
-func (p *SinkUnix) WriteTo(buf []byte, addrPort netip.AddrPort) error {
+func (p *sinkUnix) WriteTo(buf []byte, addrPort netip.AddrPort) error {
 	if !addrPort.Addr().Is4() {
 		return fmt.Errorf("SinkUnix only supports IPv4 addresses (for now)")
 	}
@@ -70,7 +69,7 @@ func (p *SinkUnix) WriteTo(buf []byte, addrPort netip.AddrPort) error {
 }
 
 // Close closes the socket
-func (p *SinkUnix) Close() error {
+func (p *sinkUnix) Close() error {
 	var closeErr error
 	err := p.rawConn.Control(func(fd uintptr) {
 		closeErr = unix.Close(int(fd))

--- a/pkg/networkpath/traceroute/packets/packet_source.go
+++ b/pkg/networkpath/traceroute/packets/packet_source.go
@@ -21,7 +21,7 @@ import (
 type Source interface {
 	// SetReadDeadline sets the deadline for when a Read() call must finish
 	SetReadDeadline(t time.Time) error
-	// Read reads a packet (including the ethernet frame)
+	// Read reads a packet (starting with the IP frame)
 	Read(buf []byte) (int, error)
 	// Close closes the socket
 	Close() error

--- a/pkg/networkpath/traceroute/packets/packet_source.go
+++ b/pkg/networkpath/traceroute/packets/packet_source.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package common
+// Package packets has packet capture/emitting/filtering logic
+package packets
 
 import (
 	"encoding/hex"
@@ -12,11 +13,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// PacketSource is an interface representing ethernet packet capture
-type PacketSource interface {
+// Source is an interface representing ethernet packet capture
+type Source interface {
 	// SetReadDeadline sets the deadline for when a Read() call must finish
 	SetReadDeadline(t time.Time) error
 	// Read reads a packet (including the ethernet frame)
@@ -26,10 +28,10 @@ type PacketSource interface {
 }
 
 // ReadAndParse reads from the given source into the buffer, and parses it with parser
-func ReadAndParse(source PacketSource, buffer []byte, parser *FrameParser) error {
+func ReadAndParse(source Source, buffer []byte, parser *FrameParser) error {
 	n, err := source.Read(buffer)
 	if errors.Is(err, os.ErrDeadlineExceeded) {
-		return &ReceiveProbeNoPktError{Err: err}
+		return &common.ReceiveProbeNoPktError{Err: err}
 	}
 	if err != nil {
 		return fmt.Errorf("ConnHandle failed to Read: %w", err)
@@ -44,7 +46,7 @@ func ReadAndParse(source PacketSource, buffer []byte, parser *FrameParser) error
 			data := hex.EncodeToString(buffer[:n])
 			return fmt.Sprintf("error parsing packet of length %d: %s, %s", n, err, data)
 		})
-		return &BadPacketError{Err: fmt.Errorf("sackDriver failed to parse packet of length %d: %w", n, err)}
+		return &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to parse packet of length %d: %w", n, err)}
 	}
 
 	return nil

--- a/pkg/networkpath/traceroute/packets/rawconn_unix.go
+++ b/pkg/networkpath/traceroute/packets/rawconn_unix.go
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package filter
+//go:build unix || linux
+
+package packets
 
 import (
 	"context"

--- a/pkg/networkpath/traceroute/packets/tcp.go
+++ b/pkg/networkpath/traceroute/packets/tcp.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// Package filter has BPF filters for sockets useful for traceroutes
-package filter
+package packets
 
 import (
 	"encoding/binary"

--- a/pkg/networkpath/traceroute/packets/tcp_test.go
+++ b/pkg/networkpath/traceroute/packets/tcp_test.go
@@ -5,7 +5,7 @@
 
 //go:build test && linux && linux_bpf
 
-package filter
+package packets
 
 import (
 	"bufio"

--- a/pkg/networkpath/traceroute/sack/sack_driver_linux.go
+++ b/pkg/networkpath/traceroute/sack/sack_driver_linux.go
@@ -8,31 +8,28 @@
 package sack
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"net/netip"
 	"os"
 	"time"
 
 	"github.com/google/gopacket/layers"
-	"golang.org/x/net/ipv4"
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
-	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/filter"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type sackDriver struct {
-	tcpConn *ipv4.RawConn
+	sink packets.Sink
 
-	source common.PacketSource
+	source packets.Source
 	buffer []byte
-	parser *common.FrameParser
+	parser *packets.FrameParser
 
 	sendTimes []time.Time
 	localAddr netip.Addr
@@ -41,22 +38,23 @@ type sackDriver struct {
 	state     *sackTCPState
 }
 
-func newSackDriver(ctx context.Context, params Params, localAddr netip.Addr) (*sackDriver, error) {
-	tcpConn, err := filter.MakeRawConn(ctx, &net.ListenConfig{}, "ip:tcp", localAddr)
+func newSackDriver(params Params, localAddr netip.Addr) (*sackDriver, error) {
+	sink, err := packets.NewSinkUnix(params.Target.Addr())
 	if err != nil {
-		return nil, fmt.Errorf("newSackDriver failed to make TCP raw conn: %w", err)
+		return nil, fmt.Errorf("newSackDriver failed to make SinkUnix: %w", err)
 	}
-	source, err := common.NewAFPacketSource()
+
+	source, err := packets.NewAFPacketSource()
 	if err != nil {
-		tcpConn.Close()
+		sink.Close()
 		return nil, fmt.Errorf("newSackDriver failed to make ICMP raw conn: %w", err)
 	}
 
 	retval := &sackDriver{
-		tcpConn:   tcpConn,
+		sink:      sink,
 		source:    source,
 		buffer:    make([]byte, 1024),
-		parser:    common.NewFrameParser(),
+		parser:    packets.NewFrameParser(),
 		sendTimes: make([]time.Time, params.ParallelParams.MaxTTL+1),
 		localAddr: localAddr,
 		localPort: 0, // to be set by ReadHandshake()
@@ -66,8 +64,8 @@ func newSackDriver(ctx context.Context, params Params, localAddr netip.Addr) (*s
 }
 
 func (s *sackDriver) Close() {
-	s.tcpConn.Close()
 	s.source.Close()
+	s.sink.Close()
 }
 
 func (s *sackDriver) GetDriverInfo() common.TracerouteDriverInfo {
@@ -96,15 +94,15 @@ func (s *sackDriver) SendProbe(ttl uint8) error {
 		state:  *s.state,
 	}
 	// TODO ipv6
-	header, packet, err := gen.generateV4(ttl)
+	packet, err := gen.generateV4(ttl)
 	if err != nil {
 		return fmt.Errorf("sackDriver failed to generate packet: %w", err)
 	}
 
 	log.TraceFunc(func() string {
-		return fmt.Sprintf("sending packet: %+v %s\n", header, hex.EncodeToString(packet))
+		return fmt.Sprintf("sending packet: %s\n", hex.EncodeToString(packet))
 	})
-	err = s.tcpConn.WriteTo(header, packet, nil)
+	err = s.sink.WriteTo(packet, s.params.Target)
 	if err != nil {
 		return fmt.Errorf("sackDriver failed to WriteToIP: %w", err)
 	}
@@ -119,7 +117,7 @@ func (s *sackDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse,
 	if err != nil {
 		return nil, fmt.Errorf("sackDriver failed to SetReadDeadline: %w", err)
 	}
-	err = common.ReadAndParse(s.source, s.buffer, s.parser)
+	err = packets.ReadAndParse(s.source, s.buffer, s.parser)
 	if err != nil {
 		return nil, err
 	}
@@ -127,9 +125,9 @@ func (s *sackDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse,
 	return s.handleProbeLayers(s.parser)
 }
 
-func (s *sackDriver) ExpectedIPPair() common.IPPair {
+func (s *sackDriver) ExpectedIPPair() packets.IPPair {
 	// from the target to us
-	return common.IPPair{
+	return packets.IPPair{
 		SrcAddr: s.params.Target.Addr(),
 		DstAddr: s.localAddr,
 	}
@@ -178,7 +176,7 @@ func (s *sackDriver) getRTTFromRelSeq(relSeq uint32) (time.Duration, error) {
 
 var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}
 
-func (s *sackDriver) handleProbeLayers(parser *common.FrameParser) (*common.ProbeResponse, error) {
+func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.ProbeResponse, error) {
 	ipPair, err := parser.GetIPPair()
 	if err != nil {
 		return nil, fmt.Errorf("sackDriver failed to get IP pair: %w", err)
@@ -224,10 +222,10 @@ func (s *sackDriver) handleProbeLayers(parser *common.FrameParser) (*common.Prob
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to get ICMP info: %w", err)}
 		}
-		if icmpInfo.ICMPType != common.TTLExceeded4 {
+		if icmpInfo.ICMPType != packets.TTLExceeded4 {
 			return nil, errPacketDidNotMatchTraceroute
 		}
-		tcpInfo, err := common.ParseTCPFirstBytes(icmpInfo.Payload)
+		tcpInfo, err := packets.ParseTCPFirstBytes(icmpInfo.Payload)
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to parse TCP info: %w", err)}
 		}
@@ -283,7 +281,7 @@ func (s *sackDriver) ReadHandshake(localPort uint16) error {
 	}
 	for !s.IsHandshakeFinished() {
 		// we should have already connected by now so it should be over quickly
-		err = common.ReadAndParse(s.source, s.buffer, s.parser)
+		err = packets.ReadAndParse(s.source, s.buffer, s.parser)
 
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			return fmt.Errorf("sackDriver readHandshake timed out")

--- a/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
+++ b/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
@@ -80,7 +80,7 @@ func runSackTraceroute(ctx context.Context, p Params) (*sackResult, error) {
 	defer cancel()
 
 	// create the raw packet connection which watches for TCP/ICMP responses
-	driver, err := newSackDriver(ctx, p, local.AddrPort().Addr())
+	driver, err := newSackDriver(p, local.AddrPort().Addr())
 	if err != nil {
 		return nil, fmt.Errorf("failed to init sack driver: %w", err)
 	}

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -60,7 +60,7 @@ TEST_PACKAGES_LIST = [
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",
-    "./pkg/networkpath/traceroute/filter/...",
+    "./pkg/networkpath/traceroute/packets/...",
 ]
 TEST_PACKAGES = " ".join(TEST_PACKAGES_LIST)
 # change `timeouts` in `test/new-e2e/system-probe/test-runner/main.go` if you change them here


### PR DESCRIPTION
This is a recreation of #36991. I did a stacked PR on top of [\[NPM-4440\] Add TracerouteSerial variant](https://github.com/DataDog/datadog-agent/pull/36936), but after I merged it, for some reason #36991 wasn't automatically retargeted to the `main` branch like normal. So then I rebased, and disaster struck... 😅 
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
1. Consolidates packet-capture related stuff by moving to the `packets` package
2. Adds the `packets.Sink` interface which is a platform-agnostic interface to send packets
3. Changes `packets.Source` to start at the IP layer, and strip the ethernet layer -- this is because it turns out Windows won't give us the ethernet layer

### Motivation
This is necessary for my next PR which will create the TCP SYN implementation of TracerouteDriver (the main goal of this series)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Updated test suite should pass:
```
sudo go test -timeout 30s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets
```
SACK traceroute should still work properly:
```
go build github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/sack/portable_sack
```


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->