### PR TITLE
[TEST] Replace k8s.io/apiserver with patched version to enable dce in cluster-agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1032,7 +1032,7 @@ replace (
 	k8s.io/api => k8s.io/api v0.31.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.31.2
-	k8s.io/apiserver => k8s.io/apiserver v0.31.2
+	k8s.io/apiserver => github.com/pgimalac/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20250607232651-96c2ef031062
 	k8s.io/client-go => k8s.io/client-go v0.31.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1574,6 +1574,8 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pgimalac/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20250607232651-96c2ef031062 h1:mydZK1AZ45++7ijYUIb5g2fnw5+R8xioMyIhfOWvJCk=
+github.com/pgimalac/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20250607232651-96c2ef031062/go.mod h1:mJ5S6E5i9O+hBQXJ8T8dEZn36vN6k29PpaFUsrpgKwg=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
@@ -2880,8 +2882,6 @@ k8s.io/apiextensions-apiserver v0.31.2 h1:W8EwUb8+WXBLu56ser5IudT2cOho0gAKeTOnyw
 k8s.io/apiextensions-apiserver v0.31.2/go.mod h1:i+Geh+nGCJEGiCGR3MlBDkS7koHIIKWVfWeRFiOsUcM=
 k8s.io/apimachinery v0.31.2 h1:i4vUt2hPK56W6mlT7Ry+AO8eEsyxMD1U44NR22CLTYw=
 k8s.io/apimachinery v0.31.2/go.mod h1:rsPdaZJfTfLsNJSQzNHQvYoTmxhoOEofxtOsF3rtsMo=
-k8s.io/apiserver v0.31.2 h1:VUzOEUGRCDi6kX1OyQ801m4A7AUPglpsmGvdsekmcI4=
-k8s.io/apiserver v0.31.2/go.mod h1:o3nKZR7lPlJqkU5I3Ove+Zx3JuoFjQobGX1Gctw6XuE=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.2.2 h1:d6nrlgROIvGJrBZnmyTibA2CvXIylet/vBE1EicilRo=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.2.2/go.mod h1:9ywHbt0kTrLyeNGgTNm7WEns34PmBMEr+9bDKTxW6wQ=
 k8s.io/cli-runtime v0.31.2 h1:7FQt4C4Xnqx8V1GJqymInK0FFsoC+fAZtbLqgXYVOLQ=

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -32,7 +32,7 @@ end
 if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true" && ENV.has_key?("BUCKET_BRANCH") && ENV['BUCKET_BRANCH'] != "nightly"
   COMPRESSION_LEVEL = 9
 else
-  COMPRESSION_LEVEL = 5
+  COMPRESSION_LEVEL = 9
 end
 
 BUILD_OCIRU = Omnibus::Config.host_distribution == "ociru"

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -22,7 +22,7 @@ end
 if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true" && ENV.has_key?("BUCKET_BRANCH") && ENV['BUCKET_BRANCH'] != "nightly"
   COMPRESSION_LEVEL = 9
 else
-  COMPRESSION_LEVEL = 5
+  COMPRESSION_LEVEL = 9
 end
 
 if ohai['platform'] == "windows"

--- a/omnibus/config/projects/installer.rb
+++ b/omnibus/config/projects/installer.rb
@@ -32,7 +32,7 @@ end
 if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true" && ENV.has_key?("BUCKET_BRANCH") && ENV['BUCKET_BRANCH'] != "nightly"
   COMPRESSION_LEVEL = 9
 else
-  COMPRESSION_LEVEL = 5
+  COMPRESSION_LEVEL = 9
 end
 
 if windows_target?

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -88,7 +88,7 @@ if ENV.has_key?('FORCED_PACKAGE_COMPRESSION_LEVEL')
 elsif ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true" && ENV.has_key?("BUCKET_BRANCH") && ENV['BUCKET_BRANCH'] != "nightly"
   COMPRESSION_LEVEL = 9
 else
-  COMPRESSION_LEVEL = 5
+  COMPRESSION_LEVEL = 9
 end
 
 # build_version is computed by an invoke command/function.

--- a/omnibus/config/projects/otel-agent.rb
+++ b/omnibus/config/projects/otel-agent.rb
@@ -27,7 +27,7 @@ end
 if ENV.has_key?("DEPLOY_AGENT") && ENV["DEPLOY_AGENT"] == "true" && ENV.has_key?("BUCKET_BRANCH") && ENV['BUCKET_BRANCH'] != "nightly"
   COMPRESSION_LEVEL = 9
 else
-  COMPRESSION_LEVEL = 5
+  COMPRESSION_LEVEL = 9
 end
 
 if ENV.has_key?("OMNIBUS_GIT_CACHE_DIR")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
This is not meant to be merged, just to get stable numbers on the impact of the change.

### What does this PR do?
Pin k8s.io/apiserver to a version which enables dead code elimination in the cluster-agent.
See https://github.com/kubernetes/kubernetes/pull/132177/s for details.

### Motivation
Reduce binary size of the cluster-agent.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
From https://github.com/DataDog/datadog-agent/pull/37745#issuecomment-2953902634, the cluster-agent docker image is reduced by ~40MiB.