### PR TITLE
[dyninst/irgen] Support inlined functions

### DIFF
--- a/pkg/dyninst/compiler/codegen/code.go
+++ b/pkg/dyninst/compiler/codegen/code.go
@@ -30,7 +30,7 @@ type cCodeSerializer struct {
 
 // CommentFunction comments a stack machine function prior to its body.
 func (s *cCodeSerializer) CommentFunction(id sm.FunctionID, pc uint32) error {
-	_, err := fmt.Fprintf(s.out, "\t// 0x%x: %s\n", pc, id.String())
+	_, err := fmt.Fprintf(s.out, "\n\t// 0x%x: %s\n", pc, id.String())
 	return err
 }
 

--- a/pkg/dyninst/compiler/compile_test.go
+++ b/pkg/dyninst/compiler/compile_test.go
@@ -70,7 +70,6 @@ func TestCompileBPFProgram(t *testing.T) {
 				IsParameter: false,
 			},
 		},
-		Lines: []ir.SubprogramLine{},
 	}
 	p := &ir.Program{
 		ID: 123,

--- a/pkg/dyninst/compiler/sm/generate.go
+++ b/pkg/dyninst/compiler/sm/generate.go
@@ -438,6 +438,10 @@ func (g *generator) EncodeLocationOp(pc uint64, op *ir.LocationOp, ops []Op) ([]
 			return nil, err
 		}
 		layoutIdx := 0
+		if len(loclist.Pieces) == 0 {
+			// Variable has loclist entry for relevant PC range, but it is still unavailable.
+			break
+		}
 		for _, locPiece := range loclist.Pieces {
 			paddedOffset := layoutPieces[layoutIdx].PaddedOffset
 			nextLayoutIdx := layoutIdx

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -554,7 +554,7 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     return 1;
   }
   const sm_opcode_t op = (sm_opcode_t)sm_read_program_uint8(sm);
-  LOG(4, "%8d %s %s", sm->pc - 1, padding(sm->pc_stack_pointer), op_code_name(op));
+  LOG(4, "%6x %s %s", sm->pc - 1, padding(sm->pc_stack_pointer), op_code_name(op));
   if (sm->pc >= stack_machine_code_len - stack_machine_code_max_op + 1) {
     return 1;
   }

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -103,6 +103,12 @@ func testDyninst(t *testing.T, sampleServicePath string) {
 				MethodName: "main.arrayArg",
 			},
 		},
+		&config.LogProbe{
+			ID: "inlined",
+			Where: &config.Where{
+				MethodName: "main.inlined",
+			},
+		},
 	}
 
 	obj, err := object.NewElfObject(binary)
@@ -203,7 +209,8 @@ func testDyninst(t *testing.T, sampleServicePath string) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, bpfOutDump.Close()) }()
 
-	for range len(probes) {
+	// Inlined function is called twice, hence extra event.
+	for range len(probes) + 1 {
 		t.Logf("reading ringbuf item")
 		require.Greater(t, rd.AvailableBytes(), 0)
 		record, err := rd.Read()

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -58,8 +58,6 @@ type Subprogram struct {
 	InlinePCRanges [][]PCRange
 	// Variables are the variables that are used in the subprogram.
 	Variables []*Variable
-	// Lines are the lines of the subprogram.
-	Lines []SubprogramLine
 }
 
 // SubprogramLine represents a line in the subprogram.

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -50,8 +50,8 @@ type Subprogram struct {
 	Name string
 	// OutOfLinePCRanges are the ranges of PC values that will be probed for the
 	// out-of-line-instances of the subprogram. These are sorted by start PC.
-	//
-	// What does this mean for inlined subprograms?
+	// Some functions may be inlined only in certain callers, in which case
+	// both OutOfLinePCRanges and InlinePCRanges will be non-empty.
 	OutOfLinePCRanges []PCRange
 	// InlinePCRanges are the ranges of PC values that will be probed for the
 	// inlined instances of the subprogram. These are sorted by start PC.

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -488,9 +488,8 @@ func populateEventsRootExpressions(probes []*ir.Probe, typeCatalog *typeCatalog)
 			}
 			event.Type = &ir.EventRootType{
 				TypeCommon: ir.TypeCommon{
-					ID: id,
-					// TODO: Give this a better name.
-					Name:     "ProbeEvent",
+					ID:       id,
+					Name:     fmt.Sprintf("Probe[%s]", probe.Subprogram.Name),
 					ByteSize: uint32(byteSize),
 				},
 				// TODO: Populate the presence bitset size and expressions.

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.yaml
@@ -16,3 +16,7 @@ probes:
   type: LOG_PROBE
   where:
     method_name: main.stringArg
+- id: e
+  type: LOG_PROBE
+  where:
+    method_name: main.inlined

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
@@ -4,73 +4,82 @@ Probes:
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 1}
+      Subprogram: {subprogram: 2}
       Events:
         - ID: 1
           Type: 39 EventRootType ProbeEvent
-          InjectionPCs: ["0x491c8a"]
+          InjectionPCs: ["0x491cea"]
           Condition: null
       Snapshot: false
     - ID: c
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 2}
+      Subprogram: {subprogram: 3}
       Events:
         - ID: 2
           Type: 40 EventRootType ProbeEvent
-          InjectionPCs: ["0x491cf3"]
+          InjectionPCs: ["0x491d53"]
           Condition: null
       Snapshot: false
     - ID: d
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 3}
+      Subprogram: {subprogram: 4}
       Events:
         - ID: 3
           Type: 41 EventRootType ProbeEvent
