### PR TITLE
Fix agent 6 branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # To edit the requirements file, open a PR on github.com/DataDog/datadog-agent-buildimages
--r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt
+-r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/59ff0fc027be93b61cf7f6af9acac415d585a296/requirements.txt

--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
@@ -33,6 +35,8 @@ type languageDetectionSuite struct {
 }
 
 func TestLanguageDetectionSuite(t *testing.T) {
+	flake.Mark(t)
+
 	agentParams := []func(*agentparams.Params) error{
 		agentparams.WithAgentConfig(configStr),
 	}

--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 // nodeMajor is the major version of nodejs that will be installed
@@ -35,6 +37,7 @@ func (s *languageDetectionSuite) installNode() {
 }
 
 func (s *languageDetectionSuite) TestNodeDetection() {
+	flake.Mark(s.T())
 	s.installNode()
 
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

> [!NOTE]
> You can review commit by commit.

This fixes the agent 6 branch to make this release [PR](https://github.com/DataDog/datadog-agent/pull/37370) passing.

Fixes:
1. Update build images requirements path (this is removed in main branch due to dda migration).
2. Backport #37524 to mark e2e language detection test as flaky.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->