### PR TITLE
[Backport 7.67.x] Secret refresh random scatter uses a minimum of 1 second

### DIFF
--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -261,7 +261,8 @@ func (r *secretResolver) startRefreshRoutine() {
 	}
 
 	if r.refreshIntervalScatter {
-		r.scatterDuration = time.Duration(rand.Int63n(int64(r.refreshInterval))) / time.Second * time.Second
+		// Scatter when the refresh happens within the interval, with a minimum of 1 second
+		r.scatterDuration = time.Duration(rand.Int63n(int64(r.refreshInterval))) + time.Second
 		log.Infof("first secret refresh will happen in %s", r.scatterDuration)
 	} else {
 		r.scatterDuration = r.refreshInterval

--- a/comp/core/secrets/secretsimpl/secrets_test.go
+++ b/comp/core/secrets/secretsimpl/secrets_test.go
@@ -881,8 +881,8 @@ func TestStartRefreshRoutineWithScatter(t *testing.T) {
 			require.NotNil(t, resolver.ticker)
 
 			if tc.scatter {
-				// The set random seed has a the scatterDuration is 5.477027098s
-				mockClock.Add(6 * time.Second)
+				// The set random seed has a the scatterDuration is 6.477027098s
+				mockClock.Add(7 * time.Second)
 
 				select {
 				case <-refreshCalledChan:


### PR DESCRIPTION
### What does this PR do?

When refreshing secrets with a random scatter, wait a minimum of 1 second. This avoids the situation where the random number generator gives an interval of 0, which causes clock.NewTicker to segfault with "non-positive interval for NewTicker"

Backport of (#37337) for 7.67.x

### Motivation

Avoid causing random segfaults.

### Describe how you validated your changes

When testing manually, forcing a scatterDuration of 0 causes this segfault to occur. I was unable to get a working unit test to cover this, but will attempt in a follow-up PR.

### Possible Drawbacks / Trade-offs

### Additional Notes
