### PR TITLE
Add an option to add a suffix on stack name when running e2e tests

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -61,6 +61,7 @@ class TestState:
         "skip": "Only run tests not matching the regular expression",
         "agent_image": 'Full image path for the agent image (e.g. "repository:tag") to run the e2e tests with',
         "cluster_agent_image": 'Full image path for the cluster agent image (e.g. "repository:tag") to run the e2e tests with',
+        "stack_name_suffix": "Suffix to add to the stack name, it can be useful when your stack is stuck in a weird state and you need to run the tests again",
     },
 )
 def run(
@@ -93,6 +94,7 @@ def run(
     logs_folder="e2e_logs",
     local_package="",
     result_json=DEFAULT_E2E_TEST_OUTPUT_JSON,
+    stack_name_suffix="",
 ):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
@@ -134,6 +136,9 @@ def run(
 
     if parsed_params:
         env_vars["E2E_STACK_PARAMS"] = json.dumps(parsed_params)
+
+    if stack_name_suffix:
+        env_vars["E2E_STACK_NAME_SUFFIX"] = stack_name_suffix
 
     gotestsum_format = "standard-verbose" if verbose else "pkgname"
 

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -328,7 +328,10 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 	if bs.params.stackName == "" {
 		sType := reflect.TypeOf(self).Elem()
 		hash := utils.StrHash(sType.PkgPath()) // hash of PkgPath in order to have a unique stack name
-		bs.params.stackName = fmt.Sprintf("e2e-%s-%s%s", sType.Name(), hash, fmt.Sprintf("-%s", stackNameSuffix))
+		bs.params.stackName = fmt.Sprintf("e2e-%s-%s", sType.Name(), hash)
+		if stackNameSuffix != "" {
+			bs.params.stackName = fmt.Sprintf("%s-%s", bs.params.stackName, stackNameSuffix)
+		}
 	}
 
 	bs.originalProvisioners = bs.params.provisioners

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -329,9 +329,10 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 		sType := reflect.TypeOf(self).Elem()
 		hash := utils.StrHash(sType.PkgPath()) // hash of PkgPath in order to have a unique stack name
 		bs.params.stackName = fmt.Sprintf("e2e-%s-%s", sType.Name(), hash)
-		if stackNameSuffix != "" {
-			bs.params.stackName = fmt.Sprintf("%s-%s", bs.params.stackName, stackNameSuffix)
-		}
+	}
+
+	if stackNameSuffix != "" {
+		bs.params.stackName = fmt.Sprintf("%s-%s", bs.params.stackName, stackNameSuffix)
 	}
 
 	bs.originalProvisioners = bs.params.provisioners

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -321,10 +321,14 @@ func (bs *BaseSuite[Env]) init(options []SuiteOption, self Suite[Env]) {
 		bs.params.skipDeleteOnFailure, _ = runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.SkipDeleteOnFailure, false)
 	}
 
+	stackNameSuffix, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.StackNameSuffix, "")
+	if err != nil {
+		bs.T().Fatalf("unable to get stack name suffix: %v", err)
+	}
 	if bs.params.stackName == "" {
 		sType := reflect.TypeOf(self).Elem()
 		hash := utils.StrHash(sType.PkgPath()) // hash of PkgPath in order to have a unique stack name
-		bs.params.stackName = fmt.Sprintf("e2e-%s-%s", sType.Name(), hash)
+		bs.params.stackName = fmt.Sprintf("e2e-%s-%s%s", sType.Name(), hash, fmt.Sprintf("-%s", stackNameSuffix))
 	}
 
 	bs.originalProvisioners = bs.params.provisioners

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -47,6 +47,8 @@ const (
 	PulumiPassword StoreKey = "pulumi_password"
 	// SkipDeleteOnFailure keep the stack on test failure
 	SkipDeleteOnFailure StoreKey = "skip_delete_on_failure"
+	// StackNameSuffix suffix to add to the stack name
+	StackNameSuffix StoreKey = "stack_name_suffix"
 	// StackParameters configuration map for the stack, in a json formatted string
 	StackParameters StoreKey = "stack_params"
 	// PipelineID  used to deploy agent artifacts from a Gitlab pipeline


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add an option to have a custom suffix on stack name. It can be useful when your e2e stack is stuck in a corrupted state and you want to run the same test again

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->