### PR TITLE
[CXP-2233] Update host info to use get hostname via the hostname component when not running in the process-agent

### DIFF
--- a/comp/process/hostinfo/component.go
+++ b/comp/process/hostinfo/component.go
@@ -12,7 +12,7 @@ import (
 
 // team: container-experiences
 
-//nolint:revive // TODO(PROC) Fix revive linter
+// Component defines the interface for accessing host information
 type Component interface {
 	Object() *checks.HostInfo
 }

--- a/comp/process/hostinfo/hostinfoimpl/hostinfo.go
+++ b/comp/process/hostinfo/hostinfoimpl/hostinfo.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	hostinfoComp "github.com/DataDog/datadog-agent/comp/process/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -27,8 +28,9 @@ func Module() fxutil.Module {
 type dependencies struct {
 	fx.In
 
-	Config config.Component
-	Logger log.Component
+	Config   config.Component
+	Hostname hostnameinterface.Component
+	Logger   log.Component
 }
 
 type hostinfo struct {
@@ -36,7 +38,7 @@ type hostinfo struct {
 }
 
 func newHostInfo(deps dependencies) (hostinfoComp.Component, error) {
-	hinfo, err := checks.CollectHostInfo(deps.Config)
+	hinfo, err := checks.CollectHostInfo(deps.Config, deps.Hostname)
 	if err != nil {
 		_ = deps.Logger.Critical("Error collecting host details:", err)
 		return nil, fmt.Errorf("error collecting host details: %v", err)

--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"google.golang.org/grpc"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"

--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"google.golang.org/grpc"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
@@ -25,13 +26,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	ddgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-// for testing purposes
-var coreAgentGetHostname = hostname.Get
 
 // HostInfo describes details of host information shared between various checks
 type HostInfo struct {
@@ -42,13 +39,13 @@ type HostInfo struct {
 }
 
 // CollectHostInfo collects host information
-func CollectHostInfo(config pkgconfigmodel.Reader) (*HostInfo, error) {
+func CollectHostInfo(config pkgconfigmodel.Reader, hostnameComp hostnameinterface.Component) (*HostInfo, error) {
 	sysInfo, err := CollectSystemInfo()
 	if err != nil {
 		return nil, err
 	}
 
-	hostName, err := resolveHostName(config)
+	hostName, err := resolveHostName(config, hostnameComp)
 	if err != nil {
 		return nil, err
 	}
@@ -60,10 +57,10 @@ func CollectHostInfo(config pkgconfigmodel.Reader) (*HostInfo, error) {
 	}, nil
 }
 
-func resolveHostName(config pkgconfigmodel.Reader) (string, error) {
+func resolveHostName(config pkgconfigmodel.Reader, hostnameComp hostnameinterface.Component) (string, error) {
 	// use the common agent hostname utility when not running in the process-agent
 	if flavor.GetFlavor() != flavor.ProcessAgent {
-		hostName, err := coreAgentGetHostname(context.TODO())
+		hostName, err := hostnameComp.Get(context.TODO())
 		if err != nil {
 			return "", fmt.Errorf("error while getting hostname: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?
- This updates the hostInfo used by the process checks to use the hostname component instead of using the global in `pkg/util/hostname`.

This is related to the effort of using the hostname components in: https://github.com/DataDog/datadog-agent/pull/36869

### Motivation
https://datadoghq.atlassian.net/browse/CXP-2233

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->