### PR TITLE
[DJM] Databricks and Scala version tags from env vars

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -133,7 +133,8 @@ func setupCommonHostTags(s *common.Setup) {
 	setIfExists(s, "DB_DRIVER_IP", "spark_host_ip", nil)
 	setIfExists(s, "DB_INSTANCE_TYPE", "databricks_instance_type", nil)
 	setClearIfExists(s, "DB_IS_JOB_CLUSTER", "databricks_is_job_cluster", nil)
-	setClearIfExists(s, "DATABRICKS_RUNTIME_VERSION", "databricks_runtime_version", nil)
+	setClearIfExists(s, "DATABRICKS_RUNTIME_VERSION", "databricks_runtime", nil)
+	setClearIfExists(s, "SPARK_SCALA_VERSION", "scala_version", nil)
 	setIfExists(s, "DD_JOB_NAME", "job_name", func(v string) string {
 		return jobNameRegex.ReplaceAllString(v, "_")
 	})
@@ -407,18 +408,7 @@ func fetchClusterTags(client *http.Client, host, token, clusterID string, s *com
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Create a copy of the custom tags
-	tags := make(map[string]string)
-	for k, v := range clusterResponse.CustomTags {
-		tags[k] = v
-	}
-
-	// Add spark_version as runtime tag if available
-	if clusterResponse.SparkVersion != "" {
-		tags["runtime"] = clusterResponse.SparkVersion
-	}
-
-	return tags, nil
+	return clusterResponse.CustomTags, nil
 }
 
 func fetchJobTags(client *http.Client, host, token, jobID string, s *common.Setup) (map[string]string, error) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set Databricks runtime version and scala version host and install tags only from Databricks env vars, which means:
- adding scala version tag
- renaming databricks runtime version tag
- removing SparkVersion extraction logic from API response

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->