### PR TITLE
[collector] Fix panic in StopCheck()

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -234,17 +234,31 @@ func (c *collectorImpl) RunCheck(inner check.Check) (checkid.ID, error) {
 
 // StopCheck halts a check and remove the instance
 func (c *collectorImpl) StopCheck(id checkid.ID) error {
+	var ch check.Check
+	var collectorScheduler *scheduler.Scheduler
+	var collectorRunner *runner.Runner
+
+	// This lock is needed because stop() can be called concurrently and sets
+	// c.runner and c.scheduler to nil
+	c.m.RLock()
 	if !c.started() {
+		c.m.RUnlock()
 		return fmt.Errorf("the collector is not running")
 	}
 
-	ch, found := c.get(id)
+	ch, found := c.checks[id]
 	if !found {
+		c.m.RUnlock()
 		return fmt.Errorf("cannot find a check with ID %s", id)
 	}
 
+	// These two are not nil because we checked that the collector is started
+	collectorScheduler = c.scheduler
+	collectorRunner = c.runner
+	c.m.RUnlock()
+
 	// unschedule the instance
-	if err := c.scheduler.Cancel(id); err != nil {
+	if err := collectorScheduler.Cancel(id); err != nil {
 		return fmt.Errorf("an error occurred while canceling the check schedule: %s", err)
 	}
 
@@ -259,7 +273,7 @@ func (c *collectorImpl) StopCheck(id checkid.ID) error {
 		stats.SetStateCancelling()
 	}
 
-	if err := c.runner.StopCheck(id); err != nil {
+	if err := collectorRunner.StopCheck(id); err != nil {
 		// still attempt to cancel the check before returning the error
 		_ = c.cancelCheck(ch, c.cancelCheckTimeout)
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)

--- a/releasenotes/notes/fix-panic-in-checks-collector-3b8f0350e2cb855c.yaml
+++ b/releasenotes/notes/fix-panic-in-checks-collector-3b8f0350e2cb855c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a panic in the checks collector that occasionally occurs when the
+    Agent is shutting down.


### PR DESCRIPTION
### What does this PR do?

Fixes a panic in the check collector. The panic only happens on shutdown.

The issue is that the `stop` function called in the fx lifecycle hooks sets `c.scheduler` and `c.runner` to nil, and that function can be called concurrently with `StopCheck` that calls functions on `c.scheduler` and `c.runner`.

### Describe how you validated your changes

CI