### PR TITLE
(fleet) pin docker version to 28.0.4 on ubuntu/debian

### DIFF
--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -103,7 +103,7 @@ func (h *Host) InstallDocker() {
 	case e2eos.AmazonLinux:
 		h.remote.MustExecute(`sudo sh -c "yum -y install docker"`)
 	default:
-		h.remote.MustExecute("curl -fsSL https://get.docker.com | sudo sh")
+		h.remote.MustExecute("curl -fsSL https://get.docker.com | sudo sh -- --version 28.0.4")
 	}
 }
 


### PR DESCRIPTION
This PR pins the version of docker to `28.0.4` on ubuntu/debian. Newer version released yesterday appear to be broken.