### PR TITLE
CODEOWNERS: forward some path from agent-delivery to agent-build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
 /.github/workflows/update_dependencies.yml           @DataDog/agent-runtimes
-/.github/workflows/buildimages-update.yml            @DataDog/agent-delivery @DataDog/agent-runtimes
+/.github/workflows/buildimages-update.yml            @DataDog/agent-build @DataDog/agent-runtimes
 /.github/workflows/collector-generate-and-update.yml @DataDog/opentelemetry-agent
 
 /.run                                                @DataDog/agent-devx
@@ -92,7 +92,7 @@
 
 /.gitlab/binary_build/cws_instrumentation.yml        @DataDog/agent-devx @DataDog/agent-security
 /.gitlab/binary_build/include.yml                    @DataDog/agent-devx
-/.gitlab/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-delivery
+/.gitlab/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-delivery @DatadDog/agent-build
 /.gitlab/functional_test/include.yml                 @DataDog/agent-devx
 /.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-delivery
 /.gitlab/install_script_testing/install_script_testing.yml          @DataDog/agent-delivery @DataDog/container-ecosystems
@@ -174,10 +174,10 @@
 /.gitlab/source_test/windows.yml                     @DataDog/agent-devx @DataDog/windows-agent
 /.gitlab/source_test/go_generate_check.yml           @DataDog/agent-security
 
-/.gitlab/package_build/                              @DataDog/agent-delivery
-/.gitlab/package_build/windows.yml                   @DataDog/agent-delivery @DataDog/windows-agent
-/.gitlab/package_build/installer.yml                 @DataDog/agent-delivery @DataDog/fleet
-/.gitlab/packaging/                                  @DataDog/agent-delivery
+/.gitlab/package_build/                              @DataDog/agent-build
+/.gitlab/package_build/windows.yml                   @DataDog/agent-build @DataDog/windows-agent
+/.gitlab/package_build/installer.yml                 @DataDog/agent-build @DataDog/fleet
+/.gitlab/packaging/                                  @DataDog/agent-build
 
 /.gitlab/benchmarks/benchmarks.yml                   @DataDog/agent-apm
 
@@ -277,19 +277,19 @@
 
 /Makefile.trace                         @DataDog/agent-apm
 
-/omnibus/                               @DataDog/agent-delivery
-/omnibus/package-scripts/agent-rpm/     @DataDog/agent-delivery @DataDog/fleet
-/omnibus/package-scripts/agent-deb/     @DataDog/agent-delivery @DataDog/fleet
-/omnibus/package-scripts/installer-deb/ @DataDog/agent-delivery @DataDog/fleet
-/omnibus/package-scripts/installer-rpm/ @DataDog/agent-delivery @DataDog/fleet
+/omnibus/                               @DataDog/agent-build
+/omnibus/package-scripts/agent-rpm/     @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/agent-deb/     @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/installer-deb/ @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/installer-rpm/ @DataDog/agent-build @DataDog/fleet
 /omnibus/python-scripts/                @DataDog/agent-integrations @DataDog/windows-agent
 /omnibus/config/patches/openscap/                         @DataDog/agent-cspm
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
-/omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-delivery
+/omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-build
 /omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
 /omnibus/config/software/sds.rb                           @DataDog/agent-log-pipelines
 /omnibus/config/software/snmp-traps.rb                    @DataDog/ndm-core
-/omnibus/config/templates/init-scripts-agent/             @DataDog/agent-delivery @DataDog/fleet
+/omnibus/config/templates/init-scripts-agent/             @DataDog/agent-build @DataDog/fleet
 /omnibus/resources/*/msi/                                 @DataDog/windows-agent
 
 # The following is managed by `dda inv lint-components` -- DO NOT EDIT
@@ -639,8 +639,8 @@
 /tasks/kernel_matrix_testing/           @DataDog/ebpf-platform
 /tasks/ebpf_verifier/                   @DataDog/ebpf-platform
 /tasks/trace_agent.py                   @DataDog/agent-apm
-/tasks/quality_gates.py                 @DataDog/agent-delivery
-/tasks/static_quality_gates/            @DataDog/agent-delivery
+/tasks/quality_gates.py                 @DataDog/agent-build
+/tasks/static_quality_gates/            @DataDog/agent-build
 /tasks/rtloader.py                      @DataDog/agent-runtimes
 /tasks/security_agent.py                @DataDog/agent-security
 /tasks/sbomgen.py                       @DataDog/agent-security
@@ -653,13 +653,13 @@
 /tasks/components.py                    @DataDog/agent-runtimes
 /tasks/components_templates             @DataDog/agent-runtimes
 /tasks/libs/ciproviders/                @DataDog/agent-devx
-/tasks/libs/common/omnibus.py           @DataDog/agent-delivery
-/tasks/omnibus.py                       @DataDog/agent-delivery
+/tasks/libs/common/omnibus.py           @DataDog/agent-build
+/tasks/omnibus.py                       @DataDog/agent-build
 /tasks/release.py                       @DataDog/agent-delivery
 /tasks/release_metrics/                 @DataDog/agent-delivery
 /tasks/libs/releasing/                  @DataDog/agent-delivery
 /tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
-/tasks/unit_tests/omnibus_tests.py      @DataDog/agent-delivery
+/tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
 /tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes
 /tasks/installer.py                     @DataDog/fleet
 /test/                                  @DataDog/agent-devx
@@ -680,7 +680,7 @@
 /test/new-e2e/test-infra-definition           @DataDog/agent-devx
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
-/test/new-e2e/tests/agent-platform            @DataDog/container-ecosystems @DataDog/agent-delivery @DataDog/agent-devx
+/test/new-e2e/tests/agent-platform            @DataDog/container-ecosystems @DataDog/agent-build @DataDog/agent-devx
 /test/new-e2e/tests/agent-runtimes            @DataDog/agent-runtimes
 /test/new-e2e/tests/agent-configuration       @DataDog/agent-configuration
 /test/new-e2e/tests/agent-metric-pipelines    @DataDog/agent-metric-pipelines
@@ -712,7 +712,7 @@
 /test/new-e2e/tests/installer/script          @DataDog/fleet @DataDog/data-jobs-monitoring
 /test/new-e2e/tests/gpu                       @Datadog/ebpf-platform
 /test/otel/                                   @DataDog/opentelemetry-agent
-/test/static/                                 @DataDog/agent-delivery
+/test/static/                                 @DataDog/agent-build
 /test/system/                                 @DataDog/agent-runtimes
 /test/system/dogstatsd/                       @DataDog/agent-metric-pipelines
 /test/benchmarks/apm_scripts/                 @DataDog/agent-apm


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Agent-Delivery split and the Agent-Build team was created, this PR forwards build related ownership to that new team.

### Motivation

Stop pinging Agent-Delivery for changes they shouldn't have to review anymore

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->