### PR TITLE
extend service command timeout by number of dependent services

### DIFF
--- a/releasenotes/notes/extend-service-cmd-timeout-for-deps-4b65d42d75d23370.yaml
+++ b/releasenotes/notes/extend-service-cmd-timeout-for-deps-4b65d42d75d23370.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Factor dependent services into the timeout when stopping the Agent service on Windows.
+    Operations such as the ``stop-service`` Agent subcommand and remote updates
+    now wait longer for the Agent and its subservices to stop before reporting an error.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
extend service command timeout by number of dependent services

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1548
We have up to 6 services to stop but it only takes 2 to hang to hit the 30 second timeout. This can block remote updates, and cause issues with other upgrade paths (files in use, etc.)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This is difficult to test, you can't simply suspend a process b/c then you'll trigger the SCM pipe timeout instead. easiest method seems to be to add a `time.Sleep(30*time.Second)` to a subprocess and rebuild it.
I added it to `cmd\trace-agent\subcommands\run\command.go` at the end of `runTraceAgentProcess`.
Then set the `DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS=60` environment variable at the machine level to prevent the hard stop timeout from triggering, too.
then run
```PowerShell
& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' stop-service
```
This command should fail in previous versions of the Agent, with this PR it should succeed

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->