### PR TITLE
fix regression detector ci for 7.66.x release branch

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -65,14 +65,6 @@ single-machine-performance-regression_detector:
     - FOUR_DAYS_BEFORE_NOW=$(date --date="-4 days +1 hour" "+%s")
     # Compute UNIX timestamp of potential baseline SHA
     - BASELINE_COMMIT_TIME=$(git -c log.showSignature=false show --no-patch --format=%ct ${BASELINE_SHA})
-    # If baseline SHA is older than expiration policy, exit with an error
-    - | # Only 1st line of multiline command echoes, which reduces debuggability, so multiline commands are a maintenance tradeoff
-      if [[ ${BASELINE_COMMIT_TIME} -le ${FOUR_DAYS_BEFORE_NOW} ]]
-      then
-          echo "ERROR: Merge-base of this branch is too old for SMP. Please update your branch by merging an up-to-date main branch into your branch or by rebasing it on an up-to-date main branch."
-          datadog-ci tag --level job --tags smp_failure_mode:"merge-base-too-old"
-          exit 1
-      fi
     - echo "Commit ${BASELINE_SHA} is recent enough"
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     - |

--- a/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/experiment.yaml
@@ -4,7 +4,7 @@ erratic: false
 target:
   name: datadog-agent
   command: /bin/entrypoint.sh
-  cpu_allotment: 8
+  cpu_allotment: 4
   memory_allotment: 4GiB
 
   environment:

--- a/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/experiment.yaml
@@ -3,7 +3,7 @@ erratic: false
 
 target:
   name: datadog-agent
-  cpu_allotment: 8
+  cpu_allotment: 4
   memory_allotment: 1g
 
   environment:


### PR DESCRIPTION
### What does this PR do?

It overrides the CI configuration to skip any image age checks for the regression detector.

Also ports https://github.com/DataDog/datadog-agent/commit/ad0e415c98bf366d5739b86c240fb2c376b1f00d to make the regression detector work with the new infra.

### Motivation

This should fix the issue that Kacper ran into in this PR: https://github.com/DataDog/datadog-agent/pull/37809

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

There should be a CI check for the regression detector on this PR and it should succeed.

### Possible Drawbacks / Trade-offs
Not a permanent fix.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->