### PR TITLE
[ACIX-894] Refactor gitlab linter tasks logic

### DIFF
--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -289,7 +289,7 @@ def print_entry_points(ctx):
     """Prints gitlab ci configuration entry points."""
 
     print(color_message('info:', Color.BLUE), 'Fetching entry points...')
-    entry_points = get_all_gitlab_ci_configurations(ctx, filter_configs=True, clean_configs=True)
+    entry_points = get_all_gitlab_ci_configurations(ctx, postprocess_options={"do_filtering": True})
 
     print(len(entry_points), 'entry points:')
     for entry_point, config in entry_points.items():

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -14,8 +14,8 @@ from tasks.kernel_matrix_testing.ci import get_kmt_dashboard_links
 from tasks.libs.ciproviders.gitlab_api import (
     compute_gitlab_ci_config_diff,
     get_all_gitlab_ci_configurations,
-    get_gitlab_ci_configuration,
     get_gitlab_repo,
+    post_process_gitlab_ci_configuration,
     print_gitlab_ci_configuration,
     resolve_gitlab_ci_configuration,
 )
@@ -270,14 +270,13 @@ def print_ci(
         This requires a full api token access level to the repository
     """
 
-    yml = get_gitlab_ci_configuration(
-        ctx,
-        input_file,
-        job=job,
+    yml = resolve_gitlab_ci_configuration(ctx, input_file, partial_resolve=partial_resolve, git_ref=git_ref)
+
+    yml = post_process_gitlab_ci_configuration(
+        yml,
+        jobs={job},
         clean=clean,
         expand_matrix=expand_matrix,
-        git_ref=git_ref,
-        partial_resolve=partial_resolve,
         keep_special_objects=keep_special_objects,
     )
 

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -252,7 +252,7 @@ def print_ci(
     keep_special_objects: bool = False,
     expand_matrix: bool = False,
     git_ref: str | None = None,
-    with_lint: bool = True,
+    partial_resolve: bool = True,
 ):
     """Prints the full gitlab ci configuration.
 
@@ -261,7 +261,9 @@ def print_ci(
         clean: Apply post processing to make output more readable (remove extends, flatten lists of lists...)
         keep_special_objects: If True, do not filter out special objects (variables, stages etc.)
         expand_matrix: Will expand matrix jobs into multiple jobs
-        with_lint: If False, do not lint the configuration
+        partial_resolve:
+            Whether to skip the gitlab `/lint` endpoint when resolving configs.
+            In this case, only `include`s will be resolved, not `extend`s or `!reference`s
         git_ref: If provided, use this git reference to fetch the configuration
 
     Notes:
@@ -275,7 +277,7 @@ def print_ci(
         clean=clean,
         expand_matrix=expand_matrix,
         git_ref=git_ref,
-        with_lint=with_lint,
+        partial_resolve=partial_resolve,
         keep_special_objects=keep_special_objects,
     )
 

--- a/tasks/gitlab_helpers.py
+++ b/tasks/gitlab_helpers.py
@@ -252,7 +252,7 @@ def print_ci(
     keep_special_objects: bool = False,
     expand_matrix: bool = False,
     git_ref: str | None = None,
-    partial_resolve: bool = True,
+    resolve_only_includes: bool = True,
 ):
     """Prints the full gitlab ci configuration.
 
@@ -261,7 +261,7 @@ def print_ci(
         clean: Apply post processing to make output more readable (remove extends, flatten lists of lists...)
         keep_special_objects: If True, do not filter out special objects (variables, stages etc.)
         expand_matrix: Will expand matrix jobs into multiple jobs
-        partial_resolve:
+        resolve_only_includes:
             Whether to skip the gitlab `/lint` endpoint when resolving configs.
             In this case, only `include`s will be resolved, not `extend`s or `!reference`s
         git_ref: If provided, use this git reference to fetch the configuration
@@ -270,7 +270,7 @@ def print_ci(
         This requires a full api token access level to the repository
     """
 
-    yml = resolve_gitlab_ci_configuration(ctx, input_file, partial_resolve=partial_resolve, git_ref=git_ref)
+    yml = resolve_gitlab_ci_configuration(ctx, input_file, resolve_only_includes=resolve_only_includes, git_ref=git_ref)
 
     yml = post_process_gitlab_ci_configuration(
         yml,

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -50,9 +50,10 @@ from tasks.kernel_matrix_testing.tool import Exit, ask, error, get_binary_target
 from tasks.kernel_matrix_testing.vars import KMT_SUPPORTED_ARCHS, KMTPaths
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.ciproviders.gitlab_api import (
-    get_gitlab_ci_configuration,
     get_gitlab_job_dependencies,
     get_gitlab_repo,
+    post_process_gitlab_ci_configuration,
+    resolve_gitlab_ci_configuration,
 )
 from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.utils import get_build_flags
@@ -2335,7 +2336,10 @@ def download_complexity_data(
 
         if gitlab_config_file is None:
             gitlab_ci_file = os.fspath(Path(__file__).parent.parent / ".gitlab-ci.yml")
-            gitlab_config = get_gitlab_ci_configuration(ctx, gitlab_ci_file, job="notify_ebpf_complexity_changes")
+            gitlab_config = resolve_gitlab_ci_configuration(ctx, gitlab_ci_file)
+            gitlab_config = post_process_gitlab_ci_configuration(
+                gitlab_config, filter_jobs="notify_ebpf_complexity_changes"
+            )
         else:
             with open(gitlab_config_file) as f:
                 parsed_file = yaml.safe_load(f)

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -819,22 +819,27 @@ def post_process_gitlab_ci_configuration(
         keep_special_objects: Will keep special objects (not jobs) in the configuration (variables, stages, etc.).
         expand_matrix: Will expand matrix jobs into multiple jobs.
     """
+    # Make sure to deepcopy the input config object before modifying it
+    # Otherwise this can have weird side effects when testing different config objects
+    # Ex: multiple contexts in the `gitlab-ci` task
+    processed_config = deepcopy(config)
+
     # Apply filtering
     if do_filtering or filter_jobs or keep_special_objects:
-        config = filter_gitlab_ci_configuration(config, filter_jobs, keep_special_objects)
+        processed_config = filter_gitlab_ci_configuration(processed_config, filter_jobs, keep_special_objects)
 
     if clean:
-        config = clean_gitlab_ci_configuration(config)
+        processed_config = clean_gitlab_ci_configuration(processed_config)
 
     # Expand matrix jobs
     if expand_matrix:
-        config = expand_matrix_jobs(config)
+        processed_config = expand_matrix_jobs(processed_config)
 
     # Override some variables with a dedicated context
     if variable_overrides:
-        config.get('variables', {}).update(variable_overrides)
+        processed_config.get('variables', {}).update(variable_overrides)
 
-    return config
+    return processed_config
 
 
 def get_all_gitlab_ci_configurations(

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -772,8 +772,10 @@ def print_gitlab_ci_configuration(yml: dict, sort_jobs: bool):
 def test_gitlab_configuration(entry_point: str, config_object: dict, context=None):
     agent = get_gitlab_repo()
     # Apply the new variables from context
+    # Important to DISABLE CLEAN AND FILTERING - the config at this point is minimally resolved (only includes)
+    # Thus, removing anything like `extends` and dotted jobs will render the config invalid
     config_object = post_process_gitlab_ci_configuration(
-        config_object, variable_overrides=context, keep_special_objects=True
+        config_object, variable_overrides=context, do_filtering=False, clean=False
     )
     config_dump = yaml.safe_dump(config_object)
     res = agent.ci_lint.create({"content": config_dump, "dry_run": True, "include_jobs": True})
@@ -840,7 +842,7 @@ def get_all_gitlab_ci_configurations(
     input_file: str = '.gitlab-ci.yml',
     resolve_only_includes: bool = False,
     git_ref: str | None = None,
-    postprocess_options: dict[str, Any] | Literal['False'] | None = None,
+    postprocess_options: dict[str, Any] | Literal[False] | None = None,
 ) -> dict[str, dict]:
     """Returns all possible gitlab CI entrypoints and corresponding fully-resolved configurations, rooted at the input file.
     This is useful when the CI contains 'trigger jobs', which launch new, independent pipelines.

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -960,12 +960,9 @@ def resolve_gitlab_ci_configuration(
         git_ref: From which git ref to read the input config file. No effect if input config is passed as a dict.
     """
 
-    if isinstance(input_config_or_file, str):
-        # Read includes
-        input_config = read_includes(ctx, input_config_or_file, return_config=True, git_ref=git_ref)
-        assert input_config
-    else:
-        input_config = input_config_or_file
+    # Read includes
+    input_config = read_includes(ctx, input_config_or_file, return_config=True, git_ref=git_ref)
+    assert input_config
 
     if resolve_only_includes:
         return input_config

--- a/tasks/libs/linter/gitlab.py
+++ b/tasks/libs/linter/gitlab.py
@@ -77,7 +77,6 @@ def get_gitlab_ci_lintable_jobs(ctx, diff_file=None, config_file=None, only_name
         A (jobs, full_config) tuple.
         `jobs` is itself a tuple of (job_name: str, job_contents: dict). If `only_names` is True, it will be a simple list of all the job names.
         `full_config` is a gitlabci config object, of the same structure as returned by `get_all_gitlab_ci_configurations`
-
     """
     # Dict of entrypoint -> config object, of the format returned by `get_all_gitlab_ci_configurations`
     configs: dict[str, dict]

--- a/tasks/libs/linter/gitlab.py
+++ b/tasks/libs/linter/gitlab.py
@@ -7,6 +7,7 @@ from invoke.exceptions import Exit
 
 from tasks.libs.ciproviders.gitlab_api import (
     MultiGitlabCIDiff,
+    get_all_gitlab_ci_configurations,
     is_leaf_job,
 )
 from tasks.libs.common.color import Color, color_message
@@ -64,34 +65,45 @@ def list_get_parameter_calls(file):
     return calls
 
 
-def get_gitlab_ci_lintable_jobs(diff_file, config_file, only_names=False):
+def get_gitlab_ci_lintable_jobs(ctx, diff_file=None, config_file=None, only_names=False):
     """Retrieves the jobs from full gitlab ci configuration file or from a diff file.
 
     Args:
         diff_file: Path to the diff file used to build MultiGitlabCIDiff obtained by compute-gitlab-ci-config.
         config_file: Path to the full gitlab ci configuration file obtained by compute-gitlab-ci-config.
+        > If none of these are passed, the full config will be generated automatically, but this will be slower.
+
+    Returns:
+        A (jobs, full_config) tuple.
+        `jobs` is itself a tuple of (job_name: str, job_contents: dict). If `only_names` is True, it will be a simple list of all the job names.
+        `full_config` is a gitlabci config object, of the same structure as returned by `get_all_gitlab_ci_configurations`
+
     """
+    # Dict of entrypoint -> config object, of the format returned by `get_all_gitlab_ci_configurations`
+    configs: dict[str, dict]
+    assert not (config_file and diff_file), "Please only pass either a config file or a diff file"
 
-    assert (
-        diff_file or config_file and not (diff_file and config_file)
-    ), "You must provide either a diff file or a config file and not both"
-
-    # Load all the jobs from the files
-    if config_file:
-        with open(config_file) as f:
-            full_config = yaml.safe_load(f)
-            jobs = [
-                (job, job_contents)
-                for contents in full_config.values()
-                for job, job_contents in contents.items()
-                if is_leaf_job(job, job_contents)
-            ]
-    else:
+    if diff_file:
+        # Special handling of diff files
         with open(diff_file) as f:
             diff = MultiGitlabCIDiff.from_dict(yaml.safe_load(f))
 
-        full_config = diff.after
+        configs = diff.after  # type: ignore
         jobs = [(job, contents) for _, job, contents, _ in diff.iter_jobs(added=True, modified=True, only_leaves=True)]
+    else:
+        if config_file:
+            with open(config_file) as f:
+                configs = yaml.safe_load(f)
+        else:
+            # If a config/diff file is not passed, build it on-demand using `get_all_gitlab_ci_configurations`
+            configs = get_all_gitlab_ci_configurations(ctx, input_file=".gitlab-ci.yml")
+
+        jobs = [
+            (job, job_contents)
+            for contents in configs.values()
+            for job, job_contents in contents.items()
+            if is_leaf_job(job, job_contents)
+        ]
 
     if not jobs:
         print(f"{color_message('Info', Color.BLUE)}: No added / modified jobs, skipping lint")
@@ -100,7 +112,7 @@ def get_gitlab_ci_lintable_jobs(diff_file, config_file, only_names=False):
     if only_names:
         jobs = [job for job, _ in jobs]
 
-    return jobs, full_config
+    return jobs, configs
 
 
 def _gitlab_ci_jobs_owners_lint(jobs, jobowners, ci_linters_config, path_jobowners):

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -253,7 +253,9 @@ def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml")
         custom_context: A custom context to test the gitlab ci file with.
     """
     print(f'{color_message("info", Color.BLUE)}: Fetching Gitlab CI configurations...')
-    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, resolve_only_includes=True)
+    configs = get_all_gitlab_ci_configurations(
+        ctx, input_file=input_file, resolve_only_includes=True, postprocess_options=False
+    )
 
     for config_filename, config_object in configs.items():
         with gitlab_section(f"Testing {config_filename}", echo=True):

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -253,7 +253,7 @@ def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml")
         custom_context: A custom context to test the gitlab ci file with.
     """
     print(f'{color_message("info", Color.BLUE)}: Fetching Gitlab CI configurations...')
-    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file)
+    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, resolve_only_includes=True)
 
     for config_filename, config_object in configs.items():
         with gitlab_section(f"Testing {config_filename}", echo=True):

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -253,7 +253,7 @@ def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml")
         custom_context: A custom context to test the gitlab ci file with.
     """
     print(f'{color_message("info", Color.BLUE)}: Fetching Gitlab CI configurations...')
-    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, partial_resolve=True)
+    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file)
 
     for config_filename, config_object in configs.items():
         with gitlab_section(f"Testing {config_filename}", echo=True):
@@ -269,10 +269,10 @@ def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml")
                 for context in all_contexts:
                     print("Test gitlab configuration with context: ", context)
                     test_gitlab_configuration(
-                        ctx, config_name=config_filename, config_object=config_object, context=dict(context)
+                        entry_point=config_filename, config_object=config_object, context=dict(context)
                     )
             else:
-                test_gitlab_configuration(ctx, config_name=config_filename, config_object=config_object)
+                test_gitlab_configuration(entry_point=config_filename, config_object=config_object)
 
 
 @task

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -292,6 +292,7 @@ def gitlab_ci_shellcheck(
     Args:
         diff_file: Path to the diff file used to build MultiGitlabCIDiff obtained by compute-gitlab-ci-config.
         config_file: Path to the full gitlab ci configuration file obtained by compute-gitlab-ci-config.
+        > If none of these are passed, the full config will be generated automatically, but this will be slower.
     """
 
     # Used by the CI to skip linting if no changes
@@ -299,7 +300,7 @@ def gitlab_ci_shellcheck(
         print('No diff file found, skipping lint')
         return
 
-    jobs, full_config = get_gitlab_ci_lintable_jobs(diff_file, config_file)
+    jobs, full_config = get_gitlab_ci_lintable_jobs(ctx, diff_file, config_file)
 
     # No change, info already printed in get_gitlab_ci_lintable_jobs
     if not full_config:
@@ -417,7 +418,7 @@ def gitlab_change_paths(ctx):
 
 
 @task
-def gitlab_ci_jobs_needs_rules(_, diff_file=None, config_file=None):
+def gitlab_ci_jobs_needs_rules(ctx, diff_file=None, config_file=None):
     """Verifies that each added / modified job contains `needs` and also `rules`.
 
     It is possible to declare a job not following these rules within `.gitlab/.ci-linters.yml`.
@@ -426,12 +427,13 @@ def gitlab_ci_jobs_needs_rules(_, diff_file=None, config_file=None):
     Args:
         diff_file: Path to the diff file used to build MultiGitlabCIDiff obtained by compute-gitlab-ci-config
         config_file: Path to the full gitlab ci configuration file obtained by compute-gitlab-ci-config
+        > If none of these are passed, the full config will be generated automatically, but this will be slower.
 
     See:
       https://datadoghq.atlassian.net/wiki/spaces/ADX/pages/4059234597/Gitlab+CI+configuration+guidelines#datadog-agent
     """
 
-    jobs, full_config = get_gitlab_ci_lintable_jobs(diff_file, config_file)
+    jobs, full_config = get_gitlab_ci_lintable_jobs(ctx, diff_file, config_file)
 
     # No change, info already printed in get_gitlab_ci_lintable_jobs
     if not full_config:
@@ -679,16 +681,17 @@ def gitlab_ci_jobs_codeowners(ctx, path_codeowners='.github/CODEOWNERS', all_fil
 
 
 @task
-def gitlab_ci_jobs_owners(_, diff_file=None, config_file=None, path_jobowners='.gitlab/JOBOWNERS'):
+def gitlab_ci_jobs_owners(ctx, diff_file=None, config_file=None, path_jobowners='.gitlab/JOBOWNERS'):
     """Verifies that each job is defined within JOBOWNERS files.
 
     Args:
         diff_file: Path to the diff file used to build MultiGitlabCIDiff obtained by compute-gitlab-ci-config
         config_file: Path to the full gitlab ci configuration file obtained by compute-gitlab-ci-config
+        > If none of these are passed, the full config will be generated automatically, but this will be slower.
         path_jobowners: Path to the JOBOWNERS file
     """
 
-    jobs, full_config = get_gitlab_ci_lintable_jobs(diff_file, config_file, only_names=True)
+    jobs, full_config = get_gitlab_ci_lintable_jobs(ctx, diff_file, config_file, only_names=True)
 
     # No change, info already printed in get_gitlab_ci_lintable_jobs
     if not full_config:

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -19,7 +19,6 @@ from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.ciproviders.gitlab_api import (
     full_config_get_all_leaf_jobs,
     full_config_get_all_stages,
-    generate_gitlab_full_configuration,
     get_all_gitlab_ci_configurations,
     get_gitlab_ci_configuration,
     get_preset_contexts,
@@ -400,7 +399,7 @@ def gitlab_change_paths(ctx):
     """Verifies that rules: changes: paths match existing files in the repository."""
 
     # Read gitlab config
-    config = generate_gitlab_full_configuration(ctx, ".gitlab-ci.yml", {}, return_dump=False, apply_postprocessing=True)
+    config = get_gitlab_ci_configuration(ctx, input_file=".gitlab-ci.yml", gitlab_context=None, return_dump=False)
     error_paths = []
     for path in set(retrieve_all_paths(config)):
         files = glob(path, recursive=True)

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -401,9 +401,7 @@ def gitlab_change_paths(ctx):
     """Verifies that rules: changes: paths match existing files in the repository."""
 
     # Read gitlab config
-    config = get_gitlab_ci_configuration(
-        ctx, input_config_or_file=".gitlab-ci.yml", gitlab_context=None, return_dump=False
-    )
+    config = get_gitlab_ci_configuration(ctx, input_config_or_file=".gitlab-ci.yml", gitlab_context=None)
     error_paths = []
     for path in set(retrieve_all_paths(config)):
         files = glob(path, recursive=True)

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -253,7 +253,7 @@ def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml")
         custom_context: A custom context to test the gitlab ci file with.
     """
     print(f'{color_message("info", Color.BLUE)}: Fetching Gitlab CI configurations...')
-    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, with_lint=False)
+    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, partial_resolve=True)
 
     for config_filename, config_object in configs.items():
         with gitlab_section(f"Testing {config_filename}", echo=True):

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -401,7 +401,7 @@ def gitlab_change_paths(ctx):
 
     # Read gitlab configs for all entrypoints
     configs = get_all_gitlab_ci_configurations(
-        ctx, input_file=".gitlab-ci.yml", filter_configs=True, clean_configs=True
+        ctx, input_file=".gitlab-ci.yml", postprocess_options={"do_filtering": True}
     )
     error_paths = []
     for _, config in configs.items():
@@ -580,7 +580,7 @@ def job_change_path(ctx, job_files=None):
     # Read gitlab configs for all entrypoints
     # The config is filtered to only include jobs
     configs = get_all_gitlab_ci_configurations(
-        ctx, input_file=".gitlab-ci.yml", filter_configs=True, clean_configs=True
+        ctx, input_file=".gitlab-ci.yml", postprocess_options={"do_filtering": True}
     )
     # Fetch all test jobs
     test_config = read_includes(ctx, job_files, return_config=True, add_file_path=True)

--- a/tasks/unit_tests/gitlab_api_tests.py
+++ b/tasks/unit_tests/gitlab_api_tests.py
@@ -59,7 +59,7 @@ class TestGitlabCiConfig(unittest.TestCase):
             'job1': {'script': 'echo "hello"'},
         }
 
-        res = filter_gitlab_ci_configuration(yml, job='job1')
+        res = filter_gitlab_ci_configuration(yml, jobs='job1')
 
         self.assertDictEqual(res, expected_yml)
 

--- a/tasks/unit_tests/linter_tests.py
+++ b/tasks/unit_tests/linter_tests.py
@@ -75,17 +75,19 @@ class TestIsGetParameterCall(unittest.TestCase):
 class TestGitlabChangePaths(unittest.TestCase):
     @patch("builtins.print")
     @patch(
-        "tasks.linter.get_gitlab_ci_configuration",
-        new=MagicMock(return_value={"rules": {"changes": {"paths": ["tasks/**/*.py"]}}}),
+        "tasks.linter.get_all_gitlab_ci_configurations",
+        new=MagicMock(return_value={".gitlab-ci.yml": {"rules": {"changes": {"paths": ["tasks/**/*.py"]}}}}),
     )
     def test_all_ok(self, print_mock):
         linter.gitlab_change_paths(MockContext())
         print_mock.assert_called_with("All rule:changes:paths from gitlab-ci are \x1b[92mvalid\x1b[0m.")
 
     @patch(
-        "tasks.linter.get_gitlab_ci_configuration",
+        "tasks.linter.get_all_gitlab_ci_configurations",
         new=MagicMock(
-            return_value={"rules": {"changes": {"paths": ["tosks/**/*.py", "tasks/**/*.py", "tusks/**/*.py"]}}}
+            return_value={
+                ".gitlab-ci.yml": {"rules": {"changes": {"paths": ["tosks/**/*.py", "tasks/**/*.py", "tusks/**/*.py"]}}}
+            }
         ),
     )
     def test_bad_paths(self):

--- a/tasks/unit_tests/linter_tests.py
+++ b/tasks/unit_tests/linter_tests.py
@@ -75,7 +75,7 @@ class TestIsGetParameterCall(unittest.TestCase):
 class TestGitlabChangePaths(unittest.TestCase):
     @patch("builtins.print")
     @patch(
-        "tasks.linter.generate_gitlab_full_configuration",
+        "tasks.linter.get_gitlab_ci_configuration",
         new=MagicMock(return_value={"rules": {"changes": {"paths": ["tasks/**/*.py"]}}}),
     )
     def test_all_ok(self, print_mock):
@@ -83,7 +83,7 @@ class TestGitlabChangePaths(unittest.TestCase):
         print_mock.assert_called_with("All rule:changes:paths from gitlab-ci are \x1b[92mvalid\x1b[0m.")
 
     @patch(
-        "tasks.linter.generate_gitlab_full_configuration",
+        "tasks.linter.get_gitlab_ci_configuration",
         new=MagicMock(
             return_value={"rules": {"changes": {"paths": ["tosks/**/*.py", "tasks/**/*.py", "tusks/**/*.py"]}}}
         ),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Cleans up and unifies the way gitlabci linting tasks run, especially in regards to how they generate the "full gitlab config". 
Also fixes some wrong behavior with `gitlab_change_paths` and `job_change_path`, these two tasks were linting only the 'root' pipeline (defined in `.gitlab-ci.yml`), but not any "called pipelines", like `.gitlab/deploy_containers`

**Call graph before the PR:**
![Gitlab CI Linters Call Graph 0 Explained](https://github.com/user-attachments/assets/76119cf1-e5b4-4bd1-9f08-518058ec6822)
> Key:
> - **Grey arrows:** Calls
> - **Purple arrows:** Need file as input
> - **Blue:** Functions handling the "full gitlab config", i.e. with multiple entrypoints, i.e. including "called pipelines"
> - **Red:** Functions handling only a single config object, i.e. only one entrypoint (usually the main `.gitlab-ci.yml`)

**Call graph after the PR:**
![Gitlab CI Linters Call Graph 3 Raw](https://github.com/user-attachments/assets/968ce1cd-231e-4df3-9a99-61fa3d55c1ef)
Notable changes:
- Fixed `job_change_path` and `gitlab_change_paths` to lint all entrypoints instead of only the root `.gitlab-ci.yml`
- Removed `get_gitlab_ci_configuration` and `generate_gitlab_full_configuration`, instead making the tasks call `get_all_gitlab_ci_configurations` directly. These functions had too little useful functionality and made the code much harder to read.
- Renamed the recursive helper function `get_ci_configurations` to `_traverse_config_search_triggers`
- `test_gitlab_configuration` no longer calls methods leading to `resolve_gitlab_ci_configurations`, instead taking the config object as input. This avoids calling the `/lint` endpoint one extra time, improving efficiency. It also does not depend on other methods in the call graph anymore, so is not represented above.
- Made `get_gitlab_ci_lintable_jobs` take config files as input only optionally, falling back to generating the config objects if necessary

### Motivation

Before trying to implement a new top-level task for running all gitlabci-related linters [ACIX-470], I needed to make sure that different linting tasks would not try to regenerate the unified gitlab config multiple times, to ensure these tasks would run as quickly as possible.

But due to the organic nature of how these tasks were built over time, there were many different paths to generating this config, and many different functions all with the same goal.
With a more unified method of generating this config, we make the code more readable and efficient, while assuring no task tries to regenerate the config if it does not need to.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

- All affected tasks run without errors on the current gitlab config
- Inputting a broken gitlab config (simple change for each of the linter tasks) does result in an error
- Some tasks are already covered by unit tests

### Possible Drawbacks / Trade-offs

- Performance impact: By fixing the two tasks mentioned above, they become a bit slower as they have to handle multiple entrypoints instead of only the root one (should be very minimal)
- Behavioral change: To the best of my knowledge, there should be none, but I might have missed some transformation in one of the helper functions that is not being executed anymore
- Loss of habit: As with any significant refactor, anyone familiar with the old code might not recognize it. In my opinion it is more easily understandable and readable in its current state, however.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[ACIX-470]: https://datadoghq.atlassian.net/browse/ACIX-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