### PR TITLE
[chore] remove upstream zaplogger dependency serializerexporter

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -194,7 +194,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/trace v0.65.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.65.1
 	go.opentelemetry.io/collector/consumer/xconsumer v0.127.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.127.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.127.0 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -15,7 +15,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface"
 	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/def"
 	metricscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-otel"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
+
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
+	"go.uber.org/zap"
 
 	"github.com/DataDog/datadog-agent/pkg/config/create"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -23,10 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
-	"go.uber.org/fx"
-	"go.uber.org/fx/fxevent"
-	"go.uber.org/zap"
 )
 
 const megaByte = 1024 * 1024
@@ -114,7 +114,7 @@ func initSerializer(logger *zap.Logger, cfg *ExporterConfig, sourceProvider sour
 			return pkgconfig
 		}),
 		fx.Provide(func(log *zap.Logger) (logdef.Component, error) {
-			zp := &datadog.Zaplogger{Logger: log}
+			zp := &ZapLoggerOtel{Logger: log}
 			return zp, nil
 		}),
 		// casts the defaultforwarder.Component to a defaultforwarder.Forwarder

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package serializerexporter
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+var _ tracelog.Logger = &ZapLoggerOtel{}
+
+// ZapLoggerOtel implements the tracelog.Logger interface on top of a zap.Logger
+// It is a duplicate of github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/zaplogger.go
+// It is used to remove the dependency on the opentelemetry-collector-contrib package.
+type ZapLoggerOtel struct {
+	// Logger is the internal zap logger
+	Logger *zap.Logger
+}
+
+// Trace implements Logger.
+func (z *ZapLoggerOtel) Trace(_ ...any) { /* N/A */ }
+
+// Tracef implements Logger.
+func (z *ZapLoggerOtel) Tracef(_ string, _ ...any) { /* N/A */ }
+
+// Debug implements Logger.
+func (z *ZapLoggerOtel) Debug(v ...any) {
+	z.Logger.Debug(fmt.Sprint(v...))
+}
+
+// Debugf implements Logger.
+func (z *ZapLoggerOtel) Debugf(format string, params ...any) {
+	z.Logger.Debug(fmt.Sprintf(format, params...))
+}
+
+// Info implements Logger.
+func (z *ZapLoggerOtel) Info(v ...any) {
+	z.Logger.Info(fmt.Sprint(v...))
+}
+
+// Infof implements Logger.
+func (z *ZapLoggerOtel) Infof(format string, params ...any) {
+	z.Logger.Info(fmt.Sprintf(format, params...))
+}
+
+// Warn implements Logger.
+func (z *ZapLoggerOtel) Warn(v ...any) error {
+	z.Logger.Warn(fmt.Sprint(v...))
+	return nil
+}
+
+// Warnf implements Logger.
+func (z *ZapLoggerOtel) Warnf(format string, params ...any) error {
+	z.Logger.Warn(fmt.Sprintf(format, params...))
+	return nil
+}
+
+// Error implements Logger.
+func (z *ZapLoggerOtel) Error(v ...any) error {
+	z.Logger.Error(fmt.Sprint(v...))
+	return nil
+}
+
+// Errorf implements Logger.
+func (z *ZapLoggerOtel) Errorf(format string, params ...any) error {
+	z.Logger.Error(fmt.Sprintf(format, params...))
+	return nil
+}
+
+// Critical implements Logger.
+func (z *ZapLoggerOtel) Critical(v ...any) error {
+	z.Logger.Error(fmt.Sprint(v...), zap.Bool("critical", true))
+	return nil
+}
+
+// Criticalf implements Logger.
+func (z *ZapLoggerOtel) Criticalf(format string, params ...any) error {
+	z.Logger.Error(fmt.Sprintf(format, params...), zap.Bool("critical", true))
+	return nil
+}
+
+// Flush implements Logger.
+func (z *ZapLoggerOtel) Flush() {
+	_ = z.Logger.Sync()
+}

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
@@ -1,0 +1,251 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package serializerexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+func TestZapLoggerOtel_Interface(t *testing.T) {
+	// Verify that ZapLoggerOtel implements tracelog.Logger interface
+	var _ tracelog.Logger = &ZapLoggerOtel{}
+}
+
+func setupTestLogger() (*ZapLoggerOtel, *observer.ObservedLogs) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	zapLogger := &ZapLoggerOtel{Logger: logger}
+	return zapLogger, recorded
+}
+
+func TestZapLoggerOtel_Trace(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	// Trace methods should be no-ops
+	zapLogger.Trace("test message")
+	zapLogger.Tracef("test %s", "formatted")
+
+	// No logs should be recorded for trace methods
+	assert.Equal(t, 0, recorded.Len())
+}
+
+func TestZapLoggerOtel_Debug(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	t.Run("Debug", func(t *testing.T) {
+		zapLogger.Debug("debug message")
+
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.DebugLevel, entry.Level)
+		assert.Equal(t, "debug message", entry.Message)
+	})
+
+	t.Run("Debug multiple args", func(t *testing.T) {
+		recorded.TakeAll() // Clear previous logs
+		zapLogger.Debug("debug", " ", "message")
+
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.DebugLevel, entry.Level)
+		assert.Equal(t, "debug message", entry.Message)
+	})
+
+	t.Run("Debugf", func(t *testing.T) {
+		recorded.TakeAll() // Clear previous logs
+		zapLogger.Debugf("debug %s %d", "message", 123)
+
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.DebugLevel, entry.Level)
+		assert.Equal(t, "debug message 123", entry.Message)
+	})
+}
+
+func TestZapLoggerOtel_Info(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	t.Run("Info", func(t *testing.T) {
+		zapLogger.Info("info message")
+
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.InfoLevel, entry.Level)
+		assert.Equal(t, "info message", entry.Message)
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		recorded.TakeAll() // Clear previous logs
+		zapLogger.Infof("info %s %d", "message", 456)
+
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.InfoLevel, entry.Level)
+		assert.Equal(t, "info message 456", entry.Message)
+	})
+}
+
+func TestZapLoggerOtel_Warn(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	t.Run("Warn", func(t *testing.T) {
+		err := zapLogger.Warn("warn message")
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.WarnLevel, entry.Level)
+		assert.Equal(t, "warn message", entry.Message)
+	})
+
+	t.Run("Warnf", func(t *testing.T) {
+		recorded.TakeAll() // Clear previous logs
+		err := zapLogger.Warnf("warn %s %d", "message", 789)
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.WarnLevel, entry.Level)
+		assert.Equal(t, "warn message 789", entry.Message)
+	})
+}
+
+func TestZapLoggerOtel_Error(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	t.Run("Error", func(t *testing.T) {
+		err := zapLogger.Error("error message")
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Equal(t, "error message", entry.Message)
+	})
+
+	t.Run("Errorf", func(t *testing.T) {
+		recorded.TakeAll() // Clear previous logs
+		err := zapLogger.Errorf("error %s %d", "message", 101)
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Equal(t, "error message 101", entry.Message)
+	})
+}
+
+func TestZapLoggerOtel_Critical(t *testing.T) {
+	zapLogger, recorded := setupTestLogger()
+
+	t.Run("Critical", func(t *testing.T) {
+		err := zapLogger.Critical("critical message")
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Equal(t, "critical message", entry.Message)
+
+		// Check for critical field
+		criticalField := findField(entry.Context, "critical")
+		require.NotNil(t, criticalField)
+		assert.IsType(t, zapcore.BoolType, criticalField.Type)
+		assert.Equal(t, int64(1), criticalField.Integer)
+	})
+
+	zapLogger, recorded = setupTestLogger()
+	t.Run("Criticalf", func(t *testing.T) {
+		err := zapLogger.Criticalf("critical %s %d", "message", 202)
+
+		assert.Nil(t, err)
+		require.Equal(t, 1, recorded.Len())
+		entry := recorded.All()[0]
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Equal(t, "critical message 202", entry.Message)
+
+		// Check for critical field
+		criticalField := findField(entry.Context, "critical")
+		require.NotNil(t, criticalField)
+		assert.IsType(t, zapcore.BoolType, criticalField.Type)
+		assert.Equal(t, int64(1), criticalField.Integer)
+	})
+}
+
+func TestZapLoggerOtel_Flush(t *testing.T) {
+	// Use a real logger to test Flush functionality
+	logger := zap.NewNop() // Use a no-op logger to avoid actual output
+	zapLogger := &ZapLoggerOtel{Logger: logger}
+
+	// This should not panic and should complete successfully
+	assert.NotPanics(t, func() {
+		zapLogger.Flush()
+	})
+}
+
+func TestZapLoggerOtel_FlushWithBufferedLogger(t *testing.T) {
+	// Create a buffered logger to test actual sync behavior
+	config := zap.NewDevelopmentConfig()
+	config.OutputPaths = []string{"stdout"}
+	logger, err := config.Build()
+	require.NoError(t, err)
+
+	zapLogger := &ZapLoggerOtel{Logger: logger}
+
+	// Add some logs
+	zapLogger.Info("test message")
+
+	// Flush should not panic
+	assert.NotPanics(t, func() {
+		zapLogger.Flush()
+	})
+}
+
+// Helper function to find a field in the context
+func findField(fields []zapcore.Field, key string) *zapcore.Field {
+	for _, field := range fields {
+		if field.Key == key {
+			return &field
+		}
+	}
+	return nil
+}
+
+// Benchmark tests
+func BenchmarkZapLoggerOtel_Info(b *testing.B) {
+	zapLogger, _ := setupTestLogger()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		zapLogger.Info("benchmark message")
+	}
+}
+
+func BenchmarkZapLoggerOtel_Infof(b *testing.B) {
+	zapLogger, _ := setupTestLogger()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		zapLogger.Infof("benchmark %s %d", "message", i)
+	}
+}
+
+func BenchmarkZapLoggerOtel_Critical(b *testing.B) {
+	zapLogger, _ := setupTestLogger()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		zapLogger.Critical("benchmark critical message")
+	}
+}

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
@@ -17,7 +17,7 @@ import (
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
-func TestZapLoggerOtel_Interface(t *testing.T) {
+func TestZapLoggerOtel_Interface(_ *testing.T) {
 	// Verify that ZapLoggerOtel implements tracelog.Logger interface
 	var _ tracelog.Logger = &ZapLoggerOtel{}
 }

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/zaplogger_test.go
@@ -102,7 +102,7 @@ func TestZapLoggerOtel_Warn(t *testing.T) {
 	t.Run("Warn", func(t *testing.T) {
 		err := zapLogger.Warn("warn message")
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.WarnLevel, entry.Level)
@@ -113,7 +113,7 @@ func TestZapLoggerOtel_Warn(t *testing.T) {
 		recorded.TakeAll() // Clear previous logs
 		err := zapLogger.Warnf("warn %s %d", "message", 789)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.WarnLevel, entry.Level)
@@ -127,7 +127,7 @@ func TestZapLoggerOtel_Error(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		err := zapLogger.Error("error message")
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
@@ -138,7 +138,7 @@ func TestZapLoggerOtel_Error(t *testing.T) {
 		recorded.TakeAll() // Clear previous logs
 		err := zapLogger.Errorf("error %s %d", "message", 101)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
@@ -152,7 +152,7 @@ func TestZapLoggerOtel_Critical(t *testing.T) {
 	t.Run("Critical", func(t *testing.T) {
 		err := zapLogger.Critical("critical message")
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
@@ -169,7 +169,7 @@ func TestZapLoggerOtel_Critical(t *testing.T) {
 	t.Run("Criticalf", func(t *testing.T) {
 		err := zapLogger.Criticalf("critical %s %d", "message", 202)
 
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		require.Equal(t, 1, recorded.Len())
 		entry := recorded.All()[0]
 		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
@@ -246,6 +246,6 @@ func BenchmarkZapLoggerOtel_Critical(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		zapLogger.Critical("benchmark critical message")
+		_ = zapLogger.Critical("benchmark critical message")
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
creates `ZapLoggerOtel` type for serializerexporter

### Motivation
Remove external dependency for logger in serializerexporter

### Describe how you validated your changes
added unit tests for functionality
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
slight duplication of code from upstream, but worth it to remove external dependency
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->