### PR TITLE
[SMP] Update quality gate limits

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "238 MiB"
+      upper_bound: "243 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "610 MiB"
+      upper_bound: "615 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "254 MiB"
+      upper_bound: "259 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

Updates quality gate limits to account for a minor memory increase as part of SMPs v22 deploy on May 28th

### Motivation

On May 28th we deployed a new version of SMP's infra. Due to some configuration changes there is a minor increase in memory across all experiments. This PR is one of the exceptional cases where we will increase the limits in order to account for measurement/infra changes.

Summary of changes:
`quality_gate_idle`: `238 MiB` -> `243 MiB`
`quality_gate_idle_all_features`: `610 MiB` -> `615 MiB`
`quality_gate_logs`: `254 MiB` -> `259 MiB`

The rational for this change is included in this [notebook](https://app.datadoghq.com/notebook/12557120/investigating-upwards-and-downwards-spikes)

This adjustment is needed to resolve [incident-38848](https://app.datadoghq.com/incidents/38848)

### Describe how you validated your changes


### Possible Drawbacks / Trade-offs

### Additional Notes
