### PR TITLE
[ebpfless] Fix UNKNOWN connection direction when dialing a closed port

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -320,6 +320,11 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 	t.updateFinFlag(conn, st, pktType, tcp, payloadLen)
 	t.updateRstFlag(conn, st, pktType, tcp, payloadLen)
 
+	// sync the ConnectionStats direction if necessary
+	if conn.Direction == network.UNKNOWN && st.connDirection != network.UNKNOWN {
+		conn.Direction = st.connDirection
+	}
+
 	stateChanged := st.tcpState != origState
 	if stateChanged {
 		ok := t.moveConn(tuple, st)
@@ -422,16 +427,6 @@ func MakeEbpflessTuple(tuple network.ConnectionTuple) PCAPTuple {
 func MakeConnStatsTuple(tuple PCAPTuple) network.ConnectionTuple {
 	// Direction is still 0, this will get set by the ebpfless tracer in finalizeConnectionDirection
 	return network.ConnectionTuple(tuple)
-}
-
-// GetConnDirection returns the direction of the connection.
-// If the SYN packet was not seen (for a pre-existing connection), it returns ConnDirUnknown.
-func (t *TCPProcessor) GetConnDirection(tuple PCAPTuple) (network.ConnectionDirection, bool) {
-	conn, ok := t.getConn(tuple)
-	if !ok {
-		return network.UNKNOWN, false
-	}
-	return conn.connDirection, true
 }
 
 func (t *TCPProcessor) markRecentlyClosed(tuple PCAPTuple) bool {

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -321,7 +321,7 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 	t.updateRstFlag(conn, st, pktType, tcp, payloadLen)
 
 	// sync the ConnectionStats direction if necessary
-	if conn.Direction == network.UNKNOWN && st.connDirection != network.UNKNOWN {
+	if conn.Direction == network.UNKNOWN {
 		conn.Direction = st.connDirection
 	}
 

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -56,6 +56,11 @@ const (
 	ProcessResultMapFull
 )
 
+// ShouldPersist returns whether this result has actionable data that can be persisted into the tracer
+func (r ProcessResult) ShouldPersist() bool {
+	return r == ProcessResultStoreConn || r == ProcessResultCloseConn
+}
+
 var statsTelemetry = struct {
 	expiredPendingConns     telemetry.Counter
 	droppedPendingConns     telemetry.Counter

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -226,6 +226,21 @@ func (t *ebpfLessTracer) processConnection(
 		return fmt.Sprintf("connection: %s", conn)
 	})
 
+	if isNewConn && result.ShouldPersist() {
+		conn.Duration = time.Duration(time.Now().UnixNano())
+		direction, err := t.guessConnectionDirection(conn, pktType)
+		if err != nil {
+			return err
+		}
+		if direction == network.UNKNOWN {
+			return fmt.Errorf("could not determine connection direction")
+		}
+		conn.Direction = direction
+
+		// now that the direction is set, hash the connection
+		t.cookieHasher.Hash(conn)
+	}
+
 	switch result {
 	case ebpfless.ProcessResultNone:
 	case ebpfless.ProcessResultStoreConn:
@@ -241,28 +256,9 @@ func (t *ebpfLessTracer) processConnection(
 			ebpfLessTracerTelemetry.droppedConnections.Inc()
 		}()
 
-		if isNewConn {
-			conn.Duration = time.Duration(time.Now().UnixNano())
-			direction, err := t.determineConnectionDirection(conn, pktType)
-			if err != nil {
-				return err
-			}
-			if direction == network.UNKNOWN {
-				return fmt.Errorf("could not determine connection direction")
-			}
-			conn.Direction = direction
-
-			// now that the direction is set, hash the connection
-			t.cookieHasher.Hash(conn)
-		}
 		maxTrackedConns := int(t.config.MaxTrackedConnections)
 		storeConnOk = ebpfless.WriteMapWithSizeLimit(t.conns, tuple, conn, maxTrackedConns)
 	case ebpfless.ProcessResultCloseConn:
-		if isNewConn {
-			// this can occur when a SYN packet is sent to a closed port and it gets back a RST.
-			// for now, our tracers do not support this type of failed connection (see TestTCPSynRst)
-			return nil
-		}
 		delete(t.conns, tuple)
 		closeCallback(conn)
 	case ebpfless.ProcessResultMapFull:
@@ -313,23 +309,11 @@ func buildTuple(pktType uint8, ip4 *layers.IPv4, ip6 *layers.IPv6, udp *layers.U
 	return tuple, flags
 }
 
-// determineConnectionDirection returns connection direction using information from the TCP processor.
-// If the TCP processor doesn't know the direction, it will attempt to guess.
-func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8) (network.ConnectionDirection, error) {
-	if conn.Type == network.TCP {
-		tuple := ebpfless.MakeEbpflessTuple(conn.ConnectionTuple)
-		dir, ok := t.tcp.GetConnDirection(tuple)
-		if !ok {
-			return network.UNKNOWN, fmt.Errorf("determineConnectionDirection: expected to find TCP connection for tuple: %+v", tuple)
-		}
-		switch dir {
-		case network.INCOMING:
-		case network.OUTGOING:
-			return dir, nil
-		case network.UNKNOWN:
-			// This happens when the TCP processor missed the SYN packet.
-			// Fall through and guess the direction.
-		}
+// guessConnectionDirection attempts to guess the connection direction based off bound ports
+func (t *ebpfLessTracer) guessConnectionDirection(conn *network.ConnectionStats, pktType uint8) (network.ConnectionDirection, error) {
+	// if we already have a direction, return that
+	if conn.Direction != network.UNKNOWN {
+		return conn.Direction, nil
 	}
 
 	ok := t.boundPorts.Find(conn.Type, conn.SPort)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3010,6 +3010,10 @@ func (s *TracerSuite) TestTCPSynRst() {
 	t := s.T()
 	cfg := testConfig()
 
+	if isPrebuilt(cfg) {
+		t.Skip("failed connections not supported on prebuilt")
+	}
+
 	tr := setupTracer(t, cfg)
 
 	// create a linux socket which will reserve a port for us

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3016,6 +3016,10 @@ func (s *TracerSuite) TestTCPSynRst() {
 
 	tr := setupTracer(t, cfg)
 
+	if tr.ebpfTracer.Type() == connection.TracerTypeFentry {
+		t.Skip("failed connections not (yet) supported on fentry")
+	}
+
 	// create a linux socket which will reserve a port for us
 	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM, 0)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes an issue where the ebpfless tracer would return bad data when a process dials a closed port. That is, when a SYN packet is immediately replied with a RST packet.

### Motivation
Hasan saw debug logs related to this on a test workload

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added a test `TestTCPSynRst` which verifies that a bad connection doesn't show up for this case:
```
PATH="$PATH" sudo -E  go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/'.*'/TestTCPSynRst
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->