### PR TITLE
[DEBUG-3985] dyninst/testprogs: use a free-standing go.mod

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -175,6 +175,7 @@ modules:
     used_by_otel: true
   pkg/config/viperconfig:
     used_by_otel: true
+  pkg/dyninst/testprogs/progs: ignored
   pkg/errors: default
   pkg/fips:
     used_by_otel: true

--- a/pkg/dyninst/testprogs/progs/go.mod
+++ b/pkg/dyninst/testprogs/progs/go.mod
@@ -1,0 +1,4 @@
+module github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+
+// Intentionally an old version.
+go 1.20.0


### PR DESCRIPTION
This will be needed to compile these testprogs binaries against go versions earlier than the one in the top-level go.mod file.

### What does this PR do?

This PR adds a go.mod file for a directory used to house test binaries for testing Go DI.

### Motivation

These are just for testing. The go version in a module file is a hard lower-bound on the Go version that can be used to compile the go program. We need to test Go programs that are compiled with older Go versions than the top-level module file.

### Additional Notes

Relates to [DEBUG-3883](https://datadoghq.atlassian.net/browse/DEBUG-3883)

[DEBUG-3883]: https://datadoghq.atlassian.net/browse/DEBUG-3883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