### PR TITLE
Enhance Docker build process for Windows by adding additional build a…

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -25,7 +25,23 @@
     - popd
 
     - get-childitem ${BUILD_CONTEXT}
-    - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} ${BUILD_ARG} --pull --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile --tag ${TARGET_TAG} ${BUILD_CONTEXT}"
+    - |
+      powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker build --no-cache `
+        --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} `
+        --build-arg DD_GIT_REPOSITORY_URL=https://github.com/DataDog/datadog-agent `
+        --build-arg DD_GIT_COMMIT_SHA=${CI_COMMIT_SHA} `
+        --build-arg DD_AGENT_VERSION=${PACKAGE_VERSION} `
+        ${BUILD_ARG} `
+        --pull `
+        --file ${BUILD_CONTEXT}/windows/amd64/Dockerfile `
+        --tag ${TARGET_TAG} `
+        --label 'org.opencontainers.image.created=$(Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")' `
+        --label 'org.opencontainers.image.authors=Datadog <package@datadoghq.com>' `
+        --label 'org.opencontainers.image.source=https://github.com/DataDog/datadog-agent' `
+        --label 'org.opencontainers.image.version=${PACKAGE_VERSION}' `
+        --label 'org.opencontainers.image.revision=${CI_COMMIT_SHA}' `
+        --label 'org.opencontainers.image.vendor=Datadog, Inc.' `
+        ${BUILD_CONTEXT}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - powershell -Command "$(Get-Location)\tools\ci\retry.ps1 docker push ${TARGET_TAG}"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 FROM ${BASE_IMAGE}
 LABEL baseimage.os "windows server core"
 LABEL baseimage.name "${BASE_IMAGE}"
+LABEL org.opencontainers.image.base.name "${BASE_IMAGE}"
+LABEL org.opencontainers.image.title="Datadog Agent"
 
 ARG WITH_JMX="false"
 ARG VARIANT="unknown"
@@ -11,6 +13,9 @@ ARG GENERAL_ARTIFACTS_CACHE_BUCKET_URL
 ARG WITH_FIPS
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
+LABEL org.opencontainers.image.authors="Datadog <package@datadoghq.com>"
+LABEL org.opencontainers.image.source="https://github.com/DataDog/datadog-agent"
+LABEL org.opencontainers.image.vendor="Datadog, Inc."
 
 USER ContainerAdministrator
 


### PR DESCRIPTION
…rguments and labels in Dockerfiles.

This includes specifying the Git repository URL, commit SHA, agent version, and various Open Container Initiative labels for better image metadata.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->