### PR TITLE
Adjust docker container memory experiment with higher limit due to SMP update that exposes docker socket

### DIFF
--- a/test/regression/cases/docker_containers_memory/experiment.yaml
+++ b/test/regression/cases/docker_containers_memory/experiment.yaml
@@ -30,7 +30,7 @@ checks:
     description: Memory usage
     bounds:
       series: total_pss_bytes
-      upper_bound: "230 MiB"
+      upper_bound: "315 MiB"
 
   # This check isn’t about agent’s performance.
   # It’s about validating that the experiment setup is correct.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Sets a higher limit for the `docker_containers_memory` experiment to ensure
`main` is in a passing state.

### Motivation

SMP updated Agent infra to 0.22 which fixes a bug to properly expose the docker
socket to the target. This results in increased memory usage, hence the
adjustment applied here.

### Describe how you validated your changes
SMP Regression Detector bounds checks should all pass on this PR

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
