### PR TITLE
service discovery: Remove mostly-duplicated struct

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
@@ -71,7 +71,7 @@ func TestShouldIgnorePid(t *testing.T) {
 				// wait until the service name becomes available
 				info, err := discovery.getServiceInfo(int32(cmd.Process.Pid))
 				assert.NoError(collect, err)
-				assert.Equal(collect, test.service, info.ddServiceName)
+				assert.Equal(collect, test.service, info.DDService)
 			}, 3*time.Second, 100*time.Millisecond)
 
 			// now can check the ignored service

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -64,30 +64,10 @@ var _ module.Module = &discovery{}
 // serviceInfo holds process data that should be cached between calls to the
 // endpoint.
 type serviceInfo struct {
-	generatedName              string
-	generatedNameSource        string
-	additionalGeneratedNames   []string
-	containerServiceName       string
-	containerServiceNameSource string
-	ddServiceName              string
-	ddServiceInjected          bool
-	tracerMetadata             []tracermetadata.TracerMetadata
-	ports                      []uint16
-	checkedContainerData       bool
-	language                   language.Language
-	apmInstrumentation         apm.Instrumentation
-	cmdLine                    []string
-	startTimeMilli             uint64
-	rss                        uint64
-	cpuTime                    uint64
-	cpuUsage                   float64
-	containerID                string
-	lastHeartbeat              int64
-	addedToMap                 bool
-	rxBytes                    uint64
-	txBytes                    uint64
-	rxBps                      float64
-	txBps                      float64
+	model.Service
+	checkedContainerData bool
+	addedToMap           bool
+	cpuTime              uint64
 }
 
 // toModelService fills the model.Service struct pointed to by out, using the
@@ -98,29 +78,9 @@ func (i *serviceInfo) toModelService(pid int32, out *model.Service) *model.Servi
 		return nil
 	}
 
+	*out = i.Service
 	out.PID = int(pid)
-	out.GeneratedName = i.generatedName
-	out.GeneratedNameSource = i.generatedNameSource
-	out.AdditionalGeneratedNames = i.additionalGeneratedNames
-	out.ContainerServiceName = i.containerServiceName
-	out.ContainerServiceNameSource = i.containerServiceNameSource
-	out.DDService = i.ddServiceName
-	out.DDServiceInjected = i.ddServiceInjected
-	out.TracerMetadata = i.tracerMetadata
-	out.Ports = i.ports
-	out.APMInstrumentation = string(i.apmInstrumentation)
-	out.Language = string(i.language)
-	out.Type = string(servicetype.Detect(i.ports))
-	out.RSS = i.rss
-	out.CommandLine = i.cmdLine
-	out.StartTimeMilli = i.startTimeMilli
-	out.CPUCores = i.cpuUsage
-	out.ContainerID = i.containerID
-	out.LastHeartbeat = i.lastHeartbeat
-	out.RxBytes = i.rxBytes
-	out.TxBytes = i.txBytes
-	out.RxBps = i.rxBps
-	out.TxBps = i.txBps
+	out.Type = string(servicetype.Detect(i.Ports))
 
 	return out
 }
@@ -627,16 +587,18 @@ func (s *discovery) getServiceInfo(pid int32) (*serviceInfo, error) {
 	cmdline, _ = s.scrubber.ScrubCommand(cmdline)
 
 	return &serviceInfo{
-		generatedName:            nameMeta.Name,
-		generatedNameSource:      string(nameMeta.Source),
-		additionalGeneratedNames: nameMeta.AdditionalNames,
-		ddServiceName:            nameMeta.DDService,
-		tracerMetadata:           tracerMetadataArr,
-		language:                 lang,
-		apmInstrumentation:       apmInstrumentation,
-		ddServiceInjected:        nameMeta.DDServiceInjected,
-		cmdLine:                  truncateCmdline(lang, cmdline),
-		startTimeMilli:           uint64(createTime),
+		Service: model.Service{
+			GeneratedName:            nameMeta.Name,
+			GeneratedNameSource:      string(nameMeta.Source),
+			AdditionalGeneratedNames: nameMeta.AdditionalNames,
+			DDService:                nameMeta.DDService,
+			DDServiceInjected:        nameMeta.DDServiceInjected,
+			TracerMetadata:           tracerMetadataArr,
+			Language:                 string(lang),
+			APMInstrumentation:       string(apmInstrumentation),
+			CommandLine:              truncateCmdline(lang, cmdline),
+			StartTimeMilli:           uint64(createTime),
+		},
 	}, nil
 }
 
@@ -751,9 +713,9 @@ func (s *discovery) getService(context parsingContext, pid int32) *model.Service
 		s.cache[pid] = info
 	}
 
