### PR TITLE
add timeout param to webhook and set it for cws

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -90,6 +90,8 @@ type Webhook interface {
 	MatchConditions() []admiv1.MatchCondition
 	// WebhookFunc runs the logic of the webhook and returns the admission response
 	WebhookFunc() admission.WebhookFunc
+	// Timeout returns the timeout for the webhook
+	Timeout() int32
 }
 
 // generateWebhooks returns the list of webhooks. The order of the webhooks returned

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -367,6 +367,7 @@ func (c *ControllerV1) generateTemplates() {
 				nsSelector,
 				objSelector,
 				webhook.MatchConditions(),
+				webhook.Timeout(),
 			),
 		)
 	}
@@ -389,17 +390,20 @@ func (c *ControllerV1) generateTemplates() {
 				nsSelector,
 				objSelector,
 				webhook.MatchConditions(),
+				webhook.Timeout(),
 			),
 		)
 	}
 	c.mutatingWebhookTemplates = mutatingWebhooks
 }
 
-func (c *ControllerV1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition) admiv1.ValidatingWebhook {
+func (c *ControllerV1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition, timeout int32) admiv1.ValidatingWebhook {
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()
-	timeout := c.config.getTimeout()
+	if timeout == 0 {
+		timeout = c.config.getTimeout()
+	}
 	failurePolicy := c.getFailurePolicy()
 
 	webhook := admiv1.ValidatingWebhook{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -442,11 +442,13 @@ func (c *ControllerV1) getValidatingWebhookSkeleton(nameSuffix, path string, ope
 	return webhook
 }
 
-func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition) admiv1.MutatingWebhook {
+func (c *ControllerV1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition, timeout int32) admiv1.MutatingWebhook {
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()
-	timeout := c.config.getTimeout()
+	if timeout == 0 {
+		timeout = c.config.getTimeout()
+	}
 	failurePolicy := c.getFailurePolicy()
 	reinvocationPolicy := c.getReinvocationPolicy()
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -170,9 +170,9 @@ func TestAdmissionControllerFailureModeV1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1.Ignore, *validatingWebhookSkeleton.FailurePolicy)
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1.Ignore, *mutatingWebhookSkeleton.FailurePolicy)
 	}
 
@@ -180,9 +180,9 @@ func TestAdmissionControllerFailureModeV1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1.Fail, *validatingWebhookSkeleton.FailurePolicy)
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1.Fail, *mutatingWebhookSkeleton.FailurePolicy)
 	}
 }
@@ -196,7 +196,7 @@ func TestAdmissionControllerReinvocationPolicyV1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.reinvocationpolicy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1.IfNeededReinvocationPolicy, *mutatingWebhookSkeleton.ReinvocationPolicy)
 	}
 }
@@ -1058,7 +1058,7 @@ func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 
 			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
 
-			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
+			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil, 0))
 		})
 	}
 }
@@ -1164,7 +1164,7 @@ func TestGetMutatingWebhookSkeletonV1(t *testing.T) {
 
 			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
 
-			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
+			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil, 0))
 		})
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -209,7 +209,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 	sideEffects := admiv1.SideEffectClassNone
 	port := int32(443)
 	timeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
-	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition, operations []admiv1.OperationType, resources []string) admiv1.MutatingWebhook {
+	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition, operations []admiv1.OperationType, resources []string, to int32) admiv1.MutatingWebhook {
 		return admiv1.MutatingWebhook{
 			Name: name,
 			ClientConfig: admiv1.WebhookClientConfig{
@@ -234,7 +234,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 			FailurePolicy:           &failurePolicy,
 			MatchPolicy:             &matchPolicy,
 			SideEffects:             &sideEffects,
-			TimeoutSeconds:          &timeout,
+			TimeoutSeconds:          &to,
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			ObjectSelector:          objSelector,
 			NamespaceSelector:       nsSelector,
@@ -266,7 +266,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -285,7 +285,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -308,7 +308,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -327,7 +327,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -350,7 +350,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -369,7 +369,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhook}
 			},
 		},
