### PR TITLE
Include tegrastats stderr when failing to run

### DIFF
--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -138,7 +138,7 @@ func (c *JetsonCheck) Run() error {
 		switch err := err.(type) {
 		case *exec.ExitError:
 			if len(tegrastatsOutput) <= 0 {
-				return fmt.Errorf("tegrastats did not produce any output: %s", err)
+				return fmt.Errorf("tegrastats did not produce any output: %s. Stderr: %s", err, string(err.Stderr))
 			}
 			// We kill the process, so ExitError is expected - as long as
 			// we got our output.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add the stderr output of `tegrastats` in the error returned by the check.

### Motivation
Help with debugging issues.
I'm looking into a support case where the error I have is `exit status 1` and it's not enough to debug.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->