### PR TITLE
[clusteragent/autoscaling/externalmetrics] Stop sending telemetry when associated `DatadogMetric` is deleted 

### DIFF
--- a/releasenotes-dca/notes/clear-ddm-telemetry-on-delete-c899ecffd2138dd7.yaml
+++ b/releasenotes-dca/notes/clear-ddm-telemetry-on-delete-c899ecffd2138dd7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Stop sending telemetry associated with a DatadogMetric when the object is deleted.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Stop sending telemetry when associated `DatadogMetric` is deleted.

### Motivation

Currently when a `DatadogMetric` that was manually created gets deleted, telemetry (`datadog.cluster_agent.external_metrics.datadog_metrics`) is still reported for it until the cluster agent is deleted. This change ensures that we successfully clean up telemetry when the object is deleted.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Manually create a `DatadogMetric` object
```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: test-metric
spec:
  query: avg:system.cpu.user{*}
```
2. Verify that you see metrics show up: `datadog.cluster_agent.external_metrics.datadog_metrics` with `name:test-metric`
3. Delete the object: `k delete datadogmetric test-metric`
4. Verify that metrics are no longer reported for it

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->