### PR TITLE
[usm] fix the script generating the gotls/lookup/luts.go file

### DIFF
--- a/pkg/network/go/goid/internal/generate_goid_lut.go
+++ b/pkg/network/go/goid/internal/generate_goid_lut.go
@@ -106,6 +106,7 @@ func run(
 	generator := &lutgen.LookupTableGenerator{
 		Package:                pkg,
 		MinGoVersion:           minGoVersion,
+		MaxGoVersion:           goversion.GoVersion{},
 		Architectures:          goArches,
 		CompilationParallelism: 1,
 		LookupFunctions: []lutgen.LookupFunction{{

--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -241,6 +241,10 @@ func (g *LookupTableGenerator) getCommand(ctx context.Context, version goversion
 		log.Printf("error install directory at %q: %v", g.InstallDirectory, err)
 		return nil
 	}
+	// Force the toolchain used to be the version we're running; fail if the any
+	// of modules want a newer toolchain instead of letting go's toolchain
+	// selection mechanism transparently use a newer version.
+	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOTOOLCHAIN", "go"+version.String()))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOPATH", filepath.Join(installDirectoryAbs, "build-gopath")))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOCACHE", filepath.Join(installDirectoryAbs, "build-gocache")))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOARCH", arch))

--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -252,7 +252,7 @@ func (g *LookupTableGenerator) getCommand(ctx context.Context, version goversion
 	// so that Go can resolve gcc in case it needs to use cgo.
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "PATH", os.Getenv("PATH")))
 
-	err = setupGoModule(ctx, command, g.TestProgramPath)
+	err = setupGoModule(ctx, command, g.TestProgramPath, version)
 	if err != nil {
 		log.Printf("error setting up go module for  %s (%s): %s", g.TestProgramPath, version, err)
 		return nil
@@ -302,7 +302,7 @@ func (g *LookupTableGenerator) inspectAllBinaries(ctx context.Context) (map[arch
 	return resultTable, nil
 }
 
-func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string) error {
+func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string, version goversion.GoVersion) error {
 	moduleDir, err := os.MkdirTemp("", "lut")
 	if err != nil {
 		return err
@@ -331,12 +331,30 @@ func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string) error
 	// modify original `exec.Cmd` object by setting the `Dir` field to the one we created
 	cmd.Dir = moduleDir
 
+	// Pin the golang.org/x/net module to an old version. Newer versions cannot
+	// be processed by Go <= 1.16 because the go.mod in x/net has the wrong
+	// format. Newer versions of the package have a go.mod file that can't be
+	// parsed by Go <= 1.16. Also, newer versions ask for Go 1.23.
+	var getCmd *exec.Cmd
+	if version.Major == 1 && version.Minor <= 23 {
+		getCmd = exec.CommandContext(ctx, "go", "get", "golang.org/x/net@v0.35.0")
+	} else {
+		getCmd = exec.CommandContext(ctx, "go", "get", "golang.org/x/net")
+	}
+	getCmd.Env = cmd.Env
+	getCmd.Dir = cmd.Dir
+	getCmd.Path = cmd.Path
+	output, err := getCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error executing 'go get': %s\n%s", err, output)
+	}
+
 	// now run `go mod tidy`
 	modCmd := exec.CommandContext(ctx, "go", "mod", "tidy")
 	modCmd.Env = cmd.Env
 	modCmd.Dir = cmd.Dir
 	modCmd.Path = cmd.Path
-	output, err := modCmd.CombinedOutput()
+	output, err = modCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error executing 'go mod tidy': %s\n%s", err, output)
 	}

--- a/pkg/network/protocols/http/gotls/lookup/internal/testprogram/program.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/testprogram/program.go
@@ -61,7 +61,7 @@ func run() error {
 	return nil
 }
 
-// This code is meant to include the netutil.limitedListenerConn type for the
+// This code is meant to include the netutil.limitListenerConn type for the
 // purposes of binary inspection. This type is sometimes behind the `net.Conn`
 // interface embedded in the `tls.Conn` type.
 func createTCPListener() {


### PR DESCRIPTION
Before this patch, the generation of the `gotls/lookup/luts.go` file was
failing: Go versions below 1.16 cannot parse the go.mod file of the
x/net module at versions above 0.35 (released a few months ago). This
patch pins the module at v0.35. We were arbitrarily using the latest
x/net version (and thus using the debug info for the latest); now we're
arbitrarily using a fixed version. Luckily, the debug info we need for
x/net is stable -- we need the offset of an embedded field in a struct.

The regenerated `luts.go` doesn't have any changes. FWIW, I think this shows
that the debug info in that file is valid for Go 1.24; I'm not sure we
ever ran the script for 1.24, since I think the release of x/net that
broke it happened a little before 1.24.