### PR TITLE
add rollback to config experiments on Windows

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -597,6 +597,8 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigUpgradeSuccessful$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigUpgradeFailure$"
       - EXTRA_PARAMS: --run "TestAgentConfig$/TestConfigUpgradeNewAgents$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenServiceDies$"
+      - EXTRA_PARAMS: --run "TestAgentConfig$/TestRevertsConfigExperimentWhenTimeout$"
       # install-exe
       - EXTRA_PARAMS: --run "TestInstallExe$/TestInstallAgentPackage$"
       # install-script

--- a/cmd/installer/subcommands/daemon/api.go
+++ b/cmd/installer/subcommands/daemon/api.go
@@ -30,6 +30,7 @@ type cliParams struct {
 	pkg     string
 	version string
 	catalog string
+	configs string
 }
 
 func apiCommands(global *command.GlobalParams) []*cobra.Command {
@@ -45,6 +46,20 @@ func apiCommands(global *command.GlobalParams) []*cobra.Command {
 			})
 		},
 	}
+
+	setConfigCatalogCmd := &cobra.Command{
+		Hidden: true,
+		Use:    "set-config-catalog configs",
+		Short:  "Internal command to set the config catalog to use",
+		Args:   cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return experimentFxWrapper(setConfigCatalog, &cliParams{
+				GlobalParams: *global,
+				configs:      args[0],
+			})
+		},
+	}
+
 	installCmd := &cobra.Command{
 		Use:     "install package version",
 		Aliases: []string{"install"},
@@ -155,6 +170,7 @@ func apiCommands(global *command.GlobalParams) []*cobra.Command {
 	}
 	return []*cobra.Command{
 		setCatalogCmd,
+		setConfigCatalogCmd,
 		startExperimentCmd,
 		stopExperimentCmd,
 		promoteExperimentCmd,
@@ -185,6 +201,15 @@ func catalog(params *cliParams, client localapiclient.Component) error {
 	err := client.SetCatalog(params.catalog)
 	if err != nil {
 		fmt.Println("Error setting catalog:", err)
+		return err
+	}
+	return nil
+}
+
+func setConfigCatalog(params *cliParams, client localapiclient.Component) error {
+	err := client.SetConfigCatalog(params.configs)
+	if err != nil {
+		fmt.Println("Error setting config catalog:", err)
 		return err
 	}
 	return nil

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -63,6 +63,7 @@ type Daemon interface {
 	Stop(ctx context.Context) error
 
 	SetCatalog(c catalog)
+	SetConfigCatalog(configs map[string]installerConfig)
 	Install(ctx context.Context, url string, args []string) error
 	Remove(ctx context.Context, pkg string) error
 	StartExperiment(ctx context.Context, url string) error
@@ -88,6 +89,7 @@ type daemonImpl struct {
 	catalog         catalog
 	catalogOverride catalog
 	configs         map[string]installerConfig
+	configsOverride map[string]installerConfig
 	requests        chan remoteAPIRequest
 	requestsWG      sync.WaitGroup
 	taskDB          *taskDB
@@ -148,6 +150,7 @@ func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installe
 		catalog:         catalog{},
 		catalogOverride: catalog{},
 		configs:         make(map[string]installerConfig),
+		configsOverride: make(map[string]installerConfig),
 		stopChan:        make(chan struct{}),
 		taskDB:          taskDB,
 	}
@@ -254,6 +257,13 @@ func (d *daemonImpl) SetCatalog(c catalog) {
 	d.m.Lock()
 	defer d.m.Unlock()
 	d.catalogOverride = c
+}
+
+// SetConfigCatalog sets the config catalog override.
+func (d *daemonImpl) SetConfigCatalog(configs map[string]installerConfig) {
+	d.m.Lock()
+	defer d.m.Unlock()
+	d.configsOverride = configs
 }
 
 // Start starts remote config and the garbage collector.
@@ -425,7 +435,11 @@ func (d *daemonImpl) startConfigExperiment(ctx context.Context, pkg string, vers
 	defer d.refreshState(ctx)
 
 	log.Infof("Daemon: Starting config experiment version %s for package %s", version, pkg)
-	config, ok := d.configs[version]
+	configs := d.configs
+	if len(d.configsOverride) > 0 {
+		configs = d.configsOverride
+	}
+	config, ok := configs[version]
 	if !ok {
 		return fmt.Errorf("could not find config version %s", version)
 	}

--- a/pkg/fleet/daemon/local_api_test.go
+++ b/pkg/fleet/daemon/local_api_test.go
@@ -3,9 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// for now the installer is not supported on windows
-//go:build !windows
-
 package daemon
 
 import (
@@ -97,6 +94,10 @@ func (m *testDaemon) GetAPMInjectionStatus() (APMInjectionStatus, error) {
 
 func (m *testDaemon) SetCatalog(catalog catalog) {
 	m.Called(catalog)
+}
+
+func (m *testDaemon) SetConfigCatalog(configs map[string]installerConfig) {
+	m.Called(configs)
 }
 
 type testLocalAPI struct {

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -524,6 +524,11 @@ func (i *installerImpl) InstallConfigExperiment(ctx context.Context, pkg string,
 		)
 	}
 
+	// HACK: close so package can be updated as watchdog runs
+	if pkg == packageDatadogAgent && runtime.GOOS == "windows" {
+		i.db.Close()
+	}
+
 	return i.hooks.PostStartConfigExperiment(ctx, pkg)
 }
 

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -613,6 +613,12 @@ func postStartConfigExperimentDatadogAgent(ctx HookContext) error {
 	// Start the agent service to pick up the new config
 	err = winutil.RestartService("datadogagent")
 	if err != nil {
+		// Agent failed to start, restore stable config
+		restoreErr := restoreStableConfigFromExperiment(ctx)
+		if restoreErr != nil {
+			log.Error(restoreErr)
+			err = fmt.Errorf("%w, %w", err, restoreErr)
+		}
 		return fmt.Errorf("failed to start agent service: %w", err)
 	}
 

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -394,7 +394,7 @@ func (s *BaseSuite) AssertSuccessfulConfigStartExperiment(configID string) {
 	s.Require().NoError(err)
 
 	s.Require().Host(s.Env().RemoteHost).HasDatadogInstaller().Status().
-		HasConfigState("datadog-agent").
+		HasConfigState(consts.AgentPackage).
 		WithExperimentConfigEqual(configID).
 		HasARunningDatadogAgentService()
 }
@@ -407,7 +407,7 @@ func (s *BaseSuite) AssertSuccessfulConfigPromoteExperiment(configID string) {
 	s.Require().NoError(err)
 
 	s.Require().Host(s.Env().RemoteHost).HasDatadogInstaller().Status().
-		HasConfigState("datadog-agent").
+		HasConfigState(consts.AgentPackage).
 		WithStableConfigEqual(configID).
 		WithExperimentConfigEqual("").
 		HasARunningDatadogAgentService()
@@ -421,7 +421,7 @@ func (s *BaseSuite) AssertSuccessfulConfigStopExperiment() {
 	s.Require().NoError(err)
 
 	s.Require().Host(s.Env().RemoteHost).HasDatadogInstaller().Status().
-		HasConfigState("datadog-agent").
+		HasConfigState(consts.AgentPackage).
 		WithExperimentConfigEqual("").
 		HasARunningDatadogAgentService()
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -189,7 +189,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
-		s.Installer().StopExperiment(consts.AgentPackage)
+		s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.AssertSuccessfulConfigStopExperiment()
 	})
 }
@@ -225,7 +225,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
-		s.Installer().StopExperiment(consts.AgentPackage)
+		s.Installer().StopConfigExperiment(consts.AgentPackage)
 		s.AssertSuccessfulConfigStopExperiment()
 	})
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -16,7 +16,7 @@ import (
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/windowscommon"
+	windowscommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 )
 
 type testAgentConfigSuite struct {
@@ -54,14 +54,10 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	}
 
 	// Start config experiment
-	_, err := s.Installer().InstallConfigExperiment(consts.AgentPackage, config)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigStartExperiment(config.ID)
+	s.mustStartConfigExperiment(config)
 
 	// Promote config experiment
-	_, err = s.Installer().PromoteConfigExperiment(consts.AgentPackage)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigPromoteExperiment(config.ID)
+	s.mustPromoteConfigExperiment(config)
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
@@ -84,25 +80,22 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 
 	// Start config experiment, block until services stop
 	s.waitForDaemonToStop(func() {
-		_, err := s.Installer().InstallConfigExperiment(consts.AgentPackage, config)
-		s.Require().NoError(err)
+		s.Installer().StartConfigExperiment(consts.AgentPackage, config)
+		// Cannot check for error here, since the daemon restarts and kills the connection
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 
-	// Assert services failed to start with invalid config
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Stopped")
-
-	// Stop config experiment
-	_, err := s.Installer().RemoveConfigExperiment(consts.AgentPackage)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigStopExperiment()
-
-	// Wait for services to be running again
+	// Wait for watchdog to restart the services with the stable config
 	s.WaitForServicesWithBackoff("Running", backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10),
 		consts.ServiceName,
 		"datadogagent",
 	)
+	s.AssertSuccessfulConfigStopExperiment()
+
+	// backend will send stop experiment now
+	s.assertDaemonStaysRunning(func() {
+		s.Installer().StopConfigExperiment(consts.AgentPackage)
+		s.AssertSuccessfulConfigStopExperiment()
+	})
 }
 
 // TestConfigUpgradeNewAgents tests that config experiments can enable security agent and system probe
@@ -141,27 +134,29 @@ func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
 		},
 	}
 
-	// Start config experiment
-	_, err = s.Installer().InstallConfigExperiment(consts.AgentPackage, config)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigStartExperiment(config.ID)
-
-	// Promote config experiment
-	_, err = s.Installer().PromoteConfigExperiment(consts.AgentPackage)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigPromoteExperiment(config.ID)
+	// Start config experiment (restarts the services)
+	s.mustStartConfigExperiment(config)
 
 	// Wait for all services to be running
 	// 30*10 -> 300 seconds (5 minutes)
-	b := backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
-	err = s.WaitForServicesWithBackoff("Running", b,
+	expectedServices := []string{
 		"datadogagent",
 		"datadog-system-probe",
 		"datadog-security-agent",
 		"datadog-process-agent",
 		"ddnpm",
 		"ddprocmon",
-	)
+	}
+	b := backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
+	err = s.WaitForServicesWithBackoff("Running", b, expectedServices...)
+	s.Require().NoError(err, "Failed waiting for services to start")
+
+	// Promote config experiment (restarts the services)
+	s.mustPromoteConfigExperiment(config)
+
+	// Wait for all services to be running
+	// 30*10 -> 300 seconds (5 minutes)
+	err = s.WaitForServicesWithBackoff("Running", b, expectedServices...)
 	s.Require().NoError(err, "Failed waiting for services to start")
 }
 
@@ -183,22 +178,14 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 		},
 	}
 
