### PR TITLE
CXP-2266 [agent] enrich process collector with container data

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -126,7 +126,7 @@ func createdProcessesToWorkloadmetaProcesses(createdProcs []*procutil.Process, p
 	return wlmProcs
 }
 
-// deletedProcessesToWorkloadMetaProcesses helper function to convert deletedProcs into wlm entities
+// deletedProcessesToWorkloadMetaProcesses helper function to convert deletedProcs into wlm entities. wlm only uses the EventType, Source, ID, and Kind for deletion events
 func deletedProcessesToWorkloadmetaProcesses(deletedProcs []*procutil.Process) []*workloadmeta.Process {
 	wlmProcs := make([]*workloadmeta.Process, len(deletedProcs))
 	for i, proc := range deletedProcs {
@@ -190,7 +190,6 @@ func (c *collector) collect(ctx context.Context, collectionTicker *clock.Ticker)
 			wlmCreatedProcs := createdProcessesToWorkloadmetaProcesses(createdProcs, pidToCid)
 
 			deletedProcs := processCacheDifference(c.lastCollectedProcesses, procs)
-			// wlm only uses the EventType, Source, ID, and Kind for deletion events
 			wlmDeletedProcs := deletedProcessesToWorkloadmetaProcesses(deletedProcs)
 
 			// send these events to the channel

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/fx"
@@ -27,17 +28,20 @@ import (
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil/mocks"
+	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 type collectorTest struct {
-	collector *collector
-	probe     *mocks.Probe
-	mockClock *clock.Mock
-	mockStore workloadmetamock.Mock
+	collector             *collector
+	probe                 *mocks.Probe
+	mockClock             *clock.Mock
+	mockStore             workloadmetamock.Mock
+	mockContainerProvider *proccontainers.MockContainerProvider
 }
 
 func setUpCollectorTest(t *testing.T, configOverrides map[string]interface{}) collectorTest {
+	// mock workloadmeta store
 	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		fx.Replace(config.MockParams{Overrides: configOverrides}),
@@ -46,14 +50,18 @@ func setUpCollectorTest(t *testing.T, configOverrides map[string]interface{}) co
 		}),
 	))
 
+	// mock container provider for container data
+	mockCtrl := gomock.NewController(t)
+	mockContainerProvider := proccontainers.NewMockContainerProvider(mockCtrl)
+
 	mockClock := clock.NewMock()
 	mockProbe := mocks.NewProbe(t)
-	processCollector := newProcessCollector(collectorID, workloadmeta.NodeAgent, mockClock, mockProbe)
+	processCollector := newProcessCollector(collectorID, workloadmeta.NodeAgent, mockClock, mockProbe, mockContainerProvider)
 
-	return collectorTest{&processCollector, mockProbe, mockClock, mockStore}
+	return collectorTest{&processCollector, mockProbe, mockClock, mockStore, mockContainerProvider}
 }
 
