### PR TITLE
autoinstrumentation: respect kubernetesResourcesLabelsAsTags

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
-	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -147,19 +146,6 @@ func NewWebhookConfig(datadogConfig config.Component) *WebhookConfig {
 		IsEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
 		Endpoint:  datadogConfig.GetString("admission_controller.auto_instrumentation.endpoint"),
 	}
-}
-
-func getPodMetaAsTags(datadogConfig config.Component) podMetaAsTags {
-	tags := configUtils.GetMetadataAsTags(datadogConfig)
-	return podMetaAsTags{
-		Labels:      tags.GetPodLabelsAsTags(),
-		Annotations: tags.GetPodAnnotationsAsTags(),
-	}
-}
-
-type podMetaAsTags struct {
-	Labels      map[string]string
-	Annotations map[string]string
 }
 
 // LanguageDetectionConfig is a struct to store the configuration for the language detection. It can be populated using

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -18,8 +18,8 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -244,7 +244,7 @@ func (m *mutatorCore) serviceNameMutator(pod *corev1.Pod) containerMutator {
 		return &serviceNameMutator{noop: true}
 	}
 
-	return newServiceNameMutator(pod)
+	return newServiceNameMutator(pod, m.config.podMetaAsTags)
 }
 
 // newInitContainerMutators constructs container mutators for behavior

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -19,9 +19,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -152,13 +154,13 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
-		serviceNameMutator = m.serviceNameMutator(pod)
+		ustEnvVarMutator = m.ustEnvVarMutator(pod)
 
 		// initContainerMutators are resource and security constraints
 		// to all the init containers the init containers that we create.
 		initContainerMutators = append(
 			m.newInitContainerMutators(requirements, pod.Namespace),
-			serviceNameMutator,
+			ustEnvVarMutator,
 		)
 		injectorOptions = libRequirementOptions{
 			containerFilter:       m.config.containerFilter,
@@ -168,7 +170,7 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		injector          = m.newInjector(pod, startTime, injectorOptions)
 		containerMutators = containerMutators{
 			config.languageDetection.containerMutator(m.config.version),
-			serviceNameMutator,
+			ustEnvVarMutator,
 		}
 	)
 
@@ -240,11 +242,34 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 // We want to get rid of the behavior when we are triggering the fallback _and_
 // it applies: https://datadoghq.atlassian.net/browse/INPLAT-458
 func (m *mutatorCore) serviceNameMutator(pod *corev1.Pod) containerMutator {
+	return newServiceNameMutator(pod, m.config.podMetaAsTags)
+}
+
+// ustEnvVarMutator will attempt to find a ust env var to inject into the pods containers if SSI is enabled.
+//
+// This is used to inject the version and env tags into the pods containers.
+//
+// The service tag/name is handled separately in the serviceNameMutator for legacy reasons.
+func (m *mutatorCore) ustEnvVarMutator(pod *corev1.Pod) containerMutator {
+	var mutators containerMutators
 	if !m.filter.IsNamespaceEligible(pod.Namespace) {
-		return &serviceNameMutator{noop: true}
+		return mutators
 	}
 
-	return newServiceNameMutator(pod, m.config.podMetaAsTags)
+	for tag, envVarName := range map[string]string{
+		tags.Version: kubernetes.VersionTagEnvVar,
+		tags.Env:     kubernetes.EnvTagEnvVar,
+	} {
+		if mutator := ustEnvVarMutatorForPodMeta(pod, m.config.podMetaAsTags, tag, envVarName); mutator != nil {
+			mutators = append(mutators, mutator)
+		}
+	}
+
+	if mutator := m.serviceNameMutator(pod); mutator != nil {
+		mutators = append(mutators, mutator)
+	}
+
+	return mutators
 }
 
 // newInitContainerMutators constructs container mutators for behavior

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/pod_meta_as_tags.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/pod_meta_as_tags.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type podMetaKind string
+
+const (
+	podMetaKindLabels      podMetaKind = "labels"
+	podMetaKindAnnotations podMetaKind = "annotations"
+)
+
+type podMetaAsTags struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+func getPodMetaAsTags(datadogConfig config.Component) podMetaAsTags {
+	tags := configUtils.GetMetadataAsTags(datadogConfig)
+	return podMetaAsTags{
+		Labels:      tags.GetPodLabelsAsTags(),
+		Annotations: tags.GetPodAnnotationsAsTags(),
+	}
+}
+
+func envVarForPodMetaMapping(pod *corev1.Pod, kind podMetaKind, mappingSource podMetaAsTags, tag, envVarName string) (corev1.EnvVar, bool) {
+	var mapping, podMeta map[string]string
+	switch kind {
+	case podMetaKindLabels:
+		mapping = mappingSource.Labels
+		podMeta = pod.Labels
+	case podMetaKindAnnotations:
+		mapping = mappingSource.Annotations
+		podMeta = pod.Annotations
+	default:
+		log.Errorf("unexpected pod meta kind: %s", kind)
+		return corev1.EnvVar{}, false
+	}
+
+	// Check if any of the mapping keys exist in the pod metadata
+	for key, value := range mapping {
+		if value != tag {
+			continue
+		}
+
+		_, exists := podMeta[key]
+		if !exists {
+			continue
+		}
+
+		return corev1.EnvVar{
+			Name:      envVarName,
+			ValueFrom: envVarSourceFromFieldRef(kind, key),
+		}, true
+	}
+
+	return corev1.EnvVar{}, false
+}
+
+// envVarSourceFromFieldRef is a helper function to create an EnvVarSource
+// for a given kind and path, e.g. "metadata.annotations['app.kubernetes.io/name']"
+func envVarSourceFromFieldRef(kind podMetaKind, path string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			FieldPath: fmt.Sprintf("metadata.%s['%s']", kind, path),
+		},
+	}
+}
+
+func ustEnvVarMutatorForPodMeta(pod *corev1.Pod, mappingSource podMetaAsTags, tag, envVarName string) *ustEnvVarMutator {
+	env, found := envVarForPodMetaMapping(pod, podMetaKindLabels, mappingSource, tag, envVarName)
+	if found {
+		return &ustEnvVarMutator{EnvVar: env}
+	}
+
+	if env, found := envVarForPodMetaMapping(pod, podMetaKindAnnotations, mappingSource, tag, envVarName); found {
+		return &ustEnvVarMutator{EnvVar: env}
+	}
+
+	return nil
+}
+
+type ustEnvVarMutator struct {
+	EnvVar corev1.EnvVar
+	Source *corev1.EnvVar
+}
+
+func (m *ustEnvVarMutator) mutateContainer(c *corev1.Container) error {
+	if m == nil {
+		return nil
+	}
+
+	if m.EnvVar.Name == "" {
+		log.Errorf("env var name is empty, skipping mutator")
+		return nil
+	}
+
+	for _, e := range c.Env {
+		if e.Name == m.EnvVar.Name {
+			return nil
+		}
+	}
+
+	var envs []corev1.EnvVar
+	envs = append(envs, m.EnvVar)
+
+	if m.Source != nil {
+		envs = append(envs, *m.Source)
+	}
+
+	c.Env = append(envs, c.Env...)
+	return nil
+}

