### PR TITLE
Fix recent static quality gate windows flake due to artifact leak

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -299,7 +299,7 @@ def exception_threshold_bump(ctx):
     :param ctx:
     :return:
     """
-    current_branch_name = get_current_branch()
+    current_branch_name = get_current_branch(ctx)
     ancestor_commit = get_common_ancestor(ctx, "HEAD")
     repo = get_gitlab_repo()
     with tempfile.TemporaryDirectory() as extract_dir, ctx.cd(extract_dir):

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -81,13 +81,11 @@ def read_byte_input(byte_input):
 
 def find_package_path(flavor, package_os, arch, extension=None):
     package_dir = os.environ['OMNIBUS_PACKAGE_DIR']
+    pipeline_id = os.environ['CI_PIPELINE_ID']
     separator = '_' if package_os == 'debian' else '-'
     if not extension:
         extension = "deb" if package_os == 'debian' else "rpm"
-    pipeline_match = ""
-    if package_os == "windows":  # Windows builds are subject to artifacts leak and need their pipeline to match the msi
-        pipeline_match = f"{os.environ['CI_PIPELINE_ID']}-1-"
-    glob_pattern = f'{package_dir}/{flavor}{separator}7*{pipeline_match}{arch}.{extension}'
+    glob_pattern = f'{package_dir}/{flavor}{separator}7*{pipeline_id}-1-{arch}.{extension}'
     package_paths = glob.glob(glob_pattern)
     if len(package_paths) > 1:
         raise Exit(code=1, message=color_message(f"Too many files matching {glob_pattern}: {package_paths}", "red"))

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -84,9 +84,12 @@ def find_package_path(flavor, package_os, arch, extension=None):
     separator = '_' if package_os == 'debian' else '-'
     if not extension:
         extension = "deb" if package_os == 'debian' else "rpm"
-    glob_pattern = f'{package_dir}/{flavor}{separator}7*{arch}.{extension}'
+    pipeline_match = ""
+    if package_os == "windows":  # Windows builds are subject to artifacts leak and need their pipeline to match the msi
+        pipeline_match = f"{os.environ['CI_PIPELINE_ID']}-1-"
+    glob_pattern = f'{package_dir}/{flavor}{separator}7*{pipeline_match}{arch}.{extension}'
     package_paths = glob.glob(glob_pattern)
-    if len(package_paths) > 1 and package_os != "windows": # Temporarily allow windows to have multiple match
+    if len(package_paths) > 1:
         raise Exit(code=1, message=color_message(f"Too many files matching {glob_pattern}: {package_paths}", "red"))
     elif len(package_paths) == 0:
         raise Exit(code=1, message=color_message(f"Couldn't find any file matching {glob_pattern}", "red"))

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -86,7 +86,7 @@ def find_package_path(flavor, package_os, arch, extension=None):
         extension = "deb" if package_os == 'debian' else "rpm"
     glob_pattern = f'{package_dir}/{flavor}{separator}7*{arch}.{extension}'
     package_paths = glob.glob(glob_pattern)
-    if len(package_paths) > 1:
+    if len(package_paths) > 1 and package_os != "windows": # Temporarily allow windows to have multiple match
         raise Exit(code=1, message=color_message(f"Too many files matching {glob_pattern}: {package_paths}", "red"))
     elif len(package_paths) == 0:
         raise Exit(code=1, message=color_message(f"Couldn't find any file matching {glob_pattern}", "red"))

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -81,11 +81,13 @@ def read_byte_input(byte_input):
 
 def find_package_path(flavor, package_os, arch, extension=None):
     package_dir = os.environ['OMNIBUS_PACKAGE_DIR']
-    pipeline_id = os.environ['CI_PIPELINE_ID']
     separator = '_' if package_os == 'debian' else '-'
     if not extension:
         extension = "deb" if package_os == 'debian' else "rpm"
-    glob_pattern = f'{package_dir}/{flavor}{separator}7*{pipeline_id}-1-{arch}.{extension}'
+    pipeline_match = ""
+    if package_os == "windows":  # Windows builds are subject to artifacts leak and need their pipeline to match the msi
+        pipeline_match = f"{os.environ['CI_PIPELINE_ID']}-1-"
+    glob_pattern = f'{package_dir}/{flavor}{separator}7*{pipeline_match}{arch}.{extension}'
     package_paths = glob.glob(glob_pattern)
     if len(package_paths) > 1:
         raise Exit(code=1, message=color_message(f"Too many files matching {glob_pattern}: {package_paths}", "red"))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Match windows msi based on their pipeline ID

### Motivation

We can have multiple msi inside of the artifacts received by static quality gates due to artifacts leak issues. Which can make the gates fails without proper matching.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

WIll force-merge once approved to prevent dev branch failures asap
