### PR TITLE
[BARX-1043] Update dca images publish jobs to use tag method for mutable tags instead of full index push

### DIFF
--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -6,6 +6,7 @@ include:
 # DCA image tagging & manifest publication
 #
 
+# Basic flavor
 .deploy_containers-dca-base:
   extends: .docker_publish_job_definition
   stage: deploy_dca
@@ -21,38 +22,59 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
 
+.deploy_mutable_dca_tags-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
+
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
-  extends: .deploy_containers-dca-base
+  extends: .deploy_mutable_dca_tags-base  
   rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
   variables:
-    VERSION: rc
+    IMG_NEW_TAGS: rc
 
 deploy_containers-dca-latest:
-  extends: .deploy_containers-dca-base
+  extends: .deploy_mutable_dca_tags-base
   rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
   variables:
-    VERSION: latest
+    IMG_NEW_TAGS: latest
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_manual_final]
 
 deploy_containers-dca_internal-rc:
-  extends: .deploy_containers-dca-base
+  extends: .deploy_mutable_dca_tags-base
   rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
   variables:
-    VERSION: rc
+    IMG_NEW_TAGS: rc
 
 deploy_containers-dca_internal-latest:
-  extends: .deploy_containers-dca-base
+  extends: .deploy_mutable_dca_tags-base
   rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
   variables:
-    VERSION: latest
+    IMG_NEW_TAGS: latest
 
+# Fips flavor
 .deploy_containers-dca-fips-base:
   extends: .docker_publish_job_definition
   stage: deploy_dca
@@ -68,34 +90,54 @@ deploy_containers-dca_internal-latest:
     - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips"
 
-deploy_containers-dca-fips-latest:
-  extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_manual_final]
-  variables:
-    VERSION: latest
-
-deploy_containers-dca-fips-rc:
-  extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_rc]
-  variables:
-    VERSION: rc
+.deploy_mutable_dca_tags-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
 
 deploy_containers-dca-fips:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
+
+deploy_containers-dca-fips-latest:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips
+
+deploy_containers-dca-fips-rc:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
 
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_manual_final]
 
 deploy_containers-dca-fips_internal-rc:
-  extends: .deploy_containers-dca-fips-base
+  extends: .deploy_mutable_dca_tags-fips-base
   rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
   variables:
-    VERSION: rc
+    IMG_NEW_TAGS: rc-fips
 
 deploy_containers-dca-fips_internal-latest:
-  extends: .deploy_containers-dca-fips-base
+  extends: .deploy_mutable_dca_tags-fips-base
   rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
   variables:
-    VERSION: latest
+    IMG_NEW_TAGS: latest-fips

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -35,7 +35,7 @@ deploy_containers-dca:
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
-  extends: .deploy_mutable_dca_tags-base  
+  extends: .deploy_mutable_dca_tags-base
   rules: !reference [.on_deploy_rc]
   needs:
     - job: deploy_containers-dca


### PR DESCRIPTION
### What does this PR do?
This PR updates the jobs which publish mutable image tags for cws-instrumentation images to use new approach which does not push full new index, but instead creates a tag that points to the existing reference.

### Motivation
Unify the images publish mechanism.

### Describe how you validated your changes
To be properly tested with the 7.68.0 RC build.

Instruction (`7.68.0-rc.1` example):

1. Trigger (or let release coordinator) build for `7.68.0-rc.1`,
2. Check jobs in `deploy_dca` stage - they should all pass,
3. Verify that the rc tag published points to the `7.68.0-rc.1` tag in public repos, for example in [dockerhub](https://hub.docker.com/r/datadog/cluster-agent/tags)