### PR TITLE
[DEBUG-3985] dyninst/...: reenable testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -801,7 +801,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.11.0 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
-	github.com/gofrs/flock v0.12.1
+	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect

--- a/pkg/dyninst/ebpf/scratch.h
+++ b/pkg/dyninst/ebpf/scratch.h
@@ -23,7 +23,10 @@
 
 typedef uint64_t buf_offset_t;
 
+#ifndef PAGE_SIZE
 #define PAGE_SIZE 4*1024
+#endif
+
 #define RINGBUF_CAPACITY ((uint64_t)1 << 23)
 #define SCRATCH_BUF_LEN ((uint64_t)1 << 15) // 32KiB
 

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -22,12 +22,13 @@ import (
 )
 
 func TestIRGenAllProbes(t *testing.T) {
-	for _, pkg := range testprogs.Packages {
+	programs := testprogs.GetPrograms(t)
+	cfgs := testprogs.GetCommonConfigs(t)
+	for _, pkg := range programs {
 		t.Run(pkg, func(t *testing.T) {
-			for _, cfg := range testprogs.CommonConfigs {
+			for _, cfg := range cfgs {
 				t.Run(cfg.String(), func(t *testing.T) {
-					bin, err := testprogs.GetBinary(pkg, cfg)
-					require.NoError(t, err)
+					bin := testprogs.GetBinary(t, pkg, cfg)
 					testAllProbes(t, bin)
 				})
 			}

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -59,7 +60,9 @@ func runFile(t *testing.T, path string) {
 	require.NoError(t, err)
 	testFile, err := deserializeTestFile(yamlFile)
 	require.NoError(t, err)
-	for _, cfg := range testprogs.CommonConfigs {
+	cfgs := testprogs.GetCommonConfigs(t)
+	assert.NotEmpty(t, cfgs)
+	for _, cfg := range cfgs {
 		t.Run(cfg.String(), func(t *testing.T) {
 			runTest(t, cfg, outDir, testFile)
 		})
@@ -72,8 +75,7 @@ func runTest(
 	outDir string,
 	testFile *testFile,
 ) {
-	binPath, err := testprogs.GetBinary(testFile.binary, cfg)
-	require.NoError(t, err)
+	binPath := testprogs.GetBinary(t, testFile.binary, cfg)
 	elfFile, err := safeelf.Open(binPath)
 	require.NoError(t, err)
 	obj, err := object.NewElfObject(elfFile)

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
@@ -8,7 +8,7 @@ Probes:
       Events:
         - ID: 1
           Type: 39 EventRootType ProbeEvent
-          InjectionPCs: [654940]
+          InjectionPCs: ["0x491c8a"]
           Condition: null
       Snapshot: false
     - ID: c
@@ -19,7 +19,7 @@ Probes:
       Events:
         - ID: 2
           Type: 40 EventRootType ProbeEvent
-          InjectionPCs: [655056]
+          InjectionPCs: ["0x491cf3"]
           Condition: null
       Snapshot: false
     - ID: d
@@ -30,47 +30,47 @@ Probes:
       Events:
         - ID: 3
           Type: 41 EventRootType ProbeEvent
-          InjectionPCs: [655372]
+          InjectionPCs: ["0x491e2a"]
           Condition: null
       Snapshot: false
 Subprograms:
     - ID: 1
       Name: main.mapArg
-      OutOfLinePCRanges: [0x9fe50..0x9fec0]
+      OutOfLinePCRanges: [0x491c80..0x491cd6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 1 GoMapType map[string]int
           Locations:
-            - Range: 0x9fe50..0x9fe88
+            - Range: 0x491c80..0x491cad
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
       Lines: []
     - ID: 2
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x9fec0..0x9ff80]
+      OutOfLinePCRanges: [0x491ce0..0x491d9b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 19 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x9fec0..0x9fef8
+            - Range: 0x491ce0..0x491d13
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x9fef8..0x9ff80
-              Pieces: [{Size: 0, InReg: false, StackOffset: 16, Register: 0}]
+            - Range: 0x491d13..0x491d9b
+              Pieces: [{Size: 0, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
       Lines: []
     - ID: 3
       Name: main.stringArg
-      OutOfLinePCRanges: [0xa0000..0xa0080]
+      OutOfLinePCRanges: [0x491e20..0x491e91]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 17 GoStringHeaderType string
           Locations:
-            - Range: 0xa0000..0xa0024
+            - Range: 0x491e20..0x491e3e
               Pieces:
                 - Size: 8
                   InReg: true
@@ -79,7 +79,7 @@ Subprograms:
                 - Size: 8
                   InReg: true
                   StackOffset: 0
-                  Register: 1
+                  Register: 3
           IsParameter: true
           IsReturn: false
       Lines: []
@@ -87,7 +87,7 @@ Types:
     - __kind: GoMapType
       ID: 1
       Name: map[string]int
-      GoRuntimeType: 63328
+      GoRuntimeType: 63488
       GoKind: 21
       HeaderType: 3 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
@@ -131,13 +131,13 @@ Types:
       ID: 4
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 39424
+      GoRuntimeType: 39488
       GoKind: 11
     - __kind: BaseType
       ID: 5
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 39616
+      GoRuntimeType: 39680
       GoKind: 12
     - __kind: PointerType
       ID: 6
@@ -177,19 +177,19 @@ Types:
       ID: 9
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 39168
+      GoRuntimeType: 39232
       GoKind: 9
     - __kind: BaseType
       ID: 10
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 39040
+      GoRuntimeType: 39104
       GoKind: 8
     - __kind: BaseType
       ID: 11
       Name: int
       ByteSize: 8
-      GoRuntimeType: 39488
+      GoRuntimeType: 39552
       GoKind: 2
     - __kind: GoSwissMapGroupsType
       ID: 12
@@ -214,7 +214,7 @@ Types:
       ID: 14
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 70336
+      GoRuntimeType: 70496
       GoKind: 25
       Fields:
         - Name: ctrl
@@ -227,7 +227,7 @@ Types:
       ID: 15
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 43488
+      GoRuntimeType: 43552
       GoKind: 17
       Count: 8
       HasCount: true
@@ -236,7 +236,7 @@ Types:
       ID: 16
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 70208
+      GoRuntimeType: 70368
       GoKind: 25
       Fields:
         - Name: key
@@ -249,7 +249,7 @@ Types:
       ID: 17
       Name: string
       ByteSize: 16
-      GoRuntimeType: 38912
+      GoRuntimeType: 38976
       GoKind: 24
       Fields:
         - Name: str
@@ -263,13 +263,13 @@ Types:
       ID: 18
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 26976
       GoKind: 22
       Pointee: 10 BaseType uint8
     - __kind: GoMapType
       ID: 19
       Name: map[string]main.bigStruct
-      GoRuntimeType: 63456
+      GoRuntimeType: 63616
       GoKind: 21
       HeaderType: 21 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
@@ -366,7 +366,7 @@ Types:
       ID: 27
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 70592
+      GoRuntimeType: 70752
       GoKind: 25
       Fields:
         - Name: ctrl
@@ -379,7 +379,7 @@ Types:
       ID: 28
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 43680
+      GoRuntimeType: 43744
       GoKind: 17
       Count: 8
       HasCount: true
@@ -388,7 +388,7 @@ Types:
       ID: 29
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 70464
+      GoRuntimeType: 70624
       GoKind: 25
       Fields:
         - Name: key
@@ -401,14 +401,14 @@ Types:
       ID: 30
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 25504
+      GoRuntimeType: 25568
       GoKind: 22
       Pointee: 31 StructureType main.bigStruct
     - __kind: StructureType
       ID: 31
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 112224
+      GoRuntimeType: 112384
       GoKind: 25
       Fields:
         - Name: Field1
@@ -439,7 +439,7 @@ Types:
       ID: 32
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 43584
+      GoRuntimeType: 43648
       GoKind: 17
       Count: 128
       HasCount: true

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
@@ -8,7 +8,7 @@ Probes:
       Events:
         - ID: 1
           Type: 39 EventRootType ProbeEvent
-          InjectionPCs: ["0x491c0a"]
+          InjectionPCs: [655084]
           Condition: null
       Snapshot: false
     - ID: c
@@ -19,7 +19,7 @@ Probes:
       Events:
         - ID: 2
           Type: 40 EventRootType ProbeEvent
-          InjectionPCs: ["0x491c73"]
+          InjectionPCs: [655200]
           Condition: null
       Snapshot: false
     - ID: d
@@ -30,47 +30,47 @@ Probes:
       Events:
         - ID: 3
           Type: 41 EventRootType ProbeEvent
-          InjectionPCs: ["0x491daa"]
+          InjectionPCs: [655516]
           Condition: null
       Snapshot: false
 Subprograms:
     - ID: 1
       Name: main.mapArg
-      OutOfLinePCRanges: [0x491c00..0x491c56]
+      OutOfLinePCRanges: [0x9fee0..0x9ff50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 1 GoMapType map[string]int
           Locations:
-            - Range: 0x491c00..0x491c2d
+            - Range: 0x9fee0..0x9ff18
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
       Lines: []
     - ID: 2
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x491c60..0x491d1b]
+      OutOfLinePCRanges: [0x9ff50..0xa0010]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 19 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x491c60..0x491c93
+            - Range: 0x9ff50..0x9ff88
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x491c93..0x491d1b
-              Pieces: [{Size: 0, InReg: false, StackOffset: 8, Register: 0}]
+            - Range: 0x9ff88..0xa0010
+              Pieces: [{Size: 0, InReg: false, StackOffset: 16, Register: 0}]
           IsParameter: true
           IsReturn: false
       Lines: []
     - ID: 3
       Name: main.stringArg
-      OutOfLinePCRanges: [0x491da0..0x491e11]
+      OutOfLinePCRanges: [0xa0090..0xa0110]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 17 GoStringHeaderType string
           Locations:
-            - Range: 0x491da0..0x491dbe
+            - Range: 0xa0090..0xa00b4
               Pieces:
                 - Size: 8
                   InReg: true
@@ -79,7 +79,7 @@ Subprograms:
                 - Size: 8
                   InReg: true
                   StackOffset: 0
-                  Register: 3
+                  Register: 1
           IsParameter: true
           IsReturn: false
       Lines: []
@@ -87,7 +87,7 @@ Types:
     - __kind: GoMapType
       ID: 1
       Name: map[string]int
-      GoRuntimeType: 63456
+      GoRuntimeType: 63360
       GoKind: 21
       HeaderType: 3 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
@@ -214,7 +214,7 @@ Types:
       ID: 14
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 70464
+      GoRuntimeType: 70368
       GoKind: 25
       Fields:
         - Name: ctrl
@@ -236,7 +236,7 @@ Types:
       ID: 16
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 70336
+      GoRuntimeType: 70240
       GoKind: 25
       Fields:
         - Name: key
@@ -269,7 +269,7 @@ Types:
     - __kind: GoMapType
       ID: 19
       Name: map[string]main.bigStruct
-      GoRuntimeType: 63584
+      GoRuntimeType: 63488
       GoKind: 21
       HeaderType: 21 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
@@ -366,7 +366,7 @@ Types:
       ID: 27
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 70720
+      GoRuntimeType: 70624
       GoKind: 25
       Fields:
         - Name: ctrl
@@ -388,7 +388,7 @@ Types:
       ID: 29
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 70592
+      GoRuntimeType: 70496
       GoKind: 25
       Fields:
         - Name: key
@@ -408,7 +408,7 @@ Types:
       ID: 31
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 112352
+      GoRuntimeType: 112256
       GoKind: 25
       Fields:
         - Name: Field1

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -21,9 +21,9 @@ import (
 // This is a very basic test of loading a Go elf object file
 // and that it more or less works and sanely loads dwarf.
 func TestElfObject(t *testing.T) {
-	for _, cfg := range testprogs.CommonConfigs {
-		binaryPath, err := testprogs.GetBinary("simple", cfg)
-		require.NoError(t, err)
+	cfgs := testprogs.GetCommonConfigs(t)
+	for _, cfg := range cfgs {
+		binaryPath := testprogs.GetBinary(t, "simple", cfg)
 		elf, err := safeelf.Open(binaryPath)
 		require.NoError(t, err)
 		obj, err := object.NewElfObject(elf)

--- a/pkg/dyninst/testprogs/test_progs.go
+++ b/pkg/dyninst/testprogs/test_progs.go
@@ -6,30 +6,209 @@
 //go:build linux_bpf
 
 // Package testprogs contains logic to build and use go programs for testing.
+//
+// The package relies on the binaries being built in the `binaries` directory
+// and the source code being available in the `progs` directory. The binaries
+// are built by the `system_probe.py` invoke script.
+//
+// The package will check the local sources to determine if the binaries are
+// up to date, but it won't rebuild them if they are not. The hope is that the
+// binaries we build will be sufficiently reproducible that we can use them for
+// testing.
 package testprogs
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
-
-	"github.com/gofrs/flock"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
 )
 
-// CommonConfigs are some common configs that we can use for testing.
-var CommonConfigs = []Config{
-	{GOARCH: Amd64, GOTOOLCHAIN: CurrentVersion},
-	{GOARCH: Arm64, GOTOOLCHAIN: CurrentVersion},
+const helpMsg = "consider running `dda inv system-probe.build-dyninst-test-programs`"
+
+// GetCommonConfigs returns a list of configurations that are suggested for
+// use in tests. In scenarios where the source code is available, other
+// configurations may still be available via GetBinary.
+func GetCommonConfigs(t *testing.T) []Config {
+	return must(t, func(state *state) ([]Config, error) {
+		return state.commonConfigs, nil
+	}, "get common configs")
+}
+
+// GetPrograms returns a list of programs that are available for testing.
+func GetPrograms(t *testing.T) []string {
+	return must(t, func(state *state) ([]string, error) {
+		return state.programs, nil
+	}, "get programs")
+}
+
+// GetBinary returns the path to the binary for the given name and
+// configuration.  If the binary is not found, it will be compiled if the source
+// code is available.
+func GetBinary(t *testing.T, name string, cfg Config) string {
+	return must(t, func(state *state) (string, error) {
+		return getBinary(state, name, cfg)
+	}, "get binary")
+}
+
+// must is a helper function that gets the state and calls the given function.
+// If the function returns an error, it will fail the test.
+func must[A any](t *testing.T, f func(*state) (A, error), errMsg string) A {
+	state, err := getState()
+	if err != nil {
+		t.Fatalf("testprogs: %v", err)
+	}
+	a, err := f(state)
+	if err != nil {
+		t.Fatalf("testprogs: %s: %v", errMsg, err)
+	}
+	return a
+}
+
+type state struct {
+	// A list of common configurations that are available for testing.
+	commonConfigs []Config
+	// A list of programs that are available for testing.
+	programs []string
+	// The directory where the binaries are stored.
+	binariesDir string
+	// The directory where the source code is stored, may be empty if the
+	// source code is not available.
+	progsSrcDir string
+	// Whether the source code is available.
+	haveSources bool
+}
+
+var (
+	globalState     state
+	globalStateErr  error
+	globalStateOnce sync.Once
+)
+
+func getState() (*state, error) {
+	globalStateOnce.Do(func() {
+		var haveSources bool
+		var progsSrcDir string
+		if _, srcPath, _, ok := runtime.Caller(0); ok {
+			srcDir := path.Dir(srcPath)
+			s, err := os.Stat(srcDir)
+			haveSources = err == nil && s.IsDir()
+			if haveSources {
+				progsSrcDir = path.Join(srcDir, "progs")
+			}
+		}
+		globalState, globalStateErr = initStateFromBinaries(
+			haveSources,
+			progsSrcDir,
+		)
+	})
+	return &globalState, globalStateErr
+}
+
+func initStateFromBinaries(
+	haveSources bool,
+	progsSrcDir string,
+) (state, error) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return state{}, fmt.Errorf("failed to read build info")
+	}
+	pkgPath := strings.TrimPrefix(
+		reflect.TypeOf(Config{}).PkgPath(),
+		buildInfo.Main.Path+"/",
+	)
+	const maxDirectoryDepth = 10
+	binariesDir := path.Join(".", pkgPath, "binaries")
+	for range maxDirectoryDepth {
+		if _, err := os.Stat(binariesDir); err == nil {
+			goto found
+		}
+		binariesDir = path.Join("..", binariesDir)
+	}
+	return state{}, fmt.Errorf("binaries directory not found; %s", helpMsg)
+found:
+	binariesDir, err := filepath.Abs(binariesDir)
+	if err != nil {
+		return state{}, fmt.Errorf("failed to get absolute path for binaries directory: %w", err)
+	}
+	// Now we want to iterate over the binaries directory and read the
+	// packages names of the directories as well as parsing out the
+	// configuration from the directory name.
+	programConfigs := map[string]int{}
+	configs := map[Config]struct{}{}
+	files, err := os.ReadDir(binariesDir)
+	if err != nil {
+		return state{}, fmt.Errorf("failed to read binaries directory: %w", err)
+	}
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		cfg, err := parseConfig(file.Name())
+		if err != nil {
+			return state{}, fmt.Errorf("failed to parse config from directory name: %w", err)
+		}
+		configs[cfg] = struct{}{}
+		files, err := os.ReadDir(path.Join(binariesDir, file.Name()))
+		if err != nil {
+			return state{}, fmt.Errorf("failed to read program directory: %w", err)
+		}
+		for _, file := range files {
+			name := file.Name()
+			if strings.HasPrefix(name, ".") {
+				continue
+			}
+			info, err := file.Info()
+			if err != nil {
+				return state{}, fmt.Errorf("failed to get file info: %w", err)
+			}
+			if !info.Mode().IsRegular() {
+				continue
+			}
+			programConfigs[file.Name()]++
+		}
+	}
+	numConfigs := len(configs)
+	programs := make([]string, 0, len(programConfigs))
+	for name := range programConfigs {
+		if programConfigs[name] == numConfigs {
+			programs = append(programs, name)
+		}
+	}
+	commonConfigs := make([]Config, 0, len(configs))
+	for cfg := range configs {
+		commonConfigs = append(commonConfigs, cfg)
+	}
+	slices.SortFunc(commonConfigs, func(a, b Config) int {
+		return cmp.Or(
+			cmp.Compare(a.GOARCH, b.GOARCH),
+			cmp.Compare(a.GOTOOLCHAIN, b.GOTOOLCHAIN),
+		)
+	})
+
+	return state{
+		commonConfigs: commonConfigs,
+		programs:      programs,
+		binariesDir:   binariesDir,
+		progsSrcDir:   progsSrcDir,
+		haveSources:   haveSources,
+	}, nil
 }
 
 // GetBinary returns the path to the binary for the given name and metadata.
-func GetBinary(
+func getBinary(
+	state *state,
 	name string,
 	cfg Config,
 ) (string, error) {
@@ -37,60 +216,51 @@ func GetBinary(
 		return "", fmt.Errorf("invalid metadata: %w", err)
 	}
 
+	binariesDir := state.binariesDir
+	progsSrcDir := state.progsSrcDir
 	binaryDir := path.Join(binariesDir, cfg.String())
 	binaryPath := path.Join(binaryDir, name)
-	progDir := path.Join(progsDir, name)
-
-	if err := os.MkdirAll(binaryDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create binary directory: %w", err)
+	progDir := path.Join(progsSrcDir, name)
+	binInfo, err := os.Stat(binaryPath)
+	if errors.Is(err, os.ErrNotExist) {
+		log.Printf(
+			"binary %q with config %q does not exist; %s",
+			name, cfg.String(),
+			helpMsg,
+		)
+		return "", nil
 	}
-	{
-		upToDate, err := checkIfUpToDate(progDir, binaryPath)
+	if err != nil {
+		return "", fmt.Errorf(
+			"failed to get binary info for %q with config %q: %w",
+			name, cfg.String(), err,
+		)
+	}
+
+	if state.haveSources {
+		upToDate, err := checkIfUpToDate(progDir, binInfo)
 		if err != nil {
-			return "", fmt.Errorf("failed to check if binary is up to date: %w", err)
+			return "", fmt.Errorf(
+				"failed to check if binary %q is up to date: %w", name, err,
+			)
 		}
-		if upToDate {
-			log.Printf("binary %q is up to date", binaryPath)
-			return binaryPath, nil
+		if !upToDate {
+			log.Printf(
+				"NOTE: binary %q with config %q is not up to date; %s",
+				name, cfg.String(),
+				helpMsg,
+			)
 		}
-	}
-
-	fLock := flock.New(path.Join(binaryDir, flockName))
-	if err := fLock.Lock(); err != nil {
-		return "", fmt.Errorf("failed to lock flock: %w", err)
-	}
-	defer fLock.Close()
-	{
-		upToDate, err := checkIfUpToDate(progDir, binaryPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to check if binary is up to date: %w", err)
-		}
-		if upToDate {
-			log.Printf("binary %q is up to date", binaryPath)
-			return binaryPath, nil
-		}
-	}
-
-	if err := compileBinary(progDir, cfg, binaryPath); err != nil {
-		return "", fmt.Errorf("failed to compile binary: %w", err)
 	}
 
 	return binaryPath, nil
 }
 
-func checkIfUpToDate(progDir string, binPath string) (bool, error) {
-	binInfo, err := os.Stat(binPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to get binary info: %w", err)
-	}
+func checkIfUpToDate(progDir string, binInfo os.FileInfo) (bool, error) {
 	binModTime := binInfo.ModTime()
-
 	files, err := os.ReadDir(progDir)
 	if err != nil {
-		return false, fmt.Errorf("failed to read program directory: %w", err)
+		return false, fmt.Errorf("failed to read program directory %q: %w", progDir, err)
 	}
 	for _, file := range files {
 		info, err := file.Info()
@@ -111,6 +281,9 @@ type Config struct {
 }
 
 // String returns a string representation of the config.
+//
+// Note that this format corresponds to the format used by the code in
+// tasks/system_probe.py that builds the binaries.
 func (m *Config) String() string {
 	return fmt.Sprintf("arch=%s,toolchain=%s", m.GOARCH, m.GOTOOLCHAIN)
 }
@@ -147,79 +320,29 @@ func (m *Config) Validate() error {
 	return nil
 }
 
+func parseConfig(s string) (Config, error) {
+	parts := strings.Split(s, ",")
+	var cfg Config
+	for _, part := range parts {
+		parts := strings.Index(part, "=")
+		if parts == -1 {
+			return Config{}, fmt.Errorf("invalid config: %q", s)
+		}
+		switch part[:parts] {
+		case "arch":
+			cfg.GOARCH = part[parts+1:]
+		case "toolchain":
+			cfg.GOTOOLCHAIN = part[parts+1:]
+		default:
+			return Config{}, fmt.Errorf("invalid config: %q", s)
+		}
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, fmt.Errorf("invalid config: %w", err)
+	}
+	return cfg, nil
+}
+
 var (
 	goVersionRegex = regexp.MustCompile(`^(go1\.\d+\.\d+|local)$`)
 )
-
-const flockName = ".flock"
-
-// binariesDir is the directory where the binaries are stored.
-var testProgsDir = func() string {
-	_, file, _, ok := runtime.Caller(1)
-	if !ok {
-		panic("unable to get current file build path")
-	}
-	return filepath.Dir(file)
-}()
-
-// binariesDir is the directory where the binaries are stored.
-var binariesDir = path.Join(testProgsDir, "binaries")
-var progsDir = path.Join(testProgsDir, "progs")
-
-// Packages is the list of packages that are available for testing.
-var Packages = func() []string {
-	files, err := os.ReadDir(progsDir)
-	if err != nil {
-		panic(err)
-	}
-	var names []string
-	for _, file := range files {
-		if !file.IsDir() {
-			continue
-		}
-		names = append(names, file.Name())
-	}
-	return names
-}()
-
-// CurrentVersion is the current go version.
-var CurrentVersion = func() string {
-	curDir := testProgsDir
-	goVersionRegex := regexp.MustCompile("\ngo (1\\.\\d+\\.\\d+)")
-	for curDir != "." && curDir != "/" {
-		goMod, err := os.ReadFile(path.Join(curDir, "go.mod"))
-		if errors.Is(err, os.ErrNotExist) {
-			curDir = filepath.Dir(curDir)
-			continue
-		}
-		if err != nil {
-			panic(err)
-		}
-		match := goVersionRegex.FindStringSubmatch(string(goMod))
-		if len(match) == 0 {
-			panic(fmt.Errorf("go.mod is invalid: %q", string(goMod)))
-		}
-		return "go" + match[1]
-	}
-	panic("go.mod not found")
-}()
-
-func compileBinary(progDir string, cfg Config, binPath string) error {
-	log.Printf("compiling binary %q", binPath)
-
-	cmd := exec.Command("go", "build", "-C", progDir, "-o", binPath, ".")
-	cmd.Env = append(os.Environ(),
-		"GOWORK=off",
-		"GOOS=linux",
-		"GOARCH="+cfg.GOARCH,
-		"GOTOOLCHAIN="+cfg.GOTOOLCHAIN,
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to compile binary: %w", err)
-	}
-
-	return nil
-}

--- a/pkg/dyninst/testprogs/test_progs_test.go
+++ b/pkg/dyninst/testprogs/test_progs_test.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package testprogs
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const inSubprocessEnvVar = "DD_DYNINST_TESTPROGS_IN_SUBPROCESS"
+
+func isInSubprocess() bool {
+	b, _ := strconv.ParseBool(os.Getenv(inSubprocessEnvVar))
+	return b
+}
+
+type configAndPrograms struct {
+	Configs  []Config
+	Programs []string
+}
+
+func TestInitFromBinaries(t *testing.T) {
+	if isInSubprocess() {
+		testInitFromBinariesInSubprocess(t)
+		return
+	}
+
+	var cases = []struct {
+		name     string
+		layout   map[string][]string
+		expected configAndPrograms
+	}{
+		{
+			name: "only overlapping binaries",
+			layout: map[string][]string{
+				"pkg/dyninst/testprogs/binaries/arch=amd64,toolchain=go1.22.5": {
+					"foo",
+					"bar",
+					".flock",
+				},
+				"pkg/dyninst/testprogs/binaries/arch=arm64,toolchain=go1.22.5": {
+					"foo",
+					".flock",
+				},
+			},
+			expected: configAndPrograms{
+				Configs: []Config{
+					{
+						GOARCH:      "amd64",
+						GOTOOLCHAIN: "go1.22.5",
+					},
+					{
+						GOARCH:      "arm64",
+						GOTOOLCHAIN: "go1.22.5",
+					},
+				},
+				Programs: []string{
+					"foo",
+				},
+			},
+		},
+	}
+	outerTestName := t.Name()
+	runCase := func(t *testing.T, expected configAndPrograms, layout map[string][]string) {
+		tmpDir, err := os.MkdirTemp("", "test_progs_test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+		for path, programs := range layout {
+			fullPath := filepath.Join(tmpDir, path)
+			os.MkdirAll(fullPath, 0755)
+			for _, program := range programs {
+				os.WriteFile(filepath.Join(fullPath, program), []byte{}, 0644)
+			}
+		}
+
+		cmd := exec.Command(os.Args[0], "--test.run="+outerTestName)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		cmd.Env = append(
+			os.Environ(),
+			inSubprocessEnvVar+"=true",
+		)
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf(
+				"failed to run testInitFromBinariesInSubprocess: %v\nstdout:\n%s\nstderr:\n%s",
+				err,
+				stdout.String(),
+				stderr.String(),
+			)
+		}
+
+		{
+			var actual configAndPrograms
+			err := json.Unmarshal(stderr.Bytes(), &actual)
+			require.NoError(t, err, "stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			runCase(t, c.expected, c.layout)
+		})
+	}
+}
+
+func testInitFromBinariesInSubprocess(t *testing.T) {
+	state, err := getState()
+	if err != nil {
+		t.Fatalf("failed to get state: %v", err)
+	}
+	out, err := json.Marshal(configAndPrograms{
+		Configs:  state.commonConfigs,
+		Programs: state.programs,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal config and programs: %v", err)
+	}
+	_, err = os.Stderr.Write(out)
+	require.NoError(t, err)
+}

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -73,6 +73,7 @@ from tasks.system_probe import (
     get_sysprobe_test_buildtags,
     get_test_timeout,
     go_package_dirs,
+    ninja_add_dyninst_test_programs,
     ninja_generate,
     setup_runtime_clang,
 )
@@ -1032,6 +1033,12 @@ def kmt_sysprobe_prepare(
         ninja_define_rules(nw)
         ninja_build_dependencies(ctx, nw, kmt_paths, go_path, arch)
         ninja_copy_ebpf_files(nw, "system-probe", kmt_paths, arch)
+        ninja_add_dyninst_test_programs(
+            ctx,
+            nw,
+            kmt_paths.sysprobe_tests,
+            go_path,
+        )
 
         build_tags = get_sysprobe_test_buildtags(False, False)
         for pkg in target_packages:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -56,6 +56,7 @@ TEST_PACKAGES_LIST = [
     "./pkg/collector/corechecks/servicediscovery/module/...",
     "./pkg/process/monitor/...",
     "./pkg/dynamicinstrumentation/...",
+    "./pkg/dyninst/...",
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import glob
+import itertools
 import json
 import os
 import platform
@@ -2145,3 +2146,110 @@ def collect_gpu_events(ctx, output_dir: str, pod_name: str, event_count: int = 1
 
     ctx.run(f"mkdir -p {output_dir}")
     ctx.run(f"kubectl {ns_arg} cp {pod_name}:/tmp/gpu-events.ndjson -c system-probe {output_dir}/gpu-events.ndjson")
+
+
+@task
+def build_dyninst_test_programs(ctx: Context, output_root: Path = "."):
+    nf_path = os.path.join(output_root, "system-probe-dyninst-test-programs.ninja")
+    with open(nf_path, "w") as nf:
+        nw = NinjaWriter(nf)
+        # NB: This mirrors the ninja setup used in the kmt.py file. The choice
+        # not to parallelize the build there at all is suspect, but we'll copy
+        # it here for now.
+        nw.pool(name="gobuild", depth=1)
+        nw.rule(
+            name="gobin",
+            command="$chdir && $env $go build -o $out $tags $ldflags $in $tool",
+        )
+        ninja_add_dyninst_test_programs(ctx, nw, output_root, "go")
+    ctx.run(f"ninja -d explain -v -f {nf_path}")
+
+
+def ninja_add_dyninst_test_programs(
+    ctx: Context,
+    nw: NinjaWriter,
+    output_root: Path,
+    go_path: str,
+):
+    """
+    This function is used to add the dyninst test programs to the ninja file.
+
+    It is used to build the test programs for the dyninst test suite across
+    the relevant architectures and go versions.
+    """
+
+    dd_module = "github.com/DataDog/datadog-agent"
+    testprogs_path = "pkg/dyninst/testprogs"
+    progs_path = f"{testprogs_path}/progs"
+    progs_prefix = f"{dd_module}/{progs_path}/"
+    output_base = f"{output_root}/{testprogs_path}/binaries"
+    build_tags = ["test", "linux_bpf"]
+
+    # Find the dependencies of the test programs.
+    tags_flag = f"-tags \"{','.join(build_tags)}\""
+    list_format = "{{ .ImportPath }} {{ .Module.Main }}: {{ join .Deps \" \" }}"
+    # Run from within the progs directory so that the go list command can find
+    # the go.mod file.
+    with ctx.cd(progs_path):
+        list_cmd = f"go list -test -f '{list_format}' {tags_flag} ./..."
+        # Disable GOWORK because our testprogs go.mod isn't listed there.
+        env = {"GOWORK": "off"}
+        res = ctx.run(list_cmd, hide=True, env=env)
+    if res.return_code != 0:
+        raise Exit(message=f"Failed to list dependencies: {res.stderr}")
+    pkg_deps = {}
+    for line in res.stdout.splitlines():
+        pkg_main, deps = line.split(": ", 1)
+        pkg, main = pkg_main.split(" ", 1)
+        pkg = pkg.removeprefix(progs_prefix)
+        if bool(main):
+            deps = (d for d in deps.split(" ") if d.startswith(progs_prefix))
+            pkg_deps[pkg] = {d.removeprefix(progs_prefix) for d in deps}
+
+    # In the future, we may want to support multiple go versions.
+    go_versions = ["go1.24.3"]
+    archs = ["amd64", "arm64"]
+
+    # Avoiding cgo aids in reproducing the build environment. It's less good in
+    # some ways because it's not likely that other folks build without CGO.
+    # Eventually we're going to want a better story for how to test against a
+    # variety of go binaries.
+    for pkg, go_version, arch in itertools.product(
+        pkg_deps.keys(),
+        go_versions,
+        archs,
+    ):
+        direct = glob.glob(f"{progs_path}/{pkg}/*.go")
+        go_files = set(direct)
+        for dep in pkg_deps[pkg]:
+            dep_files = glob.glob(f"{progs_path}/{dep}/*.go")
+            dep_files = [p for p in dep_files if not p.endswith("test.go")]
+            go_files.update(os.path.abspath(p) for p in dep_files)
+        config_str = f"arch={arch},toolchain={go_version}"
+        output_path = f"{output_base}/{config_str}/{pkg}"
+        output_path = os.path.abspath(output_path)
+        pkg_path = os.path.abspath(f"./{progs_path}/{pkg}")
+        nw.build(
+            inputs=[pkg_path],
+            outputs=[output_path],
+            implicit=list(go_files),
+            rule="gobin",
+            pool="gobuild",
+            variables={
+                "go": go_path,
+                # Run from within the package directory so that the go build
+                # command finds the go.mod file.
+                "chdir": f"cd {pkg_path}",
+                "tags": tags_flag,
+                "ldflags": "-ldflags=\"-extldflags '-static'\"",
+                "env": " ".join(
+                    [
+                        "CGO_ENABLED=0",
+                        f"GOARCH={arch}",
+                        "GOOS=linux",
+                        f"GOTOOLCHAIN={go_version}",
+                        "GOWORK=off",
+                    ]
+                ),
+            },
+        )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The primary thing that this PR achieves is enabling testing of the `pkg/dyninst/...` packages (3rd commit). In order to pull that off, two major things happen:

1) (1st commit) Build the test binaries in the various configurations we'd like during kmt prepare.
2) (2nd commit) Teach `dyninst/testprogs` to initialize from binaries and not to build sources.

### Additional Notes

Relates to https://datadoghq.atlassian.net/browse/DEBUG-3883