### PR TITLE
winbuildscript: don't install dda if it's already available

### DIFF
--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -7,11 +7,11 @@ $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
 if ($Env:TARGET_ARCH -eq "x64") {
     & ridk enable
 }
-& $Env:Python3_ROOT_DIR\python.exe -c "import dda"
-$err = $LASTEXITCODE
-if ($err -ne 0) {
-    & $Env:Python3_ROOT_DIR\python.exe -m pip install dda
-}
+# & $Env:Python3_ROOT_DIR\python.exe -c "import dda"
+# $err = $LASTEXITCODE
+# if ($err -ne 0) {
+#     & $Env:Python3_ROOT_DIR\python.exe -m pip install dda
+# }
 & $Env:Python3_ROOT_DIR\python.exe -m dda self dep sync -f legacy-tasks
 
 $PROBE_BUILD_ROOT=(Get-Location).Path

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -7,7 +7,11 @@ $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
 if ($Env:TARGET_ARCH -eq "x64") {
     & ridk enable
 }
-& $Env:Python3_ROOT_DIR\python.exe -m pip install dda
+& $Env:Python3_ROOT_DIR\python.exe -c "import dda"
+$err = $LASTEXITCODE
+if ($err -ne 0) {
+    & $Env:Python3_ROOT_DIR\python.exe -m pip install dda
+}
 & $Env:Python3_ROOT_DIR\python.exe -m dda self dep sync -f legacy-tasks
 
 $PROBE_BUILD_ROOT=(Get-Location).Path

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -5,7 +5,11 @@ $Env:Python2_ROOT_DIR=$Env:TEST_EMBEDDED_PY2
 $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
 
 & ridk enable
-& $Env:Python3_ROOT_DIR\python.exe -m pip install dda
+& $Env:Python3_ROOT_DIR\python.exe -c "import dda"
+$err = $LASTEXITCODE
+if ($err -ne 0) {
+    & $Env:Python3_ROOT_DIR\python.exe -m pip install dda
+}
 & $Env:Python3_ROOT_DIR\python.exe -m dda self dep sync -f legacy-tasks
 
 $PROBE_BUILD_ROOT=(Get-Location).Path


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Don't force `dda` install in our windows build scripts

### Motivation

This ensures we won't use an unexpected version of dda in our CI before we bump the build images

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->