### PR TITLE
omnibus: disable cache pruning on CI

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -11,6 +11,10 @@ from tasks.libs.common.utils import get_metric_origin
 from tasks.libs.releasing.version import RELEASE_JSON_DEPENDENCIES
 from tasks.release import _get_release_json_value
 
+# Increase this value to force an update to the cache key, invalidating existing
+# caches and forcing a rebuild
+CACHE_VERSION = 2
+
 
 def _get_omnibus_commits(field):
     return _get_release_json_value(f'{RELEASE_JSON_DEPENDENCIES}::{field}')
@@ -245,6 +249,7 @@ def omnibus_compute_cache_key(ctx):
         h.update(str.encode(f'{k}={v}'))
         print(f'Current hash value: {h.hexdigest()}')
     cache_key = h.hexdigest()
+    cache_key += f'_{CACHE_VERSION}'
     print(f'Cache key: {cache_key}')
     return cache_key
 

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -360,6 +360,21 @@ def send_build_metrics(ctx, overall_duration):
         print(r.text)
 
 
+def send_cache_mutation_event(ctx, pipeline_id, job_name, job_id):
+    headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'DD-API-KEY': get_dd_api_key(ctx)}
+    payload = {
+        'title': 'omnibus cache mutated',
+        'text': f"Job {job_name} in pipeline #{pipeline_id} attempted to mutate the cache after a hit",
+        'source_type_name': 'omnibus',
+        'date_happened': int(datetime.now().timestamp()),
+        'tags': [f'pipeline:{pipeline_id}', f'job:{job_name}', 'source:omnibus-cache', f'job-id:{job_id}'],
+    }
+    r = requests.post("https://api.datadoghq.com/api/v1/events", json=payload, headers=headers)
+    if not r.ok:
+        print('Failed to send cache mutation event')
+        print(r.text)
+
+
 def send_cache_miss_event(ctx, pipeline_id, job_name, job_id):
     headers = {'Accept': 'application/json', 'Content-Type': 'application/json', 'DD-API-KEY': get_dd_api_key(ctx)}
     payload = {

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -318,7 +318,7 @@ def build(
     os.remove(pip_config_file)
 
     if use_omnibus_git_cache:
-        # We only want to evict stalled tags when using the cache locally.
+        # We only want to evict stale tags when using the cache locally.
         # If the cache was fetched through a cache key and downloaded from S3 we
         # want to keep it immutable.
         if not use_remote_cache:

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -258,6 +258,8 @@ def build(
         and host_distribution != "ociru"
         and "OMNIBUS_PACKAGE_ARTIFACT_DIR" not in os.environ
     )
+    remote_cache_name = os.environ.get('CI_JOB_NAME_SLUG')
+    use_remote_cache = use_omnibus_git_cache and remote_cache_name is not None
     aws_cmd = "aws.cmd" if sys.platform == 'win32' else "aws"
     if use_omnibus_git_cache:
         # The cache will be written in the provided cache dir (see omnibus.rb) but
@@ -272,13 +274,11 @@ def build(
         # which effectively drops whatever was in omnibus_cache_dir
         install_directory = install_directory.lstrip('/')
         omnibus_cache_dir = os.path.join(omnibus_cache_dir, install_directory)
-        remote_cache_name = os.environ.get('CI_JOB_NAME_SLUG')
         # We don't want to update the cache when not running on a CI
         # Individual developers are still able to leverage the cache by providing
         # the OMNIBUS_GIT_CACHE_DIR env variable, but they won't pull from the CI
         # generated one.
         with gitlab_section("Manage omnibus cache", collapsed=True):
-            use_remote_cache = remote_cache_name is not None
             if use_remote_cache:
                 cache_state = None
                 cache_key = omnibus_compute_cache_key(ctx)

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -142,8 +142,6 @@ class TestOmnibusCache(unittest.TestCase):
             [
                 # We ran omnibus
                 r'bundle exec omnibus build agent',
-                # Listed tags for cache comparison
-                r'git -C omnibus-git-cache/opt/datadog-agent tag -l',
                 # And we created and uploaded the new cache
                 r'git -C omnibus-git-cache/opt/datadog-agent bundle create /\S+/omnibus-git-cache-bundle --tags',
                 r'aws s3 cp (\S* )?/\S+/omnibus-git-cache-bundle s3://omnibus-cache/\w+/slug',


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Stop attempting to remove duplicated tags from our remote cache when running on the CI

### Motivation

The cache key is our only way of addressing a specific cache version & the associated content.
If a cache key can yield different results, then we might end up fetching a cache artifact but only to fail to restore from it.
After the build, we would attempt to upload the new cache version but with the same cache key, which is likely to cause the same situation in the next build and so on, effectively rendering the cache useless.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->