### PR TITLE
Fix dev docs publishing

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - main
-    paths:
-    - docs/**
-    - .github/workflows/docs-dev.yml
   pull_request:
     branches:
     - main


### PR DESCRIPTION
### Motivation

On PRs we want to only run when something has changed but we want to publish anew on every commit to the `main` branch because parts of the documentation are fetched externally e.g. the tooling installation instructions https://github.com/DataDog/datadog-agent/blob/69e3afee8f4c95d25fbde4be99d0fe8fa694d021/docs/public/.hooks/inject_variables.py#L24-L35