### PR TITLE
[AGENTCFG-236] Sending the correct proto payload to the api/beta/sketches endpoint when running the connectivity command

### DIFF
--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -218,7 +218,11 @@ func sendHTTPRequestToEndpoint(ctx context.Context, client *http.Client, domain 
 
 	// Add tracing and send the request
 	req = req.WithContext(ctx)
-	req.Header.Set("Content-Type", "application/json")
+	contentType := endpointInfo.ContentType
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("DD-API-KEY", apiKey)
 
 	resp, err := client.Do(req)

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -112,7 +112,7 @@ func getEndpointsInfo(cfg model.Reader) []endpointInfo {
 
 		// v2 endpoints
 		{endpoints.SeriesEndpoint, "POST", emptyPayload, jsonCT},
-		{endpoints.SketchSeriesEndpoint, "POST", sketchPayload, protoCT}, // <- this is the critical change
+		{endpoints.SketchSeriesEndpoint, "POST", sketchPayload, protoCT},
 
 		// Flare endpoint
 		{transaction.Endpoint{Route: helpers.GetFlareEndpoint(cfg), Name: "flare"}, "HEAD", nil, jsonCT},

--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -10,10 +10,15 @@
 package connectivity
 
 import (
+	"log"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/gogo/protobuf/proto"
 )
 
 // endpointInfo is a value object that contains all the information we need to
@@ -29,28 +34,87 @@ type endpointInfo struct {
 
 	// Payload is the HTTP request body we want to send to the endpoint.
 	Payload []byte
+
+	// ContentType is media type of the payload.
+	ContentType string
+}
+
+func buildSketchPayload() *gogen.SketchPayload {
+	now := time.Now().Unix()
+
+	sketch := &gogen.SketchPayload_Sketch{
+		Metric: "example.metric",
+		Host:   "my-hostname",
+		Distributions: []gogen.SketchPayload_Sketch_Distribution{
+			{
+				Ts:    now,
+				Cnt:   1,
+				Min:   0.1,
+				Max:   0.5,
+				Avg:   0.3,
+				Sum:   0.3,
+				V:     []float64{0.3},
+				G:     []uint32{1},
+				Delta: []uint32{0},
+				Buf:   []float64{0.3},
+			},
+		},
+		Tags: []string{"tag1:value1", "tag2:value2"},
+		Metadata: &gogen.Metadata{
+			Origin: &gogen.Origin{
+				OriginProduct:  1234,
+				OriginCategory: 5678,
+				OriginService:  9012,
+			},
+		},
+	}
+
+	metadata := &gogen.CommonMetadata{
+		AgentVersion: "1.0.0",
+		Timezone:     "UTC",
+		CurrentEpoch: float64(now),
+		InternalIp:   "10.0.0.1",
+		PublicIp:     "1.2.3.4",
+		ApiKey:       "your-api-key",
+	}
+
+	payload := &gogen.SketchPayload{
+		Sketches: []gogen.SketchPayload_Sketch{*sketch},
+		Metadata: *metadata,
+	}
+
+	return payload
 }
 
 func getEndpointsInfo(cfg model.Reader) []endpointInfo {
 	emptyPayload := []byte("{}")
+	unmarshalledSketchPayload := buildSketchPayload()
+	sketchPayload, err := proto.Marshal(unmarshalledSketchPayload)
+	if err != nil {
+		log.Fatalf("Failed to marshal SketchPayload: %v", err)
+	}
+
 	checkRunPayload := []byte("{\"check\": \"test\", \"status\": 0}")
+
+	jsonCT := "application/json"
+	protoCT := "application/x-protobuf"
 
 	// Each added/modified endpointInfo should be tested on all sites.
 	return []endpointInfo{
 		// v1 endpoints
-		{endpoints.V1SeriesEndpoint, "POST", emptyPayload},
-		{endpoints.V1CheckRunsEndpoint, "POST", checkRunPayload},
-		{endpoints.V1IntakeEndpoint, "POST", emptyPayload},
+		{endpoints.V1SeriesEndpoint, "POST", emptyPayload, jsonCT},
+		{endpoints.V1CheckRunsEndpoint, "POST", checkRunPayload, jsonCT},
+		{endpoints.V1IntakeEndpoint, "POST", emptyPayload, jsonCT},
 
 		// This endpoint behaves differently depending on `site` when using `emptyPayload`. Do not modify `nil` here !
-		{endpoints.V1ValidateEndpoint, "GET", nil},
-		{endpoints.V1MetadataEndpoint, "POST", emptyPayload},
+		{endpoints.V1ValidateEndpoint, "GET", nil, jsonCT},
+		{endpoints.V1MetadataEndpoint, "POST", emptyPayload, jsonCT},
 
 		// v2 endpoints
-		{endpoints.SeriesEndpoint, "POST", emptyPayload},
-		{endpoints.SketchSeriesEndpoint, "POST", emptyPayload},
+		{endpoints.SeriesEndpoint, "POST", emptyPayload, jsonCT},
+		{endpoints.SketchSeriesEndpoint, "POST", sketchPayload, protoCT}, // <- this is the critical change
 
 		// Flare endpoint
-		{transaction.Endpoint{Route: helpers.GetFlareEndpoint(cfg), Name: "flare"}, "HEAD", nil},
+		{transaction.Endpoint{Route: helpers.GetFlareEndpoint(cfg), Name: "flare"}, "HEAD", nil, jsonCT},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
When running the command `./bin/agent/agent diagnose connectivity-datadog-core-endpoints`, the following error appears:

> Error running diagnose in Agent process: the agent was unable to get diagnoses from running agent: Post "https://localhost:5001/agent/diagnose": dial tcp 127.0.0.1:5001: connect: connection refused
> Running diagnose command locally (may take extra time to run checks locally) ...
> === Starting diagnose ===
> ......................==============
> Suite: connectivity-datadog-core-endpoints
> 
> 23. --------------
>   FAIL Connectivity to https://app.datadoghq.com/api/beta/sketches
>   Diagnosis: 
> ...Retrieving or creating a new connection
> ...Reusing a previous connection that was idle for 419.385µs
> Connection to `https://app.datadoghq.com/api/beta/sketches` failed
> Received response : 'Unable to read payload proto: cannot parse invalid wire-format data'
> Received status code 400 from the endpoint
>   Remediation: Please validate Agent configuration and firewall to access https://app.datadoghq.com/api/beta/sketches
>   Error: bad request
> 
> ....................................
> -------------------------
>   Total:59, Success:58, Fail:1

This is because we are sending [an empty JSON](https://github.com/DataDog/datadog-agent/blob/main/pkg/diagnose/connectivity/core_endpoint.go#L209) body to an endpoint that expects a [protobuf definition](https://github.com/DataDog/agent-payload/blob/94867fa6043c7ab5b2b10fccd98d04275c44819c/proto/metrics/agent_payload.proto). This PR creates a [SketchPayload](https://github.com/DataDog/agent-payload/blob/94867fa6043c7ab5b2b10fccd98d04275c44819c/proto/metrics/agent_payload.proto#L90), and sends that as that body of a protobuf content-type POST request. Since we now have to choose between sending a json content-type POST request and a protobuf one, I added a field to the `endpointInfo` struct to allow for specifying which one to use.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I actually ran the command on an agent using the PR changes, and all of the endpoints successfully report back. I also added a unit test.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->