### PR TITLE
[AGENTRUN-452] remove ShouldApply from scrubber as it is not used

### DIFF
--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -85,10 +85,6 @@ var blankRegex = regexp.MustCompile(`^\s*$`)
 type Scrubber struct {
 	singleLineReplacers []Replacer
 	multiLineReplacers  []Replacer
-
-	// shouldApply is a function that can be used to conditionally apply a replacer.
-	// If the function returns false, the replacer will not be applied.
-	shouldApply func(repl Replacer) bool
 }
 
 // New creates a new scrubber with no replacers installed.
@@ -114,11 +110,6 @@ func (c *Scrubber) AddReplacer(kind ReplacerKind, replacer Replacer) {
 	case MultiLine:
 		c.multiLineReplacers = append(c.multiLineReplacers, replacer)
 	}
-}
-
-// SetShouldApply sets a condition function to the scrubber. If the function returns false, the replacer will not be applied.
-func (c *Scrubber) SetShouldApply(shouldApply func(repl Replacer) bool) {
-	c.shouldApply = shouldApply
 }
 
 // ScrubFile scrubs credentials from file given by pathname
@@ -197,10 +188,6 @@ func (c *Scrubber) scrub(data []byte, replacers []Replacer) []byte {
 	for _, repl := range replacers {
 		if repl.Regex == nil {
 			// ignoring YAML only replacers
-			continue
-		}
-
-		if c.shouldApply != nil && !c.shouldApply(repl) {
 			continue
 		}
 

--- a/pkg/util/scrubber/yaml_scrubber.go
+++ b/pkg/util/scrubber/yaml_scrubber.go
@@ -87,10 +87,6 @@ func (c *Scrubber) ScrubDataObj(data *interface{}) {
 				continue
 			}
 
-			if c.shouldApply != nil && !c.shouldApply(replacer) {
-				continue
-			}
-
 			if replacer.YAMLKeyRegex.Match([]byte(key)) {
 				if replacer.ProcessValue != nil {
 					return true, replacer.ProcessValue(value)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove `SetShouldApply` and `shouldApply` from the scrubber, as it is not used in the codebase. 

### Motivation

Remove unused conditional logic from the scrubber, reducing the complexity of scrubber.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->