### PR TITLE
Adding a optional CI job to run unit tests with nodetreemodel config implementation

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -61,6 +61,20 @@ tests_deb-x64-py3:
   variables:
     CONDA_ENV: ddpy3
 
+tests_nodetreemodel:
+  extends:
+    - .rtloader_tests
+    - .linux_tests
+    - .linux_x64
+  after_script:
+    - !reference [.upload_junit_source]
+    - !reference [.upload_coverage]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64$CI_IMAGE_RPM_X64_SUFFIX:$CI_IMAGE_RPM_X64
+  variables:
+    CONDA_ENV: ddpy3
+    DD_CONF_NODETREEMODEL: enable
+  allow_failure: true
+
 tests_flavor_iot_deb-x64:
   extends:
     - .rtloader_tests


### PR DESCRIPTION
### What does this PR do?

Adding a optional CI job to run unit tests with nodetreemodel config implementation

### Describe how you validated your changes

No code change, this will be used to continue development of the new config implementation.