### PR TITLE
Mark HA Agent metadata test as flake

### DIFF
--- a/test/new-e2e/tests/ha-agent/haagent_metadata_test.go
+++ b/test/new-e2e/tests/ha-agent/haagent_metadata_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -39,6 +40,7 @@ log_level: debug
 }
 
 func (s *haAgentMetadataTestSuite) TestHaAgentMetadata() {
+	flake.Mark(s.T())
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		s.T().Log("try assert ha_agent metadata")
 		output := s.Env().Agent.Client.Diagnose(agentclient.WithArgs([]string{"show-metadata", "ha-agent"}))


### PR DESCRIPTION
### What does this PR do?

Marks test as flaky.

### Motivation

This test has been flaking fairly significantly since last Friday ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/954741930)).

### Describe how you validated your changes

N/A



### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->