### PR TITLE
add UseBasicParsing option

### DIFF
--- a/releasenotes/notes/install-script-telem-usebasicparsing-8300e0ce310af687.yaml
+++ b/releasenotes/notes/install-script-telem-usebasicparsing-8300e0ce310af687.yaml
@@ -2,4 +2,5 @@
 fixes:
   - |
     Fixes telemetry reporting in the Agent Install Script for Windows PowerShell
-    on hosts using PowerShell version less than 6 and with Internet Explorer removed.
+    on hosts using PowerShell version less than 6 and without Internet Explorer installed,
+    such as on a Server Core installation.

--- a/releasenotes/notes/install-script-telem-usebasicparsing-8300e0ce310af687.yaml
+++ b/releasenotes/notes/install-script-telem-usebasicparsing-8300e0ce310af687.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes telemetry reporting in the Agent Install Script for Windows PowerShell
+    on hosts using PowerShell version less than 6 and with Internet Explorer removed.

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -63,7 +63,7 @@ function Send-Telemetry($payload) {
       "Content-Type" = "application/json"
    }
    try {
-      $result = Invoke-WebRequest -Uri $telemetryUrl -Method POST -Body $payload -Headers $requestHeaders
+      $result = Invoke-WebRequest -Uri $telemetryUrl -Method POST -Body $payload -Headers $requestHeaders -UseBasicParsing
       Write-Host "Sending telemetry: $($result.StatusCode)"
    } catch {
       # Don't propagate errors when sending telemetry, because our error handling code will also


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
add UseBasicParsing option to Windows Install Script

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1541

> This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system. [[MSDN]](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-5.1#-usebasicparsing)



### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run install script on Windows Server Core 2022

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
> Beginning with PowerShell 6.0.0, all Web requests use basic parsing only [[MSDN]](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4#-usebasicparsing)

PowerShell 5.1 is still the default/pre-installed version on Windows Server 2025, so this will still be relevant for some time.