### PR TITLE
[serverless-init] Fix multiline stacktraces being split up into multiple logs

### DIFF
--- a/cmd/serverless-init/log/channel_writer.go
+++ b/cmd/serverless-init/log/channel_writer.go
@@ -34,6 +34,12 @@ func NewChannelWriter(ch chan *logConfig.ChannelMessage, isError bool) *ChannelW
 // Write buffers Writes from our stdout/stderr fd,
 // and sends to the channel once we've received newlines.
 func (cw *ChannelWriter) Write(p []byte) (n int, err error) {
+	// Flush full stacktrace without splitting by new line
+	if cw.IsError {
+		cw.sendPayload(p)
+		return
+	}
+
 	n, err = cw.Buffer.Write(p)
 	if err != nil {
 		return n, err
@@ -55,20 +61,23 @@ func (cw *ChannelWriter) Write(p []byte) (n int, err error) {
 			continue
 		}
 
-		channelMessage := &logConfig.ChannelMessage{
-			Content: []byte(line[:len(line)-1]),
-			IsError: cw.IsError,
-		}
-
-		select {
-		case cw.Channel <- channelMessage:
-			// Success case -- the channel isn't full, and can accommodate our message
-		default:
-			// Channel is full (i.e, we aren't flushing data to Datadog as our backend is down).
-			// message will be dropped.
-			log.Debug("Log dropped due to full buffer")
-		}
-
+		cw.sendPayload([]byte(line[:len(line)-1]))
 	}
 	return n, nil
+}
+
+func (cw *ChannelWriter) sendPayload(payload []byte) {
+	channelMessage := &logConfig.ChannelMessage{
+		Content: payload,
+		IsError: cw.IsError,
+	}
+
+	select {
+	case cw.Channel <- channelMessage:
+		// Success case -- the channel isn't full, and can accommodate our message
+	default:
+		// Channel is full (i.e, we aren't flushing data to Datadog as our backend is down).
+		// message will be dropped.
+		log.Debug("Log dropped due to full buffer")
+	}
 }

--- a/releasenotes/notes/fix-split-up-stacktraces-serverless-init-9c050afc1862a346.yaml
+++ b/releasenotes/notes/fix-split-up-stacktraces-serverless-init-9c050afc1862a346.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes multiline stacktraces being split up into separate logs when serverless-init is installed in-process.


### PR DESCRIPTION
### What does this PR do?

- Flushes stderr without splitting by new line
- This keeps stacktraces in a single log, rather than sending multiple one-line logs

Previously, stacktraces looked like this:
<img width="800" alt="Screenshot 2025-05-28 at 11 57 43 AM" src="https://github.com/user-attachments/assets/016db9ea-62f8-47df-a679-89af0560bc11" />

Now, they look like this:
<img width="800" alt="Screenshot 2025-06-02 at 10 20 18 AM" src="https://github.com/user-attachments/assets/e4767717-7127-4d32-9a62-b2f86b8bec0a" />

### Motivation

The old behavior was annoying for customers and led to some tickets.

### Describe how you validated your changes

Tested manually on Google Cloud Run with Node and Python. This change is simple enough and should work across all runtimes and in Azure/GCP.

Unit tests

### Possible Drawbacks / Trade-offs

None

### Additional Notes
Other possible solutions explored here: https://docs.google.com/document/d/1lFxDyiaGqneUUb1aYupUjYWFL4EbMS1s1isqtgsF_7c/edit?tab=t.0#heading=h.dnewoeovur60

This is "Solution 2" which is the simplest and does not increase overhead.