@@ -387,12 +387,12 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -415,7 +415,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -424,7 +424,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, nil, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -444,12 +444,12 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", nil, &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"})
+				}, []admiv1.MatchCondition{}, []admiv1.OperationType{admiv1.Create}, []string{"pods"}, timeout)
 				return []admiv1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -499,6 +499,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{webhook}
 			},
@@ -546,6 +547,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{webhook}
 			},
@@ -561,6 +563,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", true)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(true, false, false, mockConfig) },
 			want: func() []admiv1.MutatingWebhook {
@@ -580,6 +583,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -589,6 +593,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -604,6 +609,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", false)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(true, false, false, mockConfig) },
 			want: func() []admiv1.MutatingWebhook {
@@ -619,6 +625,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -628,6 +635,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -643,6 +651,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", true)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(true, true, false, mockConfig) },
 			want: func() []admiv1.MutatingWebhook {
@@ -662,6 +671,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -671,6 +681,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -686,6 +697,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", false)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(true, true, false, mockConfig) },
 			want: func() []admiv1.MutatingWebhook {
@@ -701,6 +713,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -710,6 +723,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -763,6 +777,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{podWebhook}
 			},
@@ -834,6 +849,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{podWebhook}
 			},
@@ -883,6 +899,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{podWebhook}
 			},
@@ -912,6 +929,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 					[]admiv1.MatchCondition{},
 					[]admiv1.OperationType{admiv1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1.MutatingWebhook{podWebhook}
 			},

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -369,6 +369,7 @@ func (c *ControllerV1beta1) generateTemplates() {
 				nsSelector,
 				objSelector,
 				convertMatchConditions(webhook.MatchConditions()),
+				webhook.Timeout(),
 			),
 		)
 	}
@@ -392,17 +393,20 @@ func (c *ControllerV1beta1) generateTemplates() {
 				nsSelector,
 				objSelector,
 				convertMatchConditions(webhook.MatchConditions()),
+				webhook.Timeout(),
 			),
 		)
 	}
 	c.mutatingWebhookTemplates = mutatingWebhooks
 }
 
-func (c *ControllerV1beta1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition) admiv1beta1.ValidatingWebhook {
+func (c *ControllerV1beta1) getValidatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition, timeout int32) admiv1beta1.ValidatingWebhook {
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := c.config.getServicePort()
-	timeout := c.config.getTimeout()
+	if timeout == 0 {
+		timeout = c.config.getTimeout()
+	}
 	failurePolicy := c.getFailurePolicy()
 
 	webhook := admiv1beta1.ValidatingWebhook{
@@ -441,11 +445,13 @@ func (c *ControllerV1beta1) getValidatingWebhookSkeleton(nameSuffix, path string
 	return webhook
 }
 
-func (c *ControllerV1beta1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition) admiv1beta1.MutatingWebhook {
+func (c *ControllerV1beta1) getMutatingWebhookSkeleton(nameSuffix, path string, operations []admiv1beta1.OperationType, resourcesMap map[string][]string, namespaceSelector, objectSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition, timeout int32) admiv1beta1.MutatingWebhook {
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := c.config.getServicePort()
-	timeout := c.config.getTimeout()
+	if timeout == 0 {
+		timeout = c.config.getTimeout()
+	}
 	failurePolicy := c.getFailurePolicy()
 	reinvocationPolicy := c.getReinvocationPolicy()
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -205,7 +205,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := int32(443)
 	timeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
-	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition, operations []admiv1beta1.OperationType, resources []string) admiv1beta1.MutatingWebhook {
+	webhook := func(name, path string, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition, operations []admiv1beta1.OperationType, resources []string, to int32) admiv1beta1.MutatingWebhook {
 		return admiv1beta1.MutatingWebhook{
 			Name: name,
 			ClientConfig: admiv1beta1.WebhookClientConfig{
@@ -230,7 +230,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 			FailurePolicy:           &failurePolicy,
 			MatchPolicy:             &matchPolicy,
 			SideEffects:             &sideEffects,
-			TimeoutSeconds:          &timeout,
+			TimeoutSeconds:          &to,
 			AdmissionReviewVersions: []string{"v1beta1"},
 			ObjectSelector:          objSelector,
 			NamespaceSelector:       nsSelector,
@@ -262,7 +262,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -281,7 +281,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -304,7 +304,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -323,7 +323,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -346,7 +346,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -365,7 +365,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
 		},
@@ -383,12 +383,12 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -411,7 +411,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -420,7 +420,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 							Values:   []string{"false"},
 						},
 					},
-				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, nil, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -440,12 +440,12 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				webhookTags := webhook("datadog.webhook.standard.tags", "/injecttags", nil, &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
 					},
-				}, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"})
+				}, []admiv1beta1.MatchCondition{}, []admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"}, timeout)
 				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
 			},
 		},
