### PR TITLE
[autodiscovery] Include all collected configs in flare and configcheck verbose

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -292,18 +292,14 @@ func (ac *AutoConfig) buildConfigCheckResponse(scrub bool) integration.ConfigChe
 	response.ConfigErrors = GetConfigErrors()
 
 	if scrub {
-		unresolved := ac.getUnresolvedTemplates()
-		scrubbedUnresolved := make(map[string][]integration.Config, len(unresolved))
-		for ids, configs := range unresolved {
-			scrubbedConfigs := make([]integration.Config, len(configs))
-			for idx, config := range configs {
-				scrubbedConfigs[idx] = ac.scrubConfig(config)
-			}
-			scrubbedUnresolved[ids] = scrubbedConfigs
+		unresolved := ac.getUnresolvedConfigs()
+		scrubbedUnresolved := make(map[string]integration.Config, len(unresolved))
+		for id, config := range unresolved {
+			scrubbedUnresolved[id] = ac.scrubConfig(config)
 		}
 		response.Unresolved = scrubbedUnresolved
 	} else {
-		response.Unresolved = ac.getUnresolvedTemplates()
+		response.Unresolved = ac.getUnresolvedConfigs()
 	}
 
 	return response
@@ -620,10 +616,10 @@ func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	ac.deleteMappingsOfCheckIDsWithSecrets(changes.Unschedule)
 }
 
-// getUnresolvedTemplates returns all templates in the cache, in their unresolved
+// getUnresolvedConfigs returns all the active configs, in their unresolved
 // state.
-func (ac *AutoConfig) getUnresolvedTemplates() map[string][]integration.Config {
-	return ac.store.templateCache.getUnresolvedTemplates()
+func (ac *AutoConfig) getUnresolvedConfigs() map[string]integration.Config {
+	return ac.cfgMgr.getActiveConfigs()
 }
 
 // GetIDOfCheckWithEncryptedSecrets returns the ID that a checkID had before

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -581,7 +581,7 @@ func TestWriteConfigEndpoint(t *testing.T) {
 			out := responseRecorder.Body.Bytes()
 			err := json.Unmarshal(out, &result)
 			require.NoError(t, err)
-			assert.Equal(t, string(result.Configs[0].Config.Instances[0]), tc.expectedResult)
+			assert.Equal(t, tc.expectedResult, string(result.Configs[0].Config.Instances[0]))
 
 			// Check also that the unresolved configs are returned
 			var unresolved []integration.Config

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -582,6 +582,14 @@ func TestWriteConfigEndpoint(t *testing.T) {
 			err := json.Unmarshal(out, &result)
 			require.NoError(t, err)
 			assert.Equal(t, string(result.Configs[0].Config.Instances[0]), tc.expectedResult)
+
+			// Check also that the unresolved configs are returned
+			var unresolved []integration.Config
+			for _, config := range result.Unresolved {
+				unresolved = append(unresolved, config)
+			}
+			require.Len(t, unresolved, 1)
+			assert.Equal(t, tc.expectedResult, string(unresolved[0].Instances[0]))
 		})
 	}
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -45,6 +45,9 @@ type configManager interface {
 	// The call is made with the manager's lock held, so callers should perform
 	// minimal work within f.
 	mapOverLoadedConfigs(func(map[string]integration.Config))
+
+	// getActiveConfigs returns the currently active configs
+	getActiveConfigs() map[string]integration.Config
 }
 
 // serviceAndADIDs bundles a service and its associated AD identifiers.
