### PR TITLE
[BARX-1044] Update deploy_container-cws jobs to use tag method for mutable tags instead of full index push

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -21,6 +21,14 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
+.deploy_mutable_cws-instrumentation_tags_base:
+  extends: .docker_publish_job_definition
+  stage: deploy_cws_instrumentation
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
+
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
@@ -28,10 +36,10 @@ deploy_containers-cws-instrumentation-rc-versioned:
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:
-  extends: .deploy_containers-cws-instrumentation-base
+  extends: .deploy_mutable_cws-instrumentation_tags_base
   rules: !reference [.on_deploy_rc]
   variables:
-    VERSION: rc
+    IMG_NEW_TAGS: rc
 
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
@@ -40,7 +48,7 @@ deploy_containers-cws-instrumentation-final-versioned:
 
 # will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
-  extends: .deploy_containers-cws-instrumentation-base
+  extends: .deploy_mutable_cws-instrumentation_tags_base
   rules: !reference [.on_deploy_manual_final]
   variables:
-    VERSION: latest
+    IMG_NEW_TAGS: latest

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -38,6 +38,9 @@ deploy_containers-cws-instrumentation-rc-versioned:
 deploy_containers-cws-instrumentation-rc-mutable:
   extends: .deploy_mutable_cws-instrumentation_tags_base
   rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-cws-instrumentation-rc-versioned
+      artifacts: false
   variables:
     IMG_NEW_TAGS: rc
 
@@ -50,5 +53,8 @@ deploy_containers-cws-instrumentation-final-versioned:
 deploy_containers-cws-instrumentation-latest:
   extends: .deploy_mutable_cws-instrumentation_tags_base
   rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-cws-instrumentation-final-versioned
+      artifacts: false
   variables:
     IMG_NEW_TAGS: latest


### PR DESCRIPTION
### What does this PR do?

This PR updates the jobs which publish mutable image tags for cws-`instrumentation` images to use new approach which does not push full new index, but instead creates a tag that points to the existing reference.

### Motivation

Unify the images publish mechanism.

### Describe how you validated your changes
To be properly tested with the 7.68.0 RC build.

Instruction (`7.68.0-rc.1` example):
1. Trigger (or let release coordinator) build for `7.68.0-rc.1`,
2. Check jobs in `deploy_cws_instrumentation` stage - they should all pass,
3. Verify that the `rc` tag published points to the `7.68.0-rc.1` tag in public repos, for example in [dockerhub](https://hub.docker.com/r/datadog/cws-instrumentation/tags)