### PR TITLE
Allow RDS autodiscovery to discover all instances by specifying an empty tag list

### DIFF
--- a/pkg/databasemonitoring/aws/aurora.go
+++ b/pkg/databasemonitoring/aws/aurora.go
@@ -84,9 +84,6 @@ func (c *Client) GetAuroraClusterEndpoints(ctx context.Context, dbClusterIdentif
 // of database instances is to first query for the cluster ids. This also means the customer
 // will only have to set a single tag on their cluster.
 func (c *Client) GetAuroraClustersFromTags(ctx context.Context, tags []string) ([]string, error) {
-	if len(tags) == 0 {
-		return nil, fmt.Errorf("at least one tag filter is required")
-	}
 	clusterIdentifiers := make([]string, 0)
 	var marker *string
 	var err error

--- a/pkg/databasemonitoring/aws/rds.go
+++ b/pkg/databasemonitoring/aws/rds.go
@@ -24,9 +24,6 @@ const (
 
 // GetRdsInstancesFromTags queries an AWS account for RDS instances with the specified tags
 func (c *Client) GetRdsInstancesFromTags(ctx context.Context, tags []string, dbmTag string) ([]Instance, error) {
-	if len(tags) == 0 {
-		return nil, fmt.Errorf("at least one tag filter is required")
-	}
 	instances := make([]Instance, 0)
 	var marker *string
 	var err error

--- a/releasenotes/notes/allow-rds-autodiscovery-with-empty-tags-c0c4061f4c12eadd.yaml
+++ b/releasenotes/notes/allow-rds-autodiscovery-with-empty-tags-c0c4061f4c12eadd.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allows RDS autodicovery to work with an empty tag list. If an
+    empty tag list is provided, the autodiscovery will not filter
+    instances based on tags, allowing all RDS instances to be
+    discovered.


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Allows RDS Autodisovery to discover all instances if the user specifies an empty array for the AD tag list.

### Motivation
Users may want to monitor all RDS instances without having to apply tags to trigger Autodiscovery. This can be useful for existing fleets where adding tags is a point of frustration, or for small fleets that can be easily monitored by a single agent.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->