### PR TITLE
assert runtime agent config reflects fleet experiment

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -79,7 +79,7 @@ func (s *BaseSuite) SetInstaller(impl DatadogInstallerRunner) {
 // so that it could be shared by multiple suites, but for now it exists only
 // on the Windows Datadog installer `BaseSuite` object.
 func (s *BaseSuite) Require() *suiteasserts.SuiteAssertions {
-	return suiteasserts.New(s.BaseSuite.Require(), s)
+	return suiteasserts.New(s, s.BaseSuite.Require())
 }
 
 // CurrentAgentVersion the version of the Agent in the current pipeline

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -6,7 +6,6 @@
 package assertions
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
@@ -19,13 +18,16 @@ type RemoteWindowsAgentAssertions struct {
 	agentClient agentclient.Agent
 }
 
-// HasConfigValue checks if the agent has a specific configuration value
+// WithConfigValueEqual checks if the Agent runtime config has a specific configuration value
 func (r *RemoteWindowsAgentAssertions) WithConfigValueEqual(key string, expectedValue string) *RemoteWindowsAgentAssertions {
 	r.context.T().Helper()
 	value, err := r.agentClient.ConfigWithError(agentclient.WithArgs([]string{"get", key}))
 	r.require.NoError(err)
 	value = strings.TrimSpace(value)
-	wrappedExpectedValue := fmt.Sprintf("%s is set to: %s", key, expectedValue)
-	r.require.Equal(wrappedExpectedValue, value, "expected config value %s to be %v, but got %v", key, expectedValue, value)
+	// Extract just the value part after "is set to: "
+	valueParts := strings.Split(value, "is set to: ")
+	r.require.Len(valueParts, 2, "unexpected config output format")
+	actualValue := strings.TrimSpace(valueParts[1])
+	r.require.Equal(expectedValue, actualValue, "expected config value %s to be %v, but got %v", key, expectedValue, actualValue)
 	return r
 }

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package assertions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+)
+
+// RemoteWindowsAgentAssertions is a type that extends the SuiteAssertions to add assertions
+// executing on a RemoteHost's Agent.
+type RemoteWindowsAgentAssertions struct {
+	*RemoteWindowsBinaryAssertions
+	agentClient agentclient.Agent
+}
+
+// HasConfigValue checks if the agent has a specific configuration value
+func (r *RemoteWindowsAgentAssertions) WithConfigValueEqual(key string, expectedValue string) *RemoteWindowsAgentAssertions {
+	r.context.T().Helper()
+	value, err := r.agentClient.ConfigWithError(agentclient.WithArgs([]string{"get", key}))
+	r.require.NoError(err)
+	value = strings.TrimSpace(value)
+	wrappedExpectedValue := fmt.Sprintf("%s is set to: %s", key, expectedValue)
+	r.require.Equal(wrappedExpectedValue, value, "expected config value %s to be %v, but got %v", key, expectedValue, value)
+	return r
+}

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_agent_asserts.go
@@ -58,14 +58,14 @@ func (c *RemoteWindowsAgentConfigAssertions) getConfigValue(key string) interfac
 			actualValue, exists := current[k]
 			c.require.True(exists, "config key %s not found", key)
 			return actualValue
-		} else {
-			// Navigate deeper
-			next, exists := current[k]
-			c.require.True(exists, "config key %s not found", key)
-			nextMap, ok := next.(map[interface{}]interface{})
-			c.require.True(ok, "config key %s is not a nested object", strings.Join(keys[:i+1], "."))
-			current = nextMap
 		}
