### PR TITLE
[usm] fix handling of missing pieces in location lists

### DIFF
--- a/pkg/network/go/bininspect/types.go
+++ b/pkg/network/go/bininspect/types.go
@@ -139,10 +139,11 @@ type FunctionMetadata struct {
 	// This is unfortunate; I don't think there is a clean way to work around this
 	// (since the data is just missing).
 	// The best solution I have found is to:
-	// - manually handle cases where entire parameters are missing
-	//   if it's known that they only occur on a specific Go version
-	//   (Go 1.16.* is one that I have found to be troublesome)
-	//   and insert the appropriate parameter locations if known.
+	// - manually handle cases where entire parameters are missing if it's known
+	//   that they only occur on a specific Go version (Go 1.16.* is completely
+	//   missing locations for a param we're interested in, and go 1.13-1.15
+	//   only has partial location info for that param) and insert the
+	//   appropriate parameter locations if known.
 	// - if all of the parameters are missing,
 	//   then I have found that manually re-implementing
 	//   the stack/register allocation algorithm for function arguments/returns
@@ -186,19 +187,14 @@ type FunctionMetadata struct {
 // but so far, taking the locations at face value and interpreting them directly
 // (specifically handling mixed stack/register locations)
 // has been successful in getting the expected values from eBPF.
-//
-// TODO: look into cases where a middle piece of a parameter has been eliminated
-//
-//	(such as the length of a slice),
-//	and make sure result is expected/handled well.
-//	Then, document such cases.
 type ParameterMetadata struct {
 	// Total size in bytes.
 	TotalSize int64
 	// Kind of variable.
 	Kind reflect.Kind
 
-	// Pieces that make up the location of this parameter at runtime
+	// Pieces that make up the location of this parameter at runtime. Empty if
+	// the parameter is completely or even partially unavailable.
 	Pieces []ParameterPiece
 }
 

--- a/pkg/network/go/dwarfutils/locexpr/exec.go
+++ b/pkg/network/go/dwarfutils/locexpr/exec.go
@@ -16,6 +16,13 @@ import (
 // LocationPiece is the result of `Exec` (returned as a list),
 // and describes whether the piece of the location is in a register (and if so, which one)
 // or if it is on the stack (and if so, at what offset).
+//
+// Note that a LocationPiece does not, by itself, tell you the offset of the
+// piece within the variable that it describes (in case the variable is
+// described by multiple pieces). A LocationPiece is always part of an array of
+// pieces which describe the whole variable; if some pieces of the variable are
+// unavailable, then the whole variable is considered unavailable and there are
+// no LocationPieces to speak of.
 type LocationPiece struct {
 	// Size of this piece in bytes
 	Size int64
@@ -37,12 +44,14 @@ func Format(expression []byte) string {
 	return buf.String()
 }
 
-// Exec statically executes a DWARF location expression
-// (see DWARF v4 spec sections 2.5, 2.6, and 7.7 for more info),
-// returning a description of the location that is either in registers
-// or on the stack.
+// Exec statically executes a DWARF location expression (see DWARF v4 spec
+// sections 2.5, 2.6, and 7.7 for more info), returning a description of the
+// location that is either in registers or on the stack. If the variable is not
+// fully available (i.e. if all or even some of the location pieces are
+// unavailable), then returns nil, nil.
 //
-// This implementation is based on github.com/go-delve/delve/pkg/proc.(*BinaryInfo).Location:
+// This implementation was originally based on
+// github.com/go-delve/delve/pkg/proc.(*BinaryInfo).Location:
 // - https://github.com/go-delve/delve/blob/75bbbbb60cecda0d65c63de7ae8cb8b8412d6fc3/pkg/proc/bininfo.go#L1062
 // which is licensed under MIT.
 func Exec(expression []byte, totalSize int64, pointerSize int) ([]LocationPiece, error) {
@@ -120,32 +129,48 @@ func Exec(expression []byte, totalSize int64, pointerSize int) ([]LocationPiece,
 		}}, nil
 	}
 
+	// If there's a single piece, Delve returns it with size 0 when it really
+	// means that it covers the whole variable.
+	if len(opPieces) == 1 && opPieces[0].Size == 0 {
+		opPieces[0].Size = int(totalSize)
+	}
+
 	// Convert the list of pieces returned by the op library
 	// into the desired type.
 	pieces := []LocationPiece{}
 	for _, opPiece := range opPieces {
-		if opPiece.Kind == op.RegPiece {
+		switch opPiece.Kind {
+		case op.RegPiece:
 			pieces = append(pieces, LocationPiece{
 				Size:     int64(opPiece.Size),
 				InReg:    true,
 				Register: int(opPiece.Val),
 			})
-		} else if opPiece.Kind == op.AddrPiece {
-			offset := int64(opPiece.Val)
-			offset = translateOffset(offset)
+		case op.AddrPiece:
+			stackOffset := int64(opPiece.Val)
+			stackOffset = translateOffset(stackOffset)
 
 			// This pointer-size offset was adapted from Delve code.
-			offset += int64(pointerSize)
+			stackOffset += int64(pointerSize)
 
 			pieces = append(pieces, LocationPiece{
 				Size:        int64(opPiece.Size),
 				InReg:       false,
-				StackOffset: offset,
+				StackOffset: stackOffset,
 			})
+		case op.ImmPiece:
+			// The Delve library reports unavailable pieces as 0-valued. For
+			// simplicity, we'll consider all immediate pieces to be
+			// unavailable.
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected piece kind %d in location expression", opPiece.Kind)
 		}
 	}
 
-	// Deduplicate the pieces in case there were any duplicates
+	// The Go compiler has bugs that result in invalid location lists;
+	// empirically, such lists sometimes contain duplicate pieces; removing the
+	// duplicates is sometimes enough to recover a valid list.
 	dedupedPieces := []LocationPiece{}
 	seenPices := make(map[LocationPiece]struct{})
 	for _, piece := range pieces {
@@ -153,6 +178,22 @@ func Exec(expression []byte, totalSize int64, pointerSize int) ([]LocationPiece,
 			dedupedPieces = append(dedupedPieces, piece)
 			seenPices[piece] = struct{}{}
 		}
+	}
+
+	piecesSize := int64(0)
+	for _, piece := range dedupedPieces {
+		piecesSize += piece.Size
+	}
+	// If we ended up with more pieces that the variable's size, then the
+	// location list is invalid (Go compiler bugs, which exist). We'll declare
+	// the whole variable as unavailable.
+	if piecesSize > totalSize {
+		return nil, nil
+	}
+	// If some pieces are unavailable, we declare the whole variable as
+	// unavailable.
+	if piecesSize < totalSize {
+		return nil, nil
 	}
 
 	return dedupedPieces, nil

--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -330,7 +330,7 @@ func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string) error
 
 	// Pin the golang.org/x/net module to an old version. Newer versions cannot
 	// be processed by Go <= 1.16 because the go.mod in x/net has the wrong
-	// format. Newer versions of the package have a go.mod file that can't be
+	// format. Newer versions of the module have a go.mod file that can't be
 	// parsed by Go <= 1.16.
 	getCmd := exec.CommandContext(ctx, "go", "get", "golang.org/x/net@v0.35.0")
 	getCmd.Env = cmd.Env

--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -234,6 +234,10 @@ func (g *LookupTableGenerator) getCommand(ctx context.Context, version goversion
 		log.Printf("error install directory at %q: %v", g.InstallDirectory, err)
 		return nil
 	}
+	// Force the toolchain used to be the version we're running; fail if the any
+	// of modules want a newer toolchain instead of letting go's toolchain
+	// selection mechanism transparently use a newer version.
+	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOTOOLCHAIN", "go"+version.String()))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOPATH", filepath.Join(installDirectoryAbs, "build-gopath")))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOCACHE", filepath.Join(installDirectoryAbs, "build-gocache")))
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "GOARCH", arch))

