### PR TITLE
[autodiscovery] Refactor to reuse code when generating config checks

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -252,50 +252,16 @@ func (ac *AutoConfig) writeConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 // GetConfigCheck returns scrubbed information from all configuration providers
 func (ac *AutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
-	var response integration.ConfigCheckResponse
-
-	configSlice := ac.GetAllConfigs()
-	sort.Slice(configSlice, func(i, j int) bool {
-		return configSlice[i].Name < configSlice[j].Name
-	})
-
-	configResponses := make([]integration.ConfigResponse, len(configSlice))
-
-	for i, config := range configSlice {
-		instanceIDs := make([]string, len(config.Instances))
-		for j, instance := range config.Instances {
-			instanceIDs[j] = string(checkid.BuildID(config.Name, config.FastDigest(), instance, config.InitConfig))
-		}
-		configResponses[i] = integration.ConfigResponse{
-			Config:      ac.scrubConfig(config),
-			InstanceIDs: instanceIDs,
-		}
-	}
-
-	response.Configs = configResponses
-
-	response.ResolveWarnings = GetResolveWarnings()
-	response.ConfigErrors = GetConfigErrors()
-
-	unresolved := ac.getUnresolvedTemplates()
-	scrubbedUnresolved := make(map[string][]integration.Config, len(unresolved))
-
-	for ids, configs := range unresolved {
-		scrubbedConfigs := make([]integration.Config, len(configs))
-		for idx, config := range configs {
-			scrubbedConfigs[idx] = ac.scrubConfig(config)
-		}
-
-		scrubbedUnresolved[ids] = scrubbedConfigs
-	}
-
-	response.Unresolved = scrubbedUnresolved
-
-	return response
+	return ac.buildConfigCheckResponse(true)
 }
 
 // getRawConfigCheck returns information from all configuration providers
 func (ac *AutoConfig) getRawConfigCheck() integration.ConfigCheckResponse {
+	return ac.buildConfigCheckResponse(false)
+}
+
+// buildConfigCheckResponse is a helper to build the ConfigCheckResponse for both scrubbed and raw configs.
+func (ac *AutoConfig) buildConfigCheckResponse(scrub bool) integration.ConfigCheckResponse {
 	var response integration.ConfigCheckResponse
 
 	configSlice := ac.GetAllConfigs()
@@ -310,6 +276,11 @@ func (ac *AutoConfig) getRawConfigCheck() integration.ConfigCheckResponse {
 		for j, instance := range config.Instances {
 			instanceIDs[j] = string(checkid.BuildID(config.Name, config.FastDigest(), instance, config.InitConfig))
 		}
+
+		if scrub {
+			config = ac.scrubConfig(config)
+		}
+
 		configResponses[i] = integration.ConfigResponse{
 			Config:      config,
 			InstanceIDs: instanceIDs,
@@ -317,10 +288,23 @@ func (ac *AutoConfig) getRawConfigCheck() integration.ConfigCheckResponse {
 	}
 
 	response.Configs = configResponses
-
 	response.ResolveWarnings = GetResolveWarnings()
 	response.ConfigErrors = GetConfigErrors()
-	response.Unresolved = ac.getUnresolvedTemplates()
+
+	if scrub {
+		unresolved := ac.getUnresolvedTemplates()
+		scrubbedUnresolved := make(map[string][]integration.Config, len(unresolved))
+		for ids, configs := range unresolved {
+			scrubbedConfigs := make([]integration.Config, len(configs))
+			for idx, config := range configs {
+				scrubbedConfigs[idx] = ac.scrubConfig(config)
+			}
+			scrubbedUnresolved[ids] = scrubbedConfigs
+		}
+		response.Unresolved = scrubbedUnresolved
+	} else {
+		response.Unresolved = ac.getUnresolvedTemplates()
+	}
 
 	return response
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -562,7 +562,7 @@ func TestWriteConfigEndpoint(t *testing.T) {
 			expectedResult: "pass: \"********\"",
 		},
 		{
-			name:           "With nil Requet",
+			name:           "With nil Request",
 			request:        nil,
 			expectedResult: "pass: \"********\"",
 		},


### PR DESCRIPTION
### What does this PR do?

This PR includes a small refactor of the autodiscovery component.

The autodiscovery implementation had two functions that were almost identical: `GetConfigCheck` and `getRawConfigCheck`. The only difference was that the first one scrubbed the configs. This PR extracts the shared code into a reusable function.

### Describe how you validated your changes

CI.