### PR TITLE
Revert "CXP-2078 add warning about pidmode misconfiguration on fargat…

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -129,8 +128,6 @@ type ProcessCheck struct {
 	statsd         statsd.ClientInterface
 
 	gpuSubscriber gpusubscriber.Component
-
-	warnOnceECSLinuxFargateMisconfig sync.Once
 }
 
 // Init initializes the singleton ProcessCheck.
@@ -298,11 +295,6 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 
 	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, p.lookupIdProbe, p.ignoreZombieProcesses, p.serviceExtractor, pidToGPUTags)
 	messages, totalProcs, totalContainers := createProcCtrMessages(p.hostInfo, procsByCtr, containers, p.maxBatchSize, p.maxBatchBytes, groupID, p.networkID, collectorProcHints)
-
-	// warn customer if "pidMode":"task" is not set in ecs linux fargate
-	p.warnOnceECSLinuxFargateMisconfig.Do(func() {
-		warnECSFargateMisconfig(containers)
-	})
 
 	// Store the last state for comparison on the next run.
 	// Note: not storing the filtered in case there are new processes that haven't had a chance to show up twice.

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -8,24 +8,21 @@
 package checks
 
 import (
-	"fmt"
 	"math"
 	"os/user"
-	"slices"
 	"strconv"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/shirou/gopsutil/v4/cpu"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
-	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
-// overridden in tests
-var hostCPUCount = system.HostCPUCount
+var (
+	// overridden in tests
+	hostCPUCount = system.HostCPUCount
+)
 
 func formatUser(fp *procutil.Process, uidProbe *LookupIdProbe) *model.ProcessUser {
 	var username string
@@ -91,24 +88,4 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	// Avoid reporting negative CPU percentages when this occurs
 	pct = math.Max(pct, 0.0)
 	return float32(pct)
-}
-
-// warnECSFargateMisconfig pidMode is currently not supported on fargate windows, see docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode
-func warnECSFargateMisconfig(containers []*model.Container) {
-	if fargate.IsFargateInstance() && !isECSFargatePidModeSetToTask(containers) {
-		log.Warn(`Process collection may be misconfigured. Please ensure your task definition has "pidMode":"task" set. See https://docs.datadoghq.com/integrations/ecs_fargate/#process-collection for more information.`)
-	}
-}
-
-// isECSFargatePidModeSetToTask checks if pidMode is set to task in task definition to allow for process collection and assumes the method is called in a fargate environment
-func isECSFargatePidModeSetToTask(containers []*model.Container) bool {
-	// aws-fargate-pause container only exists when "pidMode" is set to "task" on ecs fargate
-	ecsContainerNameTag := fmt.Sprintf("%s:%s", tags.EcsContainerName, "aws-fargate-pause")
-	for _, c := range containers {
-		// container fields are not yet populated with information from tags at this point, so we need to check the tags
-		if slices.Contains(c.Tags, ecsContainerNameTag) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -19,7 +19,6 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/shirou/gopsutil/v4/cpu"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/parser"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
@@ -376,7 +375,6 @@ func TestFormatCPUTimes(t *testing.T) {
 		})
 	}
 }
-
 func TestProcessGPUTagging(t *testing.T) {
 	p := []*procutil.Process{
 		makeProcess(1, "git clone google.com"),
@@ -426,45 +424,6 @@ func TestProcessGPUTagging(t *testing.T) {
 			for _, proc := range procs[""] {
 				assert.Equal(t, proc.Tags, tc.pidToGPUTags[proc.Pid])
 			}
-		})
-	}
-}
-
-func TestProcessIsECSFargatePidModeSetToTaskLinux(t *testing.T) {
-	for _, tc := range []struct {
-		description string
-		containers  []*model.Container
-		expected    bool
-	}{
-		{
-			description: "ecs linux fargate pidMode not set to task",
-			containers: []*model.Container{
-				{
-					Tags: []string{
-						fmt.Sprintf("%s:%s", tags.EcsContainerName, "other container"),
-						fmt.Sprintf("%s:%s", tags.ContainerName, "aws-fargate-pause"),
-						fmt.Sprintf("%s:%s", tags.ImageName, "aws-fargate-pause"),
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			description: "ecs linux fargate pidMode set to task",
-			containers: []*model.Container{
-				{
-					Tags: []string{
-						fmt.Sprintf("%s:%s", tags.EcsContainerName, "aws-fargate-pause"),
-						fmt.Sprintf("%s:%s", tags.ContainerName, "some container name"),
-						fmt.Sprintf("%s:%s", tags.ImageName, "some image name"),
-					},
-				},
-			},
-			expected: true,
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			assert.Equal(t, tc.expected, isECSFargatePidModeSetToTask(tc.containers))
 		})
 	}
 }

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -18,8 +18,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-// overridden in tests
-var numCPU = runtime.NumCPU
+var (
+	// overridden in tests
+	numCPU = runtime.NumCPU
+)
 
 func formatUser(fp *procutil.Process, _ *LookupIdProbe) *model.ProcessUser {
 	return &model.ProcessUser{
@@ -64,10 +66,4 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	// Avoid reporting negative CPU percentages when this occurs
 	overalPct = math.Max(overalPct, 0.0)
 	return float32(overalPct)
-}
-
-func warnECSFargateMisconfig(_ []*model.Container) {}
-
-func isECSFargatePidModeSetToTask(_ []*model.Container) bool {
-	return false
 }

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -83,21 +83,3 @@ func TestFormatCPUTimes(t *testing.T) {
 		})
 	}
 }
-
-func TestProcessIsECSFargatePidModeSetToTaskWindows(t *testing.T) {
-	for _, tc := range []struct {
-		description string
-		containers  []*model.Container
-		expected    bool
-	}{
-		{
-			description: "windows unsupported",
-			containers:  []*model.Container{},
-			expected:    false,
-		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
-			assert.Equal(t, tc.expected, isECSFargatePidModeSetToTask(tc.containers))
-		})
-	}
-}

--- a/releasenotes/notes/ecs-fargate-pidmode-misconfiguration-f7887b42ad48af54.yaml
+++ b/releasenotes/notes/ecs-fargate-pidmode-misconfiguration-f7887b42ad48af54.yaml
@@ -1,4 +1,0 @@
----
-enhancements:
-  - |
-    ECS Fargate (Linux): added a one-time warning when `pidMode` is not set to `task`, which will prevent process collection.


### PR DESCRIPTION
…e (#36386)"

This reverts commit 27502336a34eb2602ecb53cab73a460adba984d2.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- reverts PR: https://github.com/DataDog/datadog-agent/pull/36386 because behaviour is flaky
    - past pr emits a warning log to customers if there is a misconfiguration to allow live processes to work, but on QA testing the warning log sometimes emit's incorrectly as we currently use a questionable way to check for the ecs task definition configuration (not exposed programmatically at runtime) 
    - difficult to replicate to debug, so I decided to revert this for now as to not emit an "incorrect" warning log to customers

### Motivation
^

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->