### PR TITLE
[CXP-2285] Remove flake marker from language detection e2e test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -876,8 +876,13 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
-        # TODO: Add paths that should trigger tests for language detection
         - test/new-e2e/tests/language-detection/**/*
+        - cmd/process-agent/**/*
+        - comp/process/**/*
+        - pkg/process/**/*
+        - comp/core/workloadmeta/collectors/internal/process/**/*
+        - comp/core/workloadmeta/collectors/internal/processlanguage/**/*
+        - comp/core/workloadmeta/collectors/internal/remote/processcollector/**/*
       compare_to: $COMPARE_TO_BRANCH
 
 .on_npm_or_e2e_changes:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -876,13 +876,8 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
+        # TODO: Add paths that should trigger tests for language detection
         - test/new-e2e/tests/language-detection/**/*
-        - cmd/process-agent/**/*
-        - comp/process/**/*
-        - pkg/process/**/*
-        - comp/core/workloadmeta/collectors/internal/process/**/*
-        - comp/core/workloadmeta/collectors/internal/processlanguage/**/*
-        - comp/core/workloadmeta/collectors/internal/remote/processcollector/**/*
       compare_to: $COMPARE_TO_BRANCH
 
 .on_npm_or_e2e_changes:

--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -42,8 +41,6 @@ type languageDetectionSuite struct {
 }
 
 func TestLanguageDetectionSuite(t *testing.T) {
-	flake.Mark(t)
-
 	agentParams := []func(*agentparams.Params) error{
 		agentparams.WithAgentConfig(processConfigStr),
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
After investigating it appears that flakiness was introduced by https://github.com/DataDog/datadog-agent/pull/37288 and fixed by https://github.com/DataDog/datadog-agent/pull/37699.

The reason being due to the conflict in collector ID between the remote collector and process collector mentioned in https://github.com/DataDog/datadog-agent/pull/37699. The ID is used to store [which collectors are candidates for starting](https://github.com/DataDog/datadog-agent/blob/219029a8d1f5088a3ee79c883e64fd1c319cf4e1/comp/core/workloadmeta/impl/workloadmeta.go#L74) from a [list generated using FX value groups](https://github.com/DataDog/datadog-agent/blob/219029a8d1f5088a3ee79c883e64fd1c319cf4e1/comp/core/workloadmeta/impl/workloadmeta.go#L57). FX feeds values into a group in random order (FX [docs](https://uber-go.github.io/fx/value-groups/index.html)), so there was a race condition for which process collector would become a "candidate". This causes the test to fail if the new collector was used since its explicitly disabled for now and thus there are no process entities collected.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Test has not failed since the PR with the fix was merged when it was very consistent beforehand ([CI Test Runs](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Flanguage-detection%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZdCBFtSZhKSPQAAABhBWmRDQkZ0U0FBQmNESm1Nak0yWTBuVU4AAAAkMDE5NzQyMDUtYjVmZS00ZTkwLTlkN2ItMjg4MGI0YWNhMTg4AAT0jQ&fromUser=true&index=citest&testId=AwAAAZdCBFtSZhKSPQAAABhBWmRDQkZ0U0FBQmNESm1Nak0yWTBuVU4AAAAkMDE5NzQyMDUtYjVmZS00ZTkwLTlkN2ItMjg4MGI0YWNhMTg4AAT0jQ&trace=AwAAAZdCBFtSZhKSPQAAABhBWmRDQkZ0U0FBQmNESm1Nak0yWTBuVU4AAAAkMDE5NzQyMDUtYjVmZS00ZTkwLTlkN2ItMjg4MGI0YWNhMTg4AAT0jQ&start=1749153460628&end=1749239860628&paused=false)).


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->