### PR TITLE
chore(fleet): Create installerexec component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -343,6 +343,7 @@
 /comp/metadata/hostgpu @DataDog/ebpf-platform
 /comp/metadata/packagesigning @DataDog/agent-delivery
 /comp/trace/etwtracer @DataDog/windows-agent
+/comp/updater/installerexec @DataDog/fleet
 /comp/autoscaling/datadogclient @DataDog/container-integrations
 /comp/etw @DataDog/windows-agent
 /comp/haagent @DataDog/ndm-core

--- a/comp/README.md
+++ b/comp/README.md
@@ -646,6 +646,12 @@ Package status implements the core status component information provider interfa
 
 Package updater implements the updater component.
 
+### [comp/updater/installerexec](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater/installerexec)
+
+*Datadog Team*: fleet
+
+Package installerexec provides a component to execute installer commands
+
 ### [comp/updater/localapi](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater/localapi)
 
 Package localapi is the updater local api component.

--- a/comp/updater/installerexec/def/component.go
+++ b/comp/updater/installerexec/def/component.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package installerexec provides a component to execute installer commands
+package installerexec
+
+import (
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
+)
+
+// team: fleet
+
+// Component is the component type.
+type Component interface {
+	installertypes.Installer
+}

--- a/comp/updater/installerexec/fx/fx.go
+++ b/comp/updater/installerexec/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the installerexec component
+package fx
+
+import (
+	installerexec "github.com/DataDog/datadog-agent/comp/updater/installerexec/def"
+	installerexecimpl "github.com/DataDog/datadog-agent/comp/updater/installerexec/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			installerexecimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[installerexec.Component](),
+	)
+}

--- a/comp/updater/installerexec/impl/installerexec.go
+++ b/comp/updater/installerexec/impl/installerexec.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package installerexecimpl implements the installerexec component interface
+package installerexecimpl
+
+import (
+	installerexec "github.com/DataDog/datadog-agent/comp/updater/installerexec/def"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	iexec "github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
+	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
+)
+
+// Requires defines the dependencies for the installerexec component
+type Requires struct{}
+
+// Provides defines the output of the installerexec component
+type Provides struct {
+	Comp installerexec.Component
+}
+
+// NewComponent creates a new installerexec component
+func NewComponent(_ Requires) (Provides, error) {
+	return Provides{
+		Comp: iexec.NewInstallerExec(&env.Env{}, defaultpaths.InstallerPath),
+	}, nil
+}

