### PR TITLE
Revert "Adding a optional CI job to run nodetreemodel tests"

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -61,20 +61,6 @@ tests_deb-x64-py3:
   variables:
     CONDA_ENV: ddpy3
 
-tests_nodetreemodel:
-  extends:
-    - .rtloader_tests
-    - .linux_tests
-    - .linux_x64
-  after_script:
-    - !reference [.upload_junit_source]
-    - !reference [.upload_coverage]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64$CI_IMAGE_RPM_X64_SUFFIX:$CI_IMAGE_RPM_X64
-  variables:
-    CONDA_ENV: ddpy3
-    DD_CONF_NODETREEMODEL: enable
-  allow_failure: true
-
 tests_flavor_iot_deb-x64:
   extends:
     - .rtloader_tests


### PR DESCRIPTION
### What does this PR do?

Revert "Adding a optional CI job to run unit tests with nodetreemodel config implementation"
    
    This reverts commit ab1c6d95815c11b70d26bcf1dc3f255329be4d1e.

### Motivation

With this CI job enabled, many e2e tests fail and are spamming their owners.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
