### PR TITLE
omnibus: python: don't attempt to fetch a prebuilt openssl

### DIFF
--- a/omnibus/config/patches/python3/0001-don-t-attempt-to-fetch-openssl.patch
+++ b/omnibus/config/patches/python3/0001-don-t-attempt-to-fetch-openssl.patch
@@ -1,0 +1,25 @@
+From 47c3b011547aae2d728925ad9c44fb2c9acb2626 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Tue, 27 May 2025 10:57:12 +0200
+Subject: [PATCH] don't attempt to fetch openssl
+
+Instead, fail at build time if the expected version isn't found
+---
+ PCbuild/get_externals.bat | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/PCbuild/get_externals.bat b/PCbuild/get_externals.bat
+index e29054f5734..3f2a4c9a8cd 100644
+--- a/PCbuild/get_externals.bat
++++ b/PCbuild/get_externals.bat
+@@ -79,7 +79,6 @@ echo.Fetching external binaries...
+ 
+ set binaries=
+ if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
+-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.16.2
+ if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.15.0
+ if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
+ if NOT "%IncludeLLVM%"=="false"    set binaries=%binaries% llvm-19.1.7.0
+-- 
+2.34.1
+

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -22,6 +22,8 @@ build do
   # 2.0 is the license version here, not the python version
   license "Python-2.0"
 
+  patch source: "0001-don-t-attempt-to-fetch-openssl.patch"
+
   unless windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
     python_configure_options = [


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Don't automatically fetch openssl prebuilt binaries when building python on Windows

### Motivation

This should simplify debugging potential issues when the version expected by python changes.
Currently we would simply ignore our openssl build, and fail during python self check.
With this change, we would fail with an explicit error at build time

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->