### PR TITLE
Bump evicted sql text from shared pool info log to warn

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle/oracle_dictionary.go
@@ -29,7 +29,7 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 		err = c.db.Get(SQLStatement, sql, value)
 		reconnectOnConnectionError(c, &c.db, err)
 		if err != nil && strings.Contains(err.Error(), "no rows") {
-			log.Infof("%s The SQL text for the statement %s = %s couldn't be fetched because the SQL was evicted from shared pool", c.logPrompt, key, value)
+			log.Warnf("%s The SQL text for the statement %s = %s couldn't be fetched because the SQL was evicted from shared pool", c.logPrompt, key, value)
 			err = nil
 		}
 	case common.GoOra:
@@ -55,7 +55,7 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 			}
 			return fmt.Errorf("failed to query sql full text for %s = %s %s", key, value, err)
 		} else if sqlFullText.String == "" {
-			log.Infof("%s The SQL text for the statement %s = %s couldn't be fetched because the SQL was evicted from shared pool", c.logPrompt, key, value)
+			log.Warnf("%s The SQL text for the statement %s = %s couldn't be fetched because the SQL was evicted from shared pool", c.logPrompt, key, value)
 		}
 	}
 	return err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Bumps an info log to a warning

### Motivation

From this support ticket, it was tricky to find this log at info level, which was causing queries to be truncated with no error/warning:
https://datadoghq.atlassian.net/browse/SDBM-1763

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->