### PR TITLE
system_probe.py: delete stale dyninst testprog binaries

### DIFF
--- a/pkg/dyninst/testprogs/test_progs.go
+++ b/pkg/dyninst/testprogs/test_progs.go
@@ -154,7 +154,6 @@ found:
 		if err != nil {
 			return state{}, fmt.Errorf("failed to parse config from directory name: %w", err)
 		}
-		configs[cfg] = struct{}{}
 		files, err := os.ReadDir(path.Join(binariesDir, file.Name()))
 		if err != nil {
 			return state{}, fmt.Errorf("failed to read program directory: %w", err)
@@ -172,6 +171,8 @@ found:
 				continue
 			}
 			programConfigs[file.Name()]++
+			// Only count the config if there's at least one program for it.
+			configs[cfg] = struct{}{}
 		}
 	}
 	numConfigs := len(configs)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -2215,6 +2215,7 @@ def ninja_add_dyninst_test_programs(
     # some ways because it's not likely that other folks build without CGO.
     # Eventually we're going to want a better story for how to test against a
     # variety of go binaries.
+    outputs = set()
     for pkg, go_version, arch in itertools.product(
         pkg_deps.keys(),
         go_versions,
@@ -2229,6 +2230,7 @@ def ninja_add_dyninst_test_programs(
         config_str = f"arch={arch},toolchain={go_version}"
         output_path = f"{output_base}/{config_str}/{pkg}"
         output_path = os.path.abspath(output_path)
+        outputs.add(output_path)
         pkg_path = os.path.abspath(f"./{progs_path}/{pkg}")
         nw.build(
             inputs=[pkg_path],
@@ -2254,3 +2256,9 @@ def ninja_add_dyninst_test_programs(
                 ),
             },
         )
+
+    # Remove any previously built binaries that are no longer needed.
+    for path in glob.glob(f"{output_base}/*/*"):
+        path = os.path.abspath(path)
+        if os.path.isfile(path) and path not in outputs:
+            os.remove(path)


### PR DESCRIPTION
Before this change, if we modified the set of testprog binaries we intend to build, nothing would remove them from disk. This could lead to spurious snapshot files being generated.