--- a/pkg/network/protocols/http/gotls/lookup/internal/testprogram/program.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/testprogram/program.go
@@ -61,7 +61,7 @@ func run() error {
 	return nil
 }
 
-// This code is meant to include the netutil.limitedListenerConn type for the
+// This code is meant to include the netutil.limitListenerConn type for the
 // purposes of binary inspection. This type is sometimes behind the `net.Conn`
 // interface embedded in the `tls.Conn` type.
 func createTCPListener() {

--- a/pkg/network/protocols/http/gotls/lookup/luts.go
+++ b/pkg/network/protocols/http/gotls/lookup/luts.go
@@ -19,7 +19,7 @@ func GetWriteParams(version goversion.GoVersion, goarch string) ([]bininspect.Pa
 	switch goarch {
 	case "amd64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 17, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 8, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}, {Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: false, StackOffset: 32, Register: 0}}}}, nil
@@ -27,7 +27,7 @@ func GetWriteParams(version goversion.GoVersion, goarch string) ([]bininspect.Pa
 		return nil, fmt.Errorf("unsupported version go%d.%d.%d (min supported: go%d.%d.%d)", version.Major, version.Minor, version.Rev, 1, 13, 0)
 	case "arm64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 18, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 1}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 3}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 1}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 3}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: false, StackOffset: 32, Register: 0}, {Size: 8, InReg: false, StackOffset: 40, Register: 0}}}}, nil
@@ -43,30 +43,21 @@ func GetReadParams(version goversion.GoVersion, goarch string) ([]bininspect.Par
 	switch goarch {
 	case "amd64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 18, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 17, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
-		}
-		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 16, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 8, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 3}, {Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: true, StackOffset: 0, Register: 5}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 8, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}, {Size: 8, InReg: false, StackOffset: 24, Register: 0}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 8, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{}}}, nil
 		}
 		return nil, fmt.Errorf("unsupported version go%d.%d.%d (min supported: go%d.%d.%d)", version.Major, version.Minor, version.Rev, 1, 13, 0)
 	case "arm64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 18, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 1}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 3}}}}, nil