@@ -494,6 +494,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					},
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
@@ -540,6 +541,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					},
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create}, []string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
@@ -555,6 +557,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", true)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, false, false, mockConfig) },
 			want: func() []admiv1beta1.MutatingWebhook {
@@ -574,6 +577,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -583,6 +587,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -598,6 +603,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", false)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, false, false, mockConfig) },
 			want: func() []admiv1beta1.MutatingWebhook {
@@ -613,6 +619,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -622,6 +629,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -637,6 +645,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", true)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, true, false, mockConfig) },
 			want: func() []admiv1beta1.MutatingWebhook {
@@ -656,6 +665,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -665,6 +675,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -680,6 +691,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.enabled", true)
 				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.mutate_unlabelled", false)
 				mockConfig.SetWithoutSource("cluster_agent.service_account_name", "datadog-cluster-agent")
+				mockConfig.SetWithoutSource("admission_controller.cws_instrumentation.timeout", 2)
 			},
 			configFunc: func(mockConfig model.Config) Config { return NewConfig(false, true, false, mockConfig) },
 			want: func() []admiv1beta1.MutatingWebhook {
@@ -695,6 +707,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				execWebhook := webhook(
 					"datadog.webhook.cws.exec.instrumentation",
@@ -704,6 +717,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Connect},
 					[]string{"pods/exec"},
+					mockConfig.GetInt32("admission_controller.cws_instrumentation.timeout"),
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook, execWebhook}
 			},
@@ -757,6 +771,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook}
 			},
@@ -828,6 +843,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook}
 			},
@@ -877,6 +893,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook}
 			},
@@ -906,6 +923,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 					[]admiv1beta1.MatchCondition{},
 					[]admiv1beta1.OperationType{admiv1beta1.Create},
 					[]string{"pods"},
+					timeout,
 				)
 				return []admiv1beta1.MutatingWebhook{podWebhook}
 			},

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -166,9 +166,9 @@ func TestAdmissionControllerFailureModeV1beta1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1beta1.Ignore, *validatingWebhookSkeleton.FailurePolicy)
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1beta1.Ignore, *mutatingWebhookSkeleton.FailurePolicy)
 	}
 
@@ -176,9 +176,9 @@ func TestAdmissionControllerFailureModeV1beta1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.failure_policy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		validatingWebhookSkeleton := c.getValidatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1beta1.Fail, *validatingWebhookSkeleton.FailurePolicy)
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1beta1.Fail, *mutatingWebhookSkeleton.FailurePolicy)
 	}
 }
@@ -192,7 +192,7 @@ func TestAdmissionControllerReinvocationPolicyV1beta1(t *testing.T) {
 		mockConfig.SetWithoutSource("admission_controller.reinvocationpolicy", value)
 		c.config = NewConfig(true, false, false, mockConfig)
 
-		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil)
+		mutatingWebhookSkeleton := c.getMutatingWebhookSkeleton("foo", "/bar", []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nil, nil, nil, 0)
 		assert.Equal(t, admiv1beta1.IfNeededReinvocationPolicy, *mutatingWebhookSkeleton.ReinvocationPolicy)
 	}
 }
