### PR TITLE
discovery: collector: add remote collector support

### DIFF
--- a/comp/core/workloadmeta/collectors/catalog-core/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-core/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/process"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/processlanguage"
 	remoteprocesscollector "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/service"
 )
 
 func getCollectorOptions() []fx.Option {
@@ -42,5 +43,6 @@ func getCollectorOptions() []fx.Option {
 		processlanguage.GetFxOptions(),
 		nvml.GetFxOptions(),
 		process.GetFxOptions(),
+		service.GetFxOptions(),
 	}
 }

--- a/comp/core/workloadmeta/collectors/catalog/options.go
+++ b/comp/core/workloadmeta/collectors/catalog/options.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/service"
 )
 
 func getCollectorOptions() []fx.Option {
@@ -44,5 +45,6 @@ func getCollectorOptions() []fx.Option {
 		remoteWorkloadmetaParams(),
 		processcollector.GetFxOptions(),
 		nvml.GetFxOptions(),
+		service.GetFxOptions(),
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/service/service.go
+++ b/comp/core/workloadmeta/collectors/internal/service/service.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/DataDog/gopsutil/process"
+	"go.uber.org/fx"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	collectorID  = "service"
+	pullInterval = 30 * time.Second
+)
+
+type collector struct {
+	id      string
+	catalog workloadmeta.AgentType
+	store   workloadmeta.Component
+
+	sysProbeClient *http.Client
+	startTime      time.Time
+	startupTimeout time.Duration
+}
+
+func NewCollector() (workloadmeta.CollectorProvider, error) {
+	return workloadmeta.CollectorProvider{
+		Collector: &collector{
+			id:             collectorID,
+			catalog:        workloadmeta.NodeAgent,
+			sysProbeClient: sysprobeclient.Get(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
+			startTime:      time.Now(),
+			startupTimeout: pkgconfigsetup.Datadog().GetDuration("check_system_probe_startup_time"),
+		},
+	}, nil
+}
+
+func GetFxOptions() fx.Option {
+	return fx.Provide(NewCollector)
+}
+
+func (c *collector) Start(ctx context.Context, store workloadmeta.Component) error {
+	log.Debugf("initializing Service Discovery collector")
+	go func() {
+		ticker := time.NewTicker(pullInterval)
+		for {
+			select {
+			case <-ticker.C:
+				pids, err := process.Pids()
+				if err != nil {
+					log.Errorf("failed to get pids: %s", err)
+					continue
+				}
+
+				services, err := c.getDiscoveryServices(pids)
+				if err != nil {
+					if time.Since(c.startTime) < c.startupTimeout {
+						log.Warnf("service collector: system-probe not started yet: %v", err)
+						continue
+					}
+
+					log.Errorf("failed to get services: %s", err)
+					continue
+				}
+
+				log.Debugf("service collector: running services count: %d", services.RunningServicesCount)
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (c *collector) Pull(_ context.Context) error {
+	return nil
+}
+
+func (c *collector) GetID() string {
+	return c.id
+}
+
+func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
+	return c.catalog
+}
+
+func (c *collector) getDiscoveryServices(pids []int32) (*model.ServicesResponse, error) {
+	var responseData model.ServicesResponse
+
+	url := getDiscoveryURL("services", pids)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.sysProbeClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non-ok status code: url %s, status_code: %d, response: `%s`", req.URL, resp.StatusCode, string(body))
+	}
+
+	err = json.Unmarshal(body, &responseData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &responseData, nil
+}
+
+func getDiscoveryURL(endpoint string, pids []int32) string {
+	URL := &url.URL{
+		Scheme: "http",
+		Host:   "sysprobe",
+		Path:   "/discovery/" + endpoint,
+	}
+
+	if len(pids) > 0 {
+		pidsStr := make([]string, len(pids))
+		for i, pid := range pids {
+			pidsStr[i] = strconv.Itoa(int(pid))
+		}
+
+		query := url.Values{}
+		query.Add("pids", strings.Join(pidsStr, ","))
+		URL.RawQuery = query.Encode()
+	}
+
+	return URL.String()
+}

--- a/comp/core/workloadmeta/collectors/internal/service/service_others.go
+++ b/comp/core/workloadmeta/collectors/internal/service/service_others.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package service
+
+import (
+	"go.uber.org/fx"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func NewCollector() (workloadmeta.CollectorProvider, error) {
+	return workloadmeta.CollectorProvider{}, nil
+}
+
+func GetFxOptions() fx.Option {
+	return fx.Provide(NewCollector)
+}

--- a/comp/core/workloadmeta/collectors/internal/service/service_test.go
+++ b/comp/core/workloadmeta/collectors/internal/service/service_test.go
@@ -3,13 +3,76 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux && test
+
 package service
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
+
+// fakeHTTPClient is a test HTTP client that can be configured to return specific responses
+type fakeHTTPClient struct {
+	response *http.Response
+	err      error
+}
+
+func (c *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.response, nil
+}
+
+// createMockServicesResponse creates a mock HTTP response for the services endpoint
+func createMockServicesResponse(services []model.Service) *http.Response {
+	response := model.ServicesResponse{
+		Services: services,
+	}
+	_, _ = json.Marshal(response)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       httptest.NewRecorder().Result().Body,
+		Header:     make(http.Header),
+	}
+}
+
+// newTestCollector creates a collector for testing with mock dependencies
+func newTestCollector(t *testing.T) (*collector, workloadmetamock.Mock) {
+	mockWmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+
+	c := &collector{
+		id:             collectorID,
+		catalog:        workloadmeta.NodeAgent,
+		store:          mockWmeta,
+		serviceRetries: make(map[int32]uint),
+		ignoredPids:    make(pidSet),
+		sysProbeClient: &http.Client{},
+		startTime:      time.Now(),
+		startupTimeout: 30 * time.Second,
+	}
+	return c, mockWmeta
+}
 
 func TestGetURL(t *testing.T) {
 	cases := []struct {
@@ -38,4 +101,64 @@ func TestGetURL(t *testing.T) {
 			require.Equal(t, c.expected, url)
 		})
 	}
+}
+
+func TestCleanPidMap(t *testing.T) {
+	t.Run("removes dead pids from maps", func(t *testing.T) {
+		alivePids := make(pidSet)
+		alivePids.add(123)
+		alivePids.add(456)
+
+		retries := map[int32]uint{
+			123: 1,
+			456: 2,
+			789: 3, // dead pid
+		}
+
+		ignored := make(pidSet)
+		ignored.add(123)
+		ignored.add(999) // dead pid
+
+		cleanPidMap(alivePids, retries)
+		cleanPidMap(alivePids, ignored)
+
+		// Check that dead pids were removed
+		require.Equal(t, uint(1), retries[123])
+		require.Equal(t, uint(2), retries[456])
+		require.NotContains(t, retries, int32(789))
+
+		require.True(t, ignored.has(123))
+		require.False(t, ignored.has(999))
+	})
+}
+
+func TestGetPidsToRequest(t *testing.T) {
+	c, _ := newTestCollector(t)
+
+	// Create a set of alive PIDs
+	alivePids := make(pidSet)
+	alivePids.add(123)
+	alivePids.add(456)
+	alivePids.add(789)
+
+	// Add ignored  PID (simulating a PID that exceeded max retry attempts)
+	c.ignoredPids.add(456)
+
+	pids, pidsToService := c.getPidsToRequest(alivePids)
+
+	// Only non-ignored PIDs should be returned for querying
+	require.Len(t, pids, 2)
+	require.Contains(t, pids, int32(123))
+	require.Contains(t, pids, int32(789))
+	require.NotContains(t, pids, int32(456))
+
+	// The pidsToService map should have entries for all requested PIDs
+	// initially set to nil (will be populated later with service data)
+	require.Len(t, pidsToService, 2)
+	require.Contains(t, pidsToService, int32(123))
+	require.Contains(t, pidsToService, int32(789))
+
+	// Initially nil, will be filled by service discovery
+	require.Nil(t, pidsToService[123])
+	require.Nil(t, pidsToService[789])
 }

--- a/comp/core/workloadmeta/collectors/internal/service/service_test.go
+++ b/comp/core/workloadmeta/collectors/internal/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -23,34 +24,42 @@ import (
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
+	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/server/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-// fakeHTTPClient is a test HTTP client that can be configured to return specific responses
-type fakeHTTPClient struct {
-	response *http.Response
-	err      error
-}
+// startTestServer creates a system-probe test server that returns the specified response or error
+func startTestServer(t *testing.T, response *model.ServicesResponse, shouldError bool) (string, *httptest.Server) {
+	t.Helper()
 
-func (c *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	if c.err != nil {
-		return nil, c.err
-	}
-	return c.response, nil
-}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/discovery/services" {
+			if shouldError {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte("Internal Server Error"))
+				return
+			}
 
-// createMockServicesResponse creates a mock HTTP response for the services endpoint
-func createMockServicesResponse(services []model.Service) *http.Response {
-	response := model.ServicesResponse{
-		Services: services,
-	}
-	_, _ = json.Marshal(response)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       httptest.NewRecorder().Result().Body,
-		Header:     make(http.Header),
-	}
+			responseBytes, _ := json.Marshal(response)
+			w.Write(responseBytes)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	socketPath := testutil.SystemProbeSocketPath(t, "service-collector")
+	server, err := testutil.NewSystemProbeTestServer(handler, socketPath)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return socketPath, server
 }
 
 // newTestCollector creates a collector for testing with mock dependencies
@@ -132,33 +141,284 @@ func TestCleanPidMap(t *testing.T) {
 	})
 }
 
-func TestGetPidsToRequest(t *testing.T) {
+const (
+	// Test PIDs with descriptive names
+	pidNewService     = 123
+	pidFreshService   = 456
+	pidStaleService   = 789
+	pidDeadService    = 999
+	pidIgnoredService = 555
+
+	// Base timestamp for consistent testing - January 1, 2024, 12:00:00 UTC
+	baseTimestamp = 1704110400
+)
+
+var (
+	// Reference time for testing
+	baseTime = time.Unix(baseTimestamp, 0)
+	// 15 minute heartbeat threshold
+	heartbeatThreshold = 15 * time.Minute
+)
+
+// Service creation helpers for testing
+func createWorkloadmetaService(pid int32, name string, heartbeatOffset time.Duration) *workloadmeta.Service {
+	return &workloadmeta.Service{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindService,
+			ID:   strconv.Itoa(int(pid)),
+		},
+		Name:                     name,
+		GeneratedName:            name + "-generated",
+		GeneratedNameSource:      "cmdline",
+		AdditionalGeneratedNames: []string{name + "-alt1", name + "-alt2"},
+		DDService:                "dd-" + name,
+		DDServiceInjected:        true,
+		Ports:                    []uint16{8080, 9090},
+		APMInstrumentation:       "automatic",
+		Language:                 "go",
+		Type:                     "web_service",
+		CommandLine:              []string{"/usr/bin/" + name, "--port=8080"},
+		StartTimeMilli:           uint64(baseTime.Add(-1 * time.Hour).UnixMilli()),
+		LastHeartbeat:            baseTime.Add(heartbeatOffset).Unix(),
+	}
+}
+
+func createModelService(pid int32, name string) model.Service {
+	return model.Service{
+		PID:                      int(pid),
+		GeneratedName:            name + "-model",
+		GeneratedNameSource:      "process",
+		AdditionalGeneratedNames: []string{name + "-model-alt"},
+		TracerMetadata: []tracermetadata.TracerMetadata{
+			{
+				TracerLanguage: "python",
+				TracerVersion:  "1.0.0",
+				ServiceName:    name + "-service",
+			},
+		},
+		DDService:          "dd-model-" + name,
+		DDServiceInjected:  false,
+		Ports:              []uint16{3000, 4000},
+		APMInstrumentation: "manual",
+		Language:           "python",
+		Type:               "database",
+		CommandLine:        []string{"/opt/" + name, "--config=/etc/config"},
+		StartTimeMilli:     uint64(baseTime.Add(-30 * time.Minute).UnixMilli()),
+		LastHeartbeat:      baseTime.Unix(),
+	}
+}
+
+// Test verification helper functions
+func verifyStoredServices(t *testing.T, mockWmeta workloadmetamock.Mock, expectedPids []int32) {
+	allServices := mockWmeta.ListServices()
+	storedPids := make([]int32, len(allServices))
+	for i, service := range allServices {
+		pid, _ := strconv.Atoi(service.GetID().ID)
+		storedPids[i] = int32(pid)
+	}
+	require.ElementsMatch(t, expectedPids, storedPids, "unexpected services in store")
+}
+
+func verifyRemovedServices(t *testing.T, mockWmeta workloadmetamock.Mock, removedPids []int32) {
+	for _, removedPid := range removedPids {
+		service, err := mockWmeta.GetService(strconv.Itoa(int(removedPid)))
+		require.Nil(t, service, "service PID %d should have been removed", removedPid)
+		require.Error(t, err, "should get error when fetching removed service")
+	}
+}
+
+func verifyServiceFields(t *testing.T, mockWmeta workloadmetamock.Mock, expectedServices map[int32]model.Service) {
+	for pid, expectedModel := range expectedServices {
+		service, err := mockWmeta.GetService(strconv.Itoa(int(pid)))
+		require.NoError(t, err, "should be able to fetch service PID %d", pid)
+		require.NotNil(t, service, "service PID %d should exist", pid)
+
+		// Verify all core fields are correctly mapped from model.Service to workloadmeta.Service
+		require.Equal(t, expectedModel.GeneratedName, service.GeneratedName, "GeneratedName mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.GeneratedNameSource, service.GeneratedNameSource, "GeneratedNameSource mismatch for PID %d", pid)
+		require.ElementsMatch(t, expectedModel.AdditionalGeneratedNames, service.AdditionalGeneratedNames, "AdditionalGeneratedNames mismatch for PID %d", pid)
+		require.ElementsMatch(t, expectedModel.TracerMetadata, service.TracerMetadata, "TracerMetadata mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.DDService, service.DDService, "DDService mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.DDServiceInjected, service.DDServiceInjected, "DDServiceInjected mismatch for PID %d", pid)
+		require.ElementsMatch(t, expectedModel.Ports, service.Ports, "Ports mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.APMInstrumentation, service.APMInstrumentation, "APMInstrumentation mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.Language, service.Language, "Language mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.Type, service.Type, "Type mismatch for PID %d", pid)
+		require.ElementsMatch(t, expectedModel.CommandLine, service.CommandLine, "CommandLine mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.StartTimeMilli, service.StartTimeMilli, "StartTimeMilli mismatch for PID %d", pid)
+		require.Equal(t, expectedModel.LastHeartbeat, service.LastHeartbeat, "LastHeartbeat mismatch for PID %d", pid)
+	}
+}
+
+func TestGetPidsToRequest_Basic(t *testing.T) {
 	c, _ := newTestCollector(t)
 
 	// Create a set of alive PIDs
 	alivePids := make(pidSet)
-	alivePids.add(123)
-	alivePids.add(456)
-	alivePids.add(789)
+	alivePids.add(pidNewService)
+	alivePids.add(pidFreshService)
+	alivePids.add(pidStaleService)
 
-	// Add ignored  PID (simulating a PID that exceeded max retry attempts)
-	c.ignoredPids.add(456)
+	// Add ignored PID (simulating a PID that exceeded max retry attempts)
+	c.ignoredPids.add(pidFreshService)
 
 	pids, pidsToService := c.getPidsToRequest(alivePids)
 
 	// Only non-ignored PIDs should be returned for querying
 	require.Len(t, pids, 2)
-	require.Contains(t, pids, int32(123))
-	require.Contains(t, pids, int32(789))
-	require.NotContains(t, pids, int32(456))
+	require.Contains(t, pids, int32(pidNewService))
+	require.Contains(t, pids, int32(pidStaleService))
+	require.NotContains(t, pids, int32(pidFreshService))
 
 	// The pidsToService map should have entries for all requested PIDs
 	// initially set to nil (will be populated later with service data)
 	require.Len(t, pidsToService, 2)
-	require.Contains(t, pidsToService, int32(123))
-	require.Contains(t, pidsToService, int32(789))
+	require.Contains(t, pidsToService, int32(pidNewService))
+	require.Contains(t, pidsToService, int32(pidStaleService))
 
 	// Initially nil, will be filled by service discovery
-	require.Nil(t, pidsToService[123])
-	require.Nil(t, pidsToService[789])
+	require.Nil(t, pidsToService[pidNewService])
+	require.Nil(t, pidsToService[pidStaleService])
+}
+
+func TestServiceStoreLifetime(t *testing.T) {
+	tests := []struct {
+		name                string
+		existingServices    []*workloadmeta.Service
+		alivePids           []int32
+		ignoredPids         []int32
+		httpResponse        *model.ServicesResponse
+		httpError           error
+		expectedRequests    []int32
+		expectStored        []int32
+		expectRemoved       []int32
+		expectFieldsUpdated map[int32]model.Service
+	}{
+		{
+			name:             "new service discovered and stored",
+			existingServices: []*workloadmeta.Service{},
+			alivePids:        []int32{pidNewService},
+			httpResponse: &model.ServicesResponse{
+				Services: []model.Service{createModelService(pidNewService, "new-service")},
+			},
+			expectedRequests:    []int32{pidNewService},
+			expectStored:        []int32{pidNewService},
+			expectRemoved:       []int32{},
+			expectFieldsUpdated: map[int32]model.Service{pidNewService: createModelService(pidNewService, "new-service")},
+		},
+		{
+			name: "fresh service skipped, stale service updated",
+			existingServices: []*workloadmeta.Service{
+				createWorkloadmetaService(pidFreshService, "fresh", -5*time.Minute),  // fresh
+				createWorkloadmetaService(pidStaleService, "stale", -20*time.Minute), // stale
+			},
+			alivePids: []int32{pidFreshService, pidStaleService},
+			httpResponse: &model.ServicesResponse{
+				Services: []model.Service{createModelService(pidStaleService, "updated-stale")},
+			},
+			expectedRequests:    []int32{pidStaleService}, // only stale service
+			expectStored:        []int32{pidFreshService, pidStaleService},
+			expectRemoved:       []int32{},
+			expectFieldsUpdated: map[int32]model.Service{pidStaleService: createModelService(pidStaleService, "updated-stale")},
+		},
+		{
+			name: "dead service removed from store",
+			existingServices: []*workloadmeta.Service{
+				createWorkloadmetaService(pidFreshService, "live", -5*time.Minute),
+				createWorkloadmetaService(pidDeadService, "dead", -5*time.Minute),
+			},
+			alivePids:           []int32{pidFreshService}, // pidDeadService is dead
+			httpResponse:        &model.ServicesResponse{Services: []model.Service{}},
+			expectedRequests:    []int32{}, // pidFreshService is fresh, no requests needed
+			expectStored:        []int32{pidFreshService},
+			expectRemoved:       []int32{pidDeadService},
+			expectFieldsUpdated: map[int32]model.Service{},
+		},
+		{
+			name:        "ignored pids are skipped",
+			alivePids:   []int32{pidNewService, pidIgnoredService},
+			ignoredPids: []int32{pidIgnoredService},
+			httpResponse: &model.ServicesResponse{
+				Services: []model.Service{createModelService(pidNewService, "service-new")},
+			},
+			expectedRequests:    []int32{pidNewService}, // pidIgnoredService ignored
+			expectStored:        []int32{pidNewService},
+			expectRemoved:       []int32{},
+			expectFieldsUpdated: map[int32]model.Service{pidNewService: createModelService(pidNewService, "service-new")},
+		},
+		{
+			name: "comprehensive scenario - new, fresh, stale, dead services",
+			existingServices: []*workloadmeta.Service{
+				createWorkloadmetaService(pidFreshService, "fresh", -5*time.Minute),  // fresh - skip
+				createWorkloadmetaService(pidStaleService, "stale", -20*time.Minute), // stale - update
+				createWorkloadmetaService(pidDeadService, "dead", -10*time.Minute),   // dead - remove
+			},
+			alivePids: []int32{pidNewService, pidFreshService, pidStaleService}, // pidDeadService is dead
+			httpResponse: &model.ServicesResponse{
+				Services: []model.Service{
+					createModelService(pidNewService, "new-service"),
+					createModelService(pidStaleService, "updated-stale"),
+				},
+			},
+			expectedRequests: []int32{pidNewService, pidStaleService}, // new + stale
+			expectStored:     []int32{pidNewService, pidFreshService, pidStaleService},
+			expectRemoved:    []int32{pidDeadService},
+			expectFieldsUpdated: map[int32]model.Service{
+				pidNewService:   createModelService(pidNewService, "new-service"),
+				pidStaleService: createModelService(pidStaleService, "updated-stale"),
+			},
+		},
+		{
+			name:                "http error handled gracefully",
+			existingServices:    []*workloadmeta.Service{},
+			alivePids:           []int32{pidNewService},
+			httpError:           http.ErrNotSupported,
+			expectedRequests:    []int32{pidNewService},
+			expectStored:        []int32{}, // no services stored due to error
+			expectRemoved:       []int32{},
+			expectFieldsUpdated: map[int32]model.Service{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, mockWmeta := newTestCollector(t)
+
+			// Set up ignored PIDs
+			for _, pid := range tc.ignoredPids {
+				c.ignoredPids.add(pid)
+			}
+
+			// Pre-populate store with existing services
+			for _, service := range tc.existingServices {
+				mockWmeta.Set(service)
+			}
+
+			// Mock alive PIDs
+			alivePids := make(pidSet)
+			for _, pid := range tc.alivePids {
+				alivePids.add(pid)
+			}
+
+			// Create system-probe test server
+			socketPath, _ := startTestServer(t, tc.httpResponse, tc.httpError != nil)
+
+			// Override the collector's HTTP client to use the test socket
+			c.sysProbeClient = sysprobeclient.Get(socketPath)
+
+			// Capture which PIDs are requested (before running full update)
+			requestedPids, _ := c.getPidsToRequest(alivePids)
+
+			// Verify expected requests
+			require.ElementsMatch(t, tc.expectedRequests, requestedPids, "unexpected PIDs requested")
+
+			// Run the full update cycle
+			c.updateServices()
+
+			// Verify final state using helper functions
+			verifyStoredServices(t, mockWmeta, tc.expectStored)
+			verifyRemovedServices(t, mockWmeta, tc.expectRemoved)
+			verifyServiceFields(t, mockWmeta, tc.expectFieldsUpdated)
+		})
+	}
 }

--- a/comp/core/workloadmeta/collectors/internal/service/service_test.go
+++ b/comp/core/workloadmeta/collectors/internal/service/service_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		pids     []int32
+		expected string
+	}{
+		{
+			name:     "endpoint without pids",
+			endpoint: "services",
+			pids:     []int32{},
+			expected: "http://sysprobe/discovery/services",
+		},
+		{
+			name:     "endpoint with pids",
+			endpoint: "language",
+			pids:     []int32{1, 2, 3},
+			expected: "http://sysprobe/discovery/language?pids=1%2C2%2C3",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			url := getDiscoveryURL(c.endpoint, c.pids)
+			require.Equal(t, c.expected, url)
+		})
+	}
+}

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -104,6 +104,14 @@ type Component interface {
 	// to all entities with kind KindGPU.
 	ListGPUs() []*GPU
 
+	// GetService returns metadata about a service. It fetches the entity
+	// with kind KindService and the given ID.
+	GetService(id string) (*Service, error)
+
+	// ListServices returns metadata about all known services, equivalent
+	// to all entities with kind KindService.
+	ListServices() []*Service
+
 	// ListProcessesWithFilter returns all the processes for which the passed
 	// filter evaluates to true.
 	ListProcessesWithFilter(filterFunc EntityFilterFunc[*Process]) []*Process

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -46,6 +46,7 @@ const (
 	KindECSTask                Kind = "ecs_task"
 	KindContainerImageMetadata Kind = "container_image_metadata"
 	KindProcess                Kind = "process"
+	KindService                Kind = "service"
 	KindGPU                    Kind = "gpu"
 )
 
@@ -1515,6 +1516,44 @@ type GPUComputeCapability struct {
 func (gcc GPUComputeCapability) String() string {
 	return fmt.Sprintf("%d.%d", gcc.Major, gcc.Minor)
 }
+
+// Service represents a Service process
+type Service struct {
+	EntityID // EntityID.ID is the PID
+}
+
+// GetID implements Entity#GetID.
+func (s Service) GetID() EntityID {
+	return s.EntityID
+}
+
+// Merge implements Entity#Merge.
+func (s *Service) Merge(e Entity) error {
+	ss, ok := e.(*Service)
+	if !ok {
+		return fmt.Errorf("cannot merge Service with different kind %T", e)
+	}
+
+	return merge(s, ss)
+}
+
+// DeepCopy implements Entity#DeepCopy.
+func (s Service) DeepCopy() Entity {
+	cp := deepcopy.Copy(s).(Service)
+	return &cp
+}
+
+// String implements Entity#String.
+func (s Service) String(verbose bool) string {
+	var sb strings.Builder
+
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, s.EntityID.String(verbose))
+
+	return sb.String()
+}
+
+var _ Entity = &Service{}
 
 // CollectorStatus is the status of collector which is used to determine if the collectors
 // are not started, starting, started (pulled once)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pkgcontainersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 )
@@ -1520,6 +1521,48 @@ func (gcc GPUComputeCapability) String() string {
 // Service represents a Service process
 type Service struct {
 	EntityID // EntityID.ID is the PID
+
+	// Name is the service name (can be set from DD_SERVICE, container tags, etc.)
+	Name string
+
+	// GeneratedName is the name generated from the process info
+	GeneratedName string
+
+	// GeneratedNameSource indicates the source of the generated name
+	GeneratedNameSource string
+
+	// AdditionalGeneratedNames contains other potential names for the service
+	AdditionalGeneratedNames []string
+
+	// TracerMetadata contains APM tracer metadata
+	TracerMetadata []tracermetadata.TracerMetadata
+
+	// DDService is the value from DD_SERVICE environment variable
+	DDService string
+
+	// DDServiceInjected indicates if DD_SERVICE was injected
+	DDServiceInjected bool
+
+	// Ports is the list of ports the service is listening on
+	Ports []uint16
+
+	// APMInstrumentation indicates the APM instrumentation status
+	APMInstrumentation string
+
+	// Language is the programming language of the service
+	Language string
+
+	// Type is the service type (e.g., "web_service")
+	Type string
+
+	// CommandLine contains the command line arguments
+	CommandLine []string
+
+	// StartTimeMilli is the service start time in milliseconds since epoch
+	StartTimeMilli uint64
+
+	// LastHeartbeat is the timestamp of the last heartbeat update (Unix seconds)
+	LastHeartbeat int64
 }
 
 // GetID implements Entity#GetID.

--- a/comp/core/workloadmeta/impl/dump.go
+++ b/comp/core/workloadmeta/impl/dump.go
@@ -37,6 +37,8 @@ func (w *workloadmeta) Dump(verbose bool) wmdef.WorkloadDumpResponse {
 			info = e.String(verbose)
 		case *wmdef.GPU:
 			info = e.String(verbose)
+		case *wmdef.Service:
+			info = e.String(verbose)
 		default:
 			return "", fmt.Errorf("unsupported type %T", e)
 		}

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -425,6 +425,28 @@ func (w *workloadmeta) ListGPUs() []*wmdef.GPU {
 	return gpuList
 }
 
+// GetService implements Store#GetService
+func (w *workloadmeta) GetService(id string) (*wmdef.Service, error) {
+	entity, err := w.getEntityByKind(wmdef.KindService, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return entity.(*wmdef.Service), nil
+}
+
+// ListServices implements Store#ListServices
+func (w *workloadmeta) ListServices() []*wmdef.Service {
+	entities := w.listEntitiesByKind(wmdef.KindService)
+
+	services := make([]*wmdef.Service, 0, len(entities))
+	for i := range entities {
+		services = append(services, entities[i].(*wmdef.Service))
+	}
+
+	return services
+}
+
 // Notify implements Store#Notify
 func (w *workloadmeta) Notify(events []wmdef.CollectorEvent) {
 	if len(events) > 0 {

--- a/pkg/collector/corechecks/servicediscovery/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 type linuxImpl struct {
-	getDiscoveryServices func(client *sysprobeclient.CheckClient) (*model.ServicesResponse, error)
+	getDiscoveryServices func(client *sysprobeclient.CheckClient) (*model.CheckResponse, error)
 	sysProbeClient       *sysprobeclient.CheckClient
 }
 
@@ -32,14 +32,14 @@ func newLinuxImpl() (osImpl, error) {
 	}, nil
 }
 
-func getDiscoveryServices(client *sysprobeclient.CheckClient) (*model.ServicesResponse, error) {
-	resp, err := sysprobeclient.GetCheck[model.ServicesResponse](client, sysconfig.DiscoveryModule)
+func getDiscoveryServices(client *sysprobeclient.CheckClient) (*model.CheckResponse, error) {
+	resp, err := sysprobeclient.GetCheck[model.CheckResponse](client, sysconfig.DiscoveryModule)
 	if err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
-func (li *linuxImpl) DiscoverServices() (*model.ServicesResponse, error) {
+func (li *linuxImpl) DiscoverServices() (*model.CheckResponse, error) {
 	return li.getDiscoveryServices(li.sysProbeClient)
 }

--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -162,7 +162,7 @@ func Test_linuxImpl(t *testing.T) {
 	t.Setenv("DD_DISCOVERY_ENABLED", "true")
 
 	type checkRun struct {
-		servicesResp *model.ServicesResponse
+		servicesResp *model.CheckResponse
 		time         time.Time
 	}
 
@@ -175,21 +175,21 @@ func Test_linuxImpl(t *testing.T) {
 			name: "basic",
 			checkRun: []*checkRun{
 				{
-					servicesResp: &model.ServicesResponse{StartedServices: []model.Service{
+					servicesResp: &model.CheckResponse{StartedServices: []model.Service{
 						portTCP5000,
 						portTCP8080,
 					}},
 					time: calcTime(0),
 				},
 				{
-					servicesResp: &model.ServicesResponse{HeartbeatServices: []model.Service{
+					servicesResp: &model.CheckResponse{HeartbeatServices: []model.Service{
 						portTCP5000,
 						portTCP8080UpdatedRSS,
 					}},
 					time: calcTime(20 * time.Minute),
 				},
 				{
-					servicesResp: &model.ServicesResponse{StoppedServices: []model.Service{
+					servicesResp: &model.CheckResponse{StoppedServices: []model.Service{
 						portTCP8080UpdatedRSS,
 					}},
 					time: calcTime(20 * time.Minute),
@@ -356,8 +356,8 @@ func Test_linuxImpl(t *testing.T) {
 		},
 	}
 
-	makeServiceResponseWithTime := func(responseTime time.Time, resp *model.ServicesResponse) *model.ServicesResponse {
-		respWithTime := &model.ServicesResponse{
+	makeServiceResponseWithTime := func(responseTime time.Time, resp *model.CheckResponse) *model.CheckResponse {
+		respWithTime := &model.CheckResponse{
 			StartedServices:   make([]model.Service, 0, len(resp.StartedServices)),
 			StoppedServices:   make([]model.Service, 0, len(resp.StoppedServices)),
 			HeartbeatServices: make([]model.Service, 0, len(resp.HeartbeatServices)),
@@ -407,7 +407,7 @@ func Test_linuxImpl(t *testing.T) {
 				mTimer.EXPECT().Now().Return(cr.time).AnyTimes()
 
 				// set mocks
-				check.os.(*linuxImpl).getDiscoveryServices = func(_ *sysprobeclient.CheckClient) (*model.ServicesResponse, error) {
+				check.os.(*linuxImpl).getDiscoveryServices = func(_ *sysprobeclient.CheckClient) (*model.CheckResponse, error) {
 					return makeServiceResponseWithTime(cr.time, cr.servicesResp), nil
 				}
 				check.sender.hostname = mHostname

--- a/pkg/collector/corechecks/servicediscovery/model/model.go
+++ b/pkg/collector/corechecks/servicediscovery/model/model.go
@@ -46,3 +46,7 @@ type CheckResponse struct {
 	HeartbeatServices    []Service `json:"heartbeat_services"`
 	RunningServicesCount int       `json:"running_services_count"`
 }
+
+type ServicesResponse struct {
+	Services []Service `json:"services"`
+}

--- a/pkg/collector/corechecks/servicediscovery/model/model.go
+++ b/pkg/collector/corechecks/servicediscovery/model/model.go
@@ -39,8 +39,8 @@ type Service struct {
 	TxBps                      float64                         `json:"tx_bps"`
 }
 
-// ServicesResponse is the response for the system-probe /discovery/check endpoint.
-type ServicesResponse struct {
+// CheckResponse is the response for the system-probe /discovery/check endpoint.
+type CheckResponse struct {
 	StartedServices      []Service `json:"started_services"`
 	StoppedServices      []Service `json:"stopped_services"`
 	HeartbeatServices    []Service `json:"heartbeat_services"`

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -54,7 +54,7 @@ func TestIgnoreComm(t *testing.T) {
 	seen := make(map[int]model.Service)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		resp := getServices(collect, discovery.url)
-		for _, s := range resp.StartedServices {
+		for _, s := range resp.Services {
 			seen[s.PID] = s
 		}
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -46,7 +46,11 @@ import (
 )
 
 const (
-	pathCheck = "/check"
+	pathCheck    = "/check"
+	pathLanguage = "/language"
+	pathIo       = "/io"
+	pathNetwork  = "/network"
+	pathServices = "/services"
 
 	// Use a low cache validity to ensure that we refresh information every time
 	// the check is run if needed. This is the same as cacheValidityNoRT in
@@ -252,6 +256,11 @@ func (s *discovery) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/state", s.handleStateEndpoint)
 	httpMux.HandleFunc("/debug", s.handleDebugEndpoint)
 	httpMux.HandleFunc(pathCheck, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleCheck))
+
+	httpMux.HandleFunc(pathServices, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleServices))
+	httpMux.HandleFunc(pathLanguage, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleLanguage))
+	httpMux.HandleFunc(pathNetwork, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleNetwork))
+
 	return nil
 }
 
@@ -381,6 +390,37 @@ func (s *discovery) handleCheck(w http.ResponseWriter, req *http.Request) {
 	}
 
 	utils.WriteAsJSON(w, services, utils.CompactOutput)
+}
+
+func (s *discovery) handleServices(w http.ResponseWriter, req *http.Request) {
+	params, err := parseParams(req.URL.Query())
+	if err != nil {
+		_ = log.Errorf("invalid params to /discovery%s: %v", pathCheck, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+}
+
+func (s *discovery) handleLanguage(w http.ResponseWriter, req *http.Request) {
+	params, err := parseParams(req.URL.Query())
+	if err != nil {
+		_ = log.Errorf("invalid params to /discovery%s: %v", pathCheck, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	log.Debugf("/discovery/language params: %+v", params)
+}
+
+func (s *discovery) handleNetwork(w http.ResponseWriter, req *http.Request) {
+	params, err := parseParams(req.URL.Query())
+	if err != nil {
+		_ = log.Errorf("invalid params to /discovery%s: %v", pathCheck, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	log.Debugf("/discovery/network params: %+v", params)
 }
 
 // socketInfo stores information related to each socket.

--- a/pkg/collector/corechecks/servicediscovery/module/network_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/network_test.go
@@ -170,8 +170,8 @@ func TestNetwork(t *testing.T) {
 	params.heartbeatTime = 0
 
 	// Get the service to be recognized as started
-	_ = getServicesWithParams(t, discovery.url, &params)
-	_ = getServicesWithParams(t, discovery.url, &params)
+	_ = getCheckWithParams(t, discovery.url, &params)
+	_ = getCheckWithParams(t, discovery.url, &params)
 
 	old := model.Service{}
 
@@ -180,7 +180,7 @@ func TestNetwork(t *testing.T) {
 	// test does some basic assertions just to ensure that everything is
 	// hooked up together.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServicesWithParams(collect, discovery.url, &params)
+		resp := getCheckWithParams(collect, discovery.url, &params)
 		service := findService(pid, resp.HeartbeatServices)
 		require.NotNil(collect, service)
 		assert.NotZero(collect, service.RxBytes)
@@ -191,7 +191,7 @@ func TestNetwork(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServicesWithParams(collect, discovery.url, &params)
+		resp := getCheckWithParams(collect, discovery.url, &params)
 		service := findService(pid, resp.HeartbeatServices)
 		require.NotNil(collect, service)
 		assert.Greater(collect, service.RxBytes, old.RxBytes)
@@ -267,7 +267,7 @@ func TestNetworkStats(t *testing.T) {
 		now := mockedTime
 		discovery.mockTimeProvider.EXPECT().Now().Return(now).Times(nowCalls)
 
-		resp := getServices(collect, discovery.url)
+		resp := getCheckServices(collect, discovery.url)
 		startEvent := findService(pid, resp.StartedServices)
 		require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 	}, 30*time.Second, 100*time.Millisecond)
@@ -278,7 +278,7 @@ func TestNetworkStats(t *testing.T) {
 	now := mockedTime
 	discovery.mockTimeProvider.EXPECT().Now().Return(now).Times(nowCalls)
 
-	_ = getServicesWithParams(t, discovery.url, &params)
+	_ = getCheckWithParams(t, discovery.url, &params)
 
 	mock.EXPECT().getStats(gomock.Not(uint32(pid))).AnyTimes().Return(NetworkStats{
 		Rx: 0,
@@ -292,7 +292,7 @@ func TestNetworkStats(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	discovery.mockTimeProvider.EXPECT().Now().Return(now).Times(nowCalls)
 
-	_ = getServicesWithParams(t, discovery.url, &params)
+	_ = getCheckWithParams(t, discovery.url, &params)
 
 	now = now.Add(10 * time.Second)
 	discovery.mockTimeProvider.EXPECT().Now().Return(now).Times(nowCalls)
@@ -301,7 +301,7 @@ func TestNetworkStats(t *testing.T) {
 		Rx: 3000,
 		Tx: 8000,
 	}, nil)
-	response := getServicesWithParams(t, discovery.url, &params)
+	response := getCheckWithParams(t, discovery.url, &params)
 	service := findService(pid, response.HeartbeatServices)
 	require.NotNil(t, service)
 	require.Equal(t, 3000, int(service.RxBytes))
@@ -314,7 +314,7 @@ func TestNetworkStats(t *testing.T) {
 	discovery.mockTimeProvider.EXPECT().Now().Return(now).AnyTimes()
 	mock.EXPECT().removePid(uint32(pid)).Return(nil).Times(1)
 	mock.EXPECT().removePid(gomock.Not(uint32(pid))).AnyTimes()
-	r := getServicesWithParams(t, discovery.url, &params)
+	r := getCheckWithParams(t, discovery.url, &params)
 	t.Log(r.StoppedServices)
 
 	mock.EXPECT().close().Times(1)

--- a/pkg/collector/corechecks/servicediscovery/module/params.go
+++ b/pkg/collector/corechecks/servicediscovery/module/params.go
@@ -6,18 +6,23 @@
 package module
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
 const (
 	heartbeatParam = "heartbeat"
 	heartbeatTime  = 15 * time.Minute
+
+	pidsParam = "pids"
 )
 
 type params struct {
 	heartbeatTime time.Duration
+	pids          []int
 }
 
 func defaultParams() params {
@@ -28,6 +33,14 @@ func defaultParams() params {
 
 func (params params) updateQuery(query url.Values) {
 	query.Set(heartbeatParam, strconv.Itoa(int(params.heartbeatTime.Seconds())))
+
+	if len(params.pids) > 0 {
+		pidsStr := make([]string, len(params.pids))
+		for i, pid := range params.pids {
+			pidsStr[i] = strconv.Itoa(pid)
+		}
+		query.Set(pidsParam, strings.Join(pidsStr, ","))
+	}
 }
 
 func parseDuration(raw string) (time.Duration, error) {
@@ -39,17 +52,55 @@ func parseDuration(raw string) (time.Duration, error) {
 	return time.Duration(val) * time.Second, err
 }
 
+func parseHeartbeat(query url.Values) (time.Duration, error) {
+	raw := query.Get(heartbeatParam)
+	if raw == "" {
+		return heartbeatTime, nil
+	}
+
+	heartbeat, err := parseDuration(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return heartbeat, nil
+}
+
+func parsePids(query url.Values) ([]int, error) {
+	if !query.Has(pidsParam) {
+		return nil, nil
+	}
+
+	pidsRaw := query.Get(pidsParam)
+
+	pidsStr := strings.Split(pidsRaw, ",")
+	pids := make([]int, 0, len(pidsStr))
+	for _, raw := range pidsStr {
+		pid, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pid %q: %w", raw, err)
+		}
+
+		pids = append(pids, pid)
+	}
+
+	return pids, nil
+}
+
 func parseParams(query url.Values) (params, error) {
 	params := defaultParams()
 
-	raw := query.Get(heartbeatParam)
-	if raw != "" {
-		heartbeat, err := parseDuration(raw)
-		if err != nil {
-			return params, err
-		}
-		params.heartbeatTime = heartbeat
+	heartbeat, err := parseHeartbeat(query)
+	if err != nil {
+		return params, err
 	}
+	params.heartbeatTime = heartbeat
+
+	pids, err := parsePids(query)
+	if err != nil {
+		return params, err
+	}
+	params.pids = pids
 
 	return params, nil
 }

--- a/pkg/collector/corechecks/servicediscovery/module/params_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/params_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParams(t *testing.T) {
+func TestHeartbeatParams(t *testing.T) {
 	def := defaultParams()
 
 	values := url.Values{}
@@ -41,4 +41,18 @@ func TestParams(t *testing.T) {
 	params, err = parseParams(values)
 	require.NoError(t, err)
 	require.Equal(t, 2*time.Second, params.heartbeatTime)
+}
+
+func TestPidsParams(t *testing.T) {
+	def := defaultParams()
+
+	values := url.Values{}
+	params, err := parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, def, params)
+
+	values.Set(pidsParam, "1,2,3")
+	params, err = parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, params.pids)
 }

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -44,10 +45,11 @@ type Check struct {
 	os                       osImpl
 	sender                   *telemetrySender
 	metricDiscoveredServices telemetry.Gauge
+	wmeta                    workloadmeta.Component
 }
 
 // Factory creates a new check factory
-func Factory() option.Option[func() check.Check] {
+func Factory(wmeta workloadmeta.Component) option.Option[func() check.Check] {
 	// Since service_discovery is enabled by default, we want to prevent returning an error in Configure() for platforms
 	// where the check is not implemented. Instead of that, we return an empty check.
 	if newOSImpl == nil {
@@ -55,14 +57,15 @@ func Factory() option.Option[func() check.Check] {
 	}
 
 	return option.New(func() check.Check {
-		return newCheck()
+		return newCheck(wmeta)
 	})
 }
 
 // TODO: add metastore param
-func newCheck() *Check {
+func newCheck(wmeta workloadmeta.Component) *Check {
 	return &Check{
 		CheckBase: corechecks.NewCheckBase(CheckName),
+		wmeta:     wmeta,
 	}
 }
 

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -34,7 +34,7 @@ const (
 )
 
 type osImpl interface {
-	DiscoverServices() (*model.ServicesResponse, error)
+	DiscoverServices() (*model.CheckResponse, error)
 }
 
 var newOSImpl func() (osImpl, error)

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery_mock.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery_mock.go
@@ -42,10 +42,10 @@ func (m *MockosImpl) EXPECT() *MockosImplMockRecorder {
 }
 
 // DiscoverServices mocks base method.
-func (m *MockosImpl) DiscoverServices() (*model.ServicesResponse, error) {
+func (m *MockosImpl) DiscoverServices() (*model.CheckResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverServices")
-	ret0, _ := ret[0].(*model.ServicesResponse)
+	ret0, _ := ret[0].(*model.CheckResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -119,6 +119,6 @@ func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg c
 	corecheckLoader.RegisterCheck(containerd.CheckName, containerd.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(cri.CheckName, cri.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(ciscosdwan.CheckName, ciscosdwan.Factory())
-	corecheckLoader.RegisterCheck(servicediscovery.CheckName, servicediscovery.Factory())
+	corecheckLoader.RegisterCheck(servicediscovery.CheckName, servicediscovery.Factory(store))
 	corecheckLoader.RegisterCheck(versa.CheckName, versa.Factory())
 }


### PR DESCRIPTION
### What does this PR do?

- Adds remote collector support to service discovery functionality
- Ports module retry mechanism from existing implementation  
- Implements services endpoint for discovery module
- Adds comprehensive test coverage for the new functionality

### Motivation

### Describe how you validated your changes

Changes are covered by unit tests.

### Possible Drawbacks / Trade-offs