### PR TITLE
[ACIX-883] Auto-retry e2e tests in CI

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -73,8 +73,9 @@
     E2E_RESULT_JSON: $CI_PROJECT_DIR/e2e_test_output.json
     E2E_USE_AWS_PROFILE: "true"
     PRE_BUILT_BINARIES_FLAG: "--use-prebuilt-binaries"
+    MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
   script:
-    - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   artifacts:
@@ -120,8 +121,6 @@ go_e2e_test_binaries:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-
-
 
 .new_e2e_template_needs_windows_x64:
   extends: .new_e2e_template
@@ -573,6 +572,7 @@ new-e2e-installer-script:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
     E2E_USE_AWS_PROFILE: "false"
+    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -595,7 +595,7 @@ new-e2e-installer:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
-  retry: 1  # Force retry on this specific job to limit flakiness
+    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template
@@ -621,6 +621,7 @@ new-e2e-installer-windows:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "windows"
     E2E_USE_AWS_PROFILE: "false"
+    MAX_RETRIES_FLAG: "--max-retries=3"
   parallel:
     matrix:
       # agent-package
@@ -673,7 +674,6 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestMSIRollbackRemovesLibrary$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestMSISkipRollbackIfInstalled$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestUninstallKeepsLibrary$"
-  retry: 1  # Force retry on this specific job to limit flakiness
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template
@@ -695,7 +695,7 @@ new-e2e-installer-ansible:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
-  retry: 1  # Force retry on this specific job to limit flakiness
+    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template

--- a/.gitlab/e2e_install_packages/common.yml
+++ b/.gitlab/e2e_install_packages/common.yml
@@ -40,7 +40,7 @@
         END_MAJOR_VERSION: [7]
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token ) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION --test-washer
 
 .new-e2e_script_upgrade_persisting_integrations:
   stage: e2e_install_packages
@@ -51,7 +51,7 @@
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version 7 --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version 7 --test-washer
 
 .new-e2e_rpm:
   stage: e2e_install_packages
@@ -62,4 +62,4 @@
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --test-washer

--- a/.gitlab/e2e_install_packages/common.yml
+++ b/.gitlab/e2e_install_packages/common.yml
@@ -40,7 +40,7 @@
         END_MAJOR_VERSION: [7]
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token ) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version $START_MAJOR_VERSION --dest-agent-version $END_MAJOR_VERSION --test-washer
 
 .new-e2e_script_upgrade_persisting_integrations:
   stage: e2e_install_packages
@@ -51,7 +51,7 @@
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version 7 --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --src-agent-version 7 --test-washer
 
 .new-e2e_rpm:
   stage: e2e_install_packages
@@ -62,4 +62,4 @@
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2 # We use a single test suite and run all the platforms test as subtest
   script:
     - DATADOG_AGENT_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $INSTALL_SCRIPT_API_KEY_ORG2 token) || exit $?; export DATADOG_AGENT_API_KEY
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --test-washer
+    - dda inv -- -e new-e2e-tests.run --targets $TARGETS --max-retries 3 --junit-tar "junit-${CI_JOB_ID}.tgz" ${EXTRA_PARAMS} --test-washer

--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -326,7 +326,7 @@ def _normalize_architecture(architecture):
     return normalize_table.get(architecture, architecture)
 
 