-          InjectionPCs: ["0x491e2a"]
+          InjectionPCs: ["0x491e8a"]
+          Condition: null
+      Snapshot: false
+    - ID: e
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 1}
+      Events:
+        - ID: 4
+          Type: 42 EventRootType ProbeEvent
+          InjectionPCs: ["0x491f8a", "0x491c66"]
           Condition: null
       Snapshot: false
 Subprograms:
-    - ID: 1
+    - ID: 2
       Name: main.mapArg
-      OutOfLinePCRanges: [0x491c80..0x491cd6]
+      OutOfLinePCRanges: [0x491ce0..0x491d36]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 1 GoMapType map[string]int
+          Type: 2 GoMapType map[string]int
           Locations:
-            - Range: 0x491c80..0x491cad
+            - Range: 0x491ce0..0x491d0d
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-      Lines: []
-    - ID: 2
+    - ID: 3
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x491ce0..0x491d9b]
+      OutOfLinePCRanges: [0x491d40..0x491dfb]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 19 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x491ce0..0x491d13
+            - Range: 0x491d40..0x491d73
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x491d13..0x491d9b
+            - Range: 0x491d73..0x491dfb
               Pieces: [{Size: 0, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-      Lines: []
-    - ID: 3
+    - ID: 4
       Name: main.stringArg
-      OutOfLinePCRanges: [0x491e20..0x491e91]
+      OutOfLinePCRanges: [0x491e80..0x491ef1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 17 GoStringHeaderType string
           Locations:
-            - Range: 0x491e20..0x491e3e
+            - Range: 0x491e80..0x491e9e
               Pieces:
                 - Size: 8
                   InReg: true
@@ -82,115 +91,128 @@ Subprograms:
                   Register: 3
           IsParameter: true
           IsReturn: false
-      Lines: []
+    - ID: 1
+      Name: main.inlined
+      OutOfLinePCRanges: [0x491f80..0x491fe2]
+      InlinePCRanges: [[0x491c66..0x491cb3]]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x491c66..0x491cb3
+              Pieces: []
+            - Range: 0x491f80..0x491f99
+              Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
 Types:
-    - __kind: GoMapType
+    - __kind: BaseType
       ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 39552
+      GoKind: 2
+    - __kind: GoMapType
+      ID: 2
       Name: map[string]int
       GoRuntimeType: 63488
       GoKind: 21
-      HeaderType: 3 GoSwissMapHeaderType map<string,int>
+      HeaderType: 4 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 2
+      ID: 3
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 3 GoSwissMapHeaderType map<string,int>
+      Pointee: 4 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 3
+      ID: 4
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 5 BaseType uintptr
+          Type: 6 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 6 PointerType **table<string,int>
+          Type: 7 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       TablePtrSliceType: 33 GoSliceDataType []*table<string,int>.array
       GroupType: 14 StructureType noalg.map.group[string]int
     - __kind: BaseType
-      ID: 4
+      ID: 5
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 39488
       GoKind: 11
     - __kind: BaseType
-      ID: 5
+      ID: 6
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 39680
       GoKind: 12
     - __kind: PointerType
-      ID: 6
+      ID: 7
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 7 PointerType *table<string,int>
+      Pointee: 8 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 7
+      ID: 8
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 8 StructureType table<string,int>
+      Pointee: 9 StructureType table<string,int>
     - __kind: StructureType
-      ID: 8
+      ID: 9
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: groups
           Offset: 16
           Type: 12 GoSwissMapGroupsType groupReference<string,int>
     - __kind: BaseType
-      ID: 9
+      ID: 10
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 39232
       GoKind: 9
     - __kind: BaseType
-      ID: 10
+      ID: 11
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 39104
       GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 39552
-      GoKind: 2
     - __kind: GoSwissMapGroupsType
       ID: 12
       Name: groupReference<string,int>
@@ -202,7 +224,7 @@ Types:
           Type: 13 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       GroupType: 14 StructureType noalg.map.group[string]int
       GroupSliceType: 34 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
@@ -219,7 +241,7 @@ Types:
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: slots
           Offset: 8
           Type: 15 ArrayType noalg.[8]struct { key string; elem int }
@@ -244,7 +266,7 @@ Types:
           Type: 17 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 11 BaseType int
+          Type: 1 BaseType int
     - __kind: GoStringHeaderType
       ID: 17
       Name: string
@@ -257,7 +279,7 @@ Types:
           Type: 36 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
       Data: 35 GoStringDataType string.str
     - __kind: PointerType
       ID: 18
@@ -265,7 +287,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 26976
       GoKind: 22
-      Pointee: 10 BaseType uint8
+      Pointee: 11 BaseType uint8
     - __kind: GoMapType
       ID: 19
       Name: map[string]main.bigStruct
@@ -285,28 +307,28 @@ Types:
       Fields:
         - Name: used
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 5 BaseType uintptr
+          Type: 6 BaseType uintptr
         - Name: dirPtr
           Offset: 16
           Type: 22 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       TablePtrSliceType: 37 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 27 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
@@ -327,19 +349,19 @@ Types:
       Fields:
         - Name: used
           Offset: 0
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: groups
           Offset: 16
           Type: 25 GoSwissMapGroupsType groupReference<string,main.bigStruct>
@@ -354,7 +376,7 @@ Types:
           Type: 26 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       GroupType: 27 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 38 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
@@ -371,7 +393,7 @@ Types:
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: slots
           Offset: 8
           Type: 28 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
@@ -413,25 +435,25 @@ Types:
       Fields:
         - Name: Field1
           Offset: 0
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: data
           Offset: 56
           Type: 32 ArrayType [128]uint8
@@ -443,12 +465,12 @@ Types:
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 10 BaseType uint8
+      Element: 11 BaseType uint8
     - __kind: GoSliceDataType
       ID: 33
       Name: '[]*table<string,int>.array'
       ByteSize: 2048
-      Element: 7 PointerType *table<string,int>
+      Element: 8 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 34
       Name: '[]noalg.map.group[string]int.array'
@@ -482,10 +504,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 1 GoMapType map[string]int
+            Type: 2 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: m}
+                  Variable: {subprogram: 2, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -500,7 +522,7 @@ Types:
             Type: 19 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: m}
+                  Variable: {subprogram: 3, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -515,7 +537,22 @@ Types:
             Type: 17 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 41
+    - __kind: EventRootType
+      ID: 42
+      Name: ProbeEvent
+      ByteSize: 9
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 42

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=amd64,toolchain=go1.24.3.yaml
@@ -7,7 +7,7 @@ Probes:
       Subprogram: {subprogram: 2}
       Events:
         - ID: 1
-          Type: 39 EventRootType ProbeEvent
+          Type: 39 EventRootType Probe[main.mapArg]
           InjectionPCs: ["0x491cea"]
           Condition: null
       Snapshot: false
@@ -18,7 +18,7 @@ Probes:
       Subprogram: {subprogram: 3}
       Events:
         - ID: 2
-          Type: 40 EventRootType ProbeEvent
+          Type: 40 EventRootType Probe[main.bigMapArg]
           InjectionPCs: ["0x491d53"]
           Condition: null
       Snapshot: false
@@ -29,7 +29,7 @@ Probes:
       Subprogram: {subprogram: 4}
       Events:
         - ID: 3
-          Type: 41 EventRootType ProbeEvent
+          Type: 41 EventRootType Probe[main.stringArg]
           InjectionPCs: ["0x491e8a"]
           Condition: null
       Snapshot: false
@@ -40,7 +40,7 @@ Probes:
       Subprogram: {subprogram: 1}
       Events:
         - ID: 4
-          Type: 42 EventRootType ProbeEvent
+          Type: 42 EventRootType Probe[main.inlined]
           InjectionPCs: ["0x491f8a", "0x491c66"]
           Condition: null
       Snapshot: false
@@ -497,7 +497,7 @@ Types:
       Element: 27 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
       ID: 39
-      Name: ProbeEvent
+      Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
       Expressions:
@@ -512,7 +512,7 @@ Types:
                   ByteSize: 0
     - __kind: EventRootType
       ID: 40
-      Name: ProbeEvent
+      Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
       Expressions:
@@ -527,7 +527,7 @@ Types:
                   ByteSize: 0
     - __kind: EventRootType
       ID: 41
-      Name: ProbeEvent
+      Name: Probe[main.stringArg]
       ByteSize: 17
       PresenseBitsetSize: 1
       Expressions:
@@ -542,7 +542,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 42
-      Name: ProbeEvent
+      Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
@@ -4,73 +4,82 @@ Probes:
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 1}
+      Subprogram: {subprogram: 2}
       Events:
         - ID: 1
           Type: 39 EventRootType ProbeEvent
-          InjectionPCs: [655084]
+          InjectionPCs: [655148]
           Condition: null
       Snapshot: false
     - ID: c
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 2}
+      Subprogram: {subprogram: 3}
       Events:
         - ID: 2
           Type: 40 EventRootType ProbeEvent
-          InjectionPCs: [655200]
+          InjectionPCs: [655264]
           Condition: null
       Snapshot: false
     - ID: d
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 3}
+      Subprogram: {subprogram: 4}
       Events:
         - ID: 3
           Type: 41 EventRootType ProbeEvent
