### PR TITLE
[DEBUG-3985] tasks/system_probe.py: remove dyninst from testing

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -55,7 +55,6 @@ TEST_PACKAGES_LIST = [
     "./pkg/collector/corechecks/servicediscovery/module/...",
     "./pkg/process/monitor/...",
     "./pkg/dynamicinstrumentation/...",
-    "./pkg/dyninst/...",
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",


### PR DESCRIPTION
This is a band-aid to work around the tests as written not working in KMT.

Reverts https://github.com/DataDog/datadog-agent/pull/37491

### Possible Drawbacks / Trade-offs

This change means the dyninst tests won't run until this gets added back. That's okay for the moment.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Relates to https://datadoghq.atlassian.net/browse/DEBUG-3883