-	preferredName := info.ddServiceName
+	preferredName := info.DDService
 	if preferredName == "" {
-		preferredName = info.generatedName
+		preferredName = info.GeneratedName
 	}
 	if s.shouldIgnoreService(preferredName) {
 		s.addIgnoredPid(pid)
@@ -817,14 +779,14 @@ func (s *discovery) updateNetworkStats(deltaSeconds float64, response *model.Ser
 			continue
 		}
 
-		deltaRx := stats.Rx - info.rxBytes
-		deltaTx := stats.Tx - info.txBytes
+		deltaRx := stats.Rx - info.RxBytes
+		deltaTx := stats.Tx - info.TxBytes
 
-		info.rxBps = float64(deltaRx) / deltaSeconds
-		info.txBps = float64(deltaTx) / deltaSeconds
+		info.RxBps = float64(deltaRx) / deltaSeconds
+		info.TxBps = float64(deltaTx) / deltaSeconds
 
-		info.rxBytes = stats.Rx
-		info.txBytes = stats.Tx
+		info.RxBytes = stats.Rx
+		info.TxBytes = stats.Tx
 	}
 
 	updateResponseNetworkStats := func(services []model.Service) {
@@ -835,10 +797,10 @@ func (s *discovery) updateNetworkStats(deltaSeconds float64, response *model.Ser
 				continue
 			}
 
-			service.RxBps = info.rxBps
-			service.TxBps = info.txBps
-			service.RxBytes = info.rxBytes
-			service.TxBytes = info.txBytes
+			service.RxBps = info.RxBps
+			service.TxBps = info.TxBps
+			service.RxBytes = info.RxBytes
+			service.TxBytes = info.TxBytes
 		}
 	}
 
@@ -903,7 +865,7 @@ func (s *discovery) updateServicesCPUStats(response *model.ServicesResponse) err
 				continue
 			}
 
-			service.CPUCores = info.cpuUsage
+			service.CPUCores = info.CPUCores
 		}
 	}
 
@@ -1049,10 +1011,10 @@ func (s *discovery) enrichContainerData(service *model.Service, containers map[i
 
 	serviceInfo, ok := s.cache[int32(service.PID)]
 	if ok {
-		serviceInfo.containerServiceName = serviceName
-		serviceInfo.containerServiceNameSource = tagName
+		serviceInfo.ContainerServiceName = serviceName
+		serviceInfo.ContainerServiceNameSource = tagName
 		serviceInfo.checkedContainerData = true
-		serviceInfo.containerID = containerID
+		serviceInfo.ContainerID = containerID
 	}
 }
 
@@ -1064,9 +1026,9 @@ func (s *discovery) updateCacheInfo(response *model.ServicesResponse, now time.T
 			return
 		}
 
-		info.lastHeartbeat = now.Unix()
-		info.ports = service.Ports
-		info.rss = service.RSS
+		info.LastHeartbeat = now.Unix()
+		info.Ports = service.Ports
+		info.RSS = service.RSS
 	}
 
 	for i := range response.StartedServices {
@@ -1138,7 +1100,7 @@ func (s *discovery) getServices(params params) (*model.ServicesResponse, error) 
 				continue
 			}
 
-			serviceHeartbeatTime := time.Unix(info.lastHeartbeat, 0)
+			serviceHeartbeatTime := time.Unix(info.LastHeartbeat, 0)
 			if now.Sub(serviceHeartbeatTime).Truncate(time.Minute) < params.heartbeatTime {
 				// We only need to refresh the service info (ports, etc.) for
 				// this service if it's time to send a heartbeat.

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1063,8 +1063,8 @@ func TestCache(t *testing.T) {
 
 	for i, cmd := range cmds {
 		pid := int32(cmd.Process.Pid)
-		require.Equal(t, serviceNames[i], discovery.cache[pid].ddServiceName)
-		require.False(t, discovery.cache[pid].ddServiceInjected)
+		require.Equal(t, serviceNames[i], discovery.cache[pid].DDService)
+		require.False(t, discovery.cache[pid].DDServiceInjected)
 	}
 
 	cancel()
@@ -1434,8 +1434,8 @@ func TestValidInvalidTracerMetadata(t *testing.T) {
 
 		info, err := discovery.getServiceInfo(int32(self))
 		require.NoError(t, err)
-		require.Equal(t, language.CPlusPlus, info.language)
-		require.Equal(t, apm.Provided, info.apmInstrumentation)
+		require.Equal(t, language.CPlusPlus, language.Language(info.Language))
+		require.Equal(t, apm.Provided, apm.Instrumentation(info.APMInstrumentation))
 	})
 
 	t.Run("invalid metadata", func(t *testing.T) {
@@ -1443,7 +1443,7 @@ func TestValidInvalidTracerMetadata(t *testing.T) {
 
 		info, err := discovery.getServiceInfo(int32(self))
 		require.NoError(t, err)
-		require.Equal(t, apm.None, info.apmInstrumentation)
+		require.Equal(t, apm.None, apm.Instrumentation(info.APMInstrumentation))
 	})
 }
 

--- a/pkg/collector/corechecks/servicediscovery/module/stat.go
+++ b/pkg/collector/corechecks/servicediscovery/module/stat.go
@@ -120,7 +120,7 @@ func updateCPUCoresStats(pid int, info *serviceInfo, lastGlobalCPUTime, currentG
 	processTimeDelta := float64(usrTime + sysTime - info.cpuTime)
 	globalTimeDelta := float64(currentGlobalCPUTime - lastGlobalCPUTime)
 
-	info.cpuUsage = processTimeDelta / globalTimeDelta * float64(runtime.NumCPU())
+	info.CPUCores = processTimeDelta / globalTimeDelta * float64(runtime.NumCPU())
 	info.cpuTime = usrTime + sysTime
 
 	return nil


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The serviceInfo struct duplicates most of the fields of the Service
struct so just embed the latter in the former to simplify things.

### Motivation

Preparation for https://datadoghq.atlassian.net/browse/DSCVR-137

### Describe how you validated your changes

Unit tests and e2e tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
