### PR TITLE
Mount bazel data user root data folder on a volume instead of bind

### DIFF
--- a/bazel/.devcontainer/devcontainer.json
+++ b/bazel/.devcontainer/devcontainer.json
@@ -4,11 +4,9 @@
   },
   "mounts": [
     {
-      "source": "/tmp/bazel-devcontainer",
       "target": "/tmp/bazel/",
-      "type": "bind"
+      "type": "volume"
     }
   ],
-  "name": "bazel",
-  "remoteUser": "ubuntu"
+  "name": "bazel"
 }

--- a/bazel/.devcontainer/devcontainer.override.arm64.json
+++ b/bazel/.devcontainer/devcontainer.override.arm64.json
@@ -7,11 +7,9 @@
   },
   "mounts": [
     {
-      "source": "/tmp/bazel-devcontainer",
       "target": "/tmp/bazel/",
-      "type": "bind"
+      "type": "volume"
     }
   ],
   "name": "bazel",
-  "remoteUser": "ubuntu"
 }


### PR DESCRIPTION
### What does this PR do?

Mounts bazel data user root data folder on a volume instead of bind.

### Motivation

This error when running on macOS:

```
Extracting Bazel installation...
Starting local Bazel server (8.2.1) and connecting to it...
INFO: Invocation ID: e27e9897-f910-4846-9ee7-8c55bb5a8862
DEBUG: Rule 'rules_foreign_cc+' indicated that a canonical reproducible form can be obtained by modifying arguments commit = "1b198e7e2f733f65935a78389b5a8cdedc254cb0" and dropping ["branch"]
DEBUG: Repository rules_foreign_cc+ instantiated at:
  <builtin>: in <toplevel>
Repository rule git_repository defined at:
  /tmp/bazel/build_output/8d3050c5e4c5318d84e63597c84af52d/external/bazel_tools/tools/build_defs/repo/git.bzl:206:33: in <toplevel>
ERROR: no such package '@@+_repo_rules+python3//': error globbing [**] op=FILES: /tmp/bazel/build_output/8d3050c5e4c5318d84e63597c84af52d/external/+_repo_rules+python3/Tools (No such file or directory)
ERROR: /workspaces/bazel-wip/deps/python3/BUILD.bazel:3:15: no such package '@@+_repo_rules+python3//': error globbing [**] op=FILES: /tmp/bazel/build_output/8d3050c5e4c5318d84e63597c84af52d/external/+_repo_rules+python3/Tools (No such file or directory) and referenced by '//deps/python3:python3'
ERROR: Analysis of target '//cmd/agent:agent' failed; build aborted: Analysis failed
INFO: Elapsed time: 46.645s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```

From [this comment](https://github.com/bazelbuild/bazel/issues/22484#issuecomment-2239314017), it sounds likely that the issue is the case-independence of the macOS file system, causing folders named `build` to be interpreted specially by Bazel. Switching to a `volume` fixes this so that it's not using the host file system.

### Describe how you validated your changes

Ran bazel builds locally successfully.

### Possible Drawbacks / Trade-offs

- This makes it a bit less inconvenient to take artifacts out of the container.
- This will still likely need a different fix once we want to build native deps on macOS. This is just a quick fix to simplify local development for now.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->