### PR TITLE
Fix image deployment matrix jobs

### DIFF
--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -22,28 +22,28 @@ deploy_mutable_image_tags-a7:
     !reference [.on_final]
   parallel:
     matrix:
-      - IMG_NEW_TAGS: 7,latest
-        IMG_TAG_REFERENCE_SUFFIX: ""
-      - IMG_NEW_TAGS: 7-jmx,latest-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-jmx"
-      - IMG_NEW_TAGS: 7-servercore,latest-servercore
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore"
-      - IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
-      - IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
-        IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
-      - IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
-        IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
-      - IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
-      - IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
-      - IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
-      - IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
-      - IMG_NEW_TAGS: 7-full,latest-full
-        IMG_TAG_REFERENCE_SUFFIX: "-full"
+      - IMG_TAG_REFERENCE_SUFFIX: ""
+        IMG_NEW_TAGS: 7,latest
+      - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
+        IMG_NEW_TAGS: 7-jmx,latest-jmx
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
+        IMG_NEW_TAGS: 7-servercore,latest-servercore
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
+        IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
+      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
+        IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
+      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
+        IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
+        IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
+        IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
+        IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
+        IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
+      - IMG_TAG_REFERENCE_SUFFIX: "-full"
+        IMG_NEW_TAGS: 7-full,latest-full
 
 deploy_mutable_image_tags-a7_internal:
   extends: .deploy_mutable_image_tags_base
@@ -52,12 +52,12 @@ deploy_mutable_image_tags-a7_internal:
     !reference [.on_internal_final]
   parallel:
     matrix:
-      - IMG_NEW_TAGS: 7-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-jmx"
-      - IMG_NEW_TAGS: 7-full
-        IMG_TAG_REFERENCE_SUFFIX: "-full"
-      - IMG_NEW_TAGS: 7-fips-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"
+      - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
+        IMG_NEW_TAGS: 7-jmx
+      - IMG_TAG_REFERENCE_SUFFIX: "-full"
+        IMG_NEW_TAGS: 7-full
+      - IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"
+        IMG_NEW_TAGS: 7-fips-jmx
 
 deploy_mutable_image_tags-dogstatsd:
   extends: .docker_publish_job_definition
@@ -76,7 +76,8 @@ deploy_mutable_image_tags-a7-fips:
     !reference [.on_final]
   parallel:
     matrix:
-      - IMG_NEW_TAGS: 7-fips
-        IMG_TAG_REFERENCE_SUFFIX: "-fips"
-      - IMG_NEW_TAGS: 7-fips-jmx
-        IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"
+      - IMG_TAG_REFERENCE_SUFFIX: "-fips"
+        IMG_NEW_TAGS: 7-fips
+      - IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"
+        IMG_NEW_TAGS: 7-fips-jmx
+

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -15,35 +15,35 @@ include:
 
 # Stable tags
 
