### PR TITLE
fix(fleet): Fix unbound array variable

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -46,36 +46,36 @@ fi
 
 # This migrates legacy installs by removing the legacy deb / rpm installer package
 if command -v dpkg >/dev/null && dpkg -s datadog-installer >/dev/null 2>&1; then
-  "${sudo_cmd[@]}" datadog-installer purge >/dev/null 2>&1 || true
-  "${sudo_cmd[@]}" dpkg --purge datadog-installer >/dev/null 2>&1 || true
+  "${sudo_cmd[@]+"${sudo_cmd[@]}"}" datadog-installer purge >/dev/null 2>&1 || true
+  "${sudo_cmd[@]+"${sudo_cmd[@]}"}" dpkg --purge datadog-installer >/dev/null 2>&1 || true
 elif command -v rpm >/dev/null && rpm -q datadog-installer >/dev/null 2>&1; then
-  "${sudo_cmd[@]}" datadog-installer purge >/dev/null 2>&1 || true
-  "${sudo_cmd[@]}" rpm -e datadog-installer >/dev/null 2>&1 || true
+  "${sudo_cmd[@]+"${sudo_cmd[@]}"}" datadog-installer purge >/dev/null 2>&1 || true
+  "${sudo_cmd[@]+"${sudo_cmd[@]}"}" rpm -e datadog-installer >/dev/null 2>&1 || true
 fi
 
-"${sudo_cmd[@]}" mkdir -p "$tmp_dir"
+"${sudo_cmd[@]+"${sudo_cmd[@]}"}" mkdir -p "$tmp_dir"
 
 echo "Downloading the Datadog installer..."
 if command -v curl >/dev/null; then
-  if ! curl -L --retry 3 "$installer_url" | "${sudo_cmd[@]}" tee "$tmp_bin" >/dev/null; then
+  if ! curl -L --retry 3 "$installer_url" | "${sudo_cmd[@]+"${sudo_cmd[@]}"}" tee "$tmp_bin" >/dev/null; then
     echo "Error: Download failed with curl." >&2
     exit 1
   fi
 else
-  if ! wget --tries=3 -O - "$installer_url" | "${sudo_cmd[@]}" tee "$tmp_bin" >/dev/null; then
+  if ! wget --tries=3 -O - "$installer_url" | "${sudo_cmd[@]+"${sudo_cmd[@]}"}" tee "$tmp_bin" >/dev/null; then
     echo "Error: Download failed with wget." >&2
     exit 1
   fi
 fi
-"${sudo_cmd[@]}" chmod +x "$tmp_bin"
+"${sudo_cmd[@]+"${sudo_cmd[@]}"}" chmod +x "$tmp_bin"
 
 echo "Verifying installer integrity..."
 sha256sum -c <<<"$installer_sha256  $tmp_bin" >/dev/null
 echo "Installer integrity verified."
 
 echo "Starting the Datadog installer..."
-"${sudo_env_cmd[@]}" "$tmp_bin" setup --flavor "$flavor" "$@"
+"${sudo_env_cmd[@]+"${sudo_env_cmd[@]}"}" "$tmp_bin" setup --flavor "$flavor" "$@"
 
-"${sudo_cmd[@]}" rm -f "$tmp_bin"
+"${sudo_cmd[@]+"${sudo_cmd[@]}"}" rm -f "$tmp_bin"
 
 exit 0


### PR DESCRIPTION
### What does this PR do?
Some customers are experiencing the following error when running the installer install script: `sudo_cmd[@]: unbound variable`

Before bash 4.4, using `${a[@]}` or `${a[*]}` on an array without any elements when the no-unset option is enabled throws an unbound variable error. See [bash 4.4 release notes](https://cgit.git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?id=3ba697465bc74fab513a26dea700cc82e9f4724e#n878).

This PR fixes it by checking if the array is set before expanding it.

### Motivation

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->