### PR TITLE
Revert "Stop reporting fake Ready status in WLM based on AD annotation"

### DIFF
--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	newIdentifierLabel        = "com.datadoghq.ad.check.id"
-	legacyIdentifierLabel     = "com.datadoghq.sd.check.id"
-	tolerateUnreadyAnnotation = "ad.datadoghq.com/tolerate-unready"
+	newIdentifierLabel    = "com.datadoghq.ad.check.id"
+	legacyIdentifierLabel = "com.datadoghq.sd.check.id"
 )
 
 // ContainerListener listens to container creation through a subscription to the
@@ -130,7 +129,7 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 
 	if pod != nil {
 		svc.hosts = map[string]string{"pod": pod.IP}
-		svc.ready = pod.Ready || shouldSkipPodReadiness(pod)
+		svc.ready = pod.Ready
 
 		svc.metricsExcluded = l.IsExcluded(
 			containers.MetricsFilter,
@@ -228,12 +227,4 @@ func computeContainerServiceIDs(entity string, image string, labels map[string]s
 		ids = append(ids, short)
 	}
 	return ids
-}
-
-func shouldSkipPodReadiness(pod *workloadmeta.KubernetesPod) bool {
-	tolerate, ok := pod.Annotations[tolerateUnreadyAnnotation]
-	if !ok {
-		return false
-	}
-	return tolerate == "true"
 }

--- a/comp/core/autodiscovery/listeners/container_test.go
+++ b/comp/core/autodiscovery/listeners/container_test.go
@@ -144,7 +144,6 @@ func TestCreateContainerService(t *testing.T) {
 			Annotations: map[string]string{
 				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesContainer.Name):         `false`,
 				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesExcludedContainer.Name): `true`,
-				tolerateUnreadyAnnotation: `true`,
 			},
 		},
 		Containers: []workloadmeta.OrchestratorContainer{
@@ -294,7 +293,7 @@ func TestCreateContainerService(t *testing.T) {
 						},
 						hosts: map[string]string{"pod": pod.IP},
 						ports: []ContainerPort{},
-						ready: true,
+						ready: pod.Ready,
 					},
 				},
 			},

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -160,7 +160,7 @@ func (l *KubeletListener) createContainerService(
 	svc := &service{
 		entity:   container,
 		tagsHash: l.tagger.GetEntityHash(types.NewEntityID(types.ContainerID, container.ID), types.ChecksConfigCardinality),
-		ready:    pod.Ready || shouldSkipPodReadiness(pod),
+		ready:    pod.Ready,
 		ports:    ports,
 		extraConfig: map[string]string{
 			"pod_name":  pod.Name,

--- a/comp/core/autodiscovery/listeners/kubelet_test.go
+++ b/comp/core/autodiscovery/listeners/kubelet_test.go
@@ -141,7 +141,6 @@ func TestKubeletCreateContainerService(t *testing.T) {
 
 	podWithMetricsExcludeAnnotation := podWithAnnotations.DeepCopy().(*workloadmeta.KubernetesPod)
 	podWithMetricsExcludeAnnotation.Annotations[fmt.Sprintf("ad.datadoghq.com/%s.metrics_exclude", containerName)] = `true`
-	podWithMetricsExcludeAnnotation.Annotations[tolerateUnreadyAnnotation] = `true`
 
 	podWithLogsExcludeAnnotation := podWithAnnotations.DeepCopy().(*workloadmeta.KubernetesPod)
 	podWithLogsExcludeAnnotation.Annotations[fmt.Sprintf("ad.datadoghq.com/%s.logs_exclude", containerName)] = `true`
@@ -473,7 +472,6 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						},
 						metricsExcluded: true,
 						tagger:          taggerComponent,
-						ready:           true,
 					},
 				},
 			},

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
@@ -42,6 +42,16 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		})
 	}
 
+	var ready bool
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			if condition.Status == corev1.ConditionTrue {
+				ready = true
+			}
+			break
+		}
+	}
+
 	var pvcNames []string
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
@@ -96,7 +106,7 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		Phase:                      string(pod.Status.Phase),
 		Owners:                     owners,
 		PersistentVolumeClaimNames: pvcNames,
-		Ready:                      isPodReady(pod),
+		Ready:                      ready,
 		IP:                         pod.Status.PodIP,
 		PriorityClass:              pod.Spec.PriorityClassName,
 		QOSClass:                   string(pod.Status.QOSClass),
@@ -104,19 +114,4 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		GPUVendorList:              gpuVendorList,
 		Containers:                 containersList,
 	}
-}
-
-// Should be aligned with pkg/util/kubernetes/kubelet/kubelet.go
-// (Except the static pods that should go away as fixed long time ago)
-func isPodReady(pod *corev1.Pod) bool {
-	if pod.Status.Phase != corev1.PodRunning {
-		return false
-	}
-
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == corev1.PodReady {
-			return condition.Status == corev1.ConditionTrue
-		}
-	}
-	return false
 }

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build kubeapiserver
+//go:build kubeapiserver && test
 
 package kubernetesresourceparsers
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -371,9 +371,8 @@ func (ku *KubeUtil) GetPodForContainerID(ctx context.Context, containerID string
 		return pod, nil
 	}
 
-	// Error is not nil
 	// Retry with cache invalidation
-	if errors.IsNotFound(err) {
+	if err != nil && errors.IsNotFound(err) {
 		log.Debugf("Cannot get container %q: %s, retrying without cache...", containerID, err)
 		pods, err = ku.ForceGetLocalPodList(ctx)
 		if err != nil {
@@ -507,6 +506,9 @@ func IsPodReady(pod *Pod) bool {
 		return false
 	}
 
+	if tolerate, ok := pod.Metadata.Annotations[unreadyAnnotation]; ok && tolerate == "true" {
+		return true
+	}
 	for _, status := range pod.Status.Conditions {
 		if status.Type == "Ready" && status.Status == "True" {
 			return true

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -113,7 +113,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), changes, 2)
 	assert.Equal(suite.T(), "nginx", changes[0].Spec.Containers[0].Name)
-	require.False(suite.T(), IsPodReady(changes[0]))
+	require.True(suite.T(), IsPodReady(changes[0]))
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {


### PR DESCRIPTION
Reverts DataDog/datadog-agent#36253

It would appear that this PR exposed an issue when a pod fails a probe for an extended period of time, but recovers. This manifests as the container being unscheduled from the AD scheduler, and in the `container_name` tag missing for short periods of time.

This behavior would have always been in place, but could have been avoided with the `ad.datadoghq.com/tolerate-unready: "true"` pod annotation. The mentioned PR removed this workaround.

More details:
https://app.datadoghq.com/incidents/38767
https://datadoghq.atlassian.net/wiki/x/wwKTNAE