### PR TITLE
[OTEL-2616] Rollout scope attributes support for logs

### DIFF
--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -272,7 +272,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 // indirect
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect

--- a/comp/otelcol/ddflareextension/impl/go.sum
+++ b/comp/otelcol/ddflareextension/impl/go.sum
@@ -55,8 +55,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1 h1:g
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 h1:zL/FjmtHS3RXyX7FgYDT4tv98dy8OCt6Y9ThGFE9jIU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1/go.mod h1:rUKbulnS6cXZ7G73gjho3U4Evg8Q+4me9lGGoedjg5o=
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 h1:Sq9AXXAtGws0evohhlMOt5OiW0Nwl48h8ajzNnLXB3k=

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.27.1 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 // indirect
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
@@ -20,8 +20,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1 h1:g
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 h1:zL/FjmtHS3RXyX7FgYDT4tv98dy8OCt6Y9ThGFE9jIU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1/go.mod h1:rUKbulnS6cXZ7G73gjho3U4Evg8Q+4me9lGGoedjg5o=
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 h1:Sq9AXXAtGws0evohhlMOt5OiW0Nwl48h8ajzNnLXB3k=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.27.1 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 // indirect
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -20,8 +20,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1 h1:g
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 h1:zL/FjmtHS3RXyX7FgYDT4tv98dy8OCt6Y9ThGFE9jIU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1/go.mod h1:rUKbulnS6cXZ7G73gjho3U4Evg8Q+4me9lGGoedjg5o=
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 h1:Sq9AXXAtGws0evohhlMOt5OiW0Nwl48h8ajzNnLXB3k=

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.64.0
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1
 	github.com/stormcat24/protodep v0.1.8
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.33.0

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
@@ -6,8 +6,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.27.1 h1:t49BB0r
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.27.1/go.mod h1:sUPb/41IOTiKuFFoiqPZ1OozfbKQpg1YjRPpYzgammo=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
 github.com/DataDog/viper v1.14.0 h1:dIjTe/uJiah+QFqFZ+MXeqgmUvWhg37l37ZxFWxr3is=

--- a/go.mod
+++ b/go.mod
@@ -754,7 +754,7 @@ require (
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20241206090539-a14610dc22b6 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.27.1 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 // indirect
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 // indirect
 	github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1 h1:g
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 h1:zL/FjmtHS3RXyX7FgYDT4tv98dy8OCt6Y9ThGFE9jIU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1/go.mod h1:rUKbulnS6cXZ7G73gjho3U4Evg8Q+4me9lGGoedjg5o=
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 h1:Sq9AXXAtGws0evohhlMOt5OiW0Nwl48h8ajzNnLXB3k=

--- a/releasenotes/notes/apm-otlp-log-scope-attributes-df1d6f8de092dfe1.yaml
+++ b/releasenotes/notes/apm-otlp-log-scope-attributes-df1d6f8de092dfe1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OpenTelemetry instrumentation scope attributes are now converted into log
+    attributes.

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 // indirect
+	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect

--- a/test/otel/go.sum
+++ b/test/otel/go.sum
@@ -18,8 +18,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1 h1:g
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.27.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1 h1:Rz3kgCsNQByRlFUudqazREpOfbF33Nes+tVSvSyxEkU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.1/go.mod h1:OeDRqimnMeZjSMcaARrvcFoybgCkoiqF+Y3b8jpYP2w=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0 h1:2WxaBDx851fsThL7o+nbszfyxdhw6Y5H09sxmw6sxiw=
-github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0/go.mod h1:WOTqeY3ccHlN+5rGjvW0woZ0p7j+I/vgWVnfQKCfiAs=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1 h1:3sVVpzK28cEZJHOQKxyRBOmohEMb3OFlKJDjJTGadd4=
+github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.27.1/go.mod h1:PNONPZL7c7pgD5DlKAi6MANs89vRArjymB7biPXau6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1 h1:zL/FjmtHS3RXyX7FgYDT4tv98dy8OCt6Y9ThGFE9jIU=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.1/go.mod h1:rUKbulnS6cXZ7G73gjho3U4Evg8Q+4me9lGGoedjg5o=
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.27.1 h1:Sq9AXXAtGws0evohhlMOt5OiW0Nwl48h8ajzNnLXB3k=


### PR DESCRIPTION
### What does this PR do?

This PR upgrades the `opentelemetry-mapping-go/pkg/otlp/logs` package from v0.26.0 to v0.27.1 in the logsagentexporter (and dependents), matching the version of `opentelemetry-mapping-go/pkg/otlp/metrics`. I could have upgraded to v0.28.0, but that would have required a lot more changes.

### Motivation

This upgrade includes [this PR](https://github.com/DataDog/opentelemetry-mapping-go/pull/598), which converts OTel instrumentation scope attributes into regular log attributes, whereas they were previously ignored. I added a release note about the change, which is already in effect in the latest version of the OSS Datadog exporter.

### Describe how you validated your changes

This change is covered by unit tests in the mapping-go repository.

### Possible Drawbacks / Trade-offs

The additional attributes could come as a surprise to customers, or potentially collide with existing attributes, but given how rarely instrumentation scope attributes are used, I expect little to no impact.
