### PR TITLE
ignore uprobes for perf stats in userspace

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/ebpf-kern-user.h
+++ b/pkg/collector/corechecks/ebpf/c/runtime/ebpf-kern-user.h
@@ -3,6 +3,8 @@
 
 #include "ktypes.h"
 
+#define EBPF_CHECK_KPROBE_MISSES_CMD 0x70C14
+
 typedef struct {
     __u32 map_id;
     __u32 cpu;

--- a/pkg/collector/corechecks/ebpf/c/runtime/ebpf-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/ebpf-kern.c
@@ -7,7 +7,6 @@
 #include "bpf_metadata.h"
 
 #define F_DUPFD_CLOEXEC 1030
-#define EBPF_CHECK_KPROBE_MISSES_CMD 0x70C14
 
 typedef struct {
     u32 pid;

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/c_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/c_types.go
@@ -12,6 +12,8 @@ package ebpfcheck
 */
 import "C"
 
+const ioctlCollectKprobeMissedStatsCmd = C.EBPF_CHECK_KPROBE_MISSES_CMD
+
 type perfBufferKey C.perf_buffer_key_t
 type mmapRegion C.mmap_region_t
 type ringMmap C.ring_mmap_t

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/c_types_linux.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/c_types_linux.go
@@ -3,6 +3,8 @@
 
 package ebpfcheck
 
+const ioctlCollectKprobeMissedStatsCmd = 0x70c14
+
 type perfBufferKey struct {
 	Id  uint32
 	Cpu uint32

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -55,9 +55,6 @@ var kernelAddresses = []string{
 
 const (
 	maxMapsTracked = 20
-
-	// ioctl trigger code
-	ioctlCollectKprobeMissedStatsCmd = 0x70C14
 )
 
 // Probe is the eBPF side of the eBPF check

--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -10,6 +10,7 @@ package ebpf
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -306,6 +307,11 @@ func AddProbeFDMappings(mgr *manager.Manager) {
 		}
 
 		if specs[0].Type != ebpf.Kprobe {
+			continue
+		}
+		progType, _, _ := strings.Cut(specs[0].SectionName, "/")
+		switch progType {
+		case "uprobe", "uretprobe":
 			continue
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ignores uprobe for kprobe perf stats collection in ebpf check, rather than relying on the ebpf side, which seems to be unreliable.

### Motivation

Lots of logs like 
```
yyyy-MM-dd HH:mm:ss UTC | SYS-PROBE | WARN | (pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go:538 in getKprobeMisses) | error in eBPF program while recording kprobe statistics for *: fd is not a perf event fd
```
with uprobe/uretprobe programs
![Screenshot 2025-06-10 at 12 16 49 PM](https://github.com/user-attachments/assets/60faf46d-960c-45b8-95f9-fccde8112edd)


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
https://datadoghq.atlassian.net/browse/EBPF-758

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->