### PR TITLE
[clusteragent/autoscaling] Allow configuring local fallback activation threshold

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -42,7 +42,7 @@ const (
 
 	controllerID = "dpa-c"
 
-	staleTimestampThreshold = time.Minute * 10 // time to wait before considering a recommendation stale
+	defaultStaleTimestampThreshold = time.Minute * 10 // time to wait before considering a recommendation stale
 )
 
 var (
@@ -517,19 +517,19 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 	fallbackHorizontalScalingValues := podAutoscalerInternal.FallbackScalingValues().Horizontal
 
 	// If main scaling values are not stale, use those
-	if mainHorizontalScalingValues != nil && !isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp) {
+	if mainHorizontalScalingValues != nil && !isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, nil) {
 		return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource), activeVerticalSource
 	}
 
 	// Check if one of the following conditions are met:
 	// 1. Main scaling values are stale
 	// 2. No main scaling values have been received, and last scaling values (updated from status in event of leader election change) are stale
-	// 3. No main scaling values have been received, no scaling values have been received from status, and the pod autoscaler was created more than 3 minutes ago
-	if (mainHorizontalScalingValues != nil && isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp)) ||
-		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues != nil && isTimestampStale(currentTime, currentHorizontalScalingValues.Timestamp)) ||
-		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues == nil && isTimestampStale(currentTime, podAutoscalerInternal.CreationTimestamp())) {
+	// 3. No main scaling values have been received, no scaling values have been received from status, and the pod autoscaler was created more than 10 minutes ago
+	if (mainHorizontalScalingValues != nil && isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, nil)) ||
+		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues != nil && isTimestampStale(currentTime, currentHorizontalScalingValues.Timestamp, nil)) ||
+		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues == nil && isTimestampStale(currentTime, podAutoscalerInternal.CreationTimestamp(), nil)) {
 		// If local fallback values are usable, activate local fallback
-		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp) {
+		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp, podAutoscalerInternal.Spec().Fallback) {
 			return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerLocalValueSource), activeVerticalSource
 		}
 	}
@@ -539,6 +539,11 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 	return nil, nil
 }
 
-func isTimestampStale(currentTime, receivedTime time.Time) bool {
+func isTimestampStale(currentTime, receivedTime time.Time, fallbackPolicy *datadoghq.DatadogFallbackPolicy) bool {
+	staleTimestampThreshold := defaultStaleTimestampThreshold
+	if fallbackPolicy != nil && fallbackPolicy.Horizontal.Triggers.StaleRecommendationThresholdSeconds > 0 {
+		staleTimestampThreshold = time.Second * time.Duration(int64(fallbackPolicy.Horizontal.Triggers.StaleRecommendationThresholdSeconds))
+	}
+
 	return currentTime.Sub(receivedTime) > staleTimestampThreshold
 }

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -42,7 +42,7 @@ const (
 
 	controllerID = "dpa-c"
 
-	defaultStaleTimestampThreshold = time.Minute * 10 // time to wait before considering a recommendation stale
+	defaultStaleTimestampThreshold = 30 * time.Minute // time to wait before considering a recommendation stale
 )
 
 var (
@@ -516,26 +516,26 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 	mainHorizontalScalingValues := podAutoscalerInternal.MainScalingValues().Horizontal
 	fallbackHorizontalScalingValues := podAutoscalerInternal.FallbackScalingValues().Horizontal
 
+	staleTimestampThreshold := defaultStaleTimestampThreshold
+	if podAutoscalerInternal.Spec() != nil && podAutoscalerInternal.Spec().Fallback != nil {
+		staleTimestampThreshold = time.Second * time.Duration(int64(podAutoscalerInternal.Spec().Fallback.Horizontal.Triggers.StaleRecommendationThresholdSeconds))
+	}
+
 	// If main scaling values are not stale, use those
-	if mainHorizontalScalingValues != nil && !isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, nil) {
+	if mainHorizontalScalingValues != nil && !isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, staleTimestampThreshold) {
 		return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource), activeVerticalSource
 	}
 
 	// Check if one of the following conditions are met:
 	// 1. Main scaling values are stale
 	// 2. No main scaling values have been received, and last scaling values (updated from status in event of leader election change) are stale