-	// Start config experiment
-	_, err := s.Installer().InstallConfigExperiment(consts.AgentPackage, config)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigStartExperiment(config.ID)
+	// Start config experiment (restarts the services)
+	s.mustStartConfigExperiment(config)
 
 	// Stop the agent service to trigger watchdog rollback
 	windowscommon.StopService(s.Env().RemoteHost, consts.ServiceName)
 
 	// Assert
-	err = s.WaitForInstallerService("Running")
-	s.Require().NoError(err)
-
-	// Verify stable config is restored
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running")
+	s.AssertSuccessfulConfigStopExperiment()
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -228,22 +215,31 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 	}
 
 	// Start config experiment
-	_, err := s.Installer().InstallConfigExperiment(consts.AgentPackage, config)
-	s.Require().NoError(err)
-	s.AssertSuccessfulConfigStartExperiment(config.ID)
+	s.mustStartConfigExperiment(config)
+
+	// wait for the timeout
+	s.waitForDaemonToStop(func() {}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
 
 	// Assert
-	err = s.WaitForInstallerService("Running")
-	s.Require().NoError(err)
-
-	// Verify stable config is restored
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running")
+	s.AssertSuccessfulConfigStopExperiment()
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
 		s.Installer().StopExperiment(consts.AgentPackage)
 		s.AssertSuccessfulConfigStopExperiment()
 	})
