### PR TITLE
Avoid caching Agent artifacts in docker builds

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -34,6 +34,8 @@
       if [[ "$DEPLOY_AGENT" == "true" ]]; then
         CACHE_SOURCE="--no-cache"
       fi
+    # Temporary bypass of the above logic to do some testing
+    - CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_TARGET},mode=max"  # populate the cache
     - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     - !reference [.login_to_docker_readonly]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -34,8 +34,6 @@
       if [[ "$DEPLOY_AGENT" == "true" ]]; then
         CACHE_SOURCE="--no-cache"
       fi
-    # Temporary bypass of the above logic to do some testing
-    - CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_TARGET},mode=max"  # populate the cache
     - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     - !reference [.login_to_docker_readonly]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -14,6 +14,11 @@
     # Caching setup
     - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
     - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"
+    - |
+      DOCKER_NO_CACHE_FILTER=""
+      for target in ${NO_CACHE_TARGETS}; do
+        DOCKER_NO_CACHE_FILTER="${DOCKER_NO_CACHE_FILTER} --no-cache-filter ${target}"
+      done
     # Don't use caching on nightlies, to allow for regular cache invalidation,
     # and update the cache on both main and nightly builds
     - |
@@ -37,6 +42,7 @@
       docker buildx build --push --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
         ${CACHE_TO} \
+        ${DOCKER_NO_CACHE_FILTER} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \
         --build-arg CIBUILD=true \
         --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} \
@@ -108,6 +114,7 @@ docker_build_agent7:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 # TODO: Move this job to .gitlab/deploy_containers/deploy_containers_a7.yml.
 # This cannot be done now because of the following reasons:
@@ -141,6 +148,7 @@ docker_build_agent7_arm64:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 # build agent7 fips image
 docker_build_fips_agent7:
@@ -155,6 +163,7 @@ docker_build_fips_agent7:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips
     BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 docker_build_fips_agent7_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -168,6 +177,7 @@ docker_build_fips_agent7_arm64:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips
     BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
@@ -182,6 +192,7 @@ docker_build_agent7_jmx:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 docker_build_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -195,6 +206,7 @@ docker_build_agent7_jmx_arm64:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 docker_build_fips_agent7_jmx:
   extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
@@ -208,6 +220,7 @@ docker_build_fips_agent7_jmx:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 docker_build_fips_agent7_arm64_jmx:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -221,6 +234,7 @@ docker_build_fips_agent7_arm64_jmx:
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
     BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
+    NO_CACHE_TARGETS: extract release
 
 # agent base image: future agent images will be based on this image
 .docker_build_base_image:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -32,18 +32,19 @@ COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c  -lseccomp
 
+FROM baseimage AS extract-base
+RUN apt install --no-install-recommends -y curl ca-certificates maven xz-utils
+
 ############################################################
 #  Preparation stage: retrieval of 3rd party dependencies  #
 ############################################################
 
-FROM baseimage AS external-deps
+FROM extract-base AS external-deps
 ARG WITH_JMX_FIPS
 ARG TARGETARCH
 ARG GENERAL_ARTIFACTS_CACHE_BUCKET_URL
 
 WORKDIR /output
-
-RUN apt install --no-install-recommends -y curl ca-certificates maven xz-utils
 
 # Get s6-overlay
 ENV S6_VERSION="v2.2.0.3"
@@ -63,11 +64,9 @@ RUN if [ -n "$WITH_JMX_FIPS" ]; then cd /opt/bouncycastle-fips && mvn dependency
 #  Preparation stage: extract and cleanup  #
 ############################################
 
-FROM baseimage AS extract
+FROM extract-base AS extract
 ARG TARGETARCH
 ARG WITH_JMX
-
-RUN apt install --no-install-recommends -y xz-utils
 
 ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
 # copy everything - globbing with args wont work
@@ -102,14 +101,13 @@ RUN --mount=from=artifacts,target=/artifacts \
  && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi \
  && mkdir conf.d checks.d
 
-######################################
-#  Actual docker image construction  #
-######################################
 
-FROM baseimage AS release
-LABEL maintainer="Datadog <package@datadoghq.com>"
-ARG WITH_JMX
-ARG WITH_JMX_FIPS
+########################################################################
+#  Construct the base image for the release, everything but the Agent  #
+########################################################################
+
+FROM baseimage AS release-base
+
 ENV DOCKER_DD_AGENT=true \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
     CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
@@ -129,6 +127,9 @@ RUN apt full-upgrade -y \
   # this can be removed
   # Install libseccomp2 as required by `nosys-seccomp` wrapper
   && apt install -y iproute2 libseccomp2 tzdata adduser
+
+ARG WITH_JMX
+ARG WITH_JMX_FIPS
 
 # Install openjdk-11-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \
@@ -167,6 +168,13 @@ ENV JAVA_TOOL_OPTIONS="${WITH_JMX_FIPS:+--module-path=/opt/bouncycastle-fips -Dj
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
 COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh secrets-helper/readsecret_multiple_providers.sh /
+
+###########################################################
+#  Release docker image construction including the Agent  #
+###########################################################
+
+FROM release-base AS release
+LABEL maintainer="Datadog <package@datadoghq.com>"
 
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA


### PR DESCRIPTION
### What does this PR do?

Following #37208, this further restructures the stages to be able to leave out stages that rely on in-pipeline artifacts out of the cache.

### Motivation

As mentioned in #37208, uploading the unpacked Agent package to the docker cache is wasteful as it can never realistically be reused. In addition, we're seeing many errors (such as [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/957907093#L4269)) when exporting the cache (i.e. from main), looking like this:

```
ERROR: error writing layer blob: failed to copy: httpReadSeeker: failed open: failed to authorize: no active session for s1kh3n1vzn3cewncspttdpmav: context deadline exceeded
```

There's not a lot of references online for this error, the [only one](https://github.com/moby/buildkit/issues/5624#issuecomment-2581689868) mentions removing a final layer from the cache, so there's a chance that this may help.

### Describe how you validated your changes

I ran a pipeline that writes to cache, resulting in [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/959216673) plus its siblings. I haven't seen any cache exporting failures in any of them.

I also confirmed that those stages where Agent artifacts are unpacked / moved around are not cached, and that on save the number of uploaded layers is smaller.

### Possible Drawbacks / Trade-offs



### Additional Notes

If we still get those cache-writing errors after this I'll just disable the cache until we find a way to solve that problem.