### PR TITLE
[CWS] Add execution contexts tests

### DIFF
--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -940,6 +941,230 @@ func TestActionSetVariableInherited(t *testing.T) {
 	assert.NotNil(t, value)
 	assert.Equal(t, 1000, value)
 	assert.True(t, set)
+}
+
+func stringPtr(input string) *string {
+	return &input
+}
+
+func fakeOpenEvent(path string, pid uint32, ancestor *model.ProcessCacheEntry) *model.Event {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.FileOpenEventType)
+	event.ProcessCacheEntry = &model.ProcessCacheEntry{
+		ProcessContext: model.ProcessContext{
+			Process: model.Process{
+				PIDContext: model.PIDContext{
+					Pid: pid,
+				},
+			},
+		},
+	}
+	if ancestor != nil {
+		event.ProcessCacheEntry.ProcessContext.Ancestor = ancestor
+	}
+	event.ProcessCacheEntry.Retain()
+	event.SetFieldValue("open.file.path", path)
+	return event
+}
+
+func TestActionSetVariableInheritedFilter(t *testing.T) {
+	testPolicy := &PolicyDef{
+		Rules: []*RuleDefinition{
+			{
+				ID:         "first_execution_context",
+				Expression: `open.file.path == "/tmp/first"`,
+				Actions: []*ActionDefinition{
+					{
+						Filter: stringPtr(`${process.correlation_key} == ""`),
+						Set: &SetDefinition{
+							Name:         "correlation_key",
+							DefaultValue: "",
+							Expression:   `"first_${builtins.uuid4}"`,
+							Scope:        "process",
+							Inherited:    true,
+						},
+					},
+				},
+			},
+			{
+				ID:         "second_execution_context",
+				Expression: `open.file.path == "/tmp/second"`,
+				Actions: []*ActionDefinition{
+					{
+						Filter: stringPtr(`${process.correlation_key} in [~"first_*"]`),
+						Set: &SetDefinition{
+							Name:         "parent_correlation_keys",
+							DefaultValue: "",
+							Expression:   "${process.correlation_key}",
+							Scope:        "process",
+							Append:       true,
+							Inherited:    true,
+						},
+					},
+					{
+						Filter: stringPtr(`${process.correlation_key} in ["", ~"first_*"]`),
+						Set: &SetDefinition{
+							Name:         "correlation_key",
+							DefaultValue: "",
+							Expression:   `"second_${builtins.uuid4}"`,
+							Scope:        "process",
+							Inherited:    true,
+						},
+					},
+				},
+			},
+			{
+				ID:         "third_execution_context",
+				Expression: `open.file.path == "/tmp/third"`,
+				Actions: []*ActionDefinition{
+					{
+						Filter: stringPtr(`${process.correlation_key} in [~"first_*", ~"second_*"]`),
+						Set: &SetDefinition{
+							Name:         "parent_correlation_keys",
+							DefaultValue: "",
+							Expression:   "${process.correlation_key}",
+							Scope:        "process",
+							Append:       true,
+							Inherited:    true,
+						},
+					},
+					{
+						Filter: stringPtr(`${process.correlation_key} in ["", ~"first_*", ~"second_*"]`),
+						Set: &SetDefinition{
+							Name:         "correlation_key",
+							DefaultValue: "",
+							Expression:   `"third_${builtins.uuid4}"`,
+							Scope:        "process",
+							Inherited:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tmpDir := t.TempDir()
+
+	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	provider, err := NewPoliciesDirProvider(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loader := NewPolicyLoader(provider)
+
+	rs := newRuleSet()
+	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := rs.evalOpts
+
+	// Fetch process.correlation_key variable
+	correlationKeySECLVariable := opts.VariableStore.Get("process.correlation_key")
+	assert.NotNil(t, correlationKeySECLVariable)
+	correlationKeyScopedVariable, ok := correlationKeySECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, correlationKeyScopedVariable)
+	assert.True(t, ok)
+
+	// Fetch process.parent_correlation_keys variable
+	parentCorrelationKeysSECLVariable := opts.VariableStore.Get("process.parent_correlation_keys")
+	assert.NotNil(t, parentCorrelationKeysSECLVariable)
+	parentCorrelationKeysScopedVariable, ok := parentCorrelationKeysSECLVariable.(eval.ScopedVariable)
+	assert.NotNil(t, parentCorrelationKeysScopedVariable)
+	assert.True(t, ok)
+
+	event := fakeOpenEvent("/tmp/first", 1, nil)
+	ctx := eval.NewContext(event)
+
+	// test correlation key initial value
+	correlationKeyValue, set := correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, "", correlationKeyValue)
+	assert.False(t, set)
+
+	if !rs.Evaluate(event) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "first_"))
+	assert.True(t, set)
+
+	parentCorrelationKeysValue, _ := parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
+
+	correlationKeyFromFirstRule := correlationKeyValue.(string)
+
+	// trigger the first rule again, and make sure the correlation_key doesn't change
+	event2 := fakeOpenEvent("/tmp/first", 2, event.ProcessCacheEntry)
+	ctx = eval.NewContext(event2)
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
+
+	if !rs.Evaluate(event2) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
+
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.Equal(t, len(parentCorrelationKeysValue.([]string)), 0)
+
+	// jump to the third rule, check:
+	//  - that the correlation key is updated with the pattern from the third rule
+	//  - that the first correlation key is now in the "parent correlation keys" variable
+	event3 := fakeOpenEvent("/tmp/third", 3, event2.ProcessCacheEntry)
+	ctx = eval.NewContext(event3)
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromFirstRule)
+	assert.True(t, set)
+
+	if !rs.Evaluate(event3) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.True(t, strings.HasPrefix(correlationKeyValue.(string), "third_"))
+	assert.True(t, set)
+
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
+
+	correlationKeyFromThirdRule := correlationKeyValue.(string)
+
+	// trigger the second rule, make sure nothing changes
+	event4 := fakeOpenEvent("/tmp/second", 4, event3.ProcessCacheEntry)
+	ctx = eval.NewContext(event4)
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
+	assert.True(t, set)
+
+	if !rs.Evaluate(event4) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx)
+	assert.NotNil(t, correlationKeyValue)
+	assert.Equal(t, correlationKeyValue, correlationKeyFromThirdRule)
+	assert.True(t, set)
+
+	parentCorrelationKeysValue, _ = parentCorrelationKeysScopedVariable.GetValue(ctx)
+	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
 }
 
 func TestActionSetVariableExpression(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds tests on execution contexts.

### Motivation

This is powered by variables (and probably somehow covered by other unit tests), but this test puts all the necessary features together into one chain of rules. We want to guarantee this specific use case is covered in our test suit.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->