-		}
-		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 17, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: false, StackOffset: 32, Register: 0}}}}, nil
-		}
-		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 16, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 1}, {Size: 8, InReg: true, StackOffset: 0, Register: 2}, {Size: 8, InReg: true, StackOffset: 0, Register: 3}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 24, Register: 0}, {Size: 8, InReg: false, StackOffset: 32, Register: 0}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}, {TotalSize: 24, Kind: 0x17, Pieces: []bininspect.ParameterPiece{}}}, nil
 		}
 		return nil, fmt.Errorf("unsupported version go%d.%d.%d (min supported: go%d.%d.%d)", version.Major, version.Minor, version.Rev, 1, 13, 0)
 	default:
@@ -79,7 +70,7 @@ func GetCloseParams(version goversion.GoVersion, goarch string) ([]bininspect.Pa
 	switch goarch {
 	case "amd64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 17, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 8, Register: 0}}}}, nil
@@ -87,7 +78,7 @@ func GetCloseParams(version goversion.GoVersion, goarch string) ([]bininspect.Pa
 		return nil, fmt.Errorf("unsupported version go%d.%d.%d (min supported: go%d.%d.%d)", version.Major, version.Minor, version.Rev, 1, 13, 0)
 	case "arm64":
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 18, Rev: 0}) {
-			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 0, InReg: true, StackOffset: 0, Register: 0}}}}, nil
+			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: true, StackOffset: 0, Register: 0}}}}, nil
 		}
 		if version.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 13, Rev: 0}) {
 			return []bininspect.ParameterMetadata{{TotalSize: 8, Kind: 0x16, Pieces: []bininspect.ParameterPiece{{Size: 8, InReg: false, StackOffset: 16, Register: 0}}}}, nil


### PR DESCRIPTION
### What does this PR do?

The utility we have for interpreting variable location lists, used by
the script that generates the lookup table for Go networking probes, was
buggy when presented with location lists containing missing pieces (i.e.
partially-unavailable variables): the library would silently ignore
missing pieces, and then it would erroneously map the next piece to the
wrong offset within the variable. For example, imagine a 3-word
structure (e.g. a slice header) that's described by a location list
like:
```
DW_OP_fbreg +8, DW_OP_piece 0x8, DW_OP_piece 0x8, DW_OP_fbreg +16, DW_OP_piece 0x8
```

This location list says that the first word is available at some stack
offset, the 2nd word is unavailable, and the 3rd word is again on the
stack. For such a case, `locexpr.Exec()` would return
`[]LocationPiece{{Size:8, StackOffset:16}, {Size:8, StackOffset:24}}`.
There's no information in there about the missing middle piece. USM code
would interpret such a result as the first two words being available and
the third unavailable, which is wrong. This is bad for the live
debugger, which is using this library.

This patch modifies `locexpr.Exec()` to not pretend to deal with location
lists with unavailable pieces and cleans up various TODOs about dealing
with availability gaps. Instead, Exec() now considers such variables to
be completely unavailable (returning an empty result).

I considered extending the results of Exec() to describe
available/unavailable pieces and teaching the callers to consult that,
but it wasn't trivial and it's not needed at the moment. It also doesn't
help that the underlying Delve library we call into does not explicitly
tell you that a piece is unavailable (it tells you that the piece has a
static value of 0). The live debugger will, in the future, want to deal
with partially-available variables, but that's for another day.

Regenerationg the luts.go file with locations for the variables we want
to probe, this patch affects only a single variable (all the others are
completely available). The variable in question has its last piece
missing (it's lucky that it's the last piece because otherwise the bug
would cause corruption). It turns out that, for that particular
variable, we already had special handling because Go 1.16 did not have
debug information for it at all. We were hardcoding locations for Go
1.16, identical to locations for Go 1.13-1.15. We now hardcode the
locations for Go 1.13->1.16.

This patch also fixes another problem in locexpr.Exec() -- it returned 0
as the size of LocationPieces corresponding to single-piece expressions.
Now, it will return the size of the respective variable.

### Describe how you validated your changes

No validation; the change is not intended to have a visible effect.