### PR TITLE
[CWS] Sort rules in buckets so that execution context rules are always first

### DIFF
--- a/pkg/security/secl/rules/bucket.go
+++ b/pkg/security/secl/rules/bucket.go
@@ -12,10 +12,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+const (
+	// ExecutionContextTagName is the name of the execution context tag
+	ExecutionContextTagName = "execution_context"
+)
+
 // RuleBucket groups rules with the same event type
 type RuleBucket struct {
-	rules  []*Rule
-	fields []eval.Field
+	rules                []*Rule
+	fields               []eval.Field
+	execContextRuleCount int // number of execution context rules at the start of rules
 }
 
 // AddRule adds a rule to the bucket
@@ -30,7 +36,14 @@ func (rb *RuleBucket) AddRule(rule *Rule) error {
 		rb.fields[index] = field
 	}
 
-	rb.rules = append(rb.rules, rule)
+	if rule.Def != nil && rule.Def.Tags != nil && rule.Def.Tags[ExecutionContextTagName] == "true" {
+		rb.rules = append(rb.rules, nil)
+		copy(rb.rules[rb.execContextRuleCount+1:], rb.rules[rb.execContextRuleCount:])
+		rb.rules[rb.execContextRuleCount] = rule
+		rb.execContextRuleCount++
+	} else {
+		rb.rules = append(rb.rules, rule)
+	}
 	return nil
 }
 

--- a/pkg/security/secl/rules/bucket_test.go
+++ b/pkg/security/secl/rules/bucket_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// newTestRuleWithExecContextTag creates a *Rule with the given id and tag value
+func newTestRuleWithExecContextTag(t *testing.T, id string, execContextTag string) *Rule {
+	expression := `open.file.path == "/tmp/test"`
+	pc := ast.NewParsingContext(false)
+	evalRule, err := eval.NewRule(id, expression, pc, &eval.Opts{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	rule := &Rule{
+		PolicyRule: &PolicyRule{
+			Def: &RuleDefinition{
+				ID:         id,
+				Expression: expression,
+				Tags:       map[string]string{},
+			},
+		},
+		Rule: evalRule,
+	}
+
+	err = rule.GenEvaluator(&model.Model{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if execContextTag != "" {
+		rule.Def.Tags[ExecutionContextTagName] = execContextTag
+	}
+
+	return rule
+}
+
+func TestRuleBucket_AddRule_Order(t *testing.T) {
+	bucket := &RuleBucket{}
+
+	// Create rules with unique fields
+	e1 := newTestRuleWithExecContextTag(t, "E1", "true")
+	e2 := newTestRuleWithExecContextTag(t, "E2", "true")
+	e3 := newTestRuleWithExecContextTag(t, "E3", "true")
+	n1 := newTestRuleWithExecContextTag(t, "N1", "false")
+	n2 := newTestRuleWithExecContextTag(t, "N2", "false")
+
+	// Add in mixed order
+	for _, r := range []*Rule{e1, n2, n1, e2, e3} {
+		if err := bucket.AddRule(r); err != nil {
+			t.Error(err)
+		}
+	}
+
+	rules := bucket.GetRules()
+	ids := make([]string, len(rules))
+	for i, r := range rules {
+		ids[i] = r.Def.ID
+	}
+
+	expected := []string{"E1", "E2", "E3", "N2", "N1"}
+	if !reflect.DeepEqual(ids, expected) {
+		t.Errorf("unexpected rule order: got %v, want %v", ids, expected)
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR ensures that rules tagged with `execution_context: true` are always evaluated first compared to other rules.

### Motivation

This will ensure events are properly tagged, even when the same event triggers both an execution context rule and a normal rule.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->