-func createTestProcess1(pid int32, createTime int64) (*procutil.Process, *workloadmeta.Process) {
+func createTestProcess1(pid int32, createTime int64) *procutil.Process {
 	proc := &procutil.Process{
 		Pid:     pid,
 		Ppid:    6,
@@ -69,28 +77,10 @@ func createTestProcess1(pid int32, createTime int64) (*procutil.Process, *worklo
 			CreateTime: createTime,
 		},
 	}
-
-	expectedProc := &workloadmeta.Process{
-		EntityID: workloadmeta.EntityID{
-			Kind: workloadmeta.KindProcess,
-			ID:   strconv.Itoa(int(proc.Pid)),
-		},
-		Pid:          proc.Pid,
-		Ppid:         proc.Ppid,
-		NsPid:        proc.NsPid,
-		Name:         proc.Name,
-		Cwd:          proc.Cwd,
-		Exe:          proc.Exe,
-		Comm:         proc.Comm,
-		Cmdline:      proc.Cmdline,
-		Uids:         proc.Uids,
-		Gids:         proc.Gids,
-		CreationTime: time.UnixMilli(proc.Stats.CreateTime).UTC(),
-	}
-	return proc, expectedProc
+	return proc
 }
 
-func createTestProcess2(pid int32, createTime int64) (*procutil.Process, *workloadmeta.Process) {
+func createTestProcess2(pid int32, createTime int64) *procutil.Process {
 	proc := &procutil.Process{
 		Pid:     pid,
 		Ppid:    9,
@@ -107,7 +97,16 @@ func createTestProcess2(pid int32, createTime int64) (*procutil.Process, *worklo
 		},
 	}
 
-	expectedProc := &workloadmeta.Process{
+	return proc
+}
+
+func workloadmetaProcess(proc *procutil.Process, owner *workloadmeta.EntityID) *workloadmeta.Process {
+	// setting ContainerID since it is existing behaviour, but will be eventually removed once we only use the Owner field
+	cid := ""
+	if owner != nil {
+		cid = owner.ID
+	}
+	wlmProc := &workloadmeta.Process{
 		EntityID: workloadmeta.EntityID{
 			Kind: workloadmeta.KindProcess,
 			ID:   strconv.Itoa(int(proc.Pid)),
@@ -123,8 +122,10 @@ func createTestProcess2(pid int32, createTime int64) (*procutil.Process, *worklo
 		Uids:         proc.Uids,
 		Gids:         proc.Gids,
 		CreationTime: time.UnixMilli(proc.Stats.CreateTime).UTC(),
+		ContainerID:  cid,
+		Owner:        owner,
 	}
-	return proc, expectedProc
+	return wlmProc
 }
 
 // TestCreatedProcessesCollection tests the collector capturing new processes
@@ -133,16 +134,17 @@ func TestCreatedProcessesCollection(t *testing.T) {
 
 	creationTime1 := time.Now().Unix()
 	pid1 := int32(1234)
-	proc1, expectedProc1 := createTestProcess1(pid1, creationTime1)
+	proc1 := createTestProcess1(pid1, creationTime1)
 
 	creationTime2 := time.Now().Add(time.Second).Unix()
 	pid2 := int32(9999)
-	proc2, expectedProc2 := createTestProcess2(pid2, creationTime2)
+	proc2 := createTestProcess2(pid2, creationTime2)
 
 	for _, tc := range []struct {
 		description        string
 		configOverrides    map[string]interface{}
 		processesToCollect map[int32]*procutil.Process
+		pidToCidToCollect  map[int]string
 		expectedProcesses  map[int32]*workloadmeta.Process
 	}{
 		{
@@ -152,7 +154,7 @@ func TestCreatedProcessesCollection(t *testing.T) {
 				proc1.Pid: proc1,
 			},
 			expectedProcesses: map[int32]*workloadmeta.Process{
-				expectedProc1.Pid: expectedProc1,
+				proc1.Pid: workloadmetaProcess(proc1, nil),
 			},
 		},
 		{
@@ -163,8 +165,86 @@ func TestCreatedProcessesCollection(t *testing.T) {
 				proc2.Pid: proc2,
 			},
 			expectedProcesses: map[int32]*workloadmeta.Process{
-				expectedProc1.Pid: expectedProc1,
-				expectedProc2.Pid: expectedProc2,
+				proc1.Pid: workloadmetaProcess(proc1, nil),
+				proc2.Pid: workloadmetaProcess(proc2, nil),
+			},
+		},
+		{
+			description:     "single new process with container",
+			configOverrides: map[string]interface{}{},
+			processesToCollect: map[int32]*procutil.Process{
+				proc1.Pid: proc1,
+			},
+			pidToCidToCollect: map[int]string{
+				int(proc1.Pid): "some_container_id",
+			},
+			expectedProcesses: map[int32]*workloadmeta.Process{
+				proc1.Pid: workloadmetaProcess(proc1, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id",
+				}),
+			},
+		},
+		{
+			description:     "multiple new processes with containers",
+			configOverrides: map[string]interface{}{},
+			processesToCollect: map[int32]*procutil.Process{
+				proc1.Pid: proc1,
+				proc2.Pid: proc2,
+			},
+			pidToCidToCollect: map[int]string{
+				int(proc1.Pid): "some_container_id1",
+				int(proc2.Pid): "some_container_id2",
+			},
+			expectedProcesses: map[int32]*workloadmeta.Process{
+				proc1.Pid: workloadmetaProcess(proc1, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id1",
+				}),
+				proc2.Pid: workloadmetaProcess(proc2, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id2",
+				}),
+			},
+		},
+		{
+			description:     "multiple new processes with some containers",
+			configOverrides: map[string]interface{}{},
+			processesToCollect: map[int32]*procutil.Process{
+				proc1.Pid: proc1,
+				proc2.Pid: proc2,
+			},
+			pidToCidToCollect: map[int]string{
+				int(proc2.Pid): "some_container_id2",
+			},
+			expectedProcesses: map[int32]*workloadmeta.Process{
+				proc1.Pid: workloadmetaProcess(proc1, nil),
+				proc2.Pid: workloadmetaProcess(proc2, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id2",
+				}),
+			},
+		},
+		{
+			description:     "multiple new processes with same container",
+			configOverrides: map[string]interface{}{},
+			processesToCollect: map[int32]*procutil.Process{
+				proc1.Pid: proc1,
+				proc2.Pid: proc2,
+			},
+			pidToCidToCollect: map[int]string{
+				int(proc1.Pid): "some_container_id",
+				int(proc2.Pid): "some_container_id",
+			},
+			expectedProcesses: map[int32]*workloadmeta.Process{
+				proc1.Pid: workloadmetaProcess(proc1, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id",
+				}),
+				proc2.Pid: workloadmetaProcess(proc2, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "some_container_id",
+				}),
 			},
 		},
 	} {
@@ -180,6 +260,9 @@ func TestCreatedProcessesCollection(t *testing.T) {
 			go c.collector.stream(ctx)
 
 			c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(tc.processesToCollect, nil).Times(1)
+
+			c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(tc.pidToCidToCollect).Times(1)
+
 			// update clock to trigger processing
 			c.mockClock.Add(collectionInterval)
 
@@ -199,24 +282,26 @@ func TestProcessLifecycleCollection(t *testing.T) {
 	collectionInterval := time.Second * 10
 	creationTime1 := time.Now().Unix()
 	pid1 := int32(1234)
-	proc1, expectedProc1 := createTestProcess1(pid1, creationTime1)
+	proc1 := createTestProcess1(pid1, creationTime1)
 
 	creationTime2 := time.Now().Add(time.Second).Unix()
 	pid2 := int32(9999)
-	proc2, expectedProc2 := createTestProcess2(pid2, creationTime2)
+	proc2 := createTestProcess2(pid2, creationTime2)
 
 	// same pid as proc1 but different creation time
-	proc3, expectedProc3 := createTestProcess1(pid1, creationTime2)
+	proc3 := createTestProcess1(pid1, creationTime2)
 
 	// same pid as proc2 but different creation time
 	creationTime3 := time.Now().Add(2 * time.Second).Unix()
-	proc4, expectedProc4 := createTestProcess1(pid2, creationTime3)
+	proc4 := createTestProcess1(pid2, creationTime3)
 
 	for _, tc := range []struct {
 		description              string
 		configOverrides          map[string]interface{}
 		processesToCollectA      map[int32]*procutil.Process
+		pidToCidToCollectA       map[int]string
 		processesToCollectB      map[int32]*procutil.Process
+		pidToCidToCollectB       map[int]string
 		expectedDeletedProcesses []*workloadmeta.Process
 		expectedLiveProcesses    []*workloadmeta.Process
 	}{
@@ -231,10 +316,10 @@ func TestProcessLifecycleCollection(t *testing.T) {
 				proc2.Pid: proc2,
 			},
 			expectedDeletedProcesses: []*workloadmeta.Process{
-				expectedProc1,
+				workloadmetaProcess(proc1, nil),
 			},
 			expectedLiveProcesses: []*workloadmeta.Process{
-				expectedProc2,
+				workloadmetaProcess(proc2, nil),
 			},
 		},
 		{
@@ -247,8 +332,8 @@ func TestProcessLifecycleCollection(t *testing.T) {
 			processesToCollectB:   map[int32]*procutil.Process{},
 			expectedLiveProcesses: []*workloadmeta.Process{},
 			expectedDeletedProcesses: []*workloadmeta.Process{
-				expectedProc1,
-				expectedProc2,
+				workloadmetaProcess(proc1, nil),
+				workloadmetaProcess(proc2, nil),
 			},
 		},
 		{
@@ -263,10 +348,52 @@ func TestProcessLifecycleCollection(t *testing.T) {
 				proc4.Pid: proc4,
 			},
 			expectedLiveProcesses: []*workloadmeta.Process{
-				expectedProc3, expectedProc4,
+				workloadmetaProcess(proc3, nil),
+				workloadmetaProcess(proc4, nil),
 			},
 			expectedDeletedProcesses: []*workloadmeta.Process{
-				expectedProc1, expectedProc2,
+				workloadmetaProcess(proc1, nil),
+				workloadmetaProcess(proc2, nil),
+			},
+		},
+		{
+			description:     "2 new processes with containers, 2 finish, but 2 new processes with the same pid diff container",
+			configOverrides: map[string]interface{}{},
+			processesToCollectA: map[int32]*procutil.Process{
+				proc1.Pid: proc1,
+				proc2.Pid: proc2,
+			},
+			pidToCidToCollectA: map[int]string{
+				int(proc1.Pid): "container_id_1",
+				int(proc2.Pid): "container_id_2",
+			},
+			processesToCollectB: map[int32]*procutil.Process{
+				proc3.Pid: proc3,
+				proc4.Pid: proc4,
+			},
+			pidToCidToCollectB: map[int]string{
+				int(proc3.Pid): "container_id_3",
+				int(proc4.Pid): "container_id_4",
+			},
+			expectedLiveProcesses: []*workloadmeta.Process{
+				workloadmetaProcess(proc3, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "container_id_3",
+				}),
+				workloadmetaProcess(proc4, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "container_id_4",
+				}),
+			},
+			expectedDeletedProcesses: []*workloadmeta.Process{
+				workloadmetaProcess(proc1, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "container_id_1",
+				}),
+				workloadmetaProcess(proc2, &workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "container_id_2",
+				}),
 			},
 		},
 	} {
@@ -282,9 +409,13 @@ func TestProcessLifecycleCollection(t *testing.T) {
 			go c.collector.stream(ctx)
 
 			c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(tc.processesToCollectA, nil).Times(1)
+			c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(tc.pidToCidToCollectA).Times(1)
+
 			// update clock to trigger processing
 			c.mockClock.Add(collectionInterval)
 			c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(tc.processesToCollectB, nil).Times(1)
+
+			c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(tc.pidToCidToCollectB).Times(1)
 			// update clock to trigger processing
 			c.mockClock.Add(collectionInterval)
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -387,14 +387,8 @@ func TestProcessLifecycleCollection(t *testing.T) {
 				}),
 			},
 			expectedDeletedProcesses: []*workloadmeta.Process{
-				workloadmetaProcess(proc1, &workloadmeta.EntityID{
-					Kind: workloadmeta.KindContainer,
-					ID:   "container_id_1",
-				}),
-				workloadmetaProcess(proc2, &workloadmeta.EntityID{
-					Kind: workloadmeta.KindContainer,
-					ID:   "container_id_2",
-				}),
+				workloadmetaProcess(proc1, nil),
+				workloadmetaProcess(proc2, nil),
 			},
 		},
 	} {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -56,7 +56,7 @@ func setUpCollectorTest(t *testing.T, configOverrides map[string]interface{}) co
 
 	mockClock := clock.NewMock()
 	mockProbe := mocks.NewProbe(t)
-	processCollector := newProcessCollector(collectorID, workloadmeta.NodeAgent, mockClock, mockProbe, mockContainerProvider)
+	processCollector := newProcessCollector(collectorID, workloadmeta.NodeAgent, mockClock, mockProbe)
 
 	return collectorTest{&processCollector, mockProbe, mockClock, mockStore, mockContainerProvider}
 }
