### PR TITLE
usm: tests: Use t.Cleanup instead of local defer to cleanup unused resources

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -1627,7 +1627,7 @@ func getAndValidateKafkaStats(t *testing.T, monitor *Monitor, expectedStatsCount
 	kafkaStats := make(map[kafka.Key]*kafka.RequestStats)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		protocolStats, cleaners := monitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		kafkaProtocolStats, exists := protocolStats[protocols.Kafka]
 		// We might not have kafka stats, and it might be the expected case (to capture 0).
 		if exists {
@@ -1657,7 +1657,7 @@ func getAndValidateKafkaStatsWithErrorCodes(t *testing.T, monitor *Monitor, expe
 	kafkaStats := make(map[kafka.Key]*kafka.RequestStats)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		protocolStats, cleaners := monitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		kafkaProtocolStats, exists := protocolStats[protocols.Kafka]
 		// We might not have kafka stats, and it might be the expected case (to capture 0).
 		if exists {

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -132,7 +132,7 @@ func (s *HTTPTestSuite) TestHTTPStats() {
 
 	// Iterate through active connections until we find connection created above
 	require.Eventuallyf(t, func() bool {
-		stats := getHTTPLikeProtocolStats(monitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, monitor, protocols.HTTP)
 
 		for key, reqStats := range stats {
 			if key.Method == http.MethodGet && strings.HasSuffix(key.Path.Content.Get(), "/test") && (key.SrcPort == 8080 || key.DstPort == 8080) {
@@ -186,7 +186,7 @@ func (s *HTTPTestSuite) TestHTTPMonitorLoadWithIncompleteBuffers() {
 	// then we are using a variable to check if "we ever found it" among the iterations.
 	for i := 0; i < 10; i++ {
 		time.Sleep(10 * time.Millisecond)
-		stats := getHTTPLikeProtocolStats(monitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, monitor, protocols.HTTP)
 		for req := range abortedRequests {
 			checkRequestIncluded(t, stats, req, false)
 		}
@@ -308,7 +308,7 @@ func (s *HTTPTestSuite) TestHTTPMonitorIntegrationSlowResponse() {
 
 			// Ensure all captured transactions get sent to user-space
 			time.Sleep(10 * time.Millisecond)
-			checkRequestIncluded(t, getHTTPLikeProtocolStats(monitor, protocols.HTTP), req, tt.shouldCapture)
+			checkRequestIncluded(t, getHTTPLikeProtocolStats(t, monitor, protocols.HTTP), req, tt.shouldCapture)
 		})
 	}
 }
@@ -404,7 +404,7 @@ func (s *HTTPTestSuite) TestRSTPacketRegression() {
 	time.Sleep(100 * time.Millisecond)
 
 	// Assert that the HTTP request was correctly handled despite its forceful termination
-	stats := getHTTPLikeProtocolStats(monitor, protocols.HTTP)
+	stats := getHTTPLikeProtocolStats(t, monitor, protocols.HTTP)
 	url, err := url.Parse("http://127.0.0.1:8080/200/foobar")
 	require.NoError(t, err)
 	checkRequestIncluded(t, stats, &nethttp.Request{URL: url, Method: nethttp.MethodGet}, true)
@@ -495,7 +495,7 @@ func assertAllRequestsExists(t *testing.T, monitor *Monitor, requests []*nethttp
 	requestsExist := make([]bool, len(requests))
 
 	assert.Eventually(t, func() bool {
-		stats := getHTTPLikeProtocolStats(monitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, monitor, protocols.HTTP)
 
 		if len(stats) == 0 {
 			return false

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -220,7 +220,7 @@ func testHTTPSLibrary(t *testing.T, cfg *config.Config, fetchCmd, prefetchLibs [
 	fetchPid := uint32(requestCmd.Process.Pid)
 	t.Logf("%s pid %d", cmd[0], fetchPid)
 	assert.Eventuallyf(t, func() bool {
-		stats := getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, usmMonitor, protocols.HTTP)
 		if stats == nil {
 			return false
 		}
@@ -306,7 +306,7 @@ func (s *tlsSuite) TestOpenSSLVersions() {
 	requestsExist := make([]bool, len(requests))
 
 	require.Eventually(t, func() bool {
-		stats := getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, usmMonitor, protocols.HTTP)
 		if stats == nil {
 			return false
 		}
@@ -378,7 +378,7 @@ func (s *tlsSuite) TestOpenSSLVersionsSlowStart() {
 	expectedMissingRequestsCaught := make([]bool, len(missedRequests))
 
 	require.Eventually(t, func() bool {
-		stats := getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, usmMonitor, protocols.HTTP)
 		if stats == nil {
 			return false
 		}
@@ -598,7 +598,7 @@ func TestOldConnectionRegression(t *testing.T) {
 
 		// Ensure we have captured a request
 		statsObj, cleaners := usmMonitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		stats, ok := statsObj[protocols.HTTP]
 		require.True(t, ok)
 		httpStats, ok := stats.(map[http.Key]*http.RequestStats)
@@ -653,7 +653,7 @@ func TestLimitListenerRegression(t *testing.T) {
 
 		// Ensure we have captured a request
 		statsObj, cleaners := usmMonitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		stats, ok := statsObj[protocols.HTTP]
 		require.True(t, ok)
 		httpStats, ok := stats.(map[http.Key]*http.RequestStats)
@@ -821,7 +821,7 @@ func checkRequests(t *testing.T, usmMonitor *Monitor, expectedOccurrences int, r
 		if isHTTP2 {
 			protocolType = protocols.HTTP2
 		}
-		stats := getHTTPLikeProtocolStats(usmMonitor, protocolType)
+		stats := getHTTPLikeProtocolStats(t, usmMonitor, protocolType)
 		occurrences += PrintableInt(countRequestsOccurrences(t, stats, reqs))
 		return int(occurrences) == expectedOccurrences
 	}, 3*time.Second, 100*time.Millisecond, "Expected to find the request %v times, got %v captured. Requests not found:\n%v", expectedOccurrences, &occurrences, reqs)
@@ -916,9 +916,9 @@ func setupUSMTLSMonitor(t *testing.T, cfg *config.Config, reinit bool) *Monitor 
 }
 
 // getHTTPLikeProtocolStats returns the stats for the protocols that store their stats in a map of http.Key and *http.RequestStats as values.
-func getHTTPLikeProtocolStats(monitor *Monitor, protocolType protocols.ProtocolType) map[http.Key]*http.RequestStats {
+func getHTTPLikeProtocolStats(t *testing.T, monitor *Monitor, protocolType protocols.ProtocolType) map[http.Key]*http.RequestStats {
 	statsObj, cleaners := monitor.GetProtocolStats()
-	defer cleaners()
+	t.Cleanup(cleaners)
 	httpStats, ok := statsObj[protocolType]
 	if !ok {
 		return nil
@@ -963,7 +963,7 @@ func (s *tlsSuite) TestNodeJSTLS() {
 	requestsExist := make([]bool, len(requests))
 
 	assert.Eventually(t, func() bool {
-		stats := getHTTPLikeProtocolStats(usmMonitor, protocols.HTTP)
+		stats := getHTTPLikeProtocolStats(t, usmMonitor, protocols.HTTP)
 		if stats == nil {
 			return false
 		}

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -774,7 +774,7 @@ func validatePostgres(t *testing.T, monitor *Monitor, expectedStats map[string]m
 	found := make(map[string]map[postgres.Operation]int)
 	require.Eventually(t, func() bool {
 		statsObj, cleaners := monitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		postgresProtocolStats, exists := statsObj[protocols.Postgres]
 		if !exists {
 			return false

--- a/pkg/network/usm/redis_monitor_test.go
+++ b/pkg/network/usm/redis_monitor_test.go
@@ -223,7 +223,7 @@ func validateRedis(t *testing.T, monitor *Monitor, expectedStats map[string]map[
 	found := make(map[string]map[redis.CommandType]int)
 	require.Eventually(t, func() bool {
 		statsObj, cleaners := monitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		redisProtocolStats, exists := statsObj[protocols.Redis]
 		if !exists {
 			return false

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -533,7 +533,7 @@ func (s *usmGRPCSuite) testGRPCScenarios(t *testing.T, usmMonitor *Monitor, runC
 	res := make(map[http.Key]int)
 	assert.Eventually(t, func() bool {
 		stats, cleaners := usmMonitor.GetProtocolStats()
-		defer cleaners()
+		t.Cleanup(cleaners)
 		http2Stats, ok := stats[protocols.HTTP2]
 		if !ok {
 			return false


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replaces `defer cleaners()` (where `cleaners` is a callback returned from `GetProtocolStats`) to `t.Cleanup(cleaners)` to prevent modifying `ddsketch` objects that were returned already to the shared pool

### Motivation

We used 'defer cleaners()' for the cleaners callback returned from GetProtocolStats. However, we stored locally entries from the protocol-stats, but it was already cleaned. That can lead into flakes in the CI, as we modify sketches that were already returned to the shared pool. Thus, we couldn't guarantee a clean ddsketch

The use of 't.Cleanup(cleaners)' ensures we don't return to the pool any ddsketch object until the test is over.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->