@@ -1052,7 +1052,7 @@ func TestGetValidatingWebhookSkeletonV1beta1(t *testing.T) {
 
 			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
 
-			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
+			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil, 0))
 		})
 	}
 }
@@ -1158,7 +1158,7 @@ func TestGetMutatingWebhookSkeletonV1beta1(t *testing.T) {
 
 			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
 
-			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
+			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil, 0))
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -133,6 +133,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -95,6 +95,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
+++ b/pkg/clusteragent/admission/mutate/autoscaling/autoscaling.go
@@ -77,6 +77,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -121,6 +121,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -174,6 +174,7 @@ type WebhookForCommands struct {
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
 	admissionFunc   admission.WebhookFunc
+	timeout         int32
 }
 
 func newWebhookForCommands(admissionFunc admission.WebhookFunc) *WebhookForCommands {
@@ -186,6 +187,7 @@ func newWebhookForCommands(admissionFunc admission.WebhookFunc) *WebhookForComma
 		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Connect},
 		matchConditions: []admissionregistrationv1.MatchCondition{},
 		admissionFunc:   admissionFunc,
+		timeout:         pkgconfigsetup.Datadog().GetInt32("admission_controller.cws_instrumentation.timeout"),
 	}
 }
 
@@ -217,7 +219,7 @@ func (w *WebhookForCommands) Resources() map[string][]string {
 
 // Timeout returns the timeout for the webhook
 func (w *WebhookForCommands) Timeout() int32 {
-	return 0
+	return w.timeout
 }
 
 // Operations returns the operations on the resources specified for which

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -94,6 +94,7 @@ type WebhookForPods struct {
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
 	admissionFunc   admission.WebhookFunc
+	timeout         int32
 }
 
 func newWebhookForPods(admissionFunc admission.WebhookFunc) *WebhookForPods {
@@ -106,6 +107,7 @@ func newWebhookForPods(admissionFunc admission.WebhookFunc) *WebhookForPods {
 		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		matchConditions: []admissionregistrationv1.MatchCondition{},
 		admissionFunc:   admissionFunc,
+		timeout:         pkgconfigsetup.Datadog().GetInt32("admission_controller.cws_instrumentation.timeout"),
 	}
 }
 
@@ -133,6 +135,11 @@ func (w *WebhookForPods) Endpoint() string {
 // be invoked
 func (w *WebhookForPods) Resources() map[string][]string {
 	return w.resources
+}
+
+// Timeout returns the timeout for the webhook
+func (w *WebhookForPods) Timeout() int32 {
+	return w.timeout
 }
 
 // Operations returns the operations on the resources specified for which
@@ -206,6 +213,11 @@ func (w *WebhookForCommands) Endpoint() string {
 // be invoked
 func (w *WebhookForCommands) Resources() map[string][]string {
 	return w.resources
+}
+
+// Timeout returns the timeout for the webhook
+func (w *WebhookForCommands) Timeout() int32 {
+	return 0
 }
 
 // Operations returns the operations on the resources specified for which

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -77,6 +77,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents.go
@@ -98,6 +98,11 @@ func (w *Webhook) Resources() map[string][]string {
 	return w.resources
 }
 
+// Timeout returns the timeout for the webhook
+func (w *Webhook) Timeout() int32 {
+	return 0
+}
+
 // Operations returns the operations on the resources specified for which
 // the webhook should be invoked
 func (w *Webhook) Operations() []admissionregistrationv1.OperationType {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -821,6 +821,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.mode", "remote_copy")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.remote_copy.mount_volume", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.remote_copy.directory", "/tmp")
+	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.timeout", 2)
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.provider", "")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.endpoint", "/agentsidecar")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR updates the webhook interface to add a Timeout method which allows to specify per webhook the timeout. It makes use of it for the cws-instrumentation webhook and set it to 2sec by default.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->