@@ -255,6 +255,7 @@ func TestCreatedProcessesCollection(t *testing.T) {
 
 			// TODO: we should use Start() instead of 3 lines below when configuration is sorted as Start() is currently
 			// by default disabled
+			c.collector.containerProvider = c.mockContainerProvider
 			c.collector.store = c.mockStore
 			go c.collector.collect(ctx, c.collector.clock.Ticker(collectionInterval))
 			go c.collector.stream(ctx)
@@ -404,6 +405,7 @@ func TestProcessLifecycleCollection(t *testing.T) {
 
 			// TODO: we should use Start() instead of 3 lines below when configuration is sorted as Start() is currently
 			// by default disabled
+			c.collector.containerProvider = c.mockContainerProvider
 			c.collector.store = c.mockStore
 			go c.collector.collect(ctx, c.collector.clock.Ticker(collectionInterval))
 			go c.collector.stream(ctx)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1213,7 +1213,8 @@ type Process struct {
 	ContainerID  string
 	CreationTime time.Time
 	Language     *languagemodels.Language
-	// TODO: add future fields for privileged/service discovery data
+	// Owner will temporarily duplicate the ContainerID field until the new collector is enabled so we can then remove the ContainerID field
+	Owner *EntityID // Owner is a reference to a container in WLM
 }
 
 var _ Entity = &Process{}
@@ -1249,6 +1250,7 @@ func (p Process) String(_ bool) string {
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
 	_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
+	// TODO: add new fields once the new wlm process collector can be enabled
 
 	return sb.String()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- adds a `owner` field to the workloadmeta process entity to reference the container this process is in
    - allows future queries that ask wlm for process data to also include the container data at the same time (optimization) and prevent duplicate data storage by storing container data on the process entity
    - similar pattern exists for workloadmeta [Container struct ](https://github.com/DataDog/datadog-agent/blob/4270f621c687c35ff6fba6413bd0e8928f265527/comp/core/workloadmeta/def/types.go#L559)

### Motivation
- processes are already enriched with container data on the check and language collector. We can reduce operations on the check and aid with the future language collector consolidation if we enrich the new process collector with container data
- service discovery and process collection have duplicate data collected and we want to consolidate this to reduce resource usage for customers RFC: https://datadoghq.atlassian.net/wiki/spaces/cxg/pages/5013111768/RFC+Processes+and+Service+Discovery+Agent+Consolidation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->