### PR TITLE
Fix macos errors

### DIFF
--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -53,6 +53,8 @@ agent_dmg-x64-a7:
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true
+    - echo "Removing $OMNIBUS_GIT_CACHE_DIR if it exists"
+    - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
     # Destroy the keychain used to sign packages
     - |

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -26,14 +26,13 @@
 agent_dmg-x64-a7:
   stage: package_build
   tags: ["macos:ventura-amd64", "specific:true"]
-  # needs: ["go_mod_tidy_check"]
-  needs: []
-  # rules:
-  #    - !reference [.on_macos_gui_change]
-  #    - !reference [.on_packaging_change]
-  #    - !reference [.on_main_or_release_branch]
-  #    - !reference [.on_all_builds]
-  #    - !reference [.manual]
+  needs: ["go_mod_tidy_check"]
+  rules:
+     - !reference [.on_macos_gui_change]
+     - !reference [.on_packaging_change]
+     - !reference [.on_main_or_release_branch]
+     - !reference [.on_all_builds]
+     - !reference [.manual]
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -54,7 +53,6 @@ agent_dmg-x64-a7:
   before_script:
     # Since there is no virtualization on the macOS runners, we need to unmount the Agent dmg volume to avoid conflicts
     - sudo umount /Volumes/Agent || true
-    - echo "Removing $OMNIBUS_GIT_CACHE_DIR if it exists"
     - rm -rf "$OMNIBUS_GIT_CACHE_DIR" || true
   after_script:
     # Destroy the keychain used to sign packages

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -26,13 +26,14 @@
 agent_dmg-x64-a7:
   stage: package_build
   tags: ["macos:ventura-amd64", "specific:true"]
-  needs: ["go_mod_tidy_check"]
-  rules:
-     - !reference [.on_macos_gui_change]
-     - !reference [.on_packaging_change]
-     - !reference [.on_main_or_release_branch]
-     - !reference [.on_all_builds]
-     - !reference [.manual]
+  # needs: ["go_mod_tidy_check"]
+  needs: []
+  # rules:
+  #    - !reference [.on_macos_gui_change]
+  #    - !reference [.on_packaging_change]
+  #    - !reference [.on_main_or_release_branch]
+  #    - !reference [.on_all_builds]
+  #    - !reference [.manual]
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It is possible to let the omnibus git cache directory in an invalid state which introduces errors since there is no virtualization ([error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/963167263#L620)).
This PR cleans the omnibus git cache directory and fixes this issue.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->