### PR TITLE
[DEBUG-3985] tasks/system_probe.py: run the dyninst tests

### DIFF
--- a/pkg/dyninst/compiler/compile_test.go
+++ b/pkg/dyninst/compiler/compile_test.go
@@ -8,10 +8,30 @@
 package compiler
 
 import (
+	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
+var MinimumKernelVersion = kernel.VersionCode(5, 17, 0)
+
+func skipIfKernelNotSupported(t *testing.T) {
+	curKernelVersion, err := kernel.HostVersion()
+	require.NoError(t, err)
+	if curKernelVersion < MinimumKernelVersion {
+		t.Skipf("Kernel version %v is not supported", curKernelVersion)
+	}
+	if runtime.GOARCH != "amd64" {
+		t.Skipf("platform %v is not supported", runtime.GOARCH)
+	}
+}
+
 func TestCompileBPFProgram(t *testing.T) {
+	skipIfKernelNotSupported(t)
+
 	err := CompileBPFProgram()
 	if err != nil {
 		t.Fatalf("Failed to compile BPF program: %v", err)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -55,6 +55,7 @@ TEST_PACKAGES_LIST = [
     "./pkg/collector/corechecks/servicediscovery/module/...",
     "./pkg/process/monitor/...",
     "./pkg/dynamicinstrumentation/...",
+    "./pkg/dyninst/...",
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",


### PR DESCRIPTION
### What does this PR do?

This PR makes sure we run the dyninst tests

### Motivation

Before this change, we didn't run the dyninst tests -- that was very bad.

### Describe how you validated your changes

`dda inv -e system-probe.test` and looked at the output


Relates to https://datadoghq.atlassian.net/browse/DEBUG-3883