### PR TITLE
[DJM] Enable GPU integration for Databricks cluster if env. var is present

### DIFF
--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -43,13 +43,14 @@ type Setup struct {
 	start     time.Time
 	flavor    string
 
-	Out                     *Output
-	Env                     *env.Env
-	Ctx                     context.Context
-	Span                    *telemetry.Span
-	Packages                Packages
-	Config                  config.Config
-	DdAgentAdditionalGroups []string
+	Out                       *Output
+	Env                       *env.Env
+	Ctx                       context.Context
+	Span                      *telemetry.Span
+	Packages                  Packages
+	Config                    config.Config
+	DdAgentAdditionalGroups   []string
+	DelayedAgentRestartConfig config.DelayedAgentRestartConfig
 }
 
 // NewSetup creates a new Setup structure with some default values.
@@ -140,6 +141,9 @@ func (s *Setup) Run() (err error) {
 	err = s.restartServices(packages)
 	if err != nil {
 		return fmt.Errorf("failed to restart services: %w", err)
+	}
+	if s.DelayedAgentRestartConfig.Scheduled {
+		ScheduleDelayedAgentRestart(s, s.DelayedAgentRestartConfig.Delay, s.DelayedAgentRestartConfig.LogFile)
 	}
 	s.Out.WriteString(fmt.Sprintf("Successfully ran the %s install script in %s!\n", s.flavor, time.Since(s.start).Round(time.Second)))
 	return nil

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -190,9 +190,9 @@ var ExecuteCommandWithTimeout = func(s *Setup, command string, args ...string) (
 
 // ScheduleDelayedAgentRestart schedules an agent restart after the specified delay
 func ScheduleDelayedAgentRestart(s *Setup, delay time.Duration, logFile string) {
+	s.Out.WriteString(fmt.Sprintf("Scheduling agent restart in %v for GPU monitoring\n", delay))
 	cmd := exec.Command("nohup", "bash", "-c", fmt.Sprintf("echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Waiting %v...\" >> %[2]s.log && sleep %d && echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Restarting agent...\" >> %[2]s.log && systemctl restart datadog-agent >> %[2]s.log 2>&1", delay, logFile, int(delay.Seconds())))
 	if err := cmd.Start(); err != nil {
 		s.Out.WriteString(fmt.Sprintf("Failed to schedule restart: %v\n", err))
-		return
 	}
 }

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -183,3 +183,12 @@ var ExecuteCommandWithTimeout = func(s *Setup, command string, args ...string) (
 	}
 	return output, nil
 }
+
+// ScheduleDelayedAgentRestart schedules an agent restart after the specified delay
+func ScheduleDelayedAgentRestart(s *Setup, delay time.Duration, logFile string) {
+	cmd := exec.Command("nohup", "bash", "-c", fmt.Sprintf("echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Waiting %v...\" >> %[2]s.log && sleep %d && echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Restarting agent...\" >> %[2]s.log && systemctl restart datadog-agent >> %[2]s.log 2>&1", delay, logFile, int(delay.Seconds())))
+	if err := cmd.Start(); err != nil {
+		s.Out.WriteString(fmt.Sprintf("Failed to schedule restart: %v\n", err))
+		return
+	}
+}

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 
@@ -280,6 +281,13 @@ type APMConfigurationDefault struct {
 	IastEnabled                   *bool   `yaml:"DD_IAST_ENABLED,omitempty"`
 	DataJobsEnabled               *bool   `yaml:"DD_DATA_JOBS_ENABLED,omitempty"`
 	AppsecScaEnabled              *bool   `yaml:"DD_APPSEC_SCA_ENABLED,omitempty"`
+}
+
+// DelayedAgentRestartConfig represents the config to restart the agent with a delay at the end of the install
+type DelayedAgentRestartConfig struct {
+	Scheduled bool
+	Delay     time.Duration
+	LogFile   string
 }
 
 // mergeConfig merges the current config with the setup config.

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -224,10 +224,16 @@ type InjectTracerConfigEnvVar struct {
 // SystemProbeConfig represents the configuration to write in /etc/datadog-agent/system-probe.yaml
 type SystemProbeConfig struct {
 	RuntimeSecurityConfig RuntimeSecurityConfig `yaml:"runtime_security_config,omitempty"`
+	GPUMonitoringConfig   GPUMonitoringConfig   `yaml:"gpu_monitoring,omitempty"`
 }
 
 // RuntimeSecurityConfig represents the configuration for the runtime security
 type RuntimeSecurityConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+// GPUMonitoringConfig represents the configuration for GPU monitoring
+type GPUMonitoringConfig struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 }
 

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -144,6 +144,8 @@ type DatadogConfig struct {
 	Installer            DatadogConfigInstaller     `yaml:"installer,omitempty"`
 	DDURL                string                     `yaml:"dd_url,omitempty"`
 	LogsConfig           LogsConfig                 `yaml:"logs_config,omitempty"`
+	CollectGPUTags       bool                       `yaml:"collect_gpu_tags,omitempty"`
+	EnableNVMLDetection  bool                       `yaml:"enable_nvml_detection,omitempty"`
 }
 
 // DatadogConfigProxy represents the configuration for the proxy

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -225,8 +225,19 @@ func setClearHostTag(s *common.Setup, tagKey, value string) {
 func setupGPUIntegration(s *common.Setup) {
 	if os.Getenv("GPU_MONITORING_ENABLED") != "" {
 		s.Out.WriteString("GPU monitoring enabled via GPU_MONITORING_ENABLED environment variable\n")
+		
+		// Configure datadog.yaml for GPU tags and NVML detection
 		s.Config.DatadogYAML.CollectGPUTags = true
 		s.Config.DatadogYAML.EnableNVMLDetection = true
+		
+		// Configure system-probe.yaml for GPU monitoring
+		if s.Config.SystemProbeYAML == nil {
+			s.Config.SystemProbeYAML = &config.SystemProbeConfig{}
+		}
+		s.Config.SystemProbeYAML.GPUMonitoringConfig = config.GPUMonitoringConfig{
+			Enabled: true,
+		}
+		
 		s.Span.SetTag("gpu_monitoring_enabled", "true")
 	}
 }

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -117,6 +117,8 @@ func SetupDatabricks(s *common.Setup) error {
 	}
 	s.Span.SetTag("install_method", installMethod)
 
+	setupGPUIntegration(s)
+
 	switch os.Getenv("DB_IS_DRIVER") {
 	case "TRUE":
 		setupDatabricksDriver(s)
@@ -218,6 +220,15 @@ func setHostTag(s *common.Setup, tagKey, value string) {
 func setClearHostTag(s *common.Setup, tagKey, value string) {
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, tagKey+":"+value)
 	s.Span.SetTag("host_tag_value."+tagKey, value)
+}
+
+func setupGPUIntegration(s *common.Setup) {
+	if os.Getenv("GPU_MONITORING_ENABLED") != "" {
+		s.Out.WriteString("GPU monitoring enabled via GPU_MONITORING_ENABLED environment variable\n")
+		s.Config.DatadogYAML.CollectGPUTags = true
+		s.Config.DatadogYAML.EnableNVMLDetection = true
+		s.Span.SetTag("gpu_monitoring_enabled", "true")
+	}
 }
 
 func setupDatabricksDriver(s *common.Setup) {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -29,7 +29,7 @@ const (
 	databricksAgentVersion       = "7.66.0-1"
 	fetchTimeoutDuration         = 5 * time.Second
 	gpuIntegrationRestartTimeout = 30 * time.Second
-	restartLogFile               = "/var/log/datadog/gpu-restart"
+	restartLogFile               = "/var/log/datadog-gpu-restart"
 )
 
 var (

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -246,19 +245,8 @@ func setupGPUIntegration(s *common.Setup) {
 	s.Span.SetTag("host_tag_set.gpu_monitoring_enabled", "true")
 
 	// Agent must be restarted after NVML initialization, which occurs after init script execution
-	scheduleDelayedAgentRestart(s, gpuIntegrationRestartDelay)
-}
-
-// scheduleDelayedAgentRestart schedules an agent restart after the specified delay
-func scheduleDelayedAgentRestart(s *common.Setup, delay time.Duration) {
-	s.Out.WriteString(fmt.Sprintf("Scheduling agent restart in %v for GPU monitoring\n", delay))
-
-	cmd := exec.Command("nohup", "bash", "-c", fmt.Sprintf("echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Waiting %v...\" >> %[2]s.log && sleep %d && echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Restarting agent...\" >> %[2]s.log && systemctl restart datadog-agent >> %[2]s.log 2>&1", delay, restartLogFile, int(delay.Seconds())))
-	if err := cmd.Start(); err != nil {
-		s.Out.WriteString(fmt.Sprintf("Failed to schedule restart: %v\n", err))
-		return
-	}
-
+	s.Out.WriteString(fmt.Sprintf("Scheduling agent restart in %v for GPU monitoring\n", gpuIntegrationRestartDelay))
+	common.ScheduleDelayedAgentRestart(s, gpuIntegrationRestartDelay, restartLogFile)
 	s.Out.WriteString("Restart scheduled\n")
 }
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -225,11 +225,11 @@ func setClearHostTag(s *common.Setup, tagKey, value string) {
 func setupGPUIntegration(s *common.Setup) {
 	if os.Getenv("GPU_MONITORING_ENABLED") != "" {
 		s.Out.WriteString("GPU monitoring enabled via GPU_MONITORING_ENABLED environment variable\n")
-		
+
 		// Configure datadog.yaml for GPU tags and NVML detection
 		s.Config.DatadogYAML.CollectGPUTags = true
 		s.Config.DatadogYAML.EnableNVMLDetection = true
-		
+
 		// Configure system-probe.yaml for GPU monitoring
 		if s.Config.SystemProbeYAML == nil {
 			s.Config.SystemProbeYAML = &config.SystemProbeConfig{}
@@ -237,7 +237,7 @@ func setupGPUIntegration(s *common.Setup) {
 		s.Config.SystemProbeYAML.GPUMonitoringConfig = config.GPUMonitoringConfig{
 			Enabled: true,
 		}
-		
+
 		s.Span.SetTag("gpu_monitoring_enabled", "true")
 	}
 }

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -226,11 +226,9 @@ func setupGPUIntegration(s *common.Setup) {
 	if os.Getenv("GPU_MONITORING_ENABLED") != "" {
 		s.Out.WriteString("GPU monitoring enabled via GPU_MONITORING_ENABLED environment variable\n")
 
-		// Configure datadog.yaml for GPU tags and NVML detection
 		s.Config.DatadogYAML.CollectGPUTags = true
 		s.Config.DatadogYAML.EnableNVMLDetection = true
 
-		// Configure system-probe.yaml for GPU monitoring
 		if s.Config.SystemProbeYAML == nil {
 			s.Config.SystemProbeYAML = &config.SystemProbeConfig{}
 		}

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -246,8 +246,9 @@ func setupGPUIntegration(s *common.Setup) {
 
 	// Agent must be restarted after NVML initialization, which occurs after init script execution
 	s.Out.WriteString(fmt.Sprintf("Scheduling agent restart in %v for GPU monitoring\n", gpuIntegrationRestartDelay))
-	common.ScheduleDelayedAgentRestart(s, gpuIntegrationRestartDelay, restartLogFile)
-	s.Out.WriteString("Restart scheduled\n")
+	s.DelayedAgentRestartConfig.Scheduled = true
+	s.DelayedAgentRestartConfig.Delay = gpuIntegrationRestartDelay
+	s.DelayedAgentRestartConfig.LogFile = restartLogFile
 }
 
 func setupDatabricksDriver(s *common.Setup) {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -29,7 +29,7 @@ const (
 	databricksAgentVersion       = "7.66.0-1"
 	fetchTimeoutDuration         = 5 * time.Second
 	gpuIntegrationRestartTimeout = 30 * time.Second
-	restartLogFile               = "/var/log/gpu-restart"
+	restartLogFile               = "/var/log/datadog/gpu-restart"
 )
 
 var (
@@ -253,7 +253,7 @@ func setupGPUIntegration(s *common.Setup) {
 func scheduleDelayedAgentRestart(s *common.Setup, delay time.Duration) {
 	s.Out.WriteString(fmt.Sprintf("Scheduling agent restart in %v for GPU monitoring\n", delay))
 
-	cmd := exec.Command("nohup", "bash", "-c", fmt.Sprintf("echo '[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Waiting %v...' >> %[2]s && sleep %d && echo '[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Restarting agent...' >> %[2]s && systemctl restart datadog-agent >> %[2]s 2>&1", delay, restartLogFile, int(delay.Seconds())))
+	cmd := exec.Command("nohup", "bash", "-c", fmt.Sprintf("echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Waiting %v...\" >> %[2]s && sleep %d && echo \"[$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)] Restarting agent...\" >> %[2]s.log && systemctl restart datadog-agent >> %[2]s.log 2>&1", delay, restartLogFile, int(delay.Seconds())))
 	if err := cmd.Start(); err != nil {
 		s.Out.WriteString(fmt.Sprintf("Failed to schedule restart: %v\n", err))
 		return

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -518,11 +518,11 @@ func TestFetchDatabricksCustomTagsWithMock(t *testing.T) {
 
 func TestSetupGPUIntegration(t *testing.T) {
 	tests := []struct {
-		name                        string
-		env                         map[string]string
-		expectedCollectGPUTags      bool
-		expectedEnableNVML          bool
-		expectedSystemProbeGPU      bool
+		name                   string
+		env                    map[string]string
+		expectedCollectGPUTags bool
+		expectedEnableNVML     bool
+		expectedSystemProbeGPU bool
 	}{
 		{
 			name: "GPU monitoring enabled",

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -527,16 +527,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 		{
 			name: "GPU monitoring enabled",
 			env: map[string]string{
-				"GPU_MONITORING_ENABLED": "true",
-			},
-			expectedCollectGPUTags: true,
-			expectedEnableNVML:     true,
-			expectedSystemProbeGPU: true,
-		},
-		{
-			name: "GPU monitoring enabled with any value",
-			env: map[string]string{
-				"GPU_MONITORING_ENABLED": "1",
+				"DD_GPU_MONITORING_ENABLED": "true",
 			},
 			expectedCollectGPUTags: true,
 			expectedEnableNVML:     true,
@@ -545,7 +536,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 		{
 			name: "GPU monitoring enabled with empty string value",
 			env: map[string]string{
-				"GPU_MONITORING_ENABLED": "",
+				"DD_GPU_MONITORING_ENABLED": "",
 			},
 			expectedCollectGPUTags: false,
 			expectedEnableNVML:     false,

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -568,7 +568,9 @@ func TestSetupGPUIntegration(t *testing.T) {
 				},
 			}
 
-			setupGPUIntegration(s)
+			if os.Getenv("DD_GPU_MONITORING_ENABLED") == "true" {
+				setupGPUIntegration(s)
+			}
 
 			assert.Equal(t, tt.expectedCollectGPUTags, s.Config.DatadogYAML.CollectGPUTags)
 			assert.Equal(t, tt.expectedEnableNVML, s.Config.DatadogYAML.EnableNVMLDetection)

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -518,11 +518,12 @@ func TestFetchDatabricksCustomTagsWithMock(t *testing.T) {
 
 func TestSetupGPUIntegration(t *testing.T) {
 	tests := []struct {
-		name                    string
-		env                     map[string]string
-		expectedCollectGPUTags  bool
-		expectedEnableNVML      bool
-		expectedSpanTag         string
+		name                        string
+		env                         map[string]string
+		expectedCollectGPUTags      bool
+		expectedEnableNVML          bool
+		expectedSystemProbeGPU      bool
+		expectedSpanTag             string
 	}{
 		{
 			name: "GPU monitoring enabled",
@@ -531,6 +532,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 			},
 			expectedCollectGPUTags: true,
 			expectedEnableNVML:     true,
+			expectedSystemProbeGPU: true,
 			expectedSpanTag:        "true",
 		},
 		{
@@ -540,6 +542,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 			},
 			expectedCollectGPUTags: true,
 			expectedEnableNVML:     true,
+			expectedSystemProbeGPU: true,
 			expectedSpanTag:        "true",
 		},
 		{
@@ -549,6 +552,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 			},
 			expectedCollectGPUTags: false,
 			expectedEnableNVML:     false,
+			expectedSystemProbeGPU: false,
 			expectedSpanTag:        "",
 		},
 		{
@@ -556,6 +560,7 @@ func TestSetupGPUIntegration(t *testing.T) {
 			env:                    map[string]string{},
 			expectedCollectGPUTags: false,
 			expectedEnableNVML:     false,
+			expectedSystemProbeGPU: false,
 			expectedSpanTag:        "",
 		},
 	}
@@ -581,6 +586,16 @@ func TestSetupGPUIntegration(t *testing.T) {
 
 			assert.Equal(t, tt.expectedCollectGPUTags, s.Config.DatadogYAML.CollectGPUTags)
 			assert.Equal(t, tt.expectedEnableNVML, s.Config.DatadogYAML.EnableNVMLDetection)
+
+			// Check system-probe configuration
+			if tt.expectedSystemProbeGPU {
+				assert.NotNil(t, s.Config.SystemProbeYAML)
+				assert.Equal(t, tt.expectedSystemProbeGPU, s.Config.SystemProbeYAML.GPUMonitoringConfig.Enabled)
+			} else {
+				if s.Config.SystemProbeYAML != nil {
+					assert.Equal(t, tt.expectedSystemProbeGPU, s.Config.SystemProbeYAML.GPUMonitoringConfig.Enabled)
+				}
+			}
 
 			// Check span tag was set correctly
 			if tt.expectedSpanTag != "" {

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -523,7 +523,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 		expectedCollectGPUTags      bool
 		expectedEnableNVML          bool
 		expectedSystemProbeGPU      bool
-		expectedSpanTag             string
 	}{
 		{
 			name: "GPU monitoring enabled",
@@ -533,7 +532,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 			expectedCollectGPUTags: true,
 			expectedEnableNVML:     true,
 			expectedSystemProbeGPU: true,
-			expectedSpanTag:        "true",
 		},
 		{
 			name: "GPU monitoring enabled with any value",
@@ -543,7 +541,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 			expectedCollectGPUTags: true,
 			expectedEnableNVML:     true,
 			expectedSystemProbeGPU: true,
-			expectedSpanTag:        "true",
 		},
 		{
 			name: "GPU monitoring enabled with empty string value",
@@ -553,7 +550,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 			expectedCollectGPUTags: false,
 			expectedEnableNVML:     false,
 			expectedSystemProbeGPU: false,
-			expectedSpanTag:        "",
 		},
 		{
 			name:                   "GPU monitoring not set",
@@ -561,7 +557,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 			expectedCollectGPUTags: false,
 			expectedEnableNVML:     false,
 			expectedSystemProbeGPU: false,
-			expectedSpanTag:        "",
 		},
 	}
 
@@ -597,10 +592,6 @@ func TestSetupGPUIntegration(t *testing.T) {
 				}
 			}
 
-			// Check span tag was set correctly
-			if tt.expectedSpanTag != "" {
-				assert.Contains(t, output.String(), "GPU monitoring enabled")
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- [Jira](https://datadoghq.atlassian.net/browse/DJM-847)

This PR adds the [GPU agent integration](https://github.com/DataDog/integrations-core/tree/master/gpu) configuration to the databricks install scripts if the environment variable `GPU_MONITORING_ENABLED` is present.

There is currently a problem when using the GPU integration within Databricks cluster: when the init script for the cluster runs, the NVML check fails because the library is not yet initialised.
While I am looking at changing this in the integration directly (by having it poll for a moment before failing and bailing out), we need a more immediate solution to solve for a particular customer. 

The immediate fix is to schedule an agent restart a few seconds in the future when we are in a Databricks cluster with the GPU integration enabled. I tried various methods for that, and it turns out that creating a bash script is the most reliable method.

### Motivation

At Data Jobs Monitoring we have a prospect customer that spins up 15K+ databricks clusters every day (!!), and most, if not all, are GPU-enabled instances. 

We made a demo of GPU Monitoring on Databricks clusters using a duct-taped init bash script on one of our own Databricks workspace, after seeing it, they expressed interest in trying this out themselves. 

To simplify the configuration for them we are doing in the installer. However we don't want all customers to always have the integration enabled. It's a similar case to https://github.com/DataDog/datadog-agent/pull/37089, while the work is direct result of this customer's interest, it is also useful for other customers.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

In a similar fashion that we allow customers to opt-in to Databricks logs collection, we want to allow them to opt-in to GPU monitoring.

This is done through the addition of an environment variable. While customers using the "Manual" version of the databricks integration can modify init-script(s) themselves, we can also do follow-up work to make the GPU integration configurable via the Integration tile UI for customers on the "Managed" version of the databricks integration (see how we can dynamically do that [here](https://github.com/DataDog/dogweb/blob/marwan/djm-create-dbx-resources/integration2/databricks/domain/global_init_script.py#L25-L28))

I have tested this by taking the install scripts generated by this PR's pipeline and using it a GPU-enabled cluster, then validating that I was indeed receiving GPU metrics.

### Possible Drawbacks / Trade-offs

The only drawback is that this might end up unused, however considering trends around running ML workloads on databricks, that's very unlikely.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->