### PR TITLE
feat: added truncatedLogs metric

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -71,6 +71,12 @@ func (b *bucket) flush() *message.Message {
 	if b.shouldTruncate {
 		// The current line is too long. Mark it truncated at the end.
 		content = append(content, message.TruncatedFlag...)
+		metrics.LogsTruncated.Add(1)
+		if b.message == nil || b.message.Origin == nil {
+			metrics.TlmTruncatedCount.Inc("", "")
+		} else {
+			metrics.TlmTruncatedCount.Inc(b.message.Origin.Service(), b.message.Origin.Source())
+		}
 	}
 
 	msg := b.message

--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -126,6 +126,12 @@ func (h *MultiLineHandler) process(msg *message.Message) {
 		h.isBufferTruncated = true
 		h.sendBuffer()
 		h.shouldTruncate = true
+		metrics.LogsTruncated.Add(1)
+		if msg == nil || msg.Origin == nil {
+			metrics.TlmTruncatedCount.Inc("", "")
+		} else {
+			metrics.TlmTruncatedCount.Inc(msg.Origin.Service(), msg.Origin.Source())
+		}
 	}
 
 	if h.buffer.Len() > 0 {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -100,6 +100,10 @@ var (
 	TlmDestVirtualLatency = telemetry.NewGauge("logs_destination", "virtual_latency", []string{"instance"}, "Gauge of the destination's average latency")
 	// TlmDestWorkerResets tracks the count of times the destination worker pool resets the worker count after encountering a retryable error.
 	TlmDestWorkerResets = telemetry.NewCounter("logs_destination", "destination_worker_resets", []string{"instance"}, "Count of times the destination worker pool resets the worker count")
+	// LogsTruncated is the number of logs truncated by the Agent
+	LogsTruncated = expvar.Int{}
+	// TlmTruncatedCount tracks the count of times a log is truncated
+	TlmTruncatedCount = telemetry.NewCounter("logs", "truncated", []string{"service", "source"}, "Count the number of times a log is truncated")
 )
 
 func init() {
@@ -116,4 +120,5 @@ func init() {
 	LogsExpvars.Set("BytesMissed", &BytesMissed)
 	LogsExpvars.Set("SenderLatency", &SenderLatency)
 	LogsExpvars.Set("HttpDestinationStats", &DestinationExpVars)
+	LogsExpvars.Set("LogsTruncated", &LogsTruncated)
 }

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	assert.Equal(t, LogsExpvars.String(), `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "HttpDestinationStats": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0}`)
+	assert.Equal(t, LogsExpvars.String(), `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "HttpDestinationStats": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "LogsTruncated": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0}`)
 }

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -209,6 +209,7 @@ func (b *Builder) getMetricsStatus() map[string]string {
 	metrics["RetryCount"] = fmt.Sprintf("%v", b.logsExpVars.Get("RetryCount").(*expvar.Int).Value())
 	metrics["RetryTimeSpent"] = time.Duration(b.logsExpVars.Get("RetryTimeSpent").(*expvar.Int).Value()).String()
 	metrics["EncodedBytesSent"] = fmt.Sprintf("%v", b.logsExpVars.Get("EncodedBytesSent").(*expvar.Int).Value())
+	metrics["LogsTruncated"] = fmt.Sprintf("%v", b.logsExpVars.Get("LogsTruncated").(*expvar.Int).Value())
 	return metrics
 }
 

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -97,13 +97,13 @@ func TestStatusDeduplicateErrorsAndWarnings(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	defer Clear()
 	Clear()
-	var expected = `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "HttpDestinationStats": {}, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": ""}`
+	var expected = `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "", "HttpDestinationStats": {}, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "LogsTruncated": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": ""}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 
 	initStatus(t)
 	AddGlobalWarning("bar", "Unique Warning")
 	AddGlobalError("bar", "I am an error")
-	expected = `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "HttpDestinationStats": {}, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": "Unique Warning"}`
+	expected = `{"BytesMissed": 0, "BytesSent": 0, "DestinationErrors": 0, "DestinationLogsDropped": {}, "EncodedBytesSent": 0, "Errors": "I am an error", "HttpDestinationStats": {}, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "LogsTruncated": 0, "RetryCount": 0, "RetryTimeSpent": 0, "SenderLatency": 0, "Warnings": "Unique Warning"}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
 }
 
@@ -118,6 +118,7 @@ func TestStatusMetrics(t *testing.T) {
 	assert.Equal(t, "0", status.StatusMetrics["EncodedBytesSent"])
 	assert.Equal(t, "0", status.StatusMetrics["RetryCount"])
 	assert.Equal(t, "0s", status.StatusMetrics["RetryTimeSpent"])
+	assert.Equal(t, "0", status.StatusMetrics["LogsTruncated"])
 
 	metrics.LogsProcessed.Set(5)
 	metrics.LogsSent.Set(3)
@@ -125,6 +126,7 @@ func TestStatusMetrics(t *testing.T) {
 	metrics.EncodedBytesSent.Set(21)
 	metrics.RetryCount.Set(42)
 	metrics.RetryTimeSpent.Set(int64(time.Hour * 2))
+	metrics.LogsTruncated.Set(64)
 	status = Get(false)
 
 	assert.Equal(t, "5", status.StatusMetrics["LogsProcessed"])
@@ -133,6 +135,7 @@ func TestStatusMetrics(t *testing.T) {
 	assert.Equal(t, "21", status.StatusMetrics["EncodedBytesSent"])
 	assert.Equal(t, "42", status.StatusMetrics["RetryCount"])
 	assert.Equal(t, "2h0m0s", status.StatusMetrics["RetryTimeSpent"])
+	assert.Equal(t, "64", status.StatusMetrics["LogsTruncated"])
 
 	metrics.LogsProcessed.Set(math.MaxInt64)
 	metrics.LogsProcessed.Add(1)

--- a/releasenotes/notes/truncated_count_metric-ef102f7deabb9206.yaml
+++ b/releasenotes/notes/truncated_count_metric-ef102f7deabb9206.yaml
@@ -1,0 +1,25 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+features:
+  - |
+    Added a new `logs.truncated` metric to the Agent that reports the number of logs truncated before being sent. This metric helps monitor log volume loss due to truncation and is tagged by `service` and `source` for better visibility.
+enhancements:
+  - |
+issues:
+  - |
+deprecations:
+  - |
+security:
+  - |
+fixes:
+  - |
+other:
+  - |


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Adds the `datadog.agent.logs.truncated` metric in ```metrics.go``` 
- Modified ```single_line_handler.go```, ```multiline_handler.go```, and ```aggregator.go``` to increment our ```logs.truncated``` metric by 1 while also implementing safeguards to check whether the message or message origin is nil to successfully increment the count with the message origin service and source. 
- Changed tests in ```status_test.go``` and ```metrics_test.go``` to include and check for new metric.
- Added ```LogsTruncated``` to ```builder.go``` to expose new metric

### Motivation

This metric enables customers to monitor the number of logs truncated by the Agent. It addresses the customer feature request FRLOGSS-3606 and aligns with the internal telemetry initiative AGNTLOG-227. The metric name differs from the backend’s datadog.estimated_usage.logs.truncated_count to maintain consistency with existing Agent metric naming conventions.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran ```curl http://localhost:5000/telemetry | grep "truncated"``` to verify existence of metric on local DataDog agent.

<img width="582" alt="Screenshot 2025-06-06 at 2 36 56 PM" src="https://github.com/user-attachments/assets/086d11b7-48de-4b19-b8b7-0258d3daadf3" />

Also, modified unit tests and ran them to ensure expected behavior. 
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->