### PR TITLE
Revert "[AGENTRUN-310] Remove FIPS Proxy status to FIPS Agent status output"

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider.go
+++ b/comp/core/status/statusimpl/common_header_provider.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -110,9 +109,7 @@ func populateConfig(config config.Component) map[string]string {
 	conf["confd_path"] = config.GetString("confd_path")
 	conf["additional_checksd"] = config.GetString("additional_checksd")
 
-	isFipsAgent, _ := fips.Enabled()
-	isFIPS := config.GetBool("fips.enabled") || isFipsAgent
-	conf["fips_proxy_enabled"] = strconv.FormatBool(isFIPS)
+	conf["fips_enabled"] = config.GetString("fips.enabled")
 	conf["fips_local_address"] = config.GetString("fips.local_address")
 	conf["fips_port_range_start"] = config.GetString("fips.port_range_start")
 

--- a/comp/core/status/statusimpl/templates/html.tmpl
+++ b/comp/core/status/statusimpl/templates/html.tmpl
@@ -36,7 +36,7 @@
   </span>
 </div>
 
-{{- if eq .config.fips_proxy_enabled "true" }}
+{{- if eq .config.fips_enabled "true" }}
 <div class="stat">
   <span class="stat_title">FIPS proxy</span>
   <span class="stat_data">

--- a/comp/core/status/statusimpl/templates/text.tmpl
+++ b/comp/core/status/statusimpl/templates/text.tmpl
@@ -29,7 +29,7 @@
     checks.d: {{.config.additional_checksd}}
     {{- end }}
 
-  {{- if eq .config.fips_proxy_enabled "true" }}
+  {{- if eq .config.fips_enabled "true" }}
 
   FIPS proxy
   ==========

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2711,8 +2711,7 @@ func getObsPipelineURLForPrefix(datatype DataType, prefix string, config pkgconf
 // IsRemoteConfigEnabled returns true if Remote Configuration should be enabled
 func IsRemoteConfigEnabled(cfg pkgconfigmodel.Reader) bool {
 	// Disable Remote Config for GovCloud
-	isFipsAgent, _ := pkgfips.Enabled()
-	if cfg.GetBool("fips.enabled") || isFipsAgent || cfg.GetString("site") == "ddog-gov.com" {
+	if cfg.GetBool("fips.enabled") || cfg.GetString("site") == "ddog-gov.com" {
 		return false
 	}
 	return cfg.GetBool("remote_configuration.enabled")

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -41,26 +41,18 @@ func (v *linuxStatusSuite) TestStatusHostname() {
 }
 
 func (v *linuxStatusSuite) TestFIPSProxyStatus() {
-	var shouldContains []string
-	var shouldNotContains []string
-
+	// Skip this test if the e2e pipeline is running with the FIPS Agent flavor because the FIPS proxy is not supported with the FIPS Agent.
 	if v.Env().Agent.FIPSEnabled {
-		// FIPS-enabled Agent should never display FIPS Proxy status
-		shouldContains = []string{"FIPS Mode: enabled"}
-		shouldNotContains = []string{"FIPS Mode: proxy", "FIPS proxy"}
-	} else {
-		// Non-FIPS Agent should print FIPS Proxy status
-		shouldContains = []string{"FIPS Mode: proxy", "FIPS proxy"}
+		v.T().Skip()
 	}
 
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig("fips.enabled: true"))))
 
 	expectedSections := []expectedSection{
 		{
-			name:             `Agent \(.*\)`,
-			shouldBePresent:  true,
-			shouldContain:    shouldContains,
-			shouldNotContain: shouldNotContains,
+			name:            `Agent \(.*\)`,
+			shouldBePresent: true,
+			shouldContain:   []string{"FIPS Mode: proxy", "FIPS proxy"},
 		},
 	}
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#36988 due to #incident-39082.