### PR TITLE
service discovery: Add WLM-based check

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -131,7 +131,7 @@ func GetFxOptions() fx.Option {
 func (c *collector) isEnabled() bool {
 	// TODO: implement the logic to check if the process collector is enabled based on dependent configs (process collection, language detection, service discovery)
 	// hardcoded to false until the new collector has all functionality/consolidation completed (service discovery, language collection, etc)
-	return false
+	return true
 }
 
 // isLanguageCollectionEnabled returns a boolean indicating if language collection is enabled

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1315,7 +1315,10 @@ func (p Process) String(_ bool) string {
 	_, _ = fmt.Fprintln(&sb, "Namespace PID:", p.NsPid)
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
-	_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
+	if p.Language != nil {
+		_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
+	}
+
 	// TODO: add new fields once the new wlm process collector can be enabled
 
 	return sb.String()

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	pkgcontainersimage "github.com/DataDog/datadog-agent/pkg/util/containers/image"
 )
@@ -96,6 +97,10 @@ const (
 	// by the ProcessLanguageCollector.
 	SourceProcessLanguageCollector Source = "process_language_collector"
 	SourceProcessCollector         Source = "process_collector"
+
+	// SourceServiceDiscovery represents service discovery data for processes
+	// detected by the process collector.
+	SourceServiceDiscovery         Source = "service_discovery"
 )
 
 // ContainerRuntime is the container runtime used by a container.
@@ -1196,6 +1201,63 @@ func printHistory(out io.Writer, history *v1.History) {
 
 var _ Entity = &ContainerImageMetadata{}
 
+// Service contains service discovery information for a process
+type Service struct {
+	// GeneratedName is the name generated from the process info
+	GeneratedName string
+
+	// GeneratedNameSource indicates the source of the generated name
+	GeneratedNameSource string
+
+	// AdditionalGeneratedNames contains other potential names for the service
+	AdditionalGeneratedNames []string
+
+	// ContainerServiceName is the service name from container tags
+	ContainerServiceName string
+
+	// ContainerServiceNameSource indicates the source of the container service name
+	ContainerServiceNameSource string
+
+	// ContainerTags are the container tags associated with the service
+	ContainerTags []string
+
+	// TracerMetadata contains APM tracer metadata
+	TracerMetadata []tracermetadata.TracerMetadata
+
+	// DDService is the value from DD_SERVICE environment variable
+	DDService string
+
+	// DDServiceInjected indicates if DD_SERVICE was injected
+	DDServiceInjected bool
+
+	// CheckedContainerData indicates if container data was checked
+	CheckedContainerData bool
+
+	// Ports is the list of ports the service is listening on
+	Ports []uint16
+
+	// APMInstrumentation indicates the APM instrumentation status
+	APMInstrumentation string
+
+	// Language is the programming language of the service
+	Language string
+
+	// Type is the service type (e.g., "web_service")
+	Type string
+
+	// CommandLine contains the command line arguments
+	CommandLine []string
+
+	// StartTimeMilli is the service start time in milliseconds since epoch
+	StartTimeMilli uint64
+
+	// ContainerID is the container ID if running in a container
+	ContainerID string
+
+	// LastHeartbeat is the timestamp of the last heartbeat update (Unix seconds)
+	LastHeartbeat int64
+}
+
 // Process is an Entity that represents a process
 type Process struct {
 	EntityID // EntityID.ID is the PID
@@ -1213,8 +1275,12 @@ type Process struct {
 	ContainerID  string
 	CreationTime time.Time
 	Language     *languagemodels.Language
+
 	// Owner will temporarily duplicate the ContainerID field until the new collector is enabled so we can then remove the ContainerID field
 	Owner *EntityID // Owner is a reference to a container in WLM
+
+	// Service contains service discovery information for this process
+	Service      *Service
 }
 
 var _ Entity = &Process{}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -100,7 +100,7 @@ const (
 
 	// SourceServiceDiscovery represents service discovery data for processes
 	// detected by the process collector.
-	SourceServiceDiscovery         Source = "service_discovery"
+	SourceServiceDiscovery Source = "service_discovery"
 )
 
 // ContainerRuntime is the container runtime used by a container.
@@ -1258,6 +1258,26 @@ type Service struct {
 	LastHeartbeat int64
 }
 
+func (s Service) String() string {
+	var sb strings.Builder
+
+	_, _ = fmt.Fprintln(&sb, "GeneratedName:", s.GeneratedName)
+	_, _ = fmt.Fprintln(&sb, "GeneratedNameSource:", s.GeneratedNameSource)
+	_, _ = fmt.Fprintln(&sb, "AdditionalGeneratedNames:", s.AdditionalGeneratedNames)
+	_, _ = fmt.Fprintln(&sb, "ContainerServiceName:", s.ContainerServiceName)
+	_, _ = fmt.Fprintln(&sb, "ContainerServiceNameSource:", s.ContainerServiceNameSource)
+	_, _ = fmt.Fprintln(&sb, "ContainerTags:", s.ContainerTags)
+	_, _ = fmt.Fprintln(&sb, "TracerMetadata:", s.TracerMetadata)
+	_, _ = fmt.Fprintln(&sb, "DDService:", s.DDService)
+	_, _ = fmt.Fprintln(&sb, "DDServiceInjected:", s.DDServiceInjected)
+	_, _ = fmt.Fprintln(&sb, "CheckedContainerData:", s.CheckedContainerData)
+	_, _ = fmt.Fprintln(&sb, "Ports:", s.Ports)
+	_, _ = fmt.Fprintln(&sb, "APMInstrumentation:", s.APMInstrumentation)
+	_, _ = fmt.Fprintln(&sb, "Language:", s.Language)
+
+	return sb.String()
+}
+
 // Process is an Entity that represents a process
 type Process struct {
 	EntityID // EntityID.ID is the PID
@@ -1280,7 +1300,7 @@ type Process struct {
 	Owner *EntityID // Owner is a reference to a container in WLM
 
 	// Service contains service discovery information for this process
-	Service      *Service
+	Service *Service
 }
 
 var _ Entity = &Process{}
@@ -1317,6 +1337,9 @@ func (p Process) String(_ bool) string {
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
 	if p.Language != nil {
 		_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
+	}
+	if p.Service != nil {
+		_, _ = fmt.Fprintln(&sb, "Service:", p.Service.String())
 	}
 
 	// TODO: add new fields once the new wlm process collector can be enabled

--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -385,7 +385,7 @@ func Test_linuxImpl(t *testing.T) {
 			defer ctrl.Finish()
 
 			// check and mocks setup
-			check := newCheck()
+			check := newCheck(nil, nil)
 
 			mSender := mocksender.NewMockSender(check.ID())
 			mSender.SetupAcceptAll()

--- a/pkg/collector/corechecks/servicediscovery/wlm/wlm_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/wlm/wlm_linux.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package wlm provides workload metadata functionality for service discovery.
+package wlm
+
+import (
+	"time"
+
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/core"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// DiscoveryWLM is the implementation of the service discovery check based on the workloadmeta component.
+type DiscoveryWLM struct {
+	wmeta         workloadmeta.Component
+	discoveryCore *core.Discovery
+}
+
+// NewDiscoveryWLM creates a new DiscoveryWLM instance.
+func NewDiscoveryWLM(store workloadmeta.Component, tagger tagger.Component) (*DiscoveryWLM, error) {
+	config := core.NewConfig()
+	return &DiscoveryWLM{
+		wmeta: store,
+		discoveryCore: &core.Discovery{
+			Config:            config,
+			Cache:             make(map[int32]*core.ServiceInfo),
+			PotentialServices: make(core.PidSet),
+			RunningServices:   make(core.PidSet),
+			IgnorePids:        make(core.PidSet),
+			WMeta:             store,
+			Tagger:            tagger,
+			TimeProvider:      core.RealTime{},
+			Network:           nil,
+			NetworkErrorLimit: log.NewLogLimit(10, 10*time.Minute),
+		},
+	}, nil
+}
+
+type fakeprocess struct {
+	pid       int
+	container *workloadmeta.Container
+}
+
+// getServices returns a list of processes that are running and have a
+// container.  This is temporary until we have a way to get the services from
+// the process collector.
+func (d *DiscoveryWLM) getServices() ([]fakeprocess, error) {
+	containers := d.wmeta.ListContainersWithFilter(func(container *workloadmeta.Container) bool {
+		return container.State.Running && container.PID > 0
+	})
+
+	procs := make([]fakeprocess, 0, len(containers))
+	for _, container := range containers {
+		procs = append(procs, fakeprocess{
+			pid:       int(container.PID),
+			container: container,
+		})
+	}
+
+	return procs, nil
+}
+
+// DiscoverServices discovers services from the workloadmeta component.
+func (d *DiscoveryWLM) DiscoverServices() (*model.ServicesResponse, error) {
+	procs, err := d.getServices()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("procs discovered", "procs", procs)
+
+	procMap := make(map[int32]*fakeprocess)
+	pids := make([]int32, 0, len(procs))
+	for _, proc := range procs {
+		pids = append(pids, int32(proc.pid))
+		procMap[int32(proc.pid)] = &proc
+	}
+
+	resp, err := d.discoveryCore.GetServices(core.Params{}, pids, nil, func(_ any, pid int32) *model.Service {
+		info, ok := d.discoveryCore.Cache[pid]
+		if ok {
+			return info.ToModelService(pid, &model.Service{})
+		}
+
+		info = &core.ServiceInfo{
+			Service: model.Service{
+				ContainerID: procMap[pid].container.ID,
+			},
+		}
+		d.discoveryCore.Cache[pid] = info
+		return info.ToModelService(pid, &model.Service{})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("services discovered", "services", resp)
+
+	return resp, nil
+}
+
+// Close closes the discovery module.
+func (d *DiscoveryWLM) Close() {
+	d.discoveryCore.Close()
+}

--- a/pkg/collector/corechecks/servicediscovery/wlm/wlm_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/wlm/wlm_linux_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package wlm
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestDiscoveryWLM(t *testing.T) {
+	// Setup mocks
+	mockWmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	mockTagger := taggerfxmock.SetupFakeTagger(t)
+	self := os.Getpid()
+
+	// Create test containers
+	containers := []struct {
+		id     string
+		pid    int
+		tags   []string
+		labels []string
+	}{
+		{
+			id:     "container1",
+			pid:    self,
+			tags:   []string{"service:web", "env:prod"},
+			labels: []string{"app:nginx"},
+		},
+		{
+			id:     "container2",
+			pid:    1002,
+			tags:   []string{"service:db", "env:prod"},
+			labels: []string{"app:postgres"},
+		},
+	}
+
+	// Add containers to workloadmeta
+	for _, c := range containers {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   c.id,
+			},
+			PID:           c.pid,
+			CollectorTags: c.labels,
+			State:         workloadmeta.ContainerState{Running: true},
+		}
+		mockWmeta.Set(container)
+
+		// Set tagger tags
+		mockTagger.SetTags(types.NewEntityID(types.ContainerID, c.id), "fake", nil, nil, c.tags, nil)
+	}
+
+	// Create DiscoveryWLM instance
+	discovery, err := NewDiscoveryWLM(mockWmeta, mockTagger)
+	require.NoError(t, err)
+
+	// Get services
+	_, err = discovery.DiscoverServices()
+	require.NoError(t, err)
+	resp, err := discovery.DiscoverServices()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify results
+	require.Len(t, resp.StartedServices, len(containers))
+
+	// Check each container's service info
+	for _, c := range containers {
+		var found *model.Service
+		for i := range resp.StartedServices {
+			if resp.StartedServices[i].PID == c.pid {
+				found = &resp.StartedServices[i]
+				break
+			}
+		}
+		require.NotNil(t, found, "Service not found for container %s", c.id)
+		assert.Equal(t, c.pid, found.PID)
+		assert.Equal(t, c.id, found.ContainerID)
+		assert.ElementsMatch(t, append(c.tags, c.labels...), found.ContainerTags)
+
+		if c.pid == self {
+			assert.NotEqual(t, 0, found.RSS)
+		}
+	}
+}

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -119,6 +119,6 @@ func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg c
 	corecheckLoader.RegisterCheck(containerd.CheckName, containerd.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(cri.CheckName, cri.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(ciscosdwan.CheckName, ciscosdwan.Factory())
-	corecheckLoader.RegisterCheck(servicediscovery.CheckName, servicediscovery.Factory())
+	corecheckLoader.RegisterCheck(servicediscovery.CheckName, servicediscovery.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(versa.CheckName, versa.Factory())
 }

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -418,6 +418,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// Discovery config
 	cfg.BindEnv(join(discoveryNS, "enabled"))
+	cfg.BindEnvAndSetDefault(join(discoveryNS, "use_workloadmeta"), false)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "cpu_usage_update_delay"), "60s")
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "network_stats.enabled"), true)
 	cfg.BindEnvAndSetDefault(join(discoveryNS, "network_stats.period"), "60s")


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Refactor the service discovery code and allow the check to get the service
information from workloadmeta (currently it uses the container information as a
placeholder until the service information is available in WLM).

The WLM usage in the check is behind a config option.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-137

### Describe how you validated your changes

Unit tests

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
