### PR TITLE
[NDINT-91] update flush timing to use ticker

### DIFF
--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -233,15 +233,14 @@ func (agg *FlowAggregator) flushLoop() {
 			agg.flushLoopDone <- struct{}{}
 			return
 		// automatic flush sequence
-		case <-flushFlowsToSendTicker:
-			now := time.Now()
+		case now := <-flushFlowsToSendTicker:
 			if !lastFlushTime.IsZero() {
 				flushInterval := now.Sub(lastFlushTime)
 				agg.sender.Gauge("datadog.netflow.aggregator.flush_interval", flushInterval.Seconds(), "", nil)
 			}
 			lastFlushTime = now
 
-			flushStartTime := time.Now()
+			flushStartTime := now
 			agg.flush()
 			agg.sender.Gauge("datadog.netflow.aggregator.flush_duration", time.Since(flushStartTime).Seconds(), "", nil)
 			agg.sender.Commit()

--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -13,9 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/networkdevice/integrations"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/integrations"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -233,14 +234,12 @@ func (agg *FlowAggregator) flushLoop() {
 			agg.flushLoopDone <- struct{}{}
 			return
 		// automatic flush sequence
-		case now := <-flushFlowsToSendTicker:
+		case flushStartTime := <-flushFlowsToSendTicker:
 			if !lastFlushTime.IsZero() {
-				flushInterval := now.Sub(lastFlushTime)
+				flushInterval := flushStartTime.Sub(lastFlushTime)
 				agg.sender.Gauge("datadog.netflow.aggregator.flush_interval", flushInterval.Seconds(), "", nil)
 			}
-			lastFlushTime = now
-
-			flushStartTime := now
+			lastFlushTime = flushStartTime
 			agg.flush()
 			agg.sender.Gauge("datadog.netflow.aggregator.flush_duration", time.Since(flushStartTime).Seconds(), "", nil)
 			agg.sender.Commit()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The variable `now` reflects the "ideal logical time" the ticker represents instead of the "real wall time".

### Motivation
Using time.Now() to determine the current time introduces potential drift and inconsistency (delays due to scheduling, GC pause, etc.). We should instead use the time value implied by the ticker. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->