### PR TITLE
[CXP-2282] Add stubs for new endpoints in system probe process module

### DIFF
--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -93,13 +93,15 @@ func (t *process) statsHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 // serviceHandler handles requests for service information for given processes
-func (t *process) serviceHandler(w http.ResponseWriter, req *http.Request) {
+func (t *process) serviceHandler(_ http.ResponseWriter, _ *http.Request) {
 	// TODO: Add implementation for this handler
+	return
 }
 
 // networkHandler handles requests for network stats for given processes
-func (t *process) networkHandler(w http.ResponseWriter, req *http.Request) {
+func (t *process) networkHandler(_ http.ResponseWriter, _ *http.Request) {
 	// TODO: Add implementation for this handler
+	return
 }
 
 // Close cleans up the underlying probe object

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -95,13 +95,11 @@ func (t *process) statsHandler(w http.ResponseWriter, req *http.Request) {
 // serviceHandler handles requests for service information for given processes
 func (t *process) serviceHandler(_ http.ResponseWriter, _ *http.Request) {
 	// TODO: Add implementation for this handler
-	return
 }
 
 // networkHandler handles requests for network stats for given processes
 func (t *process) networkHandler(_ http.ResponseWriter, _ *http.Request) {
 	// TODO: Add implementation for this handler
-	return
 }
 
 // Close cleans up the underlying probe object

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -47,8 +47,9 @@ var Process = &module.Factory{
 var _ module.Module = &process{}
 
 type process struct {
-	probe     procutil.Probe
-	lastCheck atomic.Int64
+	probe           procutil.Probe
+	lastCheck       atomic.Int64
+	statsRunCounter atomic.Uint64
 }
 
 // GetStats returns stats for the module
@@ -60,32 +61,45 @@ func (t *process) GetStats() map[string]interface{} {
 
 // Register registers endpoints for the module to expose data
 func (t *process) Register(httpMux *module.Router) error {
-	var runCounter atomic.Uint64
-	httpMux.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
-		start := time.Now()
-		t.lastCheck.Store(start.Unix())
-		pids, err := getPids(req)
-		if err != nil {
-			log.Errorf("Unable to get PIDs from request: %s", err)
-			w.WriteHeader(http.StatusBadRequest)
-		}
-
-		stats, err := t.probe.StatsWithPermByPID(pids)
-		if err != nil {
-			log.Errorf("unable to retrieve process stats: %s", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		contentType := req.Header.Get("Accept")
-		marshaler := encoding.GetMarshaler(contentType)
-		writeStats(w, marshaler, stats)
-
-		count := runCounter.Add(1)
-		logProcTracerRequests(count, len(stats), start)
-	}).Methods("POST")
-
+	httpMux.HandleFunc("/stats", t.statsHandler).Methods("POST")
+	httpMux.HandleFunc("/service", t.serviceHandler).Methods("POST")
+	httpMux.HandleFunc("/network", t.networkHandler).Methods("POST")
 	return nil
+}
+
+// statsHandler handles requests for process IO stats
+func (t *process) statsHandler(w http.ResponseWriter, req *http.Request) {
+	start := time.Now()
+	t.lastCheck.Store(start.Unix())
+	pids, err := getPids(req)
+	if err != nil {
+		log.Errorf("Unable to get PIDs from request: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	stats, err := t.probe.StatsWithPermByPID(pids)
+	if err != nil {
+		log.Errorf("unable to retrieve process stats: %s", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	contentType := req.Header.Get("Accept")
+	marshaler := encoding.GetMarshaler(contentType)
+	writeStats(w, marshaler, stats)
+
+	count := t.statsRunCounter.Add(1)
+	logProcTracerRequests(count, len(stats), start)
+}
+
+// serviceHandler handles requests for service information for given processes
+func (t *process) serviceHandler(w http.ResponseWriter, req *http.Request) {
+	// TODO: Add implementation for this handler
+}
+
+// networkHandler handles requests for network stats for given processes
+func (t *process) networkHandler(w http.ResponseWriter, req *http.Request) {
+	// TODO: Add implementation for this handler
 }
 
 // Close cleans up the underlying probe object

--- a/cmd/system-probe/modules/process_test.go
+++ b/cmd/system-probe/modules/process_test.go
@@ -18,7 +18,6 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/pkg/process/encoding"
 	reqEncoding "github.com/DataDog/datadog-agent/pkg/process/encoding/request"
@@ -55,6 +54,7 @@ func TestStatsHandler(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/stats", bytes.NewReader(reqBody))
 	require.NoError(t, err)
+	req.Header.Set("Content-Type", encoding.ContentTypeProtobuf)
 
 	m.statsHandler(rec, req)
 

--- a/cmd/system-probe/modules/process_test.go
+++ b/cmd/system-probe/modules/process_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/DataDog/datadog-agent/pkg/process/encoding"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil/mocks"
+	processProto "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+)
+
+func TestStatsHandler(t *testing.T) {
+	mockProbe := mocks.NewProbe(t)
+	mockProbe.On("StatsWithPermByPID", []int32{1, 2, 3}).Return(map[int32]*procutil.StatsWithPerm{
+		1: {
+			OpenFdCount: 10,
+			IOStat: &procutil.IOCountersStat{
+				ReadCount:  1,
+				WriteCount: 1,
+				ReadBytes:  1,
+				WriteBytes: 1,
+			},
+		},
+	}, nil)
+
+	m := process{
+		probe: mockProbe,
+	}
+
+	rec := httptest.NewRecorder()
+
+	reqProto := processProto.ProcessStatRequest{
+		Pids: []int32{1},
+	}
+	reqBytes, err := proto.Marshal(&reqProto)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "/stats", bytes.NewReader(reqBytes))
+	require.NoError(t, err)
+
+	m.statsHandler(rec, req)
+
+	resBody := rec.Result().Body
+	defer resBody.Close()
+
+	resBytes, err := io.ReadAll(resBody)
+	require.NoError(t, err)
+
+	contentType := rec.Result().Header.Get("Content-type")
+	results, err := encoding.GetUnmarshaler(contentType).Unmarshal(resBytes)
+	require.NoError(t, err)
+
+	expectedResponse := &model.ProcStatsWithPermByPID{
+		StatsByPID: map[int32]*model.ProcStatsWithPerm{
+			1: {
+				OpenFDCount: 10,
+				ReadCount:   1,
+				WriteCount:  1,
+				ReadBytes:   1,
+				WriteBytes:  1,
+			},
+		},
+	}
+
+	assert.True(t, reflect.DeepEqual(expectedResponse, results))
+}

--- a/cmd/system-probe/modules/process_test.go
+++ b/cmd/system-probe/modules/process_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestStatsHandler(t *testing.T) {
 	mockProbe := mocks.NewProbe(t)
-	mockProbe.On("StatsWithPermByPID", []int32{1, 2, 3}).Return(map[int32]*procutil.StatsWithPerm{
+	mockProbe.On("StatsWithPermByPID", []int32{1}).Return(map[int32]*procutil.StatsWithPerm{
 		1: {
 			OpenFdCount: 10,
 			IOStat: &procutil.IOCountersStat{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Adds stubs for new endpoints that will be used by the process collector and process/discovery checks that just return an empty OK response. Actual functionality will be added later.
- Some minor refactors so the code is cleaner with multiple endpoints.
- Add unit tests for the stats requests


### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

We don't really need this but might make some testing easier down the line.