### PR TITLE
[USM] Use constant definitions in ebpf ssl 

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -66,6 +66,15 @@ const (
 
 	// UsmTLSAttacherName holds the name used for the uprobe attacher of tls programs. Used for tests.
 	UsmTLSAttacherName = "usm_tls"
+
+	sslSockByCtxMap     = "ssl_sock_by_ctx"
+	sslCtxByPIDTGIDMap  = "ssl_ctx_by_pid_tgid"
+	sslReadArgsMap      = "ssl_read_args"
+	sslReadExArgsMap    = "ssl_read_ex_args"
+	sslWriteArgsMap     = "ssl_write_args"
+	sslWriteExArgsMap   = "ssl_write_ex_args"
+	bioNewSocketArgsMap = "bio_new_socket_args"
+	fdBySSLBioMap       = "fd_by_ssl_bio"
 )
 
 var openSSLProbes = []manager.ProbesSelector{
@@ -233,32 +242,27 @@ var gnuTLSProbes = []manager.ProbesSelector{
 	},
 }
 
-const (
-	sslSockByCtxMap    = "ssl_sock_by_ctx"
-	sslCtxByPIDTGIDMap = "ssl_ctx_by_pid_tgid"
-)
-
 var sharedLibrariesMaps = []*manager.Map{
 	{
 		Name: sslSockByCtxMap,
 	},
 	{
-		Name: "ssl_read_args",
+		Name: sslReadArgsMap,
 	},
 	{
-		Name: "ssl_read_ex_args",
+		Name: sslReadExArgsMap,
 	},
 	{
-		Name: "ssl_write_args",
+		Name: sslWriteArgsMap,
 	},
 	{
-		Name: "ssl_write_ex_args",
+		Name: sslWriteExArgsMap,
 	},
 	{
-		Name: "bio_new_socket_args",
+		Name: bioNewSocketArgsMap,
 	},
 	{
-		Name: "fd_by_ssl_bio",
+		Name: fdBySSLBioMap,
 	},
 	{
 		Name: sslCtxByPIDTGIDMap,
@@ -545,7 +549,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "ssl_read_args": // maps/ssl_read_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_read_args_t
+	case sslReadArgsMap: // maps/ssl_read_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_read_args_t
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u64', value: 'C.ssl_read_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
@@ -554,7 +558,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "ssl_read_ex_args": // maps/ssl_read_ex_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_read_ex_args_t
+	case sslReadExArgsMap: // maps/ssl_read_ex_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_read_ex_args_t
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u64', value: 'C.ssl_read_ex_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
@@ -563,7 +567,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "ssl_write_args": // maps/ssl_write_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_write_args_t
+	case sslWriteArgsMap: // maps/ssl_write_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_write_args_t
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u64', value: 'C.ssl_write_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
@@ -572,7 +576,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "ssl_write_ex_args_t": // maps/ssl_write_ex_args_t (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_write_args_t
+	case sslWriteExArgsMap: // maps/ssl_write_ex_args_t (BPF_MAP_TYPE_HASH), key C.__u64, value C.ssl_write_args_t
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u64', value: 'C.ssl_write_ex_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
@@ -581,7 +585,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "bio_new_socket_args": // maps/bio_new_socket_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.__u32
+	case bioNewSocketArgsMap: // maps/bio_new_socket_args (BPF_MAP_TYPE_HASH), key C.__u64, value C.__u32
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u64', value: 'C.__u32'\n")
 		iter := currentMap.Iterate()
 		var key uint64
@@ -590,7 +594,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 			spew.Fdump(w, key, value)
 		}
 
-	case "fd_by_ssl_bio": // maps/fd_by_ssl_bio (BPF_MAP_TYPE_HASH), key C.__u32, value uintptr // C.void *
+	case fdBySSLBioMap: // maps/fd_by_ssl_bio (BPF_MAP_TYPE_HASH), key C.__u32, value uintptr // C.void *
 		io.WriteString(w, "Map: '"+mapName+"', key: 'C.__u32', value: 'uintptr // C.void *'\n")
 		iter := currentMap.Iterate()
 		var key uint32
@@ -646,12 +650,12 @@ func (o *sslProgram) addProcessExitProbe(options *manager.Options) {
 }
 
 var sslPidKeyMaps = []string{
-	"ssl_read_args",
-	"ssl_read_ex_args",
-	"ssl_write_args",
-	"ssl_write_ex_args",
-	"ssl_ctx_by_pid_tgid",
-	"bio_new_socket_args",
+	sslReadArgsMap,
+	sslReadExArgsMap,
+	sslWriteArgsMap,
+	sslWriteExArgsMap,
+	sslCtxByPIDTGIDMap,
+	bioNewSocketArgsMap,
 }
 
 // cleanupDeadPids clears maps of terminated processes, is invoked when raw tracepoints unavailable.

--- a/pkg/network/usm/ebpf_ssl_test.go
+++ b/pkg/network/usm/ebpf_ssl_test.go
@@ -83,7 +83,7 @@ func TestSSLMapsCleaner(t *testing.T) {
 	require.NotNil(t, monitor)
 
 	cleanProtocolMaps(t, "ssl", monitor.ebpfProgram.Manager.Manager)
-	cleanProtocolMaps(t, "bio_new_socket_args", monitor.ebpfProgram.Manager.Manager)
+	cleanProtocolMaps(t, bioNewSocketArgsMap, monitor.ebpfProgram.Manager.Manager)
 
 	// find maps by names
 	maps := getMaps(t, monitor.ebpfProgram.Manager.Manager, sslPidKeyMaps)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use constant definitions in ebpf SSL map declarations.

### Motivation

Improves code maintainability by replacing hardcoded string literals with constants for SSL eBPF map names throughout the codebase.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->