### PR TITLE
Set 'HostProcMountinfo' for Disk integration

### DIFF
--- a/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
@@ -244,8 +244,8 @@ instances:
 
     ## @param proc_mountinfo_path - string - optional
     ## Path to the file from which to read mount information when enumerating disk partitions.
-    ## By default this points at /proc/self/mounts (the same source used by Python’s psutil).
-    ## If this setting is empty or does not exist, gopsutil’s built-in fallback
+    ## By default this points at /proc/self/mounts (the same source used by Python’s disk check).
+    ## If this setting is empty or does not exist, Go’s disk check built-in fallback
     ## logic will be used in order: /proc/1/mountinfo → /proc/self/mountinfo → /proc/mounts.
     #
     # proc_mountinfo_path: /proc/self/mounts

--- a/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
@@ -241,3 +241,12 @@ instances:
     #     host: nfsserver
     #     share: /mnt/nfs_share
     #     type: nfs
+
+    ## @param proc_mountinfo_path - string - optional
+    ## Path to the file from which to read mount information when enumerating disk partitions.
+    ## By default this points at /proc/self/mounts (the same source used by Python’s psutil).
+    ## If this setting is empty or does not exist, gopsutil’s built-in fallback
+    ## logic will be used in order: /proc/1/mountinfo → /proc/self/mountinfo → /proc/mounts.
+    #
+    # proc_mountinfo_path: /proc/self/mounts
+    

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -721,7 +721,8 @@ func newCheck() check.Check {
 			DeviceTagRe:          make(map[string]string),
 			LowercaseDeviceTag:   false,
 			Timeout:              5,
-			ProcMountInfoPath:    "",
+			// Match psutil exactly setting default value (https://github.com/giampaolo/psutil/blob/3d21a43a47ab6f3c4a08d235d2a9a55d4adae9b1/psutil/_pslinux.py#L1277)
+			ProcMountInfoPath: "/proc/self/mounts",
 		},
 		includedDevices:     []regexp.Regexp{},
 		excludedDevices:     []regexp.Regexp{},

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -115,7 +115,6 @@ func compileRegExp(expr string, ignoreCase bool) (*regexp.Regexp, error) {
 type Check struct {
 	core.CheckBase
 	clock                     clock.Clock
-	diskPartitions            func(bool) ([]gopsutil_disk.PartitionStat, error)
 	diskPartitionsWithContext func(context.Context, bool) ([]gopsutil_disk.PartitionStat, error)
 	diskUsage                 func(string) (*gopsutil_disk.UsageStat, error)
 	diskIOCounters            func(...string) (map[string]gopsutil_disk.IOCountersStat, error)
@@ -681,7 +680,6 @@ func newCheck() check.Check {
 	return &Check{
 		CheckBase:                 core.NewCheckBase(CheckName),
 		clock:                     clock.New(),
-		diskPartitions:            gopsutil_disk.Partitions,
 		diskPartitionsWithContext: gopsutil_disk.PartitionsWithContext,
 		diskUsage:                 gopsutil_disk.Usage,
 		diskIOCounters:            gopsutil_disk.IOCounters,

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -8,6 +8,7 @@
 package diskv2_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -82,7 +83,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllUsageMetricsAreRe
 func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLowercaseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
 		return map[string]gopsutil_disk.IOCountersStat{
 			"/dev/SDA1": {
 				Name:       "sda1",
@@ -103,7 +104,7 @@ func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLower
 				WriteTime:  150,
 			},
 		}, nil
-	}), func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "/dev/SDA1",
@@ -183,7 +184,7 @@ func TestGivenADiskCheckWithIncludeAllDevicesFalseConfigured_WhenCheckRuns_ThenO
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturnsEmptyDevice_ThenNoUsageMetricsAreReportedForThatPartition(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "",
@@ -217,7 +218,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturn
 func TestGivenADiskCheckWithAllPartitionsFalseConfigured_WhenCheckRunsAndPartitionsSystemReturnsEmptyDevice_ThenNoUsageMetricsAreReportedForThatPartition(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "",
@@ -252,7 +253,7 @@ func TestGivenADiskCheckWithAllPartitionsFalseConfigured_WhenCheckRunsAndPartiti
 func TestGivenADiskCheckWithAllPartitionsTrueConfigured_WhenCheckRunsAndPartitionsSystemReturnsEmptyDevice_ThenUsageMetricsAreReportedForThatPartition(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "",
@@ -343,7 +344,7 @@ device_whitelist:
 func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithIso9660FileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "cdrom",
@@ -376,7 +377,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithTracefsFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "trace",

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -501,7 +501,7 @@ excluded_filesystems:
 func TestGivenADiskCheckWithExcludedFileSystemsConfiguredWithTmpfs_WhenCheckRuns_ThenUsageMetricsAreReportedForPartitionsWithDevTmpfsFileSystem(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "devtmpfs",

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -726,7 +726,7 @@ excluded_disks:
 func TestGivenADiskCheckWithExcludedDisksConfiguredWithDa2_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithSda2Devices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "sda2",

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -10,6 +10,7 @@ package diskv2_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -40,7 +41,7 @@ func createWindowsCheck(t *testing.T) check.Check {
 	diskCheckOpt := diskv2.Factory()
 	diskCheckFunc, _ := diskCheckOpt.Get()
 	diskCheck := diskCheckFunc()
-	diskCheck = diskv2.WithDiskPartitions(diskv2.WithDiskUsage(diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
 		return map[string]gopsutil_disk.IOCountersStat{
 			"\\\\?\\Volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}\\": {
 				Name:       "sda1",
@@ -65,7 +66,7 @@ func createWindowsCheck(t *testing.T) check.Check {
 			InodesFree:        500000,
 			InodesUsedPercent: 50.0,
 		}, nil
-	}), func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     `\\?\Volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}\`,
@@ -147,7 +148,7 @@ func TestGivenADiskCheckWithIncludeAllDevicesFalseConfigured_WhenCheckRuns_ThenO
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturnsEmptyDevice_ThenNoUsageMetricsAreReportedForThatPartition(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "",
@@ -218,7 +219,7 @@ device_whitelist:
 func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithIso9660FileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "cdrom",
@@ -251,7 +252,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithTracefsFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	diskCheck = diskv2.WithDiskPartitions(diskCheck, func(_ bool) ([]gopsutil_disk.PartitionStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{
 			{
 				Device:     "trace",

--- a/pkg/collector/corechecks/system/disk/diskv2/with_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/with_test.go
@@ -7,6 +7,8 @@
 package diskv2
 
 import (
+	"context"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/benbjohnson/clock"
 	gopsutil_disk "github.com/shirou/gopsutil/v4/disk"
@@ -23,6 +25,12 @@ func WithClock(c check.Check, clock clock.Clock) check.Check {
 // WithDiskPartitions sets a diskPartitions call on the Check and returns the updated Check.
 func WithDiskPartitions(c check.Check, f func(bool) ([]gopsutil_disk.PartitionStat, error)) check.Check {
 	c.(*Check).diskPartitions = f
+	return c
+}
+
+// WithDiskPartitionsWithContext sets a diskPartitionsWithContext call on the Check and returns the updated Check.
+func WithDiskPartitionsWithContext(c check.Check, f func(context.Context, bool) ([]gopsutil_disk.PartitionStat, error)) check.Check {
+	c.(*Check).diskPartitionsWithContext = f
 	return c
 }
 

--- a/pkg/collector/corechecks/system/disk/diskv2/with_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/with_test.go
@@ -22,12 +22,6 @@ func WithClock(c check.Check, clock clock.Clock) check.Check {
 	return c
 }
 
-// WithDiskPartitions sets a diskPartitions call on the Check and returns the updated Check.
-func WithDiskPartitions(c check.Check, f func(bool) ([]gopsutil_disk.PartitionStat, error)) check.Check {
-	c.(*Check).diskPartitions = f
-	return c
-}
-
 // WithDiskPartitionsWithContext sets a diskPartitionsWithContext call on the Check and returns the updated Check.
 func WithDiskPartitionsWithContext(c check.Check, f func(context.Context, bool) ([]gopsutil_disk.PartitionStat, error)) check.Check {
 	c.(*Check).diskPartitionsWithContext = f

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -55,6 +55,7 @@ func (v *diskCheckSuite) TestCheckDisk() {
 			`init_config:
 instances:
   - use_mount: false
+    proc_mountinfo_path: "/proc/self/mounts"
 `,
 			``,
 		},

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -55,7 +55,6 @@ func (v *diskCheckSuite) TestCheckDisk() {
 			`init_config:
 instances:
   - use_mount: false
-    proc_mountinfo_path: "/proc/self/mounts"
 `,
 			``,
 		},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR introduces a new configuration option `proc_mountinfo_path` (defaulting to "`/proc/self/mounts`") and updates our disk check to call `disk.PartitionsWithContext(ctx, includeAll)` instead of the previous call to `disk.Partitions(includeAll)` from `gopsutil`

### Motivation
When migrating our disk checks from Python’s `psutil` to Go’s `gopsutil`, we discovered that by default:

- `psutil` reads mount information from the current process’s namespace (`/proc/self/mounts`).
- `gopsutil` reads from `/proc/1/mountinfo`, which doesn’t reflect the container’s view.

These differences led to inconsistent results inside containers (see [here](https://ddstaging.datadoghq.com/notebook/12587989/diskv2-check-comparison)). This PR introduces a new `proc_mountinfo_path` config (defaulting to "`/proc/self/mounts`") and switches all disk-check calls to `PartitionsWithContext` (instead of `Partitions`). By carrying the override in the context, we now have per-call control of the mountinfo source, making `gopsutil` behave like `psutil` by default, while still retaining its full fallback logic for other advanced scenarios.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->