### PR TITLE
fix terminated pods collection

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -238,6 +238,7 @@ func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.
 	// Only collect pods that are in a terminated state: Succeeded, Failed, or Pending.
 	terminatedPodsTweakListOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.AndSelectors(
+			fields.OneTermNotEqualSelector("status.phase", "Pending"),
 			fields.OneTermNotEqualSelector("status.phase", "Running"),
 			fields.OneTermNotEqualSelector("status.phase", "Unknown"),
 		).String()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
We use an informer with a filter to collect deleted pods. The filter is defined as:

```
terminatedPodsTweakListOptions := func(options *metav1.ListOptions) {
	options.FieldSelector = fields.AndSelectors(
		fields.OneTermNotEqualSelector("status.phase", "Running"),
		fields.OneTermNotEqualSelector("status.phase", "Unknown"),
	).String()
}
```
This filter selects pods not in the Running or Unknown phase, meaning we're watching for pods in Pending, Succeeded, or Failed states.

When a pod transitions from Pending to Running, it no longer matches the filter. Kubernetes informers interpret this as the object being "deleted" from the filtered list — so the deletion event is triggered. In reality, the pod wasn't deleted; its status just changed in a way that caused it to be excluded by the filter.

While it’s not a major issue — since we’re just using the terminated payloads to send running pod data and the tags remain correct — it’s still unexpected behavior.  

This PR fixes the issue by updating the informer filter.

### QA

1. Deploy cluster agent with `DD_ORCHESTRATOR_EXPLORER_TERMINATED_POS_ENABLED`
2. Create a new pod
3. Check it in k8s explorer and see it has correct status
4. Delete that pod
5. Check it in k8s explorer and see it has correct status

