### PR TITLE
[autodiscovery] Delete HasRunOnce and ForceRanOnceFlag funcs

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"go.uber.org/atomic"
 	"go.uber.org/fx"
 
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
@@ -90,9 +89,6 @@ type AutoConfig struct {
 	// m covers the `configPollers`, `listenerCandidates`, `listeners`, and `listenerRetryStop`, but
 	// not the values they point to.
 	m sync.RWMutex
-
-	// ranOnce is set to 1 once the AutoConfig has been executed
-	ranOnce *atomic.Bool
 }
 
 const (
@@ -202,7 +198,6 @@ func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolv
 		store:                    newStore(),
 		cfgMgr:                   cfgMgr,
 		schedulerController:      schedulerController,
-		ranOnce:                  atomic.NewBool(false),
 		serviceListenerFactories: make(map[string]listeners.ServiceListenerFactory),
 		providerCatalog:          make(map[string]providers.ConfigProviderFactory),
 		wmeta:                    wmeta,
@@ -447,22 +442,6 @@ func (ac *AutoConfig) LoadAndRun(ctx context.Context) {
 			}
 		}
 	}
-
-	ac.ranOnce.Store(true)
-}
-
-// ForceRanOnceFlag sets the ranOnce flag.  This is used for testing other
-// components that depend on this value.
-func (ac *AutoConfig) ForceRanOnceFlag() {
-	ac.ranOnce.Store(true)
-}
-
-// HasRunOnce returns true if the AutoConfig has ran once.
-func (ac *AutoConfig) HasRunOnce() bool {
-	if ac == nil {
-		return false
-	}
-	return ac.ranOnce.Load()
 }
 
 // GetAllConfigs returns all resolved and non-template configs known to

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -23,8 +23,6 @@ import (
 type Component interface {
 	AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)
-	ForceRanOnceFlag()
-	HasRunOnce() bool
 	GetAllConfigs() []integration.Config
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -37,12 +37,6 @@ func (n *noopAutoConfig) AddConfigProvider(providers.ConfigProvider, bool, time.
 
 func (n *noopAutoConfig) LoadAndRun(context.Context) {}
 
-func (n *noopAutoConfig) ForceRanOnceFlag() {}
-
-func (n *noopAutoConfig) HasRunOnce() bool {
-	return false
-}
-
 func (n *noopAutoConfig) GetAllConfigs() []integration.Config {
 	return []integration.Config{}
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes two unused functions (`HasRunOnce` and `ForceRanOnceFlag`) from the autodiscovery component interface.

These functions were only used by the CCA logs scheduler, but that code was no longer used and has already been removed (https://github.com/DataDog/datadog-agent/pull/37534).

### Describe how you validated your changes

CI.