### PR TITLE
Reset eBPF resource mappings in lock contention tests

### DIFF
--- a/pkg/ebpf/lockcontention_test.go
+++ b/pkg/ebpf/lockcontention_test.go
@@ -86,8 +86,6 @@ func TestLockRanges(t *testing.T) {
 		t.Skip("EBPF lock contention collector not supported")
 	}
 
-	t.Skip("TestLockRanges needs to be fixed on newer kernels. Disabling for now.")
-
 	cpu, err := kernel.PossibleCPUs()
 	require.NoError(t, err)
 
@@ -152,6 +150,12 @@ func TestLockRanges(t *testing.T) {
 			spec := specs[c.mtype]
 			m := c.alloc(&spec)
 
+			t.Cleanup(func() {
+				m.Close()
+				l.Close()
+				ResetAllMappings()
+			})
+
 			mInfo, err := m.Info()
 			require.NoError(t, err)
 
@@ -162,9 +166,6 @@ func TestLockRanges(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, entries(l.objects.MapAddrFd), c.lockCount)
-
-			m.Close()
-			l.Close()
 		})
 	}
 }

--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -315,3 +315,19 @@ func AddProbeFDMappings(mgr *manager.Manager) {
 		}
 	}
 }
+
+func resetMapping[K comparable, V any](m map[K]V) {
+	for key, _ := range m {
+		delete(m, key)
+	}
+}
+
+// ResetAllMappings removes all mappings. This is useful in tests to reset state
+func ResetAllMappings() {
+	resetMapping(mapNameMapping)
+	resetMapping(mapModuleMapping)
+	resetMapping(progNameMapping)
+	resetMapping(progModuleMapping)
+	resetMapping(probeIDToFDMappings)
+	resetMapping(progIgnoredIDs)
+}

--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -317,7 +317,7 @@ func AddProbeFDMappings(mgr *manager.Manager) {
 }
 
 func resetMapping[K comparable, V any](m map[K]V) {
-	for key, _ := range m {
+	for key := range m {
 		delete(m, key)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
PR #30770 broke lock contention tests by violating a test assumption which expected only specific eBPF resources to be tracked. This PR fixes the tests by resetting eBPF resource mappings in the test.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Covered by existing tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->