+
+		// Navigate deeper
+		next, exists := current[k]
+		c.require.True(exists, "config key %s not found", key)
+		nextMap, ok := next.(map[interface{}]interface{})
+		c.require.True(ok, "config key %s is not a nested object", strings.Join(keys[:i+1], "."))
+		current = nextMap
 	}
 
 	// This should never be reached due to the loop logic

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_binary_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_binary_asserts.go
@@ -24,7 +24,7 @@ type RemoteWindowsBinaryAssertions struct {
 // WithSignature verifies the authenticode signature of the binary. This test does not call `FailNow` in case
 // the signature does not match.
 func (r *RemoteWindowsBinaryAssertions) WithSignature(expectedSignatures map[string]struct{}) *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	verify, _ := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.VerifyCodeSignature, true)
 
 	if verify {
@@ -42,7 +42,7 @@ func (r *RemoteWindowsBinaryAssertions) WithSignature(expectedSignatures map[str
 // WithVersionEqual verifies the version of a binary matches what's expected by calling "version" on it.
 // Obviously the binary must support the "version" command, which is normally the case for most Agent binaries.
 func (r *RemoteWindowsBinaryAssertions) WithVersionEqual(expected string) *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	return r.WithVersionMatchPredicate(func(actual string) {
 		r.require.Equal(expected, actual, "version should be equal")
 	})
@@ -51,7 +51,7 @@ func (r *RemoteWindowsBinaryAssertions) WithVersionEqual(expected string) *Remot
 // WithVersionNotEqual verifies the version of a binary NOT match the expected by calling "version" on it.
 // Obviously the binary must support the "version" command, which is normally the case for most Agent binaries.
 func (r *RemoteWindowsBinaryAssertions) WithVersionNotEqual(expected string) *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	return r.WithVersionMatchPredicate(func(actual string) {
 		r.require.NotEqual(expected, actual, "version should not be equal")
 	})
@@ -60,7 +60,7 @@ func (r *RemoteWindowsBinaryAssertions) WithVersionNotEqual(expected string) *Re
 // WithVersionMatchPredicate obtains the binary version by calling "version" and uses the predicate to verify
 // if the version match the expectations.
 func (r *RemoteWindowsBinaryAssertions) WithVersionMatchPredicate(predicate func(version string)) *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	actual, err := r.remoteHost.Execute(fmt.Sprintf("& \"%s\" %s", r.binaryPath, "version"))
 	r.require.NoError(err)
 	predicate(strings.TrimSpace(actual))

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -31,15 +31,15 @@ type RemoteWindowsHostAssertions struct {
 	// only get access to the assertions that can effectively run on the remote server, preventing
 	// accidental misuse.
 	require    *require.Assertions
-	suite      suite.TestingSuite
+	context    e2ecommon.Context
 	remoteHost *components.RemoteHost
 }
 
 // New returns a new RemoteWindowsHostAssertions
-func New(assertions *require.Assertions, suite suite.TestingSuite, remoteHost *components.RemoteHost) *RemoteWindowsHostAssertions {
+func New(context e2ecommon.Context, assertions *require.Assertions, remoteHost *components.RemoteHost) *RemoteWindowsHostAssertions {
 	return &RemoteWindowsHostAssertions{
 		require:    assertions,
-		suite:      suite,
+		context:    context,
 		remoteHost: remoteHost,
 	}
 }
@@ -47,7 +47,7 @@ func New(assertions *require.Assertions, suite suite.TestingSuite, remoteHost *c
 // HasAService returns an assertion object that can be used to assert things about
 // a given Windows service. If the service doesn't exist, it fails.
 func (r *RemoteWindowsHostAssertions) HasAService(serviceName string) *RemoteWindowsServiceAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	serviceConfig, err := common.GetServiceConfig(r.remoteHost, serviceName)
 	r.require.NoError(err)
 	return &RemoteWindowsServiceAssertions{RemoteWindowsHostAssertions: r, serviceConfig: serviceConfig}
@@ -56,7 +56,7 @@ func (r *RemoteWindowsHostAssertions) HasAService(serviceName string) *RemoteWin
 // HasNoService returns an assertion object that can be used to assert things about
 // a given Windows service. If the service doesn't exist, it fails.
 func (r *RemoteWindowsHostAssertions) HasNoService(serviceName string) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	_, err := common.GetServiceConfig(r.remoteHost, serviceName)
 	r.require.Error(err)
 	return r
@@ -65,7 +65,7 @@ func (r *RemoteWindowsHostAssertions) HasNoService(serviceName string) *RemoteWi
 // DirExists checks whether a directory exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
 func (r *RemoteWindowsHostAssertions) DirExists(path string, msgAndArgs ...interface{}) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	_, err := r.remoteHost.Lstat(path)
 	r.require.NoError(err, msgAndArgs...)
 	return r
@@ -73,7 +73,7 @@ func (r *RemoteWindowsHostAssertions) DirExists(path string, msgAndArgs ...inter
 
 // NoDirExists checks whether a directory does not exist in the given path.
 func (r *RemoteWindowsHostAssertions) NoDirExists(path string, msgAndArgs ...interface{}) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	_, err := r.remoteHost.Lstat(path)
 	r.require.ErrorIs(err, fs.ErrNotExist, msgAndArgs...)
 	return r
@@ -82,7 +82,7 @@ func (r *RemoteWindowsHostAssertions) NoDirExists(path string, msgAndArgs ...int
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
 func (r *RemoteWindowsHostAssertions) FileExists(path string, msgAndArgs ...interface{}) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	exists, err := r.remoteHost.FileExists(path)
 	r.require.NoError(err)
 	r.require.True(exists, msgAndArgs...)
@@ -92,7 +92,7 @@ func (r *RemoteWindowsHostAssertions) FileExists(path string, msgAndArgs ...inte
 // NoFileExists checks whether a file does not exist in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
 func (r *RemoteWindowsHostAssertions) NoFileExists(path string, msgAndArgs ...interface{}) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	exists, err := r.remoteHost.FileExists(path)
 	r.require.NoError(err)
 	r.require.False(exists, msgAndArgs...)
@@ -119,7 +119,7 @@ func (r *RemoteWindowsHostAssertions) HasARunningDatadogAgentService() *RemoteWi
 
 // HasNoDatadogAgentService checks if the remote host doesn't have a Datadog Agent installed.
 func (r *RemoteWindowsHostAssertions) HasNoDatadogAgentService() *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	r.NoFileExists(defaultAgentBinPath)
 	r.HasNoService("datadogagent")
 	return &RemoteWindowsBinaryAssertions{
@@ -131,7 +131,7 @@ func (r *RemoteWindowsHostAssertions) HasNoDatadogAgentService() *RemoteWindowsB
 // HasBinary checks if a binary exists on the remote host and returns a more specific assertion
 // allowing to run further tests on the binary.
 func (r *RemoteWindowsHostAssertions) HasBinary(path string) *RemoteWindowsBinaryAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	r.FileExists(path)
 	return &RemoteWindowsBinaryAssertions{
 		RemoteWindowsHostAssertions: r,
@@ -141,7 +141,7 @@ func (r *RemoteWindowsHostAssertions) HasBinary(path string) *RemoteWindowsBinar
 
 // HasRegistryKey checks if a registry key exists on the remote host.
 func (r *RemoteWindowsHostAssertions) HasRegistryKey(key string) *RemoteWindowsRegistryKeyAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	exists, err := common.RegistryKeyExists(r.remoteHost, key)
 	r.require.NoError(err)
 	r.require.True(exists)
@@ -153,7 +153,7 @@ func (r *RemoteWindowsHostAssertions) HasRegistryKey(key string) *RemoteWindowsR
 
 // HasNoRegistryKey checks if a registry key does not exist on the remote host.
 func (r *RemoteWindowsHostAssertions) HasNoRegistryKey(key string) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	exists, err := common.RegistryKeyExists(r.remoteHost, key)
 	r.require.NoError(err)
 	r.require.False(exists)
@@ -162,7 +162,7 @@ func (r *RemoteWindowsHostAssertions) HasNoRegistryKey(key string) *RemoteWindow
 
 // HasNamedPipe checks if a named pipe exists on the remote host
 func (r *RemoteWindowsHostAssertions) HasNamedPipe(pipeName string) *RemoteWindowsNamedPipeAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 
 	cmd := fmt.Sprintf("Test-Path '%s'", pipeName)
 	out, err := r.remoteHost.Execute(cmd)
@@ -178,7 +178,7 @@ func (r *RemoteWindowsHostAssertions) HasNamedPipe(pipeName string) *RemoteWindo
 
 // HasNoNamedPipe checks if a named pipe does not exist on the remote host
 func (r *RemoteWindowsHostAssertions) HasNoNamedPipe(pipeName string) *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 
 	cmd := fmt.Sprintf("Test-Path '%s'", pipeName)
 	out, err := r.remoteHost.Execute(cmd)
@@ -191,7 +191,7 @@ func (r *RemoteWindowsHostAssertions) HasNoNamedPipe(pipeName string) *RemoteWin
 
 // HasARunningDatadogInstallerService verifies that the Datadog Installer service is installed and correctly configured.
 func (r *RemoteWindowsHostAssertions) HasARunningDatadogInstallerService() *RemoteWindowsHostAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 
 	r.HasAService(consts.ServiceName).
 		WithStatus("Running").
@@ -219,7 +219,7 @@ func (r *RemoteWindowsHostAssertions) HasARunningDatadogInstallerService() *Remo
 
 // HasDatadogInstaller verifies that the Datadog Installer is installed on the remote host.
 func (r *RemoteWindowsHostAssertions) HasDatadogInstaller() *RemoteWindowsInstallerAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 
 	installPath, err := windowsagent.GetInstallPathFromRegistry(r.remoteHost)
 	r.require.NoError(err)

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_installer_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_installer_asserts.go
@@ -46,7 +46,7 @@ type RemoteWindowsInstallerStatusAssertions struct {
 
 // HasPackage verifies that a package is present in the status output.
 func (d *RemoteWindowsInstallerStatusAssertions) HasPackage(name string) *RemoteWindowsInstallerPackageAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Contains(d.status.Packages.States, name)
 	return &RemoteWindowsInstallerPackageAssertions{
 		RemoteWindowsInstallerStatusAssertions: d,
@@ -62,35 +62,35 @@ type RemoteWindowsInstallerPackageAssertions struct {
 
 // WithStableVersionEqual verifies the stable version of a package matches what's expected.
 func (d *RemoteWindowsInstallerPackageAssertions) WithStableVersionEqual(version string) *RemoteWindowsInstallerPackageAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Equal(version, d.status.Packages.States[d.name].Stable, "expected matching stable version for package %s", d.name)
 	return d
 }
 
 // WithExperimentVersionEqual verifies the experiment version of a package matches what's expected.
 func (d *RemoteWindowsInstallerPackageAssertions) WithExperimentVersionEqual(version string) *RemoteWindowsInstallerPackageAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Equal(version, d.status.Packages.States[d.name].Experiment, "expected matching experiment version for package %s", d.name)
 	return d
 }
 
 // WithStableVersionMatchPredicate verifies the stable version of a package by using a predicate function.
 func (d *RemoteWindowsInstallerPackageAssertions) WithStableVersionMatchPredicate(predicate func(version string)) *RemoteWindowsInstallerPackageAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	predicate(d.status.Packages.States[d.name].Stable)
 	return d
 }
 
 // WithExperimentVersionMatchPredicate verifies the experiment version of a package by using a predicate function.
 func (d *RemoteWindowsInstallerPackageAssertions) WithExperimentVersionMatchPredicate(predicate func(version string)) *RemoteWindowsInstallerPackageAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	predicate(d.status.Packages.States[d.name].Experiment)
 	return d
 }
 
 // HasConfigState asserts that a package config is present in the status output.
 func (d *RemoteWindowsInstallerStatusAssertions) HasConfigState(name string) *RemoteWindowsInstallerConfigStateAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Contains(d.status.Packages.ConfigStates, name)
 	return &RemoteWindowsInstallerConfigStateAssertions{
 		RemoteWindowsInstallerStatusAssertions: d,
@@ -106,14 +106,14 @@ type RemoteWindowsInstallerConfigStateAssertions struct {
 
 // WithStableConfigEqual asserts the stable config of a package matches what's expected.
 func (d *RemoteWindowsInstallerConfigStateAssertions) WithStableConfigEqual(config string) *RemoteWindowsInstallerConfigStateAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Equal(config, d.status.Packages.ConfigStates[d.name].Stable, "expected matching stable config for package %s", d.name)
 	return d
 }
 
 // WithExperimentConfigEqual asserts the experiment config of a package matches
 func (d *RemoteWindowsInstallerConfigStateAssertions) WithExperimentConfigEqual(config string) *RemoteWindowsInstallerConfigStateAssertions {
-	d.suite.T().Helper()
+	d.context.T().Helper()
 	d.require.Equal(config, d.status.Packages.ConfigStates[d.name].Experiment, "expected matching experiment config for package %s", d.name)
 	return d
 }

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_namedpipe_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_namedpipe_asserts.go
@@ -18,12 +18,12 @@ type RemoteWindowsNamedPipeAssertions struct {
 
 // WithSecurity asserts that the named pipe has the given security descriptor.
 func (r *RemoteWindowsNamedPipeAssertions) WithSecurity(expected common.ObjectSecurity) *RemoteWindowsNamedPipeAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	actual, err := common.GetNamedPipeSecurityInfo(r.remoteHost, r.pipename)
 	r.require.NoError(err)
-	common.AssertEqualAccessSecurity(r.suite.T(), r.pipename, expected, actual)
-	if r.suite.T().Failed() {
-		r.suite.T().FailNow()
+	common.AssertEqualAccessSecurity(r.context.T(), r.pipename, expected, actual)
+	if r.context.T().Failed() {
+		r.context.T().FailNow()
 	}
 	return r
 }

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_registry_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_registry_asserts.go
@@ -18,7 +18,7 @@ type RemoteWindowsRegistryKeyAssertions struct {
 
 // WithValueEqual verifies the value of a registry key matches what's expected.
 func (r *RemoteWindowsRegistryKeyAssertions) WithValueEqual(value, expected string) *RemoteWindowsRegistryKeyAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	actual, err := common.GetRegistryValue(r.remoteHost, r.keyPath, value)
 	r.require.NoError(err, "could not get registry value")
 	r.require.Equal(expected, actual, "registry value should be equal")

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_service_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_service_asserts.go
@@ -18,7 +18,7 @@ type RemoteWindowsServiceAssertions struct {
 
 // WithStatus asserts that the service has the given status.
 func (r *RemoteWindowsServiceAssertions) WithStatus(expectedStatus string) *RemoteWindowsServiceAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	actualStatus, err := common.GetServiceStatus(r.remoteHost, r.serviceConfig.ServiceName)
 	r.require.NoError(err)
 	r.require.Equal(expectedStatus, actualStatus)
@@ -27,7 +27,7 @@ func (r *RemoteWindowsServiceAssertions) WithStatus(expectedStatus string) *Remo
 
 // WithIdentity asserts that the service runs under the given identity.
 func (r *RemoteWindowsServiceAssertions) WithIdentity(userIdentity common.Identity) *RemoteWindowsServiceAssertions {
-	r.suite.T().Helper()
+	r.context.T().Helper()
 	r.require.Equal(userIdentity.GetSID(), r.serviceConfig.UserSID)
 	return r
 }

--- a/test/new-e2e/tests/installer/windows/suite-assertions/suite_assertions.go
+++ b/test/new-e2e/tests/installer/windows/suite-assertions/suite_assertions.go
@@ -8,28 +8,28 @@ package suiteasserts
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/remote-host-assertions"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 // SuiteAssertions is a type to help write fluent, self-contained assertions.
 // It is used as a bridge type to extend require.Assertions.
 type SuiteAssertions struct {
 	*require.Assertions
-	suite suite.TestingSuite
+	context common.Context
 }
 
 // New creates a new SuiteAssertions
-func New(r *require.Assertions, suite suite.TestingSuite) *SuiteAssertions {
+func New(ctx common.Context, r *require.Assertions) *SuiteAssertions {
 	return &SuiteAssertions{
 		Assertions: r,
-		suite:      suite,
+		context:    ctx,
 	}
 }
 
 // Host returns a RemoteWindowsHostAssertions to differentiates assertions running on the host vs assertions
 // running remotely.
 func (s *SuiteAssertions) Host(remoteHost *components.RemoteHost) *assertions.RemoteWindowsHostAssertions {
-	return assertions.New(s.Assertions, s.suite, remoteHost)
+	return assertions.New(s.context, s.Assertions, remoteHost)
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -41,6 +41,9 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 
 	// assert that setup was successful
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		WithConfigValueEqual("log_level", "info")
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -56,8 +59,16 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	// Start config experiment
 	s.mustStartConfigExperiment(config)
 
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		WithConfigValueEqual("log_level", "debug")
+
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		WithConfigValueEqual("log_level", "debug")
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -42,8 +42,8 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	// assert that setup was successful
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().
-		WithConfigValueEqual("log_level", "info")
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "info")
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -60,15 +60,15 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.mustStartConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().
-		WithConfigValueEqual("log_level", "debug")
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "debug")
 
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogAgentService().
-		WithConfigValueEqual("log_level", "debug")
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "debug")
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
@@ -101,6 +101,11 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 		"datadogagent",
 	)
 	s.AssertSuccessfulConfigStopExperiment()
+
+	// Config should be reverted to the stable config
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "info")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -193,11 +198,19 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 	// Start config experiment (restarts the services)
 	s.mustStartConfigExperiment(config)
 
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "debug")
+
 	// Stop the agent service to trigger watchdog rollback
 	windowscommon.StopService(s.Env().RemoteHost, consts.ServiceName)
 
 	// Assert
 	s.AssertSuccessfulConfigStopExperiment()
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "info")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -230,11 +243,19 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 	// Start config experiment
 	s.mustStartConfigExperiment(config)
 
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "debug")
+
 	// wait for the timeout
 	s.WaitForDaemonToStop(func() {}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 
 	// Assert
 	s.AssertSuccessfulConfigStopExperiment()
+
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().RuntimeConfig().
+		WithValueEqual("log_level", "info")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
assert runtime agent config reflects fleet experiment

Changes runtime assertions `suite TestingSuite` interface to the `e2e.Context` interface. We previously only used `T()` from `TestingSuite`, but the e2e agent client helper needs `e2e.Context` which also supplies the test output path.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1527
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->