@@ -291,6 +294,17 @@ func (cm *reconcilingConfigManager) mapOverLoadedConfigs(f func(map[string]integ
 	cm.m.Lock()
 	defer cm.m.Unlock()
 	f(cm.scheduledConfigs)
+}
+
+func (cm *reconcilingConfigManager) getActiveConfigs() map[string]integration.Config {
+	cm.m.Lock()
+	defer cm.m.Unlock()
+
+	res := make(map[string]integration.Config, len(cm.activeConfigs))
+	for k, v := range cm.activeConfigs {
+		res[k] = v
+	}
+	return res
 }
 
 // reconcileService calculates the current set of resolved templates for the

--- a/comp/core/autodiscovery/integration/response.go
+++ b/comp/core/autodiscovery/integration/response.go
@@ -6,7 +6,7 @@
 package integration
 
 // ConfigResponse holds information about the config
-// the instance IDs are precompouted to avoid discrepancies between the server and the client
+// the instance IDs are precomputed to avoid discrepancies between the server and the client
 // The InstanceIDs must have the same order as the instances in the Config struct
 type ConfigResponse struct {
 	InstanceIDs []string `json:"instance_ids"`
@@ -18,5 +18,5 @@ type ConfigCheckResponse struct {
 	Configs         []ConfigResponse    `json:"configs"`
 	ResolveWarnings map[string][]string `json:"resolve_warnings"`
 	ConfigErrors    map[string]string   `json:"config_errors"`
-	Unresolved      map[string][]Config `json:"unresolved"`
+	Unresolved      map[string]Config   `json:"unresolved"`
 }

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -8,6 +8,7 @@ package flare
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/fatih/color"
 
@@ -43,13 +44,11 @@ func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug
 			}
 		}
 		if len(cr.Unresolved) > 0 {
-			fmt.Fprintf(w, "\n=== %s Configs ===\n", color.YellowString("Unresolved"))
-			for ids, configs := range cr.Unresolved {
-				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Auto-discovery IDs"), color.YellowString(ids))
-				fmt.Fprintf(w, "%s:\n", color.BlueString("Templates"))
-				for _, config := range configs {
-					fmt.Fprintln(w, config.String())
-				}
+			fmt.Fprintf(w, "\n=== %s configs (matched and unmatched) ===\n", color.MagentaString("Collected"))
+			for _, config := range cr.Unresolved {
+				adIdentifiers := strings.Join(config.ADIdentifiers, ",") // Will be empty for non-template configs
+				fmt.Fprintf(w, "\n%s: %s\n", color.BlueString("Auto-discovery IDs"), color.YellowString(adIdentifiers))
+				fmt.Fprintln(w, config.String())
 			}
 		}
 	}

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -45,11 +45,10 @@ func TestPrintConfigCheck(t *testing.T) {
 		ResolveWarnings: map[string][]string{
 			"some_identifier": {"some_warning"},
 		},
-		Unresolved: map[string][]integration.Config{
+		Unresolved: map[string]integration.Config{
 			"unresolved_config": {
-				{
-					Instances: []integration.Data{integration.Data("{unresolved:sad}")},
-				},
+				ADIdentifiers: []string{"unresolved_config"},
+				Instances:     []integration.Data{integration.Data("{unresolved:sad}")},
 			},
 		},
 	}
@@ -86,10 +85,9 @@ Log Config:
 some_identifier
 * some_warning
 
-=== Unresolved Configs ===
+=== Collected configs (matched and unmatched) ===
 
 Auto-discovery IDs: unresolved_config
-Templates:
 check_name: ""
 init_config: null
 instances:

--- a/releasenotes/notes/ad-fix-list-unresolved-3dc5a2556e7a6f6c.yaml
+++ b/releasenotes/notes/ad-fix-list-unresolved-3dc5a2556e7a6f6c.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``agent configcheck --verbose`` command and flares now include a section
+    that lists all collected configurations, both matched and unmatched. This
+    addition aids debugging by revealing which configurations the Agent has
+    detected.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the autodiscovery component.

The `agent configcheck --verbose` command and flares were supposed to display a section with all unresolved configurations (both matched and unmatched), as shown here: https://github.com/DataDog/datadog-agent/blob/3dfd9d29a724757a73c8bde25472039e9c101194/pkg/flare/config_check.go#L45

However, this broke in a previous version, and the list of unresolved configs is now always empty. This is because autodiscovery relies on its template cache store to retrieve them, but that store is never updated: https://github.com/DataDog/datadog-agent/blob/3dfd9d29a724757a73c8bde25472039e9c101194/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go#L642

I believe that having all collected configurations (both matched and unmatched) is helpful for debugging. It’s sometimes important to see exactly what configurations autodiscovery collected. That’s why I think it’s worth fixing this, even though it has been broken for several versions.

Thanks to this change we can also delete some unused code in `comp/core/autodiscovery/autodiscoveryimpl/templatecache.go` and `comp/core/autodiscovery/autodiscoveryimpl/store.go`, but I'll do that in a separate PR.

This is an example of what `agent configcheck --verbose` shows in the “Collected configs” section after this change (only the first few lines are shown, as there are many configurations). The first section, which lists the configured checks, remains unchanged.

```

... Configured checks here (this part remains unchanged) ...

=== Collected configs (matched and unmatched) ===

Auto-discovery IDs: cluster-agent
check_name: datadog_cluster_agent
init_config: null
instances:
- prometheus_url: http://%%host%%:5000/metrics
logs_config: null


Auto-discovery IDs: proxyv2,proxyv2-rhel8
check_name: istio
init_config: null
instances:
- istio_mesh_endpoint: http://%%host%%:15020/stats/prometheus
  send_histograms_buckets: true
  tag_by_endpoint: false
logs_config: null


Auto-discovery IDs: kyototycoon
check_name: kyototycoon
init_config: null
instances:
- report_url: http://%%host%%:1978/rpc/report
logs_config: null


Auto-discovery IDs: kubedns-amd64,k8s-dns-kube-dns-amd64,k8s-dns-kube-dns
check_name: kube_dns
init_config: null
instances:
- prometheus_endpoint: http://%%host%%:10055/metrics
  tags:
  - dns-pod:%%host%%
logs_config: null

...

```

### Describe how you validated your changes

I added unit tests and also manually confirmed that  `agent configcheck --verbose` and the flares now include all collected configurations.