### PR TITLE
Update to an available version of maven for windows fips Docker builds

### DIFF
--- a/Dockerfiles/agent/install-fips.ps1
+++ b/Dockerfiles/agent/install-fips.ps1
@@ -11,18 +11,18 @@ if ("$env:WITH_FIPS" -ne "true") {
     exit 0
 }
 
-$maven_sha512 = '8BEAC8D11EF208F1E2A8DF0682B9448A9A363D2AD13CA74AF43705549E72E74C9378823BF689287801CBBFC2F6EA9596201D19CCACFDFB682EE8A2FF4C4418BA'
+$maven_sha512 = '2e24dbea0407489d45b4d8214afff96fb57b54a5ef2bb6878f65fbce9b4141685b878ec5c53e9d07d4b1bf166bb5c4f80d540a13013b133a250ec9d85effa37c'
 
 if ("$env:WITH_JMX" -ne "false") {
     cd \fips-build
-    Invoke-WebRequest -Outfile maven.zip https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip
+    Invoke-WebRequest -Outfile maven.zip https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip
     if ((Get-FileHash -Algorithm SHA512 maven.zip).Hash -eq $maven_sha512) {
         Write-Host "Maven checksum match"
     } else {
         Write-Error "Checksum mismatch"
     }
     Expand-Archive -Force -Path maven.zip -DestinationPath .
-    .\apache-maven-3.9.9\bin\mvn -D maven.repo.local=maven-repo dependency:copy-dependencies
+    .\apache-maven-3.9.10\bin\mvn -D maven.repo.local=maven-repo dependency:copy-dependencies
     New-Item -Force -ItemType directory -Path 'C:/Program Files/Datadog/BouncyCastle FIPS/'
     Move-Item -Force -Path @("target/dependency/*.jar", "java.security", "bc-fips.policy") 'C:/Program Files/Datadog/BouncyCastle FIPS/'
     \java\bin\java --module-path 'C:\Program Files\Datadog\BouncyCastle FIPS' org.bouncycastle.util.DumpInfo


### PR DESCRIPTION
### What does this PR do?

Updates maven to 3.9.10 on the script that installs bouncycastle FIPS for Windows Docker images.

### Motivation

Fix permanent failures on docker_build_fips_agent7_windows2022_core_jmx (such as https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/973648272)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->