-	// 3. No main scaling values have been received, no scaling values have been received from status, and the pod autoscaler was created more than 10 minutes ago
-	if (mainHorizontalScalingValues != nil && isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, nil)) ||
-		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues != nil && isTimestampStale(currentTime, currentHorizontalScalingValues.Timestamp, nil)) ||
-		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues == nil && isTimestampStale(currentTime, podAutoscalerInternal.CreationTimestamp(), nil)) {
+	// 3. No main scaling values have been received, no scaling values have been received from status, and the pod autoscaler was created more than (threshold) minutes ago
+	if (mainHorizontalScalingValues != nil && isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, staleTimestampThreshold)) ||
+		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues != nil && isTimestampStale(currentTime, currentHorizontalScalingValues.Timestamp, staleTimestampThreshold)) ||
+		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues == nil && isTimestampStale(currentTime, podAutoscalerInternal.CreationTimestamp(), staleTimestampThreshold)) {
 
 		// If local fallback values are usable, activate local fallback
-		var fallbackPolicy *datadoghq.DatadogFallbackPolicy
-		if podAutoscalerInternal.Spec() != nil {
-			fallbackPolicy = podAutoscalerInternal.Spec().Fallback
-		}
-
-		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp, fallbackPolicy) {
+		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp, staleTimestampThreshold) {
 			return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerLocalValueSource), activeVerticalSource
 		}
 	}
@@ -545,11 +545,6 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 	return nil, nil
 }
 
-func isTimestampStale(currentTime, receivedTime time.Time, fallbackPolicy *datadoghq.DatadogFallbackPolicy) bool {
-	staleTimestampThreshold := defaultStaleTimestampThreshold
-	if fallbackPolicy != nil && fallbackPolicy.Horizontal.Triggers.StaleRecommendationThresholdSeconds > 0 {
-		staleTimestampThreshold = time.Second * time.Duration(int64(fallbackPolicy.Horizontal.Triggers.StaleRecommendationThresholdSeconds))
-	}
-
+func isTimestampStale(currentTime, receivedTime time.Time, staleTimestampThreshold time.Duration) bool {
 	return currentTime.Sub(receivedTime) > staleTimestampThreshold
 }

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -528,8 +528,14 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 	if (mainHorizontalScalingValues != nil && isTimestampStale(currentTime, mainHorizontalScalingValues.Timestamp, nil)) ||
 		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues != nil && isTimestampStale(currentTime, currentHorizontalScalingValues.Timestamp, nil)) ||
 		(mainHorizontalScalingValues == nil && currentHorizontalScalingValues == nil && isTimestampStale(currentTime, podAutoscalerInternal.CreationTimestamp(), nil)) {
+
 		// If local fallback values are usable, activate local fallback
-		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp, podAutoscalerInternal.Spec().Fallback) {
+		var fallbackPolicy *datadoghq.DatadogFallbackPolicy
+		if podAutoscalerInternal.Spec() != nil {
+			fallbackPolicy = podAutoscalerInternal.Spec().Fallback
+		}
+
+		if fallbackHorizontalScalingValues != nil && !isTimestampStale(currentTime, fallbackHorizontalScalingValues.Timestamp, fallbackPolicy) {
 			return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerLocalValueSource), activeVerticalSource
 		}
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -763,7 +763,7 @@ func TestIsTimestampStale(t *testing.T) {
 
 	// no fallback policy, use default stale timestamp threshold
 	assert.False(t, isTimestampStale(currentTime, receivedTime, defaultStaleTimestampThreshold))
-	receivedTime = currentTime.Add(-1 * time.Minute * 11)
+	receivedTime = currentTime.Add(-1 * time.Minute * 31)
 	assert.True(t, isTimestampStale(currentTime, receivedTime, defaultStaleTimestampThreshold))
 
 	// fallback policy with stale recommendation threshold

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -761,23 +761,17 @@ func TestIsTimestampStale(t *testing.T) {
 	currentTime := time.Now()
 	receivedTime := currentTime.Add(-1 * time.Minute)
 
-	// no fallback policy
-	assert.False(t, isTimestampStale(currentTime, receivedTime, nil))
+	// no fallback policy, use default stale timestamp threshold
+	assert.False(t, isTimestampStale(currentTime, receivedTime, defaultStaleTimestampThreshold))
 	receivedTime = currentTime.Add(-1 * time.Minute * 11)
-	assert.True(t, isTimestampStale(currentTime, receivedTime, nil))
+	assert.True(t, isTimestampStale(currentTime, receivedTime, defaultStaleTimestampThreshold))
 
 	// fallback policy with stale recommendation threshold
-	fallbackPolicy := &datadoghq.DatadogFallbackPolicy{
-		Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-			Triggers: datadoghq.HorizontalFallbackTriggers{
-				StaleRecommendationThresholdSeconds: 120,
-			},
-		},
-	}
+	staleTimestampThreshold := time.Second * 120
 	receivedTime = currentTime.Add(-1 * time.Minute)
-	assert.False(t, isTimestampStale(currentTime, receivedTime, fallbackPolicy))
+	assert.False(t, isTimestampStale(currentTime, receivedTime, staleTimestampThreshold))
 	receivedTime = currentTime.Add(-1 * time.Minute * 2)
-	assert.False(t, isTimestampStale(currentTime, receivedTime, fallbackPolicy))
+	assert.False(t, isTimestampStale(currentTime, receivedTime, staleTimestampThreshold))
 	receivedTime = currentTime.Add(-1 * time.Minute * 3)
-	assert.True(t, isTimestampStale(currentTime, receivedTime, fallbackPolicy))
+	assert.True(t, isTimestampStale(currentTime, receivedTime, staleTimestampThreshold))
 }

