### PR TITLE
Update Agent RC fips mutable tags to 7-rc-fips

### DIFF
--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -72,7 +72,7 @@ deploy_mutable_image_tags-a7-full-rc:
       - SUFFIX: ["-full"]
 
 deploy_mutable_image_tags-a7-fips-rc:
-  extends: .deploy_mutable_image_tags_base
+  extends: .deploy_mutable_image_tags_7-rc
   rules:
     !reference [.on_rc]
   needs:
@@ -80,10 +80,9 @@ deploy_mutable_image_tags-a7-fips-rc:
       artifacts: false
   parallel:
     matrix:
-      - SUFFIX: ["-fips"]
-        IMG_NEW_TAGS: ["7-fips-rc"]
-      - SUFFIX: ["-fips-jmx"]
-        IMG_NEW_TAGS: ["7-fips-rc-jmx"]
+      - SUFFIX:
+          - "-fips"
+          - "-fips-jmx"
 
 # Jobs [.on_internal_rc]
 
@@ -99,7 +98,7 @@ deploy_mutable_image_tags-a7_internal-rc:
       - SUFFIX: [""]
 
 deploy_mutable_image_tags-a7-fips_internal-rc:
-  extends: .deploy_mutable_image_tags_base
+  extends: .deploy_mutable_image_tags_7-rc
   rules:
     !reference [.on_internal_rc]
   needs:
@@ -107,10 +106,9 @@ deploy_mutable_image_tags-a7-fips_internal-rc:
       artifacts: false
   parallel:
     matrix:
-      - SUFFIX: ["-fips"]
-        IMG_NEW_TAGS: ["7-fips-rc"]
-      - SUFFIX: ["-fips-jmx"]
-        IMG_NEW_TAGS: ["7-fips-rc-jmx"]
+      - SUFFIX:
+          - "-fips"
+          - "-fips-jmx"
 
 # Jobs [.on_internal_final]
 


### PR DESCRIPTION
### What does this PR do?

We currently produce mutable image tags for Agent RC in fips flavor in the form `7-fips-rc` and `7-fips-rc-jmx` which is inconsistent with the rest of the images.

This PR changes the target tags to `7-rc-fips` and `7-rc-fips-jmx`

### Motivation

Unify the Agent images tagging.

### Describe how you validated your changes
Change tested in the gitlab pipeline editor/validator. It requires the actual RC build to be 100% sure.

Instruction:
1. Run (or let Release Coordinator) the Agent RC build (7.68.0 would be the first affected),
2. Check if the `deploy_mutable_image_tags-a7-fips-rc` and `deploy_mutable_image_tags-a7-fips_internal-rc` jobs passed and produced correct tags.
Example:
If it was `7.68.0-rc.1` build, then we should see `7-rc-fips` tag pointing to the same image that is under `7.68.0-rc.1-fips` and `7-rc-fips-jmx` to `7.68.0-rc.1-fips-jmx`. The easiest place to check would be on the [dockerhub](https://hub.docker.com/r/datadog/agent)

### Additional notes
https://github.com/DataDog/image-vuln-scans/pull/1986 has to be merged around the time we produce new image tag, so there is no mismatch on the scanner side.