### PR TITLE
Add tests for dev container usage

### DIFF
--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -19,7 +19,7 @@ runs:
     shell: bash
 
   - name: Install dda
-    uses: DataDog/datadog-agent-dev@4540b9f990efec2113005942a3b434ed93eeebb8
+    uses: DataDog/datadog-agent-dev@1c61de50a7dfef056026a4ba7cad75239b5ab324
     with:
       version: ${{ inputs.version || steps.set-version.outputs.version }}
       features: ${{ inputs.features }}

--- a/.github/workflows/test-devcontainer-update.yml
+++ b/.github/workflows/test-devcontainer-update.yml
@@ -1,0 +1,19 @@
+name: test devcontainer update
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .gitlab-ci.yml
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-devcontainer.yml
+    if: github.actor == 'renovate[bot]'

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -1,0 +1,52 @@
+name: test devcontainer
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+
+    - name: Install dda
+      uses: ./.github/actions/install-dda
+      with:
+        version: "0.13.0"
+        features: legacy-tasks
+
+    - name: Build image
+      run: |
+        git clone https://github.com/DataDog/datadog-agent-buildimages.git
+        cd datadog-agent-buildimages
+        dda run build devcontainer --tag legacy-devenv
+
+    - name: Create Dev Container config
+      run: dda inv -- devcontainer.setup --image legacy-devenv
+
+    - name: Ensure mount paths exist
+      run: |
+        mkdir -p ~/.ssh
+
+    - name: Install Dev Container CLI
+      run: npm install -g @devcontainers/cli
+
+    - name: Start Dev Container
+      run: devcontainer up --workspace-folder .
+
+    - name: Test Agent build
+      run: devcontainer exec --workspace-folder . dda inv agent.hacky-dev-image-build --target-image=agent


### PR DESCRIPTION
### What does this PR do?

This adds a new GitHub actions reusable workflow that can be triggered manually that verifies dev container functionality, and another that calls that workflow upon build image updates (which implies a new developer image) such as this https://github.com/DataDog/datadog-agent/pull/37383

See example run: https://github.com/DataDog/datadog-agent/actions/runs/15291964627

### Motivation

Catch future regressions when new builds occur

### Additional Notes

The next planned step is to swap out the old image for the new one https://github.com/DataDog/datadog-agent/pull/37261