### PR TITLE
[util/safeelf] Re-export elf.SectionHeader

### DIFF
--- a/pkg/util/safeelf/types.go
+++ b/pkg/util/safeelf/types.go
@@ -11,6 +11,7 @@ import "debug/elf" //nolint:depguard
 type Prog = elf.Prog
 type Symbol = elf.Symbol
 type Section = elf.Section
+type SectionHeader = elf.SectionHeader
 type SectionType = elf.SectionType
 type SectionIndex = elf.SectionIndex
 


### PR DESCRIPTION
### What does this PR do?
Re-export elf.SectionHeader

### Motivation
We want to use SectionHeader type directly.

https://datadoghq.atlassian.net/browse/DEBUG-3887