### PR TITLE
Prevent Omnibus build errors on consecutive runs for the installer

### DIFF
--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -8,7 +8,7 @@ require 'pathname'
 
 name 'installer'
 
-source path: '..'
+source path: '..',
        options: {
          exclude: ["**/testdata/**/*"],
        }

--- a/omnibus/config/software/installer.rb
+++ b/omnibus/config/software/installer.rb
@@ -9,6 +9,9 @@ require 'pathname'
 name 'installer'
 
 source path: '..'
+       options: {
+         exclude: ["**/testdata/**/*"],
+       }
 relative_path 'src/github.com/DataDog/datadog-agent'
 
 build do


### PR DESCRIPTION
### What does this PR do?

Copies https://github.com/DataDog/datadog-agent/blob/be4e7b319f8bcec13810958df4de948bdeaf74a6/omnibus/config/software/datadog-agent.rb#L30-L32

### Motivation

```
 [PathFetcher: installer] I | 2025-06-10T05:28:27+00:00 | Copying from `..'
#<Thread:0x0000597dee3b1e90 /omnibus/vendor/bundle/ruby/2.7.0/bundler/gems/omnibus-ruby-49bffd5cbf5f/lib/omnibus/thread_pool.rb:56 run> terminated with exception (report_on_exception is true):
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/fileutils.rb:374:in `symlink': File exists @ syserr_fail2_in - /omnibus/src/installer/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/usm/testdata/root/testdata/bins/notjs/.. (Errno::EEXIST)
```