+}
+
+func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows.ConfigExperiment) {
+	s.Installer().StartConfigExperiment(consts.AgentPackage, config)
+	// Cannot check for error here, since the daemon restarts and kills the connection
+
+	s.AssertSuccessfulConfigStartExperiment(config.ID)
+}
+
+func (s *testAgentConfigSuite) mustPromoteConfigExperiment(config installerwindows.ConfigExperiment) {
+	s.Installer().PromoteConfigExperiment(consts.AgentPackage)
+	// Cannot check for error here, since the daemon restarts and kills the connection
+
+	s.AssertSuccessfulConfigPromoteExperiment(config.ID)
 }

--- a/test/new-e2e/tests/windows/common/registry.go
+++ b/test/new-e2e/tests/windows/common/registry.go
@@ -48,7 +48,8 @@ func SetRegistryDWORDValue(host *components.RemoteHost, path string, name string
 //
 // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-itemproperty?view=powershell-7.4#-type
 func SetTypedRegistryValue(host *components.RemoteHost, path string, name string, value string, typeName string) error {
-	cmd := fmt.Sprintf("New-Item -Path '%s' -Force; Set-ItemProperty -Path '%s' -Name '%s' -Value '%s' -Type '%s'", path, path, name, value, typeName)
+	// Note: Need Test-path because -Force removes the key if it already exists
+	cmd := fmt.Sprintf("if (-not (Test-Path -Path '%s')) { New-Item -Path '%s' -Force } Set-ItemProperty -Path '%s' -Name '%s' -Value '%s' -Type '%s'", path, path, path, name, value, typeName)
 	_, err := host.Execute(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
add rollback to config experiments on Windows

Same as update experiments, watchdog process restores stable if services stop or timeout 

Adds `set-config-catalog` daemon API/subcommand set, similar to `set-catalog`, to allow for overriding the configs used by the daemon.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1529

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
new e2e tests cover scenario where service starts but then fails somehow
- TestRevertsConfigExperimentWhenServiceDies
- TestRevertsConfigExperimentWhenTimeout

existing e2e test cover scenario where service fails to start at all
- TestConfigUpgradeFailure (invalid config)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
local API tests work fine but requires follow-up PR for correctness with the backend
- https://github.com/DataDog/datadog-agent/pull/37667