### PR TITLE
dyninst: workaround to fix KMT and run tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -729,6 +729,7 @@ workflow:
   - pkg/process/monitor/*
   - pkg/util/kernel/**/*
   - pkg/dynamicinstrumentation/**/*
+  - pkg/dyninst/**/*
   - pkg/gpu/**/*
   - .gitlab/kernel_matrix_testing/system_probe.yml
   - .gitlab/kernel_matrix_testing/common.yml

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -8,6 +8,7 @@
 package irgen_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -27,6 +28,10 @@ func TestIRGenAllProbes(t *testing.T) {
 			for _, cfg := range testprogs.CommonConfigs {
 				t.Run(cfg.String(), func(t *testing.T) {
 					bin, err := testprogs.GetBinary(pkg, cfg)
+					if errors.Is(err, testprogs.ErrProgsDirNotFound) {
+						t.Skip("progs directory not found, skipping test")
+						return
+					}
 					require.NoError(t, err)
 					testAllProbes(t, bin)
 				})

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -9,6 +9,7 @@ package irgen_test
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"os"
 	"path"
@@ -22,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/config"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/obgect"
+	object "github.com/DataDog/datadog-agent/pkg/dyninst/obgect"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
@@ -73,6 +74,10 @@ func runTest(
 	testFile *testFile,
 ) {
 	binPath, err := testprogs.GetBinary(testFile.binary, cfg)
+	if errors.Is(err, testprogs.ErrProgsDirNotFound) {
+		t.Skip("progs directory not found, skipping test")
+		return
+	}
 	require.NoError(t, err)
 	elfFile, err := safeelf.Open(binPath)
 	require.NoError(t, err)

--- a/pkg/dyninst/obgect/elf_test.go
+++ b/pkg/dyninst/obgect/elf_test.go
@@ -9,11 +9,12 @@ package object_test
 
 import (
 	"debug/dwarf"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/dyninst/obgect"
+	object "github.com/DataDog/datadog-agent/pkg/dyninst/obgect"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
@@ -23,6 +24,10 @@ import (
 func TestElfObject(t *testing.T) {
 	for _, cfg := range testprogs.CommonConfigs {
 		binaryPath, err := testprogs.GetBinary("simple", cfg)
+		if errors.Is(err, testprogs.ErrProgsDirNotFound) {
+			t.Skip("progs directory not found, skipping test")
+			return
+		}
 		require.NoError(t, err)
 		elf, err := safeelf.Open(binaryPath)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR does two things:
1) It ensures that the system-probe tests run for any changes to `pkg/dyninst`.
2) It puts a band-aid on failures that are currently occurring in KMT tests because of bad assumptions.

### Motivation

The build is broken, and tests were not running.

### Describe how you validated your changes

CI

### Possible Drawbacks / Trade-offs

This is just a band-aid -- the dyninst tests aren't yet running in KMT. That change will come next.

### Additional Notes

Relates to [DEBUG-3883](https://datadoghq.atlassian.net/browse/DEBUG-3883)

[DEBUG-3883]: https://datadoghq.atlassian.net/browse/DEBUG-3883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