### PR TITLE
[CNM-4440] Add UDP traceroute driver

### DIFF
--- a/pkg/networkpath/traceroute/common/common.go
+++ b/pkg/networkpath/traceroute/common/common.go
@@ -73,7 +73,7 @@ func LocalAddrForHost(destIP net.IP, destPort uint16) (*net.UDPAddr, net.Conn, e
 	// this is a quick way to get the local address for connecting to the host
 	// using UDP as the network type to avoid actually creating a connection to
 	// the host, just get the OS to give us a local IP and local ephemeral port
-	conn, err := net.Dial("udp4", net.JoinHostPort(destIP.String(), strconv.Itoa(int(destPort))))
+	conn, err := net.Dial("udp", net.JoinHostPort(destIP.String(), strconv.Itoa(int(destPort))))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/networkpath/traceroute/tcp/tcp_traceroute.go
+++ b/pkg/networkpath/traceroute/tcp/tcp_traceroute.go
@@ -31,7 +31,7 @@ func (t *TCPv4) Traceroute() (*common.Results, error) {
 	t.srcPort = port
 
 	// get this platform's tcpDriver implementation
-	driver, err := t.getTracerouteDriver()
+	driver, err := t.newTracerouteDriver()
 	if err != nil {
 		return nil, fmt.Errorf("TCP Traceroute failed to getTracerouteDriver: %w", err)
 	}

--- a/pkg/networkpath/traceroute/tcp/tcp_traceroute_linux.go
+++ b/pkg/networkpath/traceroute/tcp/tcp_traceroute_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
 )
 
-func (t *TCPv4) getTracerouteDriver() (*tcpDriver, error) {
+func (t *TCPv4) newTracerouteDriver() (*tcpDriver, error) {
 	targetAddr, ok := common.UnmappedAddrFromSlice(t.Target)
 	if !ok {
 		return nil, fmt.Errorf("failed to get netipAddr for target %s", t.Target)

--- a/pkg/networkpath/traceroute/tcp/tcp_traceroute_nolinux.go
+++ b/pkg/networkpath/traceroute/tcp/tcp_traceroute_nolinux.go
@@ -11,6 +11,6 @@ import (
 	"fmt"
 )
 
-func (*TCPv4) getTracerouteDriver() (*tcpDriver, error) {
+func (*TCPv4) newTracerouteDriver() (*tcpDriver, error) {
 	return nil, fmt.Errorf("TCP getTracerouteDriver is not yet supported on this platform")
 }

--- a/pkg/networkpath/traceroute/udp/portable_udp/portable_udp.go
+++ b/pkg/networkpath/traceroute/udp/portable_udp/portable_udp.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package main contains a portable binary to easily run SYN traceroutes
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/udp"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
+)
+
+func main() {
+	loglevel := os.Getenv("LOG_LEVEL")
+	if loglevel == "" {
+		loglevel = "warn"
+	}
+	println(loglevel)
+
+	err := pkglogsetup.SetupLogger(
+		pkglogsetup.LoggerName("udp"),
+		loglevel,
+		"",
+		"",
+		false,
+		true,
+		false,
+		pkgconfigsetup.Datadog(),
+	)
+	if err != nil {
+		fmt.Printf("SetupLogger failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	if len(os.Args) < 2 {
+		println("Usage: portable_udp <target>")
+		os.Exit(1)
+	}
+	target := netip.MustParseAddrPort(os.Args[1])
+
+	cfg := udp.NewUDPv4(target.Addr().AsSlice(), target.Port(), 1, 1, 30, 10*time.Millisecond, 1*time.Second)
+
+	results, err := cfg.Traceroute()
+	if err != nil {
+		fmt.Printf("Traceroute failed: %s\n", err)
+		os.Exit(1)
+	}
+	json, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		fmt.Printf("Error marshalling results: %s\n", err)
+		os.Exit(1)
+	}
+	println(string(json))
+}

--- a/pkg/networkpath/traceroute/udp/udp_driver.go
+++ b/pkg/networkpath/traceroute/udp/udp_driver.go
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package udp
+
+import (
+	"fmt"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/google/gopacket/layers"
+)
+
+type probeID struct {
+	packetID uint16
+	checksum uint16
+}
+type probeData struct {
+	sendTime time.Time
+	ttl      uint8
+}
+
+type udpDriver struct {
+	config *UDPv4
+
+	sink packets.Sink
+
+	source packets.Source
+	buffer []byte
+	parser *packets.FrameParser
+
+	// mu guards against concurrent access to sentProbes
+	mu         sync.Mutex
+	sentProbes map[probeID]probeData
+}
+
+func newUDPDriver(config *UDPv4, sink packets.Sink, source packets.Source) *udpDriver {
+	return &udpDriver{
+		config: config,
+
+		sink: sink,
+
+		source: source,
+		buffer: make([]byte, 1024),
+		parser: packets.NewFrameParser(),
+
+		sentProbes: make(map[probeID]probeData),
+	}
+}
+
+func (u *udpDriver) storeProbe(probeID probeID, data probeData) bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	// refuse to store it if we somehow would overwrite
+	if _, ok := u.sentProbes[probeID]; ok {
+		return false
+	}
+
+	u.sentProbes[probeID] = data
+	return true
+}
+
+func (u *udpDriver) findMatchingProbe(probeID probeID) (probeData, bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	data, ok := u.sentProbes[probeID]
+	return data, ok
+}
+
+func (u *udpDriver) getLocalAddrPort() netip.AddrPort {
+	addr, _ := common.UnmappedAddrFromSlice(u.config.srcIP)
+	return netip.AddrPortFrom(addr, u.config.srcPort)
+
+}
+
+func (u *udpDriver) getTargetAddrPort() netip.AddrPort {
+	addr, _ := common.UnmappedAddrFromSlice(u.config.Target)
+	return netip.AddrPortFrom(addr, u.config.TargetPort)
+}
+
+var _ common.TracerouteDriver = &udpDriver{}
+
+// GetDriverInfo returns metadata about this driver
+func (u *udpDriver) GetDriverInfo() common.TracerouteDriverInfo {
+	return common.TracerouteDriverInfo{
+		SupportsParallel: true,
+	}
+}
+
+// SendProbe sends a traceroute packet with a specific TTL
+func (u *udpDriver) SendProbe(ttl uint8) error {
+	ipHdr, buffer, checksum, _, err := u.config.createRawUDPBuffer(u.config.srcIP, u.config.srcPort, u.config.Target, u.config.TargetPort, int(ttl))
+	if err != nil {
+		return fmt.Errorf("udpDriver SendProbe failed to createRawUDPBuffer: %w", err)
+	}
+
+	probeID := probeID{packetID: uint16(ipHdr.ID), checksum: checksum}
+	data := probeData{sendTime: time.Now(), ttl: ttl}
+	log.Tracef("sending probe with ttl=%d, packetID=%d, checksum=%d", ttl, ipHdr.ID, checksum)
+	ok := u.storeProbe(probeID, data)
+	if !ok {
+		return fmt.Errorf("udpDriver Sendprobe tried to sent the same probe ID twice for ttl=%d", ttl)
+	}
+
+	err = u.sink.WriteTo(buffer, u.getTargetAddrPort())
+	if err != nil {
+		return fmt.Errorf("tcpDriver SendProbe failed to write packet: %w", err)
+	}
+	return nil
+}
+
+// ReceiveProbe polls to get a traceroute response with a timeouu.
+func (u *udpDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse, error) {
+	err := u.source.SetReadDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return nil, fmt.Errorf("tcpDriver failed to SetReadDeadline: %w", err)
+	}
+
+	err = packets.ReadAndParse(u.source, u.buffer, u.parser)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.handleProbeLayers()
+}
+
+func (u *udpDriver) handleProbeLayers() (*common.ProbeResponse, error) {
+	ipPair, err := u.parser.GetIPPair()
+	if err != nil {
+		return nil, fmt.Errorf("udpDriver failed to get IP pair: %w", err)
+	}
+
+	var probe probeData
+
+	switch u.parser.GetTransportLayer() {
+	case layers.LayerTypeICMPv4:
+		if !u.parser.IsTTLExceeded() && !u.parser.IsDestinationUnreachable() {
+			return nil, common.ErrPacketDidNotMatchTraceroute
+		}
+
+		icmpInfo, err := u.parser.GetICMPInfo()
+		if err != nil {
+			return nil, &common.BadPacketError{Err: fmt.Errorf("udpDriver failed to get ICMP info: %w", err)}
+		}
+
+		// make sure the source/destination match
+		udpInfo, err := packets.ParseUDPFirstBytes(icmpInfo.Payload)
+		if err != nil {
+			return nil, &common.BadPacketError{Err: fmt.Errorf("udpDriver failed to parse UDP info: %w", err)}
+		}
+
+		icmpSrc := netip.AddrPortFrom(icmpInfo.ICMPPair.SrcAddr, udpInfo.SrcPort)
+		icmpDst := netip.AddrPortFrom(icmpInfo.ICMPPair.DstAddr, udpInfo.DstPort)
+		local := u.getLocalAddrPort()
+		target := u.getTargetAddrPort()
+
+		if icmpDst != target {
+			log.Tracef("udpDriver ignored ICMP packet which had another destination: expected=%s, actual=%s", target, icmpDst)
+			return nil, common.ErrPacketDidNotMatchTraceroute
+		}
+
+		if !u.config.LoosenICMPSrc && icmpSrc != local {
+			log.Tracef("udpDriver ignored packet which had another source: expected=%s, actual=%s", local, icmpSrc)
+			return nil, common.ErrPacketDidNotMatchTraceroute
+		}
+
+		probeID := probeID{packetID: icmpInfo.WrappedPacketID, checksum: udpInfo.Checksum}
+		probe, _ = u.findMatchingProbe(probeID)
+		if probe == (probeData{}) {
+			log.Warnf("couldn't find probe matching packetID=%d and checksum=%d", probeID.packetID, probeID.checksum)
+		}
+	default:
+		return nil, common.ErrPacketDidNotMatchTraceroute
+	}
+
+	if probe == (probeData{}) {
+		return nil, common.ErrPacketDidNotMatchTraceroute
+	}
+	rtt := time.Since(probe.sendTime)
+
+	return &common.ProbeResponse{
+		TTL:    probe.ttl,
+		IP:     ipPair.SrcAddr,
+		RTT:    rtt,
+		IsDest: ipPair.SrcAddr == u.getTargetAddrPort().Addr(),
+	}, nil
+}

--- a/pkg/networkpath/traceroute/udp/udp_driver.go
+++ b/pkg/networkpath/traceroute/udp/udp_driver.go
@@ -40,6 +40,7 @@ type udpDriver struct {
 	sentProbes map[probeID]probeData
 }
 
+//nolint:unused // This is used, but not on all platforms yet
 func newUDPDriver(config *UDPv4, sink packets.Sink, source packets.Source) *udpDriver {
 	return &udpDriver{
 		config: config,

--- a/pkg/networkpath/traceroute/udp/udp_traceroute.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute.go
@@ -24,7 +24,7 @@ func (t *UDPv4) Traceroute() (*common.Results, error) {
 	t.srcPort = uint16(addr.Port)
 
 	// get this platform's tcpDriver implementation
-	driver, err := t.getTracerouteDriver()
+	driver, err := t.newTracerouteDriver()
 	if err != nil {
 		return nil, fmt.Errorf("UDP Traceroute failed to getTracerouteDriver: %w", err)
 	}

--- a/pkg/networkpath/traceroute/udp/udp_traceroute.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package udp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+)
+
+// Traceroute runs a TCP traceroute
+func (t *UDPv4) Traceroute() (*common.Results, error) {
+	addr, conn, err := common.LocalAddrForHost(t.Target, t.TargetPort)
+	if err != nil {
+		return nil, fmt.Errorf("UDP Traceroute failed to get local address for target: %w", err)
+	}
+	defer conn.Close()
+	t.srcIP = addr.IP
+	t.srcPort = uint16(addr.Port)
+
+	// get this platform's tcpDriver implementation
+	driver, err := t.getTracerouteDriver()
+	if err != nil {
+		return nil, fmt.Errorf("UDP Traceroute failed to getTracerouteDriver: %w", err)
+	}
+
+	params := common.TracerouteParallelParams{
+		TracerouteParams: common.TracerouteParams{
+			MinTTL:            t.MinTTL,
+			MaxTTL:            t.MaxTTL,
+			TracerouteTimeout: t.Timeout,
+			PollFrequency:     100 * time.Millisecond,
+			SendDelay:         t.Delay,
+		},
+	}
+	resp, err := common.TracerouteParallel(context.Background(), driver, params)
+	if err != nil {
+		return nil, err
+	}
+
+	hops, err := common.ToHops(params.TracerouteParams, resp)
+	if err != nil {
+		return nil, fmt.Errorf("UDP traceroute ToHops failed: %w", err)
+	}
+
+	result := &common.Results{
+		Source:     t.srcIP,
+		SourcePort: t.srcPort,
+		Target:     t.Target,
+		DstPort:    t.TargetPort,
+		Hops:       hops,
+		Tags:       nil,
+	}
+
+	return result, nil
+}

--- a/pkg/networkpath/traceroute/udp/udp_traceroute_linux.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute_linux.go
@@ -14,7 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
 )
 
-func (u *UDPv4) getTracerouteDriver() (*udpDriver, error) {
+//nolint:unused // This is used, but not on all platforms yet
+func (u *UDPv4) newTracerouteDriver() (*udpDriver, error) {
 	targetAddr, ok := common.UnmappedAddrFromSlice(u.Target)
 	if !ok {
 		return nil, fmt.Errorf("failed to get netipAddr for target %s", u.Target)

--- a/pkg/networkpath/traceroute/udp/udp_traceroute_linux.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute_linux.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package udp
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+)
+
+func (u *UDPv4) getTracerouteDriver() (*udpDriver, error) {
+	targetAddr, ok := common.UnmappedAddrFromSlice(u.Target)
+	if !ok {
+		return nil, fmt.Errorf("failed to get netipAddr for target %s", u.Target)
+	}
+	u.Target = targetAddr.AsSlice()
+
+	sink, err := packets.NewSinkUnix(targetAddr)
+	if err != nil {
+		return nil, fmt.Errorf("Traceroute failed to make SinkUnix: %w", err)
+	}
+
+	source, err := packets.NewAFPacketSource()
+	if err != nil {
+		sink.Close()
+		return nil, fmt.Errorf("Traceroute failed to make AFPacketSource: %w", err)
+	}
+
+	return newUDPDriver(u, sink, source), nil
+}

--- a/pkg/networkpath/traceroute/udp/udp_traceroute_nolinux.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute_nolinux.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package udp
+
+import (
+	"fmt"
+)
+
+func (*UDPv4) getTracerouteDriver() (*udpDriver, error) {
+	return nil, fmt.Errorf("UDP getTracerouteDriver is not supported on this platform")
+}

--- a/pkg/networkpath/traceroute/udp/udp_traceroute_nolinux.go
+++ b/pkg/networkpath/traceroute/udp/udp_traceroute_nolinux.go
@@ -11,6 +11,6 @@ import (
 	"fmt"
 )
 
-func (*UDPv4) getTracerouteDriver() (*udpDriver, error) {
+func (*UDPv4) newTracerouteDriver() (*udpDriver, error) {
 	return nil, fmt.Errorf("UDP getTracerouteDriver is not supported on this platform")
 }

--- a/pkg/networkpath/traceroute/udp/udpv4.go
+++ b/pkg/networkpath/traceroute/udp/udpv4.go
@@ -32,6 +32,11 @@ type (
 		Timeout    time.Duration // full timeout for all packets
 		icmpParser icmp.Parser
 		buffer     gopacket.SerializeBuffer
+
+		// LoosenICMPSrc disables checking the source IP/port in ICMP payloads when enabled.
+		// Reason: Some environments don't properly translate the payload of an ICMP TTL exceeded
+		// packet meaning you can't trust the source address to correspond to your own private IP.
+		LoosenICMPSrc bool
 	}
 )
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a UDP traceroute driver (for IPv4)
### Motivation
This is the last variant needed to have feature parity with the existing traceroute methods

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Build for an ec2 box:
```
GOARCH=amd64 go build github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/udp/portable_udp
```
2. `scp` it to the ec2 box
3. Traceroute to example.com: `sudo -E ./portable_udp 23.192.228.84:33434`


### Possible Drawbacks / Trade-offs
Doesn't work for IPv6 yet. Also this isn't tested like the TCP driver yet

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->