### PR TITLE
[DEBUG-3985] dyninst: run system-probe tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -738,6 +738,7 @@ workflow:
   - pkg/process/monitor/*
   - pkg/util/kernel/**/*
   - pkg/dynamicinstrumentation/**/*
+  - pkg/dyninst/**/*
   - pkg/gpu/**/*
   - .gitlab/kernel_matrix_testing/system_probe.yml
   - .gitlab/kernel_matrix_testing/common.yml


### PR DESCRIPTION
This tree is now part of the system-probe development process and will eventually be a part of the system probe. We want kmt and the likes to run against it.

### What does this PR do?

This PR makes `pkg/dyninst/...` changes trigger the system-probe tests.

### Motivation

This is where the new implementation of dynamicinstrumentation is going. It will eventually replace that package.

Relates to https://datadoghq.atlassian.net/browse/DEBUG-3883