### PR TITLE
APM: Reduce likelihood of receiver shutdown panic

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -579,6 +579,8 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 
 // handleTraces knows how to handle a bunch of traces
 func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.Request) {
+	r.wg.Add(1)
+	defer r.wg.Done()
 	tracen, err := traceCount(req)
 	if err == errInvalidHeaderTraceCountValue {
 		log.Errorf("Failed to count traces: %s", err)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -680,8 +680,6 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		ProcessTags:            ptags,
 		ContainerTags:          ctags,
 	}
-	r.wg.Add(1) // This wait group ensures Stop() does not close the r.out channel before we return (to prevent a panic)
-	defer r.wg.Done()
 	r.out <- payload
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move our usage of waitgroup to cover the entire `process` function to ensure that the Stop() function doesn't close the `out` channel until we've processed all payloads

### Motivation
This should reduce the incidence of panics during shutdown

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I ran this locally with a test tracer to ensure it still functions correctly and saw it was successful. I also attempted to recreate the `send after close` panic (before and after) and could not do so locally.

### Possible Drawbacks / Trade-offs
This does not fully resolve this issue, there is still a narrow window in which this issue can still occur. I have been unable to identify the underlying issue that is causing server.Shutdown() to not block until all handlers return, so this is a stop-gap measure to reduce incidence while continuing investigation.

The use of a wait group here for ever incoming trace payload will incur a very small performance cost.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->