-          InjectionPCs: [655516]
+          InjectionPCs: [655580]
+          Condition: null
+      Snapshot: false
+    - ID: e
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 1}
+      Events:
+        - ID: 4
+          Type: 42 EventRootType ProbeEvent
+          InjectionPCs: [655836, 655040]
           Condition: null
       Snapshot: false
 Subprograms:
-    - ID: 1
+    - ID: 2
       Name: main.mapArg
-      OutOfLinePCRanges: [0x9fee0..0x9ff50]
+      OutOfLinePCRanges: [0x9ff20..0x9ff90]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 1 GoMapType map[string]int
+          Type: 2 GoMapType map[string]int
           Locations:
-            - Range: 0x9fee0..0x9ff18
+            - Range: 0x9ff20..0x9ff58
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-      Lines: []
-    - ID: 2
+    - ID: 3
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x9ff50..0xa0010]
+      OutOfLinePCRanges: [0x9ff90..0xa0050]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 19 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x9ff50..0x9ff88
+            - Range: 0x9ff90..0x9ffc8
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x9ff88..0xa0010
+            - Range: 0x9ffc8..0xa0050
               Pieces: [{Size: 0, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
-      Lines: []
-    - ID: 3
+    - ID: 4
       Name: main.stringArg
-      OutOfLinePCRanges: [0xa0090..0xa0110]
+      OutOfLinePCRanges: [0xa00d0..0xa0150]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 17 GoStringHeaderType string
           Locations:
-            - Range: 0xa0090..0xa00b4
+            - Range: 0xa00d0..0xa00f4
               Pieces:
                 - Size: 8
                   InReg: true
@@ -82,115 +91,128 @@ Subprograms:
                   Register: 1
           IsParameter: true
           IsReturn: false
-      Lines: []
+    - ID: 1
+      Name: main.inlined
+      OutOfLinePCRanges: [0xa01d0..0xa0240]
+      InlinePCRanges: [[0x9fec0..0x9fefc]]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x9fec0..0x9fefc
+              Pieces: []
+            - Range: 0xa01d0..0xa01f0
+              Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
 Types:
-    - __kind: GoMapType
+    - __kind: BaseType
       ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 39520
+      GoKind: 2
+    - __kind: GoMapType
+      ID: 2
       Name: map[string]int
       GoRuntimeType: 63360
       GoKind: 21
-      HeaderType: 3 GoSwissMapHeaderType map<string,int>
+      HeaderType: 4 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 2
+      ID: 3
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 3 GoSwissMapHeaderType map<string,int>
+      Pointee: 4 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 3
+      ID: 4
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 5 BaseType uintptr
+          Type: 6 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 6 PointerType **table<string,int>
+          Type: 7 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       TablePtrSliceType: 33 GoSliceDataType []*table<string,int>.array
       GroupType: 14 StructureType noalg.map.group[string]int
     - __kind: BaseType
-      ID: 4
+      ID: 5
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 39456
       GoKind: 11
     - __kind: BaseType
-      ID: 5
+      ID: 6
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 39648
       GoKind: 12
     - __kind: PointerType
-      ID: 6
+      ID: 7
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 7 PointerType *table<string,int>
+      Pointee: 8 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 7
+      ID: 8
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 8 StructureType table<string,int>
+      Pointee: 9 StructureType table<string,int>
     - __kind: StructureType
-      ID: 8
+      ID: 9
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: groups
           Offset: 16
           Type: 12 GoSwissMapGroupsType groupReference<string,int>
     - __kind: BaseType
-      ID: 9
+      ID: 10
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 39200
       GoKind: 9
     - __kind: BaseType
-      ID: 10
+      ID: 11
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 39072
       GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 39520
-      GoKind: 2
     - __kind: GoSwissMapGroupsType
       ID: 12
       Name: groupReference<string,int>
@@ -202,7 +224,7 @@ Types:
           Type: 13 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       GroupType: 14 StructureType noalg.map.group[string]int
       GroupSliceType: 34 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
@@ -219,7 +241,7 @@ Types:
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: slots
           Offset: 8
           Type: 15 ArrayType noalg.[8]struct { key string; elem int }
@@ -244,7 +266,7 @@ Types:
           Type: 17 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 11 BaseType int
+          Type: 1 BaseType int
     - __kind: GoStringHeaderType
       ID: 17
       Name: string
@@ -257,7 +279,7 @@ Types:
           Type: 36 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
       Data: 35 GoStringDataType string.str
     - __kind: PointerType
       ID: 18
@@ -265,7 +287,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 10 BaseType uint8
+      Pointee: 11 BaseType uint8
     - __kind: GoMapType
       ID: 19
       Name: map[string]main.bigStruct
@@ -285,28 +307,28 @@ Types:
       Fields:
         - Name: used
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 5 BaseType uintptr
+          Type: 6 BaseType uintptr
         - Name: dirPtr
           Offset: 16
           Type: 22 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       TablePtrSliceType: 37 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 27 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
@@ -327,19 +349,19 @@ Types:
       Fields:
         - Name: used
           Offset: 0
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 9 BaseType uint16
+          Type: 10 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 10 BaseType uint8
+          Type: 11 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: groups
           Offset: 16
           Type: 25 GoSwissMapGroupsType groupReference<string,main.bigStruct>
@@ -354,7 +376,7 @@ Types:
           Type: 26 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
       GroupType: 27 StructureType noalg.map.group[string]main.bigStruct
       GroupSliceType: 38 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
@@ -371,7 +393,7 @@ Types:
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 4 BaseType uint64
+          Type: 5 BaseType uint64
         - Name: slots
           Offset: 8
           Type: 28 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
@@ -413,25 +435,25 @@ Types:
       Fields:
         - Name: Field1
           Offset: 0
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field2
           Offset: 8
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field3
           Offset: 16
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field4
           Offset: 24
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field5
           Offset: 32
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field6
           Offset: 40
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: Field7
           Offset: 48
-          Type: 11 BaseType int
+          Type: 1 BaseType int
         - Name: data
           Offset: 56
           Type: 32 ArrayType [128]uint8
@@ -443,12 +465,12 @@ Types:
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 10 BaseType uint8
+      Element: 11 BaseType uint8
     - __kind: GoSliceDataType
       ID: 33
       Name: '[]*table<string,int>.array'
       ByteSize: 2048
-      Element: 7 PointerType *table<string,int>
+      Element: 8 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 34
       Name: '[]noalg.map.group[string]int.array'
@@ -482,10 +504,10 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 1 GoMapType map[string]int
+            Type: 2 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 1, index: 0, name: m}
+                  Variable: {subprogram: 2, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -500,7 +522,7 @@ Types:
             Type: 19 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: m}
+                  Variable: {subprogram: 3, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -515,7 +537,22 @@ Types:
             Type: 17 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 41
+    - __kind: EventRootType
+      ID: 42
+      Name: ProbeEvent
+      ByteSize: 9
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 42

--- a/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple/arch=arm64,toolchain=go1.24.3.yaml
@@ -7,7 +7,7 @@ Probes:
       Subprogram: {subprogram: 2}
       Events:
         - ID: 1
-          Type: 39 EventRootType ProbeEvent
+          Type: 39 EventRootType Probe[main.mapArg]
           InjectionPCs: [655148]
           Condition: null
       Snapshot: false
@@ -18,7 +18,7 @@ Probes:
       Subprogram: {subprogram: 3}
       Events:
         - ID: 2
-          Type: 40 EventRootType ProbeEvent
+          Type: 40 EventRootType Probe[main.bigMapArg]
           InjectionPCs: [655264]
           Condition: null
       Snapshot: false
@@ -29,7 +29,7 @@ Probes:
       Subprogram: {subprogram: 4}
       Events:
         - ID: 3
-          Type: 41 EventRootType ProbeEvent
+          Type: 41 EventRootType Probe[main.stringArg]
           InjectionPCs: [655580]
           Condition: null
       Snapshot: false
@@ -40,7 +40,7 @@ Probes:
       Subprogram: {subprogram: 1}
       Events:
         - ID: 4
-          Type: 42 EventRootType ProbeEvent
+          Type: 42 EventRootType Probe[main.inlined]
           InjectionPCs: [655836, 655040]
           Condition: null
       Snapshot: false
@@ -497,7 +497,7 @@ Types:
       Element: 27 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
       ID: 39
-      Name: ProbeEvent
+      Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
       Expressions:
@@ -512,7 +512,7 @@ Types:
                   ByteSize: 0
     - __kind: EventRootType
       ID: 40
-      Name: ProbeEvent
+      Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
       Expressions:
@@ -527,7 +527,7 @@ Types:
                   ByteSize: 0
     - __kind: EventRootType
       ID: 41
-      Name: ProbeEvent
+      Name: Probe[main.stringArg]
       ByteSize: 17
       PresenseBitsetSize: 1
       Expressions:
@@ -542,7 +542,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 42
-      Name: ProbeEvent
+      Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/testprogs/progs/events_simple/main.go
+++ b/pkg/dyninst/testprogs/progs/events_simple/main.go
@@ -23,6 +23,9 @@ func main() {
 	c := 3
 	sliceArg([]*int{&a, &b, &c})
 	arrayArg([3]*int{&a, &b, &c})
+	inlined(1)
+	// Passing inlined function via pointer forces it to have additional out-of-line instantiation.
+	outer(inlined)
 }
 
 //go:noinline
@@ -43,4 +46,13 @@ func sliceArg(s []*int) {
 //go:noinline
 func arrayArg(a [3]*int) {
 	fmt.Println(a)
+}
+
+func inlined(i int) {
+	fmt.Println(i)
+}
+
+//go:noinline
+func outer(f func(int)) {
+	f(2)
 }

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -15,6 +15,9 @@ func main() {
 	stringSliceArg([]string{"c"})
 	intSliceArg([]int{1})
 	stringArg("d")
+	inlined(1)
+	// Passing inlined function as an argument forces out-of-line instantation.
+	funcArg(inlined)
 }
 
 //go:noinline
@@ -56,4 +59,13 @@ func stringArg(s string) {
 //go:noinline
 func intSliceArg(s []int) {
 	fmt.Println(s)
+}
+
+func inlined(x int) {
+	fmt.Println(x)
+}
+
+//go:noinline
+func funcArg(f func(int)) {
+	f(2)
 }


### PR DESCRIPTION
### What does this PR do?

Handle inlined functions when parsing DWARF.

Inlined functions are split between 3 types of DWARF entries:
 - subprogram, with inlined tag - abstract definition with its name, and names of params/variables
 - inlined_subroutine - instance of function, referencing the abstract definition including pc and location information
 - subprogram, out-of-line instance - present whenever function is inlined, but not everywhere, one more instance of function, referencing the abstract definition including pc and location information

We combine all the information to produce ir.Subprograms and ir.Probes.

### Motivation

https://datadoghq.atlassian.net/browse/DEBUG-3998