-# deploy_mutable_image_tags-a7:
-#   extends: .deploy_mutable_image_tags_base
-#   stage: deploy_mutable_image_tags
-#   rules:
-#     !reference [.on_final]
-#   parallel:
-#     matrix:
-#       - IMG_TAG_REFERENCE_SUFFIX: ""
-#         IMG_NEW_TAGS: 7,latest
-#       - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
-#         IMG_NEW_TAGS: 7-jmx,latest-jmx
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
-#         IMG_NEW_TAGS: 7-servercore,latest-servercore
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
-#         IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
-#       - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
-#         IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
-#       - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
-#         IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
-#         IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
-#         IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
-#         IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
-#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
-#         IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
-#       - IMG_TAG_REFERENCE_SUFFIX: "-full"
-#         IMG_NEW_TAGS: 7-full,latest-full
+deploy_mutable_image_tags-a7:
+  extends: .deploy_mutable_image_tags_base
+  stage: deploy_mutable_image_tags
+  rules:
+    !reference [.on_final]
+  parallel:
+    matrix:
+      - IMG_TAG_REFERENCE_SUFFIX: ""
+        IMG_NEW_TAGS: ["7, latest"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
+        IMG_NEW_TAGS: ["7-jmx, latest-jmx"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
+        IMG_NEW_TAGS: ["7-servercore, latest-servercore"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
+        IMG_NEW_TAGS: ["7-servercore-jmx, latest-servercore-jmx"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
+        IMG_NEW_TAGS: ["7-ltsc2019, latest-ltsc2019"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
+        IMG_NEW_TAGS: ["7-ltsc2022, latest-ltsc2022"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
+        IMG_NEW_TAGS: ["7-servercore-ltsc2019, latest-servercore-ltsc2019"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
+        IMG_NEW_TAGS: ["7-servercore-ltsc2022, latest-servercore-ltsc2022"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
+        IMG_NEW_TAGS: ["7-servercore-ltsc2019-jmx, latest-servercore-ltsc2019-jmx"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
+        IMG_NEW_TAGS: ["7-servercore-ltsc2022-jmx, latest-servercore-ltsc2022-jmx"]
+      - IMG_TAG_REFERENCE_SUFFIX: "-full"
+        IMG_NEW_TAGS: ["7-full, latest-full"]
 
 deploy_mutable_image_tags-a7_internal:
   extends: .deploy_mutable_image_tags_base

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -23,27 +23,27 @@ deploy_mutable_image_tags-a7:
   parallel:
     matrix:
       - IMG_TAG_REFERENCE_SUFFIX: [""]
-        IMG_NEW_TAGS: ["7, latest"]
+        IMG_NEW_TAGS: ["7,latest"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-jmx"]
-        IMG_NEW_TAGS: ["7-jmx, latest-jmx"]
+        IMG_NEW_TAGS: ["7-jmx,latest-jmx"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-servercore"]
-        IMG_NEW_TAGS: ["7-servercore, latest-servercore"]
+        IMG_NEW_TAGS: ["7-servercore,latest-servercore"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-jmx"]
-        IMG_NEW_TAGS: ["7-servercore-jmx, latest-servercore-jmx"]
+        IMG_NEW_TAGS: ["7-servercore-jmx,latest-servercore-jmx"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-ltsc2019"]
-        IMG_NEW_TAGS: ["7-ltsc2019, latest-ltsc2019"]
+        IMG_NEW_TAGS: ["7-ltsc2019,latest-ltsc2019"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-ltsc2022"]
-        IMG_NEW_TAGS: ["7-ltsc2022, latest-ltsc2022"]
+        IMG_NEW_TAGS: ["7-ltsc2022,latest-ltsc2022"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2019"]
-        IMG_NEW_TAGS: ["7-servercore-ltsc2019, latest-servercore-ltsc2019"]
+        IMG_NEW_TAGS: ["7-servercore-ltsc2019,latest-servercore-ltsc2019"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2022"]
-        IMG_NEW_TAGS: ["7-servercore-ltsc2022, latest-servercore-ltsc2022"]
+        IMG_NEW_TAGS: ["7-servercore-ltsc2022,latest-servercore-ltsc2022"]
       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
-        IMG_NEW_TAGS: ["7-servercore-ltsc2019-jmx, latest-servercore-ltsc2019-jmx"]
+        IMG_NEW_TAGS: ["7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2022-jmx"]
-        IMG_NEW_TAGS: ["7-servercore-ltsc2022-jmx, latest-servercore-ltsc2022-jmx"]
+        IMG_NEW_TAGS: ["7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx"]
       - IMG_TAG_REFERENCE_SUFFIX: ["-full"]
-        IMG_NEW_TAGS: ["7-full, latest-full"]
+        IMG_NEW_TAGS: ["7-full,latest-full"]
 
 deploy_mutable_image_tags-a7_internal:
   extends: .deploy_mutable_image_tags_base

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -11,7 +11,7 @@ include:
   dependencies: []
   before_script:
     - VERSION="$(dda inv agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export AGENT_REFERENCE=${AGENT_REPOSITORY}:${VERSION}
+    - export IMG_TAG_REFERENCE=${AGENT_REPOSITORY}:${VERSION}${IMG_TAG_REFERENCE_SUFFIX}
 
 # Stable tags
 
@@ -23,27 +23,27 @@ deploy_mutable_image_tags-a7:
   parallel:
     matrix:
       - IMG_NEW_TAGS: 7,latest
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}
+        IMG_TAG_REFERENCE_SUFFIX: ""
       - IMG_NEW_TAGS: 7-jmx,latest-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-jmx"
       - IMG_NEW_TAGS: 7-servercore,latest-servercore
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore"
       - IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
       - IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-ltsc2019
+        IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
       - IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-ltsc2022
+        IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
       - IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore-ltsc2019
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
       - IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore-ltsc2022
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
       - IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore-ltsc2019-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
       - IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-servercore-ltsc2022-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
       - IMG_NEW_TAGS: 7-full,latest-full
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-full
+        IMG_TAG_REFERENCE_SUFFIX: "-full"
 
 deploy_mutable_image_tags-a7_internal:
   extends: .deploy_mutable_image_tags_base
@@ -53,14 +53,14 @@ deploy_mutable_image_tags-a7_internal:
   parallel:
     matrix:
       - IMG_NEW_TAGS: 7-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-jmx"
       - IMG_NEW_TAGS: 7-full
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-full
+        IMG_TAG_REFERENCE_SUFFIX: "-full"
       - IMG_NEW_TAGS: 7-fips-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-fips-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"
 
 deploy_mutable_image_tags-dogstatsd:
-  extends: .deploy_mutable_image_tags_base
+  extends: .docker_publish_job_definition
   stage: deploy_mutable_image_tags
   rules:
     !reference [.on_final]
@@ -77,6 +77,6 @@ deploy_mutable_image_tags-a7-fips:
   parallel:
     matrix:
       - IMG_NEW_TAGS: 7-fips
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-fips
+        IMG_TAG_REFERENCE_SUFFIX: "-fips"
       - IMG_NEW_TAGS: 7-fips-jmx
-        IMG_TAG_REFERENCE: ${AGENT_REFERENCE}-fips-jmx
+        IMG_TAG_REFERENCE_SUFFIX: "-fips-jmx"

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -22,27 +22,27 @@ deploy_mutable_image_tags-a7:
     !reference [.on_final]
   parallel:
     matrix:
-      - IMG_TAG_REFERENCE_SUFFIX: ""
+      - IMG_TAG_REFERENCE_SUFFIX: [""]
         IMG_NEW_TAGS: ["7, latest"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-jmx"]
         IMG_NEW_TAGS: ["7-jmx, latest-jmx"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-servercore"]
         IMG_NEW_TAGS: ["7-servercore, latest-servercore"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-jmx"]
         IMG_NEW_TAGS: ["7-servercore-jmx, latest-servercore-jmx"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-ltsc2019"]
         IMG_NEW_TAGS: ["7-ltsc2019, latest-ltsc2019"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-ltsc2022"]
         IMG_NEW_TAGS: ["7-ltsc2022, latest-ltsc2022"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2019"]
         IMG_NEW_TAGS: ["7-servercore-ltsc2019, latest-servercore-ltsc2019"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2022"]
         IMG_NEW_TAGS: ["7-servercore-ltsc2022, latest-servercore-ltsc2022"]
       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
         IMG_NEW_TAGS: ["7-servercore-ltsc2019-jmx, latest-servercore-ltsc2019-jmx"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-servercore-ltsc2022-jmx"]
         IMG_NEW_TAGS: ["7-servercore-ltsc2022-jmx, latest-servercore-ltsc2022-jmx"]
-      - IMG_TAG_REFERENCE_SUFFIX: "-full"
+      - IMG_TAG_REFERENCE_SUFFIX: ["-full"]
         IMG_NEW_TAGS: ["7-full, latest-full"]
 
 deploy_mutable_image_tags-a7_internal:

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -15,35 +15,35 @@ include:
 
 # Stable tags
 
-deploy_mutable_image_tags-a7:
-  extends: .deploy_mutable_image_tags_base
-  stage: deploy_mutable_image_tags
-  rules:
-    !reference [.on_final]
-  parallel:
-    matrix:
-      - IMG_TAG_REFERENCE_SUFFIX: ""
-        IMG_NEW_TAGS: 7,latest
-      - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
-        IMG_NEW_TAGS: 7-jmx,latest-jmx
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
-        IMG_NEW_TAGS: 7-servercore,latest-servercore
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
-        IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
-      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
-        IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
-      - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
-        IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
-        IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
-        IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
-        IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
-      - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
-        IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
-      - IMG_TAG_REFERENCE_SUFFIX: "-full"
-        IMG_NEW_TAGS: 7-full,latest-full
+# deploy_mutable_image_tags-a7:
+#   extends: .deploy_mutable_image_tags_base
+#   stage: deploy_mutable_image_tags
+#   rules:
+#     !reference [.on_final]
+#   parallel:
+#     matrix:
+#       - IMG_TAG_REFERENCE_SUFFIX: ""
+#         IMG_NEW_TAGS: 7,latest
+#       - IMG_TAG_REFERENCE_SUFFIX: "-jmx"
+#         IMG_NEW_TAGS: 7-jmx,latest-jmx
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore"
+#         IMG_NEW_TAGS: 7-servercore,latest-servercore
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-jmx"
+#         IMG_NEW_TAGS: 7-servercore-jmx,latest-servercore-jmx
+#       - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2019"
+#         IMG_NEW_TAGS: 7-ltsc2019,latest-ltsc2019
+#       - IMG_TAG_REFERENCE_SUFFIX: "-ltsc2022"
+#         IMG_NEW_TAGS: 7-ltsc2022,latest-ltsc2022
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019"
+#         IMG_NEW_TAGS: 7-servercore-ltsc2019,latest-servercore-ltsc2019
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022"
+#         IMG_NEW_TAGS: 7-servercore-ltsc2022,latest-servercore-ltsc2022
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2019-jmx"
+#         IMG_NEW_TAGS: 7-servercore-ltsc2019-jmx,latest-servercore-ltsc2019-jmx
+#       - IMG_TAG_REFERENCE_SUFFIX: "-servercore-ltsc2022-jmx"
+#         IMG_NEW_TAGS: 7-servercore-ltsc2022-jmx,latest-servercore-ltsc2022-jmx
+#       - IMG_TAG_REFERENCE_SUFFIX: "-full"
+#         IMG_NEW_TAGS: 7-full,latest-full
 
 deploy_mutable_image_tags-a7_internal:
   extends: .deploy_mutable_image_tags_base


### PR DESCRIPTION
### What does this PR do?

As gitlab does not support dynamic values in the matrix definition I moved the resolution of the variables to the pre-script and left only static values in the matrix itself.

For some reason I had to wrap everything in the brackets to pass the gitlab linter validation, even though there are examples elsewhere that works ok - I am not sure what exactly is the factor here.

### Motivation

Fix the mutable tags promotion jobs.

### Describe how you validated your changes

I created the dummy branch with bypassed job rules and it looks like now the parameters are passed correctly - [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/955283085) - the publish job failed because it was meant to be run for the final builds and not the dev image.
