### PR TITLE
feat(dda): Enable automatic bump with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
       {
         "matchDepNames": ["linux-images", "windows-images"],
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main"
+      },
+      {
+        "matchDepNames": ["DataDog/datadog-agent-dev"],
+        "changelogUrl": "https://github.com/DataDog/datadog-agent-dev/releases/tag/v{{newValue}}",
+        "schedule": ["3 4 5 6,12 *"]
       }
     ],
     "pre-commit": {
@@ -52,6 +57,15 @@
           "(?<currentValue>[0-9]+.[0-9]+)"
         ],
         "depNameTemplate": "protocolbuffers/protobuf",
+        "datasourceTemplate": "github-releases"
+      },
+      {
+        "customType": "regex",
+        "fileMatch": [".dda/version"],
+        "matchStrings": [
+          "(?<currentValue>[0-9]+.[0-9]+.[0-9]+)"
+        ],
+        "depNameTemplate": "DataDog/datadog-agent-dev",
         "datasourceTemplate": "github-releases"
       },
       {


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Enable automatic bump of dda releases with renovate. 

### Motivation
automation

### Describe how you validated your changes
Tested on a dedicated repo https://github.com/chouetz/psychic-guacamole/pull/153
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->