### PR TITLE
[USM] Fix KMT test command go list relative paths

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1007,8 +1007,8 @@ def go_package_dirs(packages, build_tags):
     format_arg = '{{ .Dir }}'
     buildtags_arg = ",".join(build_tags)
 
-     # Prepend module path if the package path is relative
-     # and doesn't start with ./ (which go list handles correctly for local paths)
+    # Prepend module path if the package path is relative
+    # and doesn't start with ./ (which go list handles correctly for local paths)
     if not is_windows:
         full_path_packages = []
         module_path = "github.com/DataDog/datadog-agent/"

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1006,7 +1006,18 @@ def go_package_dirs(packages, build_tags):
 
     format_arg = '{{ .Dir }}'
     buildtags_arg = ",".join(build_tags)
-    packages_arg = " ".join(packages)
+
+    # Prepend module path if the package path is relative
+    # and doesn't start with ./ (which go list handles correctly for local paths)
+    full_path_packages = []
+    module_path = "github.com/DataDog/datadog-agent/"
+    for pkg in packages:
+        if not pkg.startswith(".") and not pkg.startswith(module_path):
+            full_path_packages.append(module_path + pkg)
+        else:
+            full_path_packages.append(pkg)
+    packages_arg = " ".join(full_path_packages)
+
     cmd = f"go list -find -f \"{format_arg}\" -mod=readonly -tags \"{buildtags_arg}\" {packages_arg}"
 
     target_packages = [p.strip() for p in check_output(cmd, shell=True, encoding='utf-8').split("\n")]

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1007,16 +1007,19 @@ def go_package_dirs(packages, build_tags):
     format_arg = '{{ .Dir }}'
     buildtags_arg = ",".join(build_tags)
 
-    # Prepend module path if the package path is relative
-    # and doesn't start with ./ (which go list handles correctly for local paths)
-    full_path_packages = []
-    module_path = "github.com/DataDog/datadog-agent/"
-    for pkg in packages:
-        if not pkg.startswith(".") and not pkg.startswith(module_path):
-            full_path_packages.append(module_path + pkg)
-        else:
-            full_path_packages.append(pkg)
-    packages_arg = " ".join(full_path_packages)
+     # Prepend module path if the package path is relative
+     # and doesn't start with ./ (which go list handles correctly for local paths)
+    if not is_windows:
+        full_path_packages = []
+        module_path = "github.com/DataDog/datadog-agent/"
+        for pkg in packages:
+            if not pkg.startswith(".") and not pkg.startswith(module_path):
+                full_path_packages.append(module_path + pkg)
+            else:
+                full_path_packages.append(pkg)
+        packages_arg = " ".join(full_path_packages)
+    else:
+        packages_arg = " ".join(packages)
 
     cmd = f"go list -find -f \"{format_arg}\" -mod=readonly -tags \"{buildtags_arg}\" {packages_arg}"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This change makes the script more robust by ensuring that it always provides go list with package paths in a format that Go's tooling universally understands.

### Motivation

Fix `dda inv -e kmt.test` command execution 

### Describe how you validated your changes

Before the change I have run the following command:

```
dda inv -e kmt.test --stack=mystack --vms=x86-amazon5.4-disto --packages=pkg/network/usm --run="TestTLSSuite/.*/.*/TestNativeTLSMapsCleanup"
```

And I have received the following error:

```
File "/root/miniforge3/envs/ddpy3/lib/python3.12/subprocess.py", line 571, in run raise CalledProcessError(retcode, process.args, subprocess.CalledProcessError: Command 'go list -find -f "{{ .Dir }}" -mod=readonly -tags "datadog.no_waf,ec2,grpcnotrace,linux_bpf,netcgo,npm,nvml,trivy_no_javadb,zlib,zstd,test" pkg/network/usm' returned non-zero exit status 1.
```

After my change the command worked as expected. 


<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->