### PR TITLE
Fix nodetreemodel not handling all map interface

### DIFF
--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -16,16 +16,24 @@ import (
 // ErrNotFound is an error for when a key is not found
 var ErrNotFound = fmt.Errorf("not found")
 
-func mapInterfaceToMapString(m map[interface{}]interface{}) map[string]interface{} {
-	res := make(map[string]interface{}, len(m))
-	for k, v := range m {
+func mapToMapString(m reflect.Value) map[string]interface{} {
+	if v, ok := m.Interface().(map[string]interface{}); ok {
+		// no need to convert the map
+		return v
+	}
+
+	res := make(map[string]interface{}, m.Len())
+
+	iter := m.MapRange()
+	for iter.Next() {
+		k := iter.Key()
 		mk := ""
-		if str, ok := k.(string); ok {
-			mk = str
+		if k.Kind() == reflect.String {
+			mk = k.Interface().(string)
 		} else {
-			mk = fmt.Sprintf("%s", k)
+			mk = fmt.Sprintf("%s", k.Interface())
 		}
-		res[mk] = v
+		res[mk] = iter.Value().Interface()
 	}
 	return res
 }
@@ -54,21 +62,19 @@ func NewNodeTree(v interface{}, source model.Source) (Node, error) {
 		return newLeafNode(nil, source), nil
 	}
 	switch it := v.(type) {
-	case map[interface{}]interface{}:
-		children, err := makeChildNodeTrees(mapInterfaceToMapString(it), source)
-		if err != nil {
-			return nil, err
-		}
-		return newInnerNode(children), nil
-	case map[string]interface{}:
-		children, err := makeChildNodeTrees(it, source)
-		if err != nil {
-			return nil, err
-		}
-		return newInnerNode(children), nil
 	case []interface{}:
 		return newLeafNode(it, source), nil
 	}
+
+	// handle all map types that can be converted to map[string]interface{}
+	if v := reflect.ValueOf(v); v.Kind() == reflect.Map {
+		children, err := makeChildNodeTrees(mapToMapString(v), source)
+		if err != nil {
+			return nil, err
+		}
+		return newInnerNode(children), nil
+	}
+
 	if isScalar(v) {
 		return newLeafNode(v, source), nil
 	}

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -120,6 +120,7 @@ func unmarshalKeyReflection(cfg model.Reader, key string, target interface{}, op
 	if err != nil {
 		return err
 	}
+
 	outValue := reflect.ValueOf(target)
 	if outValue.Kind() == reflect.Pointer {
 		outValue = reflect.Indirect(outValue)
@@ -205,6 +206,7 @@ func copyStruct(target reflect.Value, input nodetreemodel.Node, currPath []strin
 			usedFields[fieldKey] = struct{}{}
 			continue
 		}
+
 		child, err := input.GetChild(fieldKey)
 		if err == nodetreemodel.ErrNotFound {
 			continue

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -299,6 +299,81 @@ endpoints:
 	}
 }
 
+func TestUnmarshalAllMapString(t *testing.T) {
+	mockConfig := newEmptyMockConf(t)
+	mockConfig.SetKnown("test")
+
+	type testString struct {
+		A string
+		B string
+	}
+	checkString := func() {
+		obj := testString{}
+		err := unmarshalKeyReflection(mockConfig, "test", &obj)
+		require.NoError(t, err)
+		assert.Equal(t, testString{A: "a", B: "b"}, obj)
+	}
+	mockConfig.Set("test", map[string]string{"a": "a", "b": "b"}, model.SourceAgentRuntime)
+	checkString()
+
+	mockConfig.Set("test", map[interface{}]string{"a": "a", "b": "b"}, model.SourceAgentRuntime)
+	checkString()
+
+	mockConfig.Set("test", map[interface{}]interface{}{"a": "a", "b": "b"}, model.SourceAgentRuntime)
+	checkString()
+
+	mockConfig.Set("test", map[string]interface{}{"a": "a", "b": "b"}, model.SourceAgentRuntime)
+	checkString()
+}
+
+func TestUnmarshalAllMapInt(t *testing.T) {
+	mockConfig := newEmptyMockConf(t)
+	mockConfig.SetKnown("test")
+
+	type testInt struct {
+		A int
+		B int
+	}
+	checkInt := func() {
+		objInt := testInt{}
+		err := unmarshalKeyReflection(mockConfig, "test", &objInt)
+		require.NoError(t, err)
+		assert.Equal(t, testInt{A: 1, B: 2}, objInt)
+	}
+	mockConfig.Set("test", map[string]int{"a": 1, "b": 2}, model.SourceAgentRuntime)
+	checkInt()
+
+	mockConfig.Set("test", map[interface{}]int{"a": 1, "b": 2}, model.SourceAgentRuntime)
+	checkInt()
+
+	mockConfig.Set("test", map[interface{}]interface{}{"a": 1, "b": 2}, model.SourceAgentRuntime)
+	checkInt()
+}
+
+func TestUnmarshalAllMapBool(t *testing.T) {
+	mockConfig := newEmptyMockConf(t)
+	mockConfig.SetKnown("test")
+
+	type testBool struct {
+		A bool
+		B bool
+	}
+	checkBool := func() {
+		objBool := testBool{}
+		err := unmarshalKeyReflection(mockConfig, "test", &objBool)
+		require.NoError(t, err)
+		assert.Equal(t, testBool{A: true, B: true}, objBool)
+	}
+	mockConfig.Set("test", map[string]bool{"a": true, "b": true}, model.SourceAgentRuntime)
+	checkBool()
+
+	mockConfig.Set("test", map[interface{}]bool{"a": true, "b": true}, model.SourceAgentRuntime)
+	checkBool()
+
+	mockConfig.Set("test", map[interface{}]interface{}{"a": true, "b": true}, model.SourceAgentRuntime)
+	checkBool()
+}
+
 type featureConfig struct {
 	Enabled bool `yaml:"enabled"`
 }


### PR DESCRIPTION
### What does this PR do?

YAML will only return map[string]interface{} and map[interface{}]interface{}. But through manual `Set`, other types of map can make their way in the config.

### Describe how you validated your changes

Running the CI with nodetreemodel is enough