### PR TITLE
fix(uprobes): Reduce noisy logging in uprobe attacher

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -472,6 +472,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 		PerformInitialScan:             true,
 		EnablePeriodicScanNewProcesses: true,
 		SharedLibsLibset:               sharedlibraries.LibsetCrypto,
+		EnableDetailedLogging:          false,
 	}
 
 	o := &sslProgram{


### PR DESCRIPTION
### What does this PR do?
This pull request introduces two changes to reduce log noise originating from the eBPF uprobe attacher:
- Adds a Log Limiter: A rate limiter is added to the handleLibraryOpen and handleProcessStart functions in the UprobeAttacher. This prevents floods of warnings when the agent tries to attach probes to very short-lived processes, which is a common and usually benign race condition.
- Disables Detailed Logging: The EnableDetailedLogging flag is explicitly set to false for the USM/TLS uprobe attacher configuration. This prevents verbose debug logs, which are not intended for production, from being enabled.

### Motivation
In environments with high process churn the system-probe can generate a large volume of warnings

### Describe how you validated your changes
- code compiles
- existing tests are passing correctly

### Possible Drawbacks / Trade-offs

### Additional Notes
https://datadoghq.atlassian.net/browse/EBPF-756
https://datadoghq.atlassian.net/browse/EBPF-757

Fixes https://github.com/DataDog/datadog-agent/issues/38198
