### PR TITLE
(fleet) Update E2E tests not to fail .NET SSI install when IIS is not installed

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_no_iis_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_no_iis_test.go
@@ -34,29 +34,24 @@ func (s *testDotnetLibraryInstallSuiteWithoutIIS) TestInstallDotnetLibraryPackag
 
 	// TODO: remove override once image is published in prod
 	_, err := s.Installer().InstallPackage("datadog-apm-library-dotnet",
-		installer.WithVersion("3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"),
+		installer.WithVersion("3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1"),
 		installer.WithRegistry("install.datad0g.com.internal.dda-testing.com"),
 	)
-	s.Require().Error(err, "Installing the dotnet library package without IIS should fail")
-	// TODO today the package does not get deleted but I think it should
-	// s.Require().Host(s.Env().RemoteHost).
-	// 	NoDirExists(consts.GetStableDirFor("datadog-apm-library-dotnet"),
-	// 		"the package directory should not exist")
+	s.Require().NoError(err, "Installing the dotnet library package without IIS should not fail")
 }
 
 func (s *testDotnetLibraryInstallSuiteWithoutIIS) TestMSIInstallDotnetLibraryFailsWithoutIIS() {
-	version := "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
-	s.Require().Error(s.Installer().Install(
+	version := "3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1"
+	s.Require().NoError(s.Installer().Install(
 		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=iis"),
 		// TODO: remove override once image is published in prod
-		// TODO: support DD_INSTALLER_REGISTRY_URL
-		installerwindows.WithMSIArg("SITE=datad0g.com"),
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com.internal.dda-testing.com"),
 		installerwindows.WithMSIArg(fmt.Sprintf("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:%s", version)),
 		installerwindows.WithMSILogFile("install-rollback.log"),
 	))
 	defer s.Installer().Purge()
 
 	s.Require().Host(s.Env().RemoteHost).
-		NoDirExists(consts.GetStableDirFor("datadog-apm-library-dotnet"),
-			"the package directory should not exist")
+		DirExists(consts.GetStableDirFor("datadog-apm-library-dotnet"),
+			"the package directory should exist")
 }

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
@@ -66,8 +66,8 @@ func (s *testDotnetLibraryInstallSuite) TestReinstall() {
 
 func (s *testDotnetLibraryInstallSuite) TestUpdate() {
 	const (
-		initialVersion = "3.13.0-pipeline.58926677.beta.sha-af5a1fab-1"
-		upgradeVersion = "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
+		initialVersion = "3.19.0-pipeline.67299728.beta.sha-c05ddfb1-1"
+		upgradeVersion = "3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1"
 	)
 	flake.Mark(s.T())
 
@@ -134,8 +134,8 @@ func (s *testDotnetLibraryInstallSuite) TestRemovePackageFailsIfInUse() {
 func (s *testDotnetLibraryInstallSuite) TestUpgradeAndDowngradePackage() {
 	flake.Mark(s.T())
 	const (
-		initialVersion = "3.13.0-pipeline.58926677.beta.sha-af5a1fab-1"
-		upgradeVersion = "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
+		initialVersion = "3.19.0-pipeline.67299728.beta.sha-c05ddfb1-1"
+		upgradeVersion = "3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1"
 	)
 	// Install initial version
 	s.installDotnetAPMLibraryWithVersion(initialVersion)
@@ -181,7 +181,7 @@ func (s *testDotnetLibraryInstallSuite) TestRemoveCorruptedPackageFails() {
 func (s *testDotnetLibraryInstallSuite) installDotnetAPMLibrary() {
 	// TODO remove override once image is published in prod
 	output, err := s.Installer().InstallPackage("datadog-apm-library-dotnet",
-		installer.WithVersion("3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"),
+		installer.WithVersion("3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1"),
 		installer.WithRegistry("install.datad0g.com.internal.dda-testing.com"),
 	)
 	s.Require().NoErrorf(err, "failed to install the dotnet library package: %s", output)

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
@@ -39,11 +39,11 @@ func (s *testAgentMSIInstallsDotnetLibrary) SetupSuite() {
 
 	s.previousDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("PREVIOUS_DOTNET_VERSION_PACKAGE"))
 	if s.previousDotnetLibraryVersion.PackageVersion() == "" {
-		s.previousDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion("3.13.0-pipeline.58926677.beta.sha-af5a1fab-1")
+		s.previousDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion("3.19.0-pipeline.67299728.beta.sha-c05ddfb1-1")
 	}
 	s.currentDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("CURRENT_DOTNET_VERSION_PACKAGE"))
 	if s.currentDotnetLibraryVersion.PackageVersion() == "" {
-		s.currentDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion("3.13.0-pipeline.58951229.beta.sha-af5a1fab-1")
+		s.currentDotnetLibraryVersion = installerwindows.NewVersionFromPackageVersion("3.19.0-pipeline.67351320.beta.sha-c05ddfb1-1")
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR updates E2E of the datadog-installer to ensure that lack of an IIS installation does not prevent installing the .NET library OCI package on Windows.

### Motivation

Make it easier for Windows customers to use the same installation command for all their hosts without having to know if IIS is installed on them or not.  

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

These tests are validated by E2E tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->