### PR TITLE
Use raw tracepoints for net_dev_queue

### DIFF
--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -38,9 +38,10 @@ const (
 	// ProtocolClassifierGRPCSocketFilter runs a classification rules for gRPC protocols.
 	ProtocolClassifierGRPCSocketFilter ProbeFuncName = "socket__classifier_grpc"
 
-	// NetDevQueue runs a tracepoint that allows us to correlate __sk_buf (in a socket filter) with the `struct sock*`
-	// belongs (but hidden) for it.
-	NetDevQueue ProbeFuncName = "tracepoint__net__net_dev_queue"
+	// NetDevQueueRawTracepoint runs a raw tracepoint that allows us to correlate __sk_buf (in a socket filter) with the `struct sock*`
+	NetDevQueueRawTracepoint ProbeFuncName = "raw_tracepoint__net__net_dev_queue"
+	// NetDevQueueTracepoint is the tracepoint version of the same probe attach on kernels less than 4.17
+	NetDevQueueTracepoint ProbeFuncName = "tracepoint__net__net_dev_queue"
 
 	// TCPSendMsg traces the tcp_sendmsg() system call
 	TCPSendMsg ProbeFuncName = "kprobe__tcp_sendmsg"

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 
 	manager "github.com/DataDog/ebpf-manager"
+	libebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -58,6 +60,11 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 		return nil, err
 	}
 
+	netDevQueue := probes.NetDevQueueTracepoint
+	if features.HaveProgramType(libebpf.RawTracepoint) == nil {
+		netDevQueue = probes.NetDevQueueRawTracepoint
+	}
+
 	hasSendPage := HasTCPSendPage(kv)
 
 	if c.CollectTCPv4Conns || c.CollectTCPv6Conns {
@@ -68,7 +75,7 @@ func enabledProbes(c *config.Config, runtimeTracer, coreTracer bool) (map[probes
 			enableProbe(enabled, probes.ProtocolClassifierQueuesSocketFilter)
 			enableProbe(enabled, probes.ProtocolClassifierDBsSocketFilter)
 			enableProbe(enabled, probes.ProtocolClassifierGRPCSocketFilter)
-			enableProbe(enabled, probes.NetDevQueue)
+			enableProbe(enabled, netDevQueue)
 			enableProbe(enabled, probes.TCPCloseCleanProtocolsReturn)
 		}
 		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPSendMsg, probes.TCPSendMsgPre410, kv410))

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -16,7 +16,7 @@ import (
 )
 
 var mainProbes = []probes.ProbeFuncName{
-	probes.NetDevQueue,
+	probes.NetDevQueueTracepoint,
 	probes.ProtocolClassifierEntrySocketFilter,
 	probes.ProtocolClassifierTLSClientSocketFilter,
 	probes.ProtocolClassifierTLSServerSocketFilter,
@@ -103,6 +103,11 @@ func initManager(mgr *ddebpf.Manager, runtimeTracer bool) error {
 		probes.UnderscoredSKBFreeDatagramLocked,
 		probes.SKBConsumeUDP,
 	}, funcNameToProbe)...)
+
+	// add Probe for net_dev_queue attached via raw tracepoint
+	mgr.Probes = append(mgr.Probes,
+		&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: probes.NetDevQueueRawTracepoint, UID: probeUID}, TracepointName: "net_dev_queue", TracepointCategory: "net"},
+	)
 
 	if !runtimeTracer {
 		// the runtime compiled tracer has no need for separate probes targeting specific kernel versions, since it can

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -62,7 +62,7 @@ func NewConntrackOffsetGuesser(cfg *config.Config) (OffsetGuesser, error) {
 				// it twice in a process (once by the tracer offset guesser)
 				// does not seem to work; this will be not be enabled,
 				// so explicitly disabled, and the manager won't load it
-				{ProbeIdentificationPair: idPair(probes.NetDevQueue)}},
+				{ProbeIdentificationPair: idPair(probes.NetDevQueueTracepoint)}},
 		},
 		status:       &ConntrackStatus{},
 		tcpv6Enabled: tcpv6EnabledConst,

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -95,7 +95,7 @@ func NewTracerOffsetGuesser() (OffsetGuesser, error) {
 				{ProbeIdentificationPair: idPair(probes.IP6MakeSkb)},
 				{ProbeIdentificationPair: idPair(probes.IP6MakeSkbPre470)},
 				{ProbeIdentificationPair: idPair(probes.TCPv6ConnectReturn), KProbeMaxActive: 128},
-				{ProbeIdentificationPair: idPair(probes.NetDevQueue)},
+				{ProbeIdentificationPair: idPair(probes.NetDevQueueTracepoint)},
 			},
 		},
 	}, nil
@@ -218,7 +218,7 @@ func (*tracerOffsetGuesser) Probes(c *config.Config) (map[probes.ProbeFuncName]s
 		return nil, fmt.Errorf("could not kernel version: %w", err)
 	}
 	if kv >= kernel.VersionCode(4, 7, 0) {
-		enableProbe(p, probes.NetDevQueue)
+		enableProbe(p, probes.NetDevQueueTracepoint)
 	}
 
 	if c.CollectTCPv6Conns || c.CollectUDPv6Conns {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support to use raw_tracepoints for net_dev_queue probes.


### Motivation

The recursion protection for kprobes and tracepoints is fairly heavy handed. It works by disallowing eBPF programs to nest on the same CPU, using a per-cpu variable [bpf_prog_active](https://elixir.bootlin.com/linux/latest/source/kernel/trace/bpf_trace.c#L117).

For the probe in question this is problematic because it runs from within IRQ context, which means it can nest on to another eBPF program running from within a user context. This causes the probe to be skipped in such cases. Depending on the number of eBPF programs attached and the load on a system these misses can be very high.

Raw tracepoints on the other hand have more precise nesting control. An eBPF program attached to a raw tracepoint is skipped only if it is nesting a running instance of the same program. Converting this probe to use a raw tracepoint instead can therefore completely eliminate misses due to nesting, since these only run from a single context.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Covered by existing UTs.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Statistics on misses of raw tracepoints are exposed via recursion counts. These stats were added from [kernel versions 6.7+](https://github.com/torvalds/linux/commit/dd8657894c11b03c6eb0fd53fe9d7fec2072d18b).

To observe these misses happening, we can use https://github.com/DataDog/ami-builder/pull/191 (running kernel 6.8), run system-probe, generate load, and then use the eBPF check to get recursion counts for all attached programs.