--- a/releasenotes-dca/notes/auto-instru-supports-labelsAsTags-836cb560dd4d1389.yaml
+++ b/releasenotes-dca/notes/auto-instru-supports-labelsAsTags-836cb560dd4d1389.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    The auto-instrumentation webhook supports labels and annotations as tags configuration.
+    If any of the label or annotation mappings for the incoming pod correspond to Universal
+    Service Tags (``service``, ``env``, or ``version``), the webhook will also add the corresponding
+    UST environment variable to the pod (``DD_SERVICE``, ``DD_ENV``, or ``DD_VERSION``).


### PR DESCRIPTION
### What does this PR do?

Related to #36754 but an inverse where the admission controller respects `kubernetesResources{Labels,Annotations}AsTags` configuration.

### Motivation

https://docs.google.com/document/d/1InoHTXcu92Jk1Re8YyDt3QhDJbXpNtuJbX9vUdR5Y6U/edit?tab=t.0

### Testing

```yaml
helm:
  namespaces:
  - name: "application"
  apps:

  - name: python-no-name
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      - name: DD_SERVICE
        value: ""
      image:
        repository: ddstanistan/test-python-app
        tag: 2cd78dez-amd64
      podLabels:
        language: python
      service:
        port: "8080"

  - name: python-named
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      image:
        repository: ddstanistan/test-python-app
        tag: 2cd78dez-amd64
      podLabels:
        language: python
      labels:
        app-name: "python-app-test"
      service:
        port: "8080"

  - name: python-named-another
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      image:
        repository: ddstanistan/test-python-app
        tag: 2cd78dez-amd64
      podLabels:
        language: python
      labels:
        app-name: "banana"
      service:
        port: "8080"

  versions:

    agent:
      tag: v67567933-4cec84b6-7-amd64
      repository: ddstanistan/agent

    cluster_agent:
      tag: v67567933-4cec84b6-amd64
      repository: ddstanistan/cluster-agent

    injector: 0.39.1

  config:

    datadog:
      clusterName: "stanistan-1-gke"
      site: us5.datadoghq.com
      tags:
      - "env:test"

      kubernetesResourcesLabelsAsTags:
        pods:
          app-name: service
        deployments.apps:
          app-name: service
        replicasets.apps:
          app-name: service

      clusterTagger:
        collectKubernetesTags: true

      apm:

        socketEnabled: false
        portEnabled: true

        instrumentation:
          enabled: true
          targets:
          - name: python-apps

            # apps that look like this.
            podSelector:
              matchLabels:
                language: python


            # get this tracer version.
            ddTraceVersions:
              python: "3"
```

The k8s resources are linked:

<img width="788" alt="Screenshot 2025-06-12 at 2 27 22 PM" src="https://github.com/user-attachments/assets/31cd5fd0-82c0-4641-a5a3-636b97d0b043" />

<img width="1218" alt="Screenshot 2025-06-12 at 2 28 40 PM" src="https://github.com/user-attachments/assets/296dceab-a54b-459b-b696-531eaaaf87ff" />