--- a/comp/updater/installerexec/mock/mock.go
+++ b/comp/updater/installerexec/mock/mock.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the installerexec component
+package mock
+
+import (
+	"testing"
+
+	installerexec "github.com/DataDog/datadog-agent/comp/updater/installerexec/def"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/commands"
+)
+
+// Mock returns a mock for installerexec component.
+func Mock(_ *testing.T) installerexec.Component {
+	return commands.NewInstallerMock()
+}

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/bootstrap"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
@@ -31,6 +30,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -83,7 +83,7 @@ type daemonImpl struct {
 	stopChan chan struct{}
 
 	env             *env.Env
-	installer       func(*env.Env) installer.Installer
+	installer       func(*env.Env) installertypes.Installer
 	rc              *remoteConfig
 	catalog         catalog
 	catalogOverride catalog
@@ -93,8 +93,8 @@ type daemonImpl struct {
 	taskDB          *taskDB
 }
 
-func newInstaller(installerBin string) func(env *env.Env) installer.Installer {
-	return func(env *env.Env) installer.Installer {
+func newInstaller(installerBin string) func(env *env.Env) installertypes.Installer {
+	return func(env *env.Env) installertypes.Installer {
 		return exec.NewInstallerExec(env, installerBin)
 	}
 }
@@ -139,7 +139,7 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config config.Re
 	return newDaemon(rc, installer, env, taskDB), nil
 }
 
-func newDaemon(rc *remoteConfig, installer func(env *env.Env) installer.Installer, env *env.Env, taskDB *taskDB) *daemonImpl {
+func newDaemon(rc *remoteConfig, installer func(env *env.Env) installertypes.Installer, env *env.Env, taskDB *taskDB) *daemonImpl {
 	i := &daemonImpl{
 		env:             env,
 		rc:              rc,

--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -237,7 +237,7 @@ func newTestInstaller(t *testing.T) *testInstaller {
 	require.NoError(t, err)
 	daemon := newDaemon(
 		rc,
-		func(_ *env.Env) installer.Installer { return pm },
+		func(_ *env.Env) installertypes.Installer { return pm },
 		&env.Env{RemoteUpdates: true},
 		taskDB,
 	)

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -79,7 +80,7 @@ func (c *cmd) stop(err error) {
 
 type installerCmd struct {
 	*cmd
-	installer.Installer
+	installertypes.Installer
 }
 
 func newInstallerCmd(operation string) (_ *installerCmd, err error) {
@@ -89,7 +90,7 @@ func newInstallerCmd(operation string) (_ *installerCmd, err error) {
 			cmd.stop(err)
 		}
 	}()
-	var i installer.Installer
+	var i installertypes.Installer
 	if MockInstaller != nil {
 		i = MockInstaller
 	} else {

--- a/pkg/fleet/installer/commands/command_mock.go
+++ b/pkg/fleet/installer/commands/command_mock.go
@@ -8,19 +8,19 @@ package commands
 import (
 	"context"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 )
 
 var (
 	// MockInstaller is used for testing
-	MockInstaller installer.Installer
+	MockInstaller installertypes.Installer
 )
 
 type installerMock struct{}
 
 // NewInstallerMock returns a new installerMock.
-func NewInstallerMock() installer.Installer {
+func NewInstallerMock() installertypes.Installer {
 	return &installerMock{}
 }
 

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -39,38 +40,6 @@ const (
 	packageDatadogInstaller = "datadog-installer"
 	packageAPMLibraryDotnet = "datadog-apm-library-dotnet"
 )
-
-// Installer is a package manager that installs and uninstalls packages.
-type Installer interface {
-	IsInstalled(ctx context.Context, pkg string) (bool, error)
-
-	AvailableDiskSpace() (uint64, error)
-	State(ctx context.Context, pkg string) (repository.State, error)
-	States(ctx context.Context) (map[string]repository.State, error)
-	ConfigState(ctx context.Context, pkg string) (repository.State, error)
-	ConfigStates(ctx context.Context) (map[string]repository.State, error)
-
-	Install(ctx context.Context, url string, args []string) error
-	ForceInstall(ctx context.Context, url string, args []string) error
-	SetupInstaller(ctx context.Context, path string) error
-	Remove(ctx context.Context, pkg string) error
-	Purge(ctx context.Context)
-
-	InstallExperiment(ctx context.Context, url string) error
-	RemoveExperiment(ctx context.Context, pkg string) error
-	PromoteExperiment(ctx context.Context, pkg string) error
-
-	InstallConfigExperiment(ctx context.Context, pkg string, version string, rawConfig []byte) error
-	RemoveConfigExperiment(ctx context.Context, pkg string) error
-	PromoteConfigExperiment(ctx context.Context, pkg string) error
-
-	GarbageCollect(ctx context.Context) error
-
-	InstrumentAPMInjector(ctx context.Context, method string) error
-	UninstrumentAPMInjector(ctx context.Context, method string) error
-
-	Close() error
-}
 
 // installerImpl is the implementation of the package manager.
 type installerImpl struct {
@@ -88,7 +57,7 @@ type installerImpl struct {
 }
 
 // NewInstaller returns a new Package Manager.
-func NewInstaller(env *env.Env) (Installer, error) {
+func NewInstaller(env *env.Env) (installertypes.Installer, error) {
 	err := ensureRepositoriesExist()
 	if err != nil {
 		return nil, fmt.Errorf("could not ensure packages and config directory exists: %w", err)

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	installertypes "github.com/DataDog/datadog-agent/pkg/fleet/installer/types"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -39,7 +40,7 @@ var (
 // Setup allows setup scripts to define packages and configurations to install.
 type Setup struct {
 	configDir string
-	installer installer.Installer
+	installer installertypes.Installer
 	start     time.Time
 	flavor    string
 

--- a/pkg/fleet/installer/types/interface.go
+++ b/pkg/fleet/installer/types/interface.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package types provides the installer types and interfaces. This is to avoid importing too many dependencies
+// when importing these types in other packages.
+package types
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+)
+
+// Installer is a package manager that installs and uninstalls packages.
+type Installer interface {
+	IsInstalled(ctx context.Context, pkg string) (bool, error)
+
+	AvailableDiskSpace() (uint64, error)
+	State(ctx context.Context, pkg string) (repository.State, error)
+	States(ctx context.Context) (map[string]repository.State, error)
+	ConfigState(ctx context.Context, pkg string) (repository.State, error)
+	ConfigStates(ctx context.Context) (map[string]repository.State, error)
+
+	Install(ctx context.Context, url string, args []string) error
+	ForceInstall(ctx context.Context, url string, args []string) error
+	SetupInstaller(ctx context.Context, path string) error
+	Remove(ctx context.Context, pkg string) error
+	Purge(ctx context.Context)
+
+	InstallExperiment(ctx context.Context, url string) error
+	RemoveExperiment(ctx context.Context, pkg string) error
+	PromoteExperiment(ctx context.Context, pkg string) error
+
+	InstallConfigExperiment(ctx context.Context, pkg string, version string, rawConfig []byte) error
+	RemoveConfigExperiment(ctx context.Context, pkg string) error
+	PromoteConfigExperiment(ctx context.Context, pkg string) error
+
+	GarbageCollect(ctx context.Context) error
+
+	InstrumentAPMInjector(ctx context.Context, method string) error
+	UninstrumentAPMInjector(ctx context.Context, method string) error
+
+	Close() error
+}

--- a/pkg/util/defaultpaths/path_darwin.go
+++ b/pkg/util/defaultpaths/path_darwin.go
@@ -37,6 +37,8 @@ var (
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
+	// InstallerPath holds the path to the installer binary
+	InstallerPath = filepath.Join(_here, "..", "..", "embedded", "bin", "installer")
 )
 
 // GetDistPath returns the fully qualified path to the 'dist' directory

--- a/pkg/util/defaultpaths/path_freebsd.go
+++ b/pkg/util/defaultpaths/path_freebsd.go
@@ -37,6 +37,8 @@ var (
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
+	// InstallerPath holds the path to the installer binary
+	InstallerPath = filepath.Join(_here, "..", "..", "embedded", "bin", "installer")
 )
 
 // GetDistPath returns the fully qualified path to the 'dist' directory

--- a/pkg/util/defaultpaths/path_nix.go
+++ b/pkg/util/defaultpaths/path_nix.go
@@ -39,6 +39,8 @@ var (
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
+	// InstallerPath holds the path to the installer binary
+	InstallerPath = filepath.Join(_here, "..", "..", "embedded", "bin", "installer")
 )
 
 // GetDistPath returns the fully qualified path to the 'dist' directory

--- a/pkg/util/defaultpaths/path_windows.go
+++ b/pkg/util/defaultpaths/path_windows.go
@@ -21,6 +21,8 @@ var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "checks.d")
 	distPath     string
+	// InstallerPath holds the path to the installer binary
+	InstallerPath = filepath.Join(_here, "..", "..", "embedded", "bin", "installer")
 )
 
 var (


### PR DESCRIPTION
### What does this PR do?
Creates the `installerexec` component -- this is to simplify the revert of https://github.com/DataDog/datadog-agent/pull/37496 and unblock the rest of the team

The component is currently unused

### Motivation

### Describe how you validated your changes
Unit / E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->