### PR TITLE
Prevent simultaneous use of --no-cache and --no-cache-filter

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -11,6 +11,8 @@
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
       fi
+    # XXX: Test 'nightly' behaviour
+    - BUCKET_BRANCH="nightly"
     # Caching setup
     - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
     - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -11,8 +11,6 @@
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
       fi
-    # XXX: Test 'nightly' behaviour
-    - BUCKET_BRANCH="nightly"
     # Caching setup
     - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
     - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -15,15 +15,16 @@
     - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
     - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"
     - |
-      DOCKER_NO_CACHE_FILTER=""
+      DOCKER_NO_CACHE=""
       for target in ${NO_CACHE_TARGETS}; do
-        DOCKER_NO_CACHE_FILTER="${DOCKER_NO_CACHE_FILTER} --no-cache-filter ${target}"
+        DOCKER_NO_CACHE="${DOCKER_NO_CACHE_FILTER} --no-cache-filter ${target}"
       done
     # Don't use caching on nightlies, to allow for regular cache invalidation,
     # and update the cache on both main and nightly builds
     - |
       if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
-        CACHE_SOURCE="--no-cache"
+        DOCKER_NO_CACHE="--no-cache"
+        CACHE_SOURCE=""
         CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_TARGET},mode=max"
       fi
       if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
@@ -32,7 +33,8 @@
     # Don't use the cache on deploy pipelines to make sure we get the latest of everything
     - |
       if [[ "$DEPLOY_AGENT" == "true" ]]; then
-        CACHE_SOURCE="--no-cache"
+        DOCKER_NO_CACHE="--no-cache"
+        CACHE_SOURCE=""
       fi
     - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
@@ -42,7 +44,7 @@
       docker buildx build --push --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
         ${CACHE_TO} \
-        ${DOCKER_NO_CACHE_FILTER} \
+        ${DOCKER_NO_CACHE} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \
         --build-arg CIBUILD=true \
         --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} \

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -14,6 +14,7 @@
     # Caching setup
     - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
     - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"
+    - CACHE_TO=""
     - |
       DOCKER_NO_CACHE=""
       for target in ${NO_CACHE_TARGETS}; do


### PR DESCRIPTION
### What does this PR do?

Make `--no-cache` and `--no-cache-filter` exclusive when building Docker images.

### Motivation

Nightly pipelines triggered this untested code path which set both `--no-cache` and `--no-cache-filter`, which are not compatible, resulting in failures such as [this](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/960508277#L131), with this error message:

```
error: --no-cache and --no-cache-filter cannot currently be used together
```

### Describe how you validated your changes

I'll set the variable to trigger the "nightly" code path to confirm that it works before merging.
UPDATE: Done: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/960747514

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->