### PR TITLE
[CWS] include seclwin sync in `cws-go-generate`

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -707,7 +707,6 @@ def go_generate_check(ctx):
         [cws_go_generate],
         [generate_cws_documentation],
         [gen_mocks],
-        [sync_secl_win_pkg],
     ]
     failing_tasks = []
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -536,6 +536,7 @@ def generate_cws_documentation(ctx, go_generate=False):
 
 @task
 def cws_go_generate(ctx, verbose=False):
+    # run different `go generate` for pkg/security/secl and pkg/security
     ctx.run("go install golang.org/x/tools/cmd/stringer")
     ctx.run("go install github.com/mailru/easyjson/easyjson")
     ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/generators/accessors")
@@ -558,6 +559,9 @@ def cws_go_generate(ctx, verbose=False):
         )
 
     ctx.run("go generate -tags=linux_bpf,cws_go_generate ./pkg/security/...")
+
+    # synchronize the seclwin package from the secl package
+    sync_secl_win_pkg(ctx)
 
 
 @task


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

With the end goal of reducing the amount of task to remember when building new CWS features, this PR modifies the `cws-go-generate` task to directly call the seclwin sync task. Allowing to mostly use `cws-go-generate` for everything.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->