### PR TITLE
Revert "omnibus: update libffi from 3.2.1 to 3.4.8 (#37451)"

### DIFF
--- a/omnibus/config/patches/libffi/libffi-3.2.1-disable-multi-os-directory.patch
+++ b/omnibus/config/patches/libffi/libffi-3.2.1-disable-multi-os-directory.patch
@@ -1,0 +1,83 @@
+--- libffi-3.2.1-orig/configure.ac	2014-11-12 05:56:51.000000000 -0600
++++ libffi-3.2.1/configure.ac	2015-10-29 15:53:41.695055040 -0500
+@@ -590,6 +590,10 @@
+     AC_DEFINE(USING_PURIFY, 1, [Define this if you are using Purify and want to suppress spurious messages.])
+   fi)
+ 
++AC_ARG_ENABLE(multi-os-directory,
++[  --disable-multi-os-directory
++                          disable use of gcc --print-multi-os-directory to change the library installation directory])
++                          
+ # These variables are only ever used when we cross-build to X86_WIN32.
+ # And we only support this with GCC, so...
+ if test "x$GCC" = "xyes"; then
+@@ -601,11 +605,13 @@
+     toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+     toolexeclibdir="${libdir}"
+   fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
++  if test x"$enable_multi_os_directory" != x"no"; then
++    multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
++    case $multi_os_directory in
++      .) ;; # Avoid trailing /.
++      ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
++    esac
++  fi
+   AC_SUBST(toolexecdir)
+ else
+   toolexeclibdir="${libdir}"
+--- libffi-3.2.1-orig/configure	2014-11-12 11:59:57.000000000 +0000
++++ libffi-3.2.1/configure	2015-10-30 19:50:51.082221000 +0000
+@@ -886,6 +886,7 @@
+ enable_structs
+ enable_raw_api
+ enable_purify_safety
++enable_multi_os_directory
+ '
+       ac_precious_vars='build_alias
+ host_alias
+@@ -1538,6 +1539,8 @@
+   --disable-structs       omit code for struct support
+   --disable-raw-api       make the raw api unavailable
+   --enable-purify-safety  purify-safe mode
++  --disable-multi-os-directory
++                          disable use of gcc --print-multi-os-directory to change the library installation directory
+ 
+ Optional Packages:
+   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+@@ -18714,6 +18717,12 @@
+ fi
+ 
+ 
++# Check whether --enable-multi-os-directory was given.
++if test "${enable_multi_os_directory+set}" = set; then :
++  enableval=$enable_multi_os_directory;
++fi
++
++
+ # These variables are only ever used when we cross-build to X86_WIN32.
+ # And we only support this with GCC, so...
+ if test "x$GCC" = "xyes"; then
+@@ -18725,11 +18734,13 @@
+     toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+     toolexeclibdir="${libdir}"
+   fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
++  if test x"$enable_multi_os_directory" != x"no"; then
++    multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
++    case $multi_os_directory in
++      .) ;; # Avoid trailing /.
++      ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
++    esac
++  fi
+ 
+ else
+   toolexeclibdir="${libdir}"

--- a/omnibus/config/software/libffi.rb
+++ b/omnibus/config/software/libffi.rb
@@ -16,7 +16,7 @@
 
 name "libffi"
 
-default_version "3.4.8"
+default_version "3.2.1"
 
 license "MIT"
 license_file "LICENSE"
@@ -25,9 +25,9 @@ skip_transitive_dependency_licensing true
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?
 
-version("3.4.8") { source sha256: "bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b" }
+version("3.2.1") { source sha256: "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37" }
 
-source url: "https://github.com/libffi/libffi/releases/download/v#{version}/libffi-#{version}.tar.gz"
+source url: "https://sourceware.org/ftp/libffi/libffi-#{version}.tar.gz"
 
 relative_path "libffi-#{version}"
 
@@ -36,7 +36,17 @@ build do
 
   env["INSTALL"] = "/opt/freeware/bin/install" if aix?
 
-  configure_command = ["--disable-static", "--disable-docs", "--disable-multi-os-directory"]
+  configure_command = ["--disable-static", "--disable-docs"]
+
+  # AIX's old version of patch doesn't like the patch here
+  unless aix?
+    # Patch to disable multi-os-directory via configure flag (don't use /lib64)
+    # Works on all platforms, and is compatible on 32bit platforms as well
+    if version == "3.2.1"
+      patch source: "libffi-3.2.1-disable-multi-os-directory.patch", plevel: 1, env: env
+      configure_command << "--disable-multi-os-directory"
+    end
+  end
 
   configure(*configure_command, env: env)
 
@@ -48,4 +58,9 @@ build do
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env
   end
+
+  # libffi's default install location of header files is awful...
+  mkdir "#{install_dir}/embedded/include"
+  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
+
 end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This reverts commit 0d51e095fee8fd5bca17d13bf279dc4a38e8c43e.

### Motivation

`new-e2e-installer` test is failing since this commit was merged

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->