-def produce_junit_tar(file, result_path):
+def produce_junit_tar(files: list[str], result_path):
     """
     Produce a tgz file containing all given files JUnit XML files and add a special file
     with additional tags.
@@ -339,7 +339,8 @@ def produce_junit_tar(file, result_path):
         "os.architecture": _normalize_architecture(platform.machine()),
     }
     with tarfile.open(result_path, "w:gz") as tgz:
-        tgz.add(file, arcname=file.replace(os.path.sep, "-"))
+        for file in files:
+            tgz.add(file, arcname=file.replace(os.path.sep, "-"))
 
         tags_file = io.BytesIO()
         for k, v in tags.items():

--- a/tasks/libs/testing/e2e.py
+++ b/tasks/libs/testing/e2e.py
@@ -1,0 +1,55 @@
+from collections.abc import Iterable
+
+
+def create_test_selection_regex(test_names: list[str]) -> str:
+    """
+    Create a regex to exact-match the tests in the targets list.
+    Ex: ["TestFoo", "TestBar"] -> "^(?:TestFoo|TestBar)$"
+    """
+    if not test_names:
+        return ""
+
+    # Remove any whitespace and eventual ^$ surrounding the test names
+    processed_names = [name.strip().strip("^$") for name in test_names]
+
+    # Join them with a pipe to create an OR regex
+    regex_body = "|".join(processed_names)
+    if len(processed_names) > 1:
+        # If we have more than one test, we need to group them with a non-capturing group
+        regex_body = f"(?:{regex_body})"
+
+    return f'"^{regex_body}$"'
+
+
+def filter_only_leaf_tests(tests: Iterable[tuple[str, str]]) -> set[tuple[str, str]]:
+    """
+    Given some (package, test_name) tuples, return only the leaf tests.
+    A test is a leaf if it is not a parent of any other test in the list (within the same package).
+    """
+    # Sort tests by descending depth (number of '/' in test name)
+    tests_sorted = sorted(tests, key=lambda t: len(t[1].split('/')))
+    leaf_tests: set[tuple[str, str]] = set()
+    for candidate_test in tests_sorted:
+        # If none of the known leaf tests is a child of the candidate test, then the candidate test is a leaf
+        is_leaf = all(not _is_child(candidate_test, known_leaf_test) for known_leaf_test in leaf_tests)
+        if is_leaf:
+            leaf_tests.add(candidate_test)
+    return leaf_tests
+
+
+def _is_child(test1: tuple[str, str], test2: tuple[str, str]) -> bool:
+    """
+    Returns True if test1 is a child of test2.
+    Example: is_child(("pkg", "TestAgent/TestFeatureA"), ("pkg", "TestAgent")) == True
+    """
+    if test1[0] != test2[0]:
+        return False
+    splitted_test1 = test1[1].split('/')
+    splitted_test2 = test2[1].split('/')
+    if len(splitted_test2) > len(splitted_test1):
+        return False
+
+    for part1, part2 in zip(splitted_test1, splitted_test2, strict=False):
+        if part1 != part2:
+            return False
+    return True

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -379,6 +379,18 @@ def run(
         test_profiler=None,
     )
 
+    washer = TestWasher(test_output_json_file=result_json)
+    failed_tests = washer.get_failing_tests()
+
+    # Remove any known flaky tests from the failed tests
+    known_flaky_failures = washer.get_flaky_failures()
+    to_retry = {  # noqa: F841
+        (package, test_name)
+        for package, tests in failed_tests.items()
+        for test_name in tests
+        if package not in known_flaky_failures or test_name not in known_flaky_failures[package]
+    }
+
     success = process_test_result(test_res, junit_tar, AgentFlavor.base, test_washer)
 
     if running_in_ci():

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -13,8 +13,8 @@ import shutil
 import tempfile
 import threading
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import yaml

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -462,7 +462,7 @@ def run(
             args=args,
             cmd=cmd,
             env=env_vars,
-            junit_tar=junit_tar,
+            junit_tar="",  # No need to store JUnit results for teardown-only runs
             result_json="/dev/null",  # No need to store results for teardown-only runs
             test_profiler=None,
         )

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -64,8 +64,9 @@ class TestResult(ExecResult):
         self.result_type = "Tests"
         # Path to the result.json file output by gotestsum (should always be present)
         self.result_json_path = None
-        # Path to the junit file output by gotestsum (only present if specified in dda inv test)
-        self.junit_file_path = None
+        # List of paths to the junit files output by gotestsum (only present if specified in dda inv test)
+        # We have multiple because each retry will produce a new junit file
+        self.junit_file_paths = []
 
     def get_failing_tests(self) -> tuple[set[str], dict[str, set[str]]]:
         obj: ResultJson = ResultJson.from_file(self.result_json_path)

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -78,13 +78,13 @@ class TestWasher:
             or (package in self.known_flaky_tests and test in self.known_flaky_tests[package])
         )
 
-    def get_failing_tests(self) -> dict:
+    def get_failing_tests(self) -> dict[str, set[str]]:
         """
         Read the test output json file and return the tests that are failing
         """
         return self.test_output_json.failing_tests  # type: ignore[assignment]
 
-    def get_flaky_failures(self) -> dict:
+    def get_flaky_failures(self) -> dict[str, set[str]]:
         """
         Return failures that are due to flakiness. A test is considered flaky if it failed because of a flake.
         In the following cases the test failure is considered a flaky failure:

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -69,6 +69,8 @@ const (
 	DevMode StoreKey = "dev_mode"
 	// InitOnly config flag parameter name
 	InitOnly StoreKey = "init_only"
+	// TeardownOnly config flag parameter name
+	TeardownOnly StoreKey = "teardown_only"
 	// PreInitialized config flag parameter name
 	PreInitialized StoreKey = "pre_initialized"
 	// MajorVersion config flag parameter name

--- a/test/new-e2e/pkg/runner/parameters/store_env.go
+++ b/test/new-e2e/pkg/runner/parameters/store_env.go
@@ -42,6 +42,7 @@ var envVariablesByStoreKey = map[StoreKey]string{
 	PulumiVerboseProgressStreams: "E2E_PULUMI_VERBOSE_PROGRESS_STREAMS",
 	DevMode:                      "E2E_DEV_MODE",
 	InitOnly:                     "E2E_INIT_ONLY",
+	TeardownOnly:                 "E2E_TEARDOWN_ONLY",
 	MajorVersion:                 "E2E_MAJOR_VERSION",
 	PreInitialized:               "E2E_PRE_INITIALIZED",
 	FIPS:                         "E2E_FIPS",

--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -35,10 +35,12 @@ type baseSuite[Env any] struct {
 
 func (suite *baseSuite[Env]) BeforeTest(suiteName, testName string) {
 	suite.T().Logf("START  %s/%s %s", suiteName, testName, time.Now())
+	suite.BaseSuite.BeforeTest(suiteName, testName)
 }
 
 func (suite *baseSuite[Env]) AfterTest(suiteName, testName string) {
 	suite.T().Logf("FINISH %s/%s %s", suiteName, testName, time.Now())
+	suite.BaseSuite.AfterTest(suiteName, testName)
 }
 
 type testMetricArgs struct {


### PR DESCRIPTION
Note: this PR depends on #38227

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Following-up on ACIX-859 and #36422, try a new method for automatically rerunning failing e2e tests. This new method does not re-run tests that are already known as flaky and whose failure is accepted, contrary to what the previous method would do.

### Motivation

Increase CI reliability and diminish the impact (lost time) of flaky (but not yet marked as flaky) tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

TBD

### Possible Drawbacks / Trade-offs

Increased pipeline runtime + lost visibility on which tests are failing/flaky

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->