--- a/pkg/clusteragent/autoscaling/workload/local/recommendation_settings_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommendation_settings_test.go
@@ -15,27 +15,24 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestNewResourceRecommenderSettings(t *testing.T) {
 	tests := []struct {
-		name           string
-		objective      datadoghqcommon.DatadogPodAutoscalerObjective
-		fallbackPolicy *datadoghq.DatadogFallbackPolicy
-		want           *resourceRecommenderSettings
-		err            error
+		name      string
+		objective datadoghqcommon.DatadogPodAutoscalerObjective
+		want      *resourceRecommenderSettings
+		err       error
 	}{
 		{
 			name: "Invalid resource type",
 			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: "something-invalid",
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("Invalid target type: something-invalid"),
+			want: nil,
+			err:  fmt.Errorf("Invalid target type: something-invalid"),
 		},
 		{
 			name: "Pod resource - CPU target utilization",
@@ -49,7 +46,6 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
 			want: &resourceRecommenderSettings{
 				metricName:                 "container.cpu.usage",
 				lowWatermark:               0.75,
@@ -70,7 +66,6 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
 			want: &resourceRecommenderSettings{
 				metricName:                 "container.memory.usage",
 				lowWatermark:               0.75,
@@ -85,9 +80,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 				Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: nil,
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("nil target"),
+			want: nil,
+			err:  fmt.Errorf("nil target"),
 		},
 		{
 			name: "Pod resource - invalid name",
@@ -101,9 +95,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid resource name: some-resource"),
+			want: nil,
+			err:  fmt.Errorf("invalid resource name: some-resource"),
 		},
 		{
 			name: "Pod resource - nil utilization",
@@ -116,9 +109,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid utilization value: missing utilization value"),
+			want: nil,
+			err:  fmt.Errorf("invalid utilization value: missing utilization value"),
 		},
 		{
 			name: "Pod resource - out of bounds utilization value",
@@ -132,9 +124,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid utilization value: utilization value must be between 1 and 100"),
+			want: nil,
+			err:  fmt.Errorf("invalid utilization value: utilization value must be between 1 and 100"),
 		},
 		{
 			name: "Container resource - CPU target utilization",
@@ -186,9 +177,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 				Type:              datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
 				ContainerResource: nil,
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("nil target"),
+			want: nil,
+			err:  fmt.Errorf("nil target"),
 		},
 		{
 			name: "Container resource - invalid name",
@@ -202,9 +192,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					},
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid resource name: some-resource"),
+			want: nil,
+			err:  fmt.Errorf("invalid resource name: some-resource"),
 		},
 		{
 			name: "Container resource - nil utilization",
@@ -218,9 +207,8 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					Container: "container-foo",
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid utilization value: missing utilization value"),
+			want: nil,
+			err:  fmt.Errorf("invalid utilization value: missing utilization value"),
 		},
 		{
 			name: "Container resource - out of bounds utilization value",
@@ -235,43 +223,14 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 					Container: "container-foo",
 				},
 			},
-			fallbackPolicy: nil,
-			want:           nil,
-			err:            fmt.Errorf("invalid utilization value: utilization value must be between 1 and 100"),
-		},
-		{
-			name: "Custom fallback setting - stale data threshold",
-			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
-				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
-				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
-					Name: "cpu",
-					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
-						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
-						Utilization: pointer.Ptr(int32(80)),
-					},
-				},
-			},
-			fallbackPolicy: &datadoghq.DatadogFallbackPolicy{
-				Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-					Enabled: true,
-					Triggers: datadoghq.HorizontalFallbackTriggers{
-						StaleRecommendationThresholdSeconds: 120,
-					},
-				},
-			},
-			want: &resourceRecommenderSettings{
-				metricName:                 "container.cpu.usage",
-				lowWatermark:               0.75,
-				highWatermark:              0.85,
-				fallbackStaleDataThreshold: 120,
-			},
-			err: nil,
+			want: nil,
+			err:  fmt.Errorf("invalid utilization value: utilization value must be between 1 and 100"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recommenderSettings, err := newResourceRecommenderSettings(tt.fallbackPolicy, tt.objective)
+			recommenderSettings, err := newResourceRecommenderSettings(tt.objective)
 			if tt.err != nil {
 				assert.Error(t, err, tt.err.Error())
 			} else {

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
@@ -78,7 +78,7 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 	recommendedReplicas := model.HorizontalScalingValues{}
 
 	for _, objective := range objectives {
-		recSettings, err := newResourceRecommenderSettings(dpai.Spec().Fallback, objective)
+		recSettings, err := newResourceRecommenderSettings(objective)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get resource recommender settings: %s", err)
 		}

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -432,11 +432,6 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fallbackPolicy := &datadoghq.DatadogFallbackPolicy{
-				Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-					Enabled: true,
-				},
-			}
 			objective := datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
@@ -447,7 +442,7 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 					},
 				},
 			}
-			recSettings, err := newResourceRecommenderSettings(fallbackPolicy, objective)
+			recSettings, err := newResourceRecommenderSettings(objective)
 			assert.NoError(t, err)
 			utilization, err := calculateUtilization(*recSettings, tt.pods, tt.queryResult, tt.currentTime)
 			if err != nil {
@@ -803,11 +798,6 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fallbackPolicy := &datadoghq.DatadogFallbackPolicy{
-			Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-				Enabled: true,
-			},
-		}
 		objective := datadoghqcommon.DatadogPodAutoscalerObjective{
 			Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
 			ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
@@ -820,7 +810,7 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(fallbackPolicy, objective)
+			recSettings, err := newResourceRecommenderSettings(objective)
 			assert.NoError(t, err)
 			utilization, err := calculateUtilization(*recSettings, tt.pods, tt.queryResult, tt.currentTime)
 			if err != nil {
@@ -873,7 +863,7 @@ func TestCalculateReplicas(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(nil, datadoghqcommon.DatadogPodAutoscalerObjective{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
@@ -1520,7 +1510,7 @@ func TestRecommend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(nil, datadoghqcommon.DatadogPodAutoscalerObjective{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow configuring local fallback activation threshold by setting the following in the DPA:
```
spec:
  owner: Local
  ...
  fallback:
    horizontal:
      enabled: true
      triggers:
        staleRecommendationThresholdSeconds: 600
```

Also change the default threshold to activate local fallback to `30 minutes`

### Motivation

Previously, `staleRecommendationThresholdSeconds` controlled when a metric would be considered stale when calculating the local fallback recommendations, even though the documentation had it intended to control when local fallback would be activated. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

1. Modify `staleRecommendationThresholdSeconds`
2. Verify that local fallback activation occurs following the newly configured threshold value

### Possible Drawbacks / Trade-offs

We no longer give users the ability to control which metrics are considered stale for the purposes of local fallback recommendations (by default we use a timeframe of `60s`). 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->