### PR TITLE
[CWS] Cache netns sockets on snapshot

### DIFF
--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -11,9 +11,10 @@ package resolvers
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dns"
 	"os"
 	"sort"
+
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dns"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
@@ -337,8 +338,10 @@ func (r *EBPFResolvers) snapshotBoundSockets() error {
 		return err
 	}
 
+	boundSocketSnapshotter := procfs.NewBoundSocketSnapshotter()
+
 	for _, proc := range processes {
-		bs, err := procfs.GetBoundSockets(proc)
+		bs, err := boundSocketSnapshotter.GetBoundSockets(proc)
 		if err != nil {
 			log.Debugf("sockets snapshot failed for (pid: %v): %s", proc.Pid, err)
 			continue

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -263,7 +263,7 @@ func extractPathFromSmapsLine(line []byte) (string, bool) {
 }
 
 func (pn *ProcessNode) snapshotBoundSockets(p *process.Process, stats *Stats, newEvent func() *model.Event) {
-	boundSockets, err := procfs.GetBoundSockets(p)
+	boundSockets, err := procfs.NewBoundSocketSnapshotter().GetBoundSockets(p)
 	if err != nil {
 		seclog.Warnf("error while listing sockets (pid: %v): %s", p.Pid, err)
 		return


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a per network namespace cache to avoid parsing multiple times the sockets of a same network namespace during snapshot.

### Motivation

Files under /proc/pid/net/<tcp,udp,tcp6,udp6> list sockets for the network namespace of the process (instead of the process itself). This means we can cache the result per netns instead of parsing everything for each new process.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->