### PR TITLE
dyninst: extract symbols from Go binaries for SymDB

### DIFF
--- a/pkg/dyninst/dwarf/dwarfutil/util.go
+++ b/pkg/dyninst/dwarf/dwarfutil/util.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dwarfutil
+
+import (
+	"debug/dwarf"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+)
+
+// ProcessLocations processes a location field from a DWARF entry, parsing
+// location lists.
+//
+// unit is the DWARF compile unit entry that contains the location field.
+// blockRanges are the PC ranges of the lexical block containing the variable.
+// typeSize is the size, in bytes, of the type of the variable.
+func ProcessLocations(
+	locField *dwarf.Field,
+	unit *dwarf.Entry,
+	reader *loclist.Reader,
+	blockRanges []ir.PCRange,
+	typeSize uint32,
+	pointerSize uint8,
+) ([]ir.Location, error) {
+	var locations []ir.Location
+	switch locField.Class {
+	case dwarf.ClassLocListPtr:
+		offset, ok := locField.Val.(int64)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unexpected location field type: %T", locField.Val,
+			)
+		}
+		loclist, err := reader.Read(unit, offset, typeSize)
+		if err != nil {
+			return nil, err
+		}
+		if len(loclist.Default) > 0 {
+			return nil, fmt.Errorf("unexpected default location pieces")
+		}
+		locations = loclist.Locations
+
+	case dwarf.ClassExprLoc:
+		instr, ok := locField.Val.([]byte)
+		if !ok {
+			return nil, fmt.Errorf(
+				"unexpected location field type: %T", locField.Val,
+			)
+		}
+		pieces, err := loclist.ParseInstructions(instr, pointerSize, typeSize)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range blockRanges {
+			locations = append(locations, ir.Location{
+				Range:  r,
+				Pieces: pieces,
+			})
+		}
+	default:
+		return nil, fmt.Errorf(
+			"unexpected %s class: %s",
+			locField.Attr, locField.Class,
+		)
+	}
+
+	return locations, nil
+}
+
+// FilterIncompleteLocationLists filters out location lists that have missing pieces.
+func FilterIncompleteLocationLists(lists []ir.Location) []ir.Location {
+	var filtered []ir.Location
+	for _, loc := range lists {
+		if len(loc.Pieces) == 0 {
+			continue // Skip empty locations
+		}
+		allPiecesPresent := true
+		for _, piece := range loc.Pieces {
+			if piece.Op == nil {
+				allPiecesPresent = false
+				break
+			}
+		}
+		if allPiecesPresent {
+			filtered = append(filtered, loc)
+		}
+	}
+	return filtered
+}

--- a/pkg/dyninst/symdb/func_name.go
+++ b/pkg/dyninst/symdb/func_name.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package symdb
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Utilities for parsing Go function names.
+
+var (
+	// The parsing goes as follows:
+	// - an optional package name: (((.*/)?.*?)\.)?. Consume (greedily)
+	// everything up to the last slash, and then non-greedily up to the
+	// following dot.
+	// - an optional type name: (\(?\*?(.*?)\)?\.)?. The type name maybe be
+	// between parens and also start with a '*' if it's a pointer receiver;
+	// otherwise the type name is not wrapped in parens. Note that we won't
+	// parse correctly if there is a type name and no package name. Hopefully that
+	// doesn't exist.
+	//   - note that we don't include the optional '*' in the capture group. We
+	//     don't differentiate between pointer and value receivers.
+	//   - note the lazy capture group for the type name: .*?. It's lazy because
+	//     otherwise it also captures the following ')'
+	//   - the function name: (.*)
+	parseFuncNameRE = regexp.MustCompile(`^((?P<pkg>(.*/)?.*?)\.)?(\(?\*?(?P<typ>.*?)\)?\.)?(?P<name>.*)$`)
+	pkgIdx          = parseFuncNameRE.SubexpIndex("pkg")
+	typIdx          = parseFuncNameRE.SubexpIndex("typ")
+	nameIdx         = parseFuncNameRE.SubexpIndex("name")
+
+	// Recognize anonymous functions declared inside a function that is not a method.
+	// They look like:
+	// github.com/.../pkg.myFunc.func1
+	// internal/bytealg.init.0
+	parseAnonymousFuncNameRE = regexp.MustCompile(`^((?P<pkg>(.*/)?\w*?)\.)?(?P<func>(\w*?\.)?((func|gowrap|(\d+)).*))$`)
+	anonPkgIdx               = parseFuncNameRE.SubexpIndex("pkg")
+	anonNameIdx              = parseFuncNameRE.SubexpIndex("name")
+
+	// Recognize funky functions corresponding to anonymous functions defined
+	// inside inlined functions. These have names like:
+	// runtime.gcMarkDone.forEachP.func5
+	// "forEachP.func5" is an anonymous function defined inside forEachP, and
+	// "runtime.gcMarkDone" is the functions inside which "forEachP" is inlined.
+	parseAnonFuncInsideInlinedFunc = regexp.MustCompile(`^((?P<pkg>(.*/)?\w*?)\.)\w+\.\w+\.func(\d)+$`)
+)
+
+type FuncName struct {
+	Package string
+	// Type is the type of the receiver, if any. Empty if this function is not a
+	// method. The type is not a pointer type even if the method has a
+	// pointer-receiver; the base type is returned, without the '*'.
+	Type string
+	Name string
+	// QualifiedName looks like
+	// github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*raftSchedulerShard).worker
+	QualifiedName string
+
+	// GenericFunction is set if the function takes type arguments. We don't
+	// support parsing these functions at the moment, so no other fields except
+	// QualifiedName are set.
+	GenericFunction bool
+}
+
+func (f *FuncName) Empty() bool {
+	return *f == (FuncName{})
+}
+
+// ParseFuncName parses a Go qualified function name. For a qualifiedName name
+// like:
+// github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*raftSchedulerShard).worker
+// the package is: github.com/cockroachdb/cockroach/pkg/kv/kvserver
+// the type is: raftSchedulerShard (note that it doesn't include the '*' signifying a pointer receiver).
+// the name is: worker
+//
+// Returns (zero value, nil) if the function should be ignored.
+//
+// Cases we need to support:
+// github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*raftSchedulerShard).worker
+// github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed.rangefeedFactory.Run
+// github.com/klauspost/compress/zstd.sequenceDecs_decode_amd64
+// indexbytebody
+// github.com/.../pkg.myFunc.func0
+// internal/bytealg.init.0
+func ParseFuncName(qualifiedName string) (FuncName, error) {
+	// Filter out generic functions, e.g.
+	// os.init.OnceValue[go.shape.interface { Error() string }].func3
+	// Note that this name is weird -- os.init is neither a package nor a type,
+	// but rather it has something to do with the generic function's caller.
+	if strings.ContainsRune(qualifiedName, '[') {
+		return FuncName{
+			QualifiedName:   qualifiedName,
+			GenericFunction: true,
+		}, nil
+	}
+
+	// Ignore anonymous functions declared inside inlined functions. These are
+	// DWARF entries corresponding to anonymous functions that are defined
+	// inside a function that was inlined. We don't know what to do with them
+	// because the debug info doesn't point back to the abstract origin.
+	if parseAnonFuncInsideInlinedFunc.FindString(qualifiedName) != "" {
+		return FuncName{}, nil
+	}
+
+	// First, we need to distinguish between the following cases:
+	// github.com/.../pkg.myType.myMethod
+	// and
+	// github.com/.../pkg.myFunc.func1
+	//
+	// The former is a method on a type called myType. The latter is a function
+	// called myFunc.func1. We recognize the former case by checking if the name
+	// starts with some known prefixes. Note that a method like:
+	// github.com/.../pkg.myType.myMethod.func1
+	// will not match our regex; it'll be handled by the general case below.
+
+	// See if the function name looks like an anonymous function declared inside a
+	// function that's not a method.
+	groups := parseAnonymousFuncNameRE.FindStringSubmatch(qualifiedName)
+	if groups != nil {
+		return FuncName{
+			Package:       groups[anonPkgIdx],
+			Name:          groups[anonNameIdx],
+			QualifiedName: qualifiedName,
+		}, nil
+	}
+
+	// We're not dealing with the anonymous function in function case.
+	groups = parseFuncNameRE.FindStringSubmatch(qualifiedName)
+	if groups == nil {
+		return FuncName{}, fmt.Errorf("failed to parse function qualified name: %s", qualifiedName)
+	}
+
+	return FuncName{
+		Package:       groups[pkgIdx],
+		Type:          groups[typIdx],
+		Name:          groups[nameIdx],
+		QualifiedName: qualifiedName,
+	}, nil
+}

--- a/pkg/dyninst/symdb/func_name_test.go
+++ b/pkg/dyninst/symdb/func_name_test.go
@@ -1,0 +1,52 @@
+package symdb_test
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParseFuncName(t *testing.T) {
+	tests := []struct {
+		testName      string
+		qualifiedName string
+		expected      symdb.FuncName
+	}{
+		{"simple func", "github.com/cockroachdb/cockroach/pkg/kv.func1",
+			symdb.FuncName{
+				Package: "github.com/cockroachdb/cockroach/pkg/kv",
+				Type:    "",
+				Name:    "func1",
+			},
+		},
+		{"method", "github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftSchedulerShard.worker",
+			symdb.FuncName{
+				Package: "github.com/cockroachdb/cockroach/pkg/kv/kvserver",
+				Type:    "raftSchedulerShard",
+				Name:    "worker",
+			},
+		},
+		{"method with ptr receiver", "github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*raftSchedulerShard).worker",
+			symdb.FuncName{
+				Package: "github.com/cockroachdb/cockroach/pkg/kv/kvserver",
+				Type:    "raftSchedulerShard",
+				Name:    "worker",
+			},
+		},
+		{"generic function", "os.init.OnceValue[go.shape.interface { Error() string }].func3",
+			symdb.FuncName{
+				GenericFunction: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			result, err := symdb.ParseFuncName(tt.qualifiedName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.expected.QualifiedName = tt.qualifiedName
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -1,0 +1,772 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package symdb
+
+import (
+	"debug/dwarf"
+	"debug/gosym"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/dwarfutil"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
+)
+
+// Symbols models the symbols from a binary that get exported to SymDB.
+type Symbols struct {
+	Packages []Package
+}
+
+type Package struct {
+	Name      string
+	Functions []Function
+	Types     []Type
+}
+
+type Type struct {
+	Name    string
+	Methods []Function
+	// Fields contains the struct fields. Empty if the type is not a struct.
+	Fields []Field
+
+	// NOTE: Go debug info doesn't have file:line info for types. For structs,
+	// we could perhaps use the file:line info of the first method.
+}
+
+// Field describes a field of a struct type.
+type Field struct {
+	Name string
+	// The fully-qualified name of the field's type. Pointer types start with a
+	// "*" (e.g. *main.bigStruct).
+	Type string
+}
+
+// Function models a Go function or method. It is represented in SymDB as a
+// scope.
+type Function struct {
+	// The function's unqualified name.
+	Name string
+	File string
+	// The function itself represents a lexical block, with variables and
+	// sub-scopes.
+	Scope
+}
+
+func (f Function) empty() bool {
+	return f.Name == ""
+}
+
+// Scope represents a function or another lexical block.
+type Scope struct {
+	StartLine int
+	EndLine   int
+	Scopes    []Scope
+	Variables []Variable
+}
+
+// Variable represents a variable or function argument.
+type Variable struct {
+	Name     string
+	TypeName string
+	// FunctionArgument indicates if this variable is a function argument, as
+	// opposed to a local variable. Function arguments can only appear inside
+	// Function, never inside Scope.
+	FunctionArgument bool
+	// The line on which the variable was declared in the source code. Note that
+	// the variable is not necessarily actually available to be captured by the
+	// debugger from that line to the end of the lexical block; see
+	// AvailableLineRanges.
+	DeclLine            int
+	AvailableLineRanges [][2]int
+}
+
+// SymDBBuilder walks the DWARF data for a binary, extracting symbols in the
+// SymDB format.
+type SymDBBuilder struct {
+	// The DWARF data to extract symbols from.
+	dwarfData *dwarf.Data
+	// The Go symbol table for the binary, used to resolve PC addresses to
+	// functions.
+	sym *gosym.Table
+	// The location list reader used to read location lists for variables.
+	loclistReader *loclist.Reader
+	// The size of pointers for the binary's architecture, in bytes.
+	pointerSize int
+
+	// typesCache will accumulate types as we look them up to resolve variables
+	// and functions.
+	typesCache *dwarfutils.TypeFinder
+
+	// typesInfo maps from type qualified name to the Type being built for the
+	// exploration results. Used to gradually add methods to Types as we
+	// discover them.
+	types map[string]Type
+
+	// The compile unit currently being processed by explore* functions.
+	currentCompileUnit        *dwarf.Entry
+	filesInCurrentCompileUnit []string
+
+	// Stack of blocks currently being explored. Variable location lists can
+	// make references to the current block and its PC ranges; they will look at
+	// the top of this stack.
+	blockStack []codeBlock
+}
+
+// PCRange corresponds to a range of program counters (PCs). Ranges are
+// inclusive of the start and exclusive of the end.
+type PCRange = [2]uint64
+
+// codeBlock abstracts LexicalBlocks, Subprograms and InlinedSubroutines. They
+// all correspond to a list of PC ranges.
+type codeBlock interface {
+	resolvePCRanges(dwarfData *dwarf.Data) ([]PCRange, error)
+}
+
+// dwarfBlock is the implementation of codeBlock for lexical blocks.
+type dwarfBlock struct {
+	// The DWARF entry for the lexical block.
+	entry    *dwarf.Entry
+	pcRanges []PCRange
+	// pcRangesResolved is set if pcRanges has been already calculated.
+	pcRangesResolved bool
+}
+
+// dwarfBlock implements codeBlock.
+var _ codeBlock = (*dwarfBlock)(nil)
+
+// resolvePCRanges parses and memoizes the ranges attribute of the dwarf entry.
+func (d *dwarfBlock) resolvePCRanges(dwarfData *dwarf.Data) ([]PCRange, error) {
+	if d.pcRangesResolved {
+		return d.pcRanges, nil
+	}
+
+	ranges, err := dwarfData.Ranges(d.entry)
+	if err != nil {
+		return nil, err
+	}
+	d.pcRanges = ranges
+	d.pcRangesResolved = true
+	return d.pcRanges, nil
+}
+
+// resolveLine computes the start and end lines of the lexical block by
+// combining PC ranges from DWARF with pclinetab data. Returns [0,0] if the
+// block has no address ranges, and thus no lines.
+func (d *dwarfBlock) resolveLines(dwarfData *dwarf.Data, funcTable *gosym.Func) ([2]int, error) {
+	// Find the start and end lines of the block by going through the address
+	// ranges, resolving them to lines, and selecting the minimum and maximum.
+	ranges, err := d.resolvePCRanges(dwarfData)
+	if err != nil {
+		return [2]int{}, err
+	}
+	if len(ranges) == 0 {
+		return [2]int{}, nil
+	}
+	startLine := math.MaxInt
+	endLine := 0
+	for _, r := range ranges {
+		rangeStartLine := funcTable.LineTable.PCToLine(r[0])
+		rangeEndLine := funcTable.LineTable.PCToLine(r[1])
+		if rangeStartLine < startLine {
+			startLine = rangeStartLine
+		}
+		if rangeEndLine > endLine {
+			endLine = rangeEndLine
+		}
+	}
+	return [2]int{startLine, endLine}, nil
+}
+
+// subprogBlock is the implementation of codeBlock for subprograms. The block's
+// PC ranges are resolved trivially to a single range.
+type subprogBlock struct {
+	lowpc  uint64
+	highpc uint64
+}
+
+// subprogBlock implements codeBlock.
+var _ codeBlock = subprogBlock{}
+
+// resolvePCRanges implements the codeBlock interface.
+func (s subprogBlock) resolvePCRanges(*dwarf.Data) ([]PCRange, error) {
+	return []PCRange{{s.lowpc, s.highpc}}, nil
+}
+
+func NewSymDBBuilder(file *object.ElfFile) (*SymDBBuilder, error) {
+	dwarfData, err := file.DWARF()
+	if err != nil {
+		return nil, err
+	}
+
+	lineTableSect := file.Section(".gopclntab")
+	if lineTableSect == nil {
+		return nil, fmt.Errorf("missing .gopclntab section")
+	}
+	textSect := file.Section(".text")
+	if textSect == nil {
+		return nil, fmt.Errorf("missing required sections")
+	}
+	lineTableData, err := lineTableSect.Data()
+	if err != nil {
+		return nil, fmt.Errorf("read .gopclntab: %w", err)
+	}
+	textAddr := file.Section(".text").Addr
+	lineTable := gosym.NewLineTable(lineTableData, textAddr)
+	symTable, err := gosym.NewTable([]byte{}, lineTable)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse .gosymtab: %w", err)
+	}
+	loclistReader, err := file.LoclistReader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create loclist reader: %w", err)
+	}
+
+	return &SymDBBuilder{
+		dwarfData:     dwarfData,
+		sym:           symTable,
+		loclistReader: loclistReader,
+		pointerSize:   int(file.Architecture().PointerSize()),
+		typesCache:    dwarfutils.NewTypeFinder(dwarfData),
+		types:         make(map[string]Type),
+	}, nil
+}
+
+// ExtractSymbols walks the DWARF data and accumulates the symbols to send to
+// SymDB.
+func (b *SymDBBuilder) ExtractSymbols() (Symbols, error) {
+	var res Symbols
+	entryReader := b.dwarfData.Reader()
+
+	// Recognize compile units, which are the top-level entries in the DWARF
+	// data corresponding to Go packages.
+	for entry, err := entryReader.Next(); entry != nil; entry, err = entryReader.Next() {
+		if err != nil {
+			return Symbols{}, err
+		}
+
+		if entry.Tag != dwarf.TagCompileUnit {
+			entryReader.SkipChildren()
+			continue
+		}
+
+		pkg, err := b.exploreCompileUnit(entry, entryReader)
+		if err != nil {
+			return Symbols{}, err
+		}
+		res.Packages = append(res.Packages, pkg)
+	}
+	return res, nil
+}
+
+func (b *SymDBBuilder) currentBlock() codeBlock {
+	return b.blockStack[len(b.blockStack)-1]
+}
+
+func (b *SymDBBuilder) pushBlock(block codeBlock) {
+	b.blockStack = append(b.blockStack, block)
+}
+
+func (b *SymDBBuilder) popBlock() {
+	if len(b.blockStack) == 0 {
+		panic("popBlock called on empty block stack")
+	}
+	b.blockStack = b.blockStack[:len(b.blockStack)-1]
+}
+
+func (b *SymDBBuilder) resolveType(offset dwarf.Offset) (godwarf.Type, error) {
+	typ, err := b.typesCache.FindTypeByOffset(offset)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap pointer types until we reach a non-pointer type.
+	for t, ok := typ.(*godwarf.PtrType); ok; t, ok = typ.(*godwarf.PtrType) {
+		typ = t.Type
+	}
+
+	// Check if we've seen this type before. If we haven't, add it to the types
+	// map.
+	name := typ.Common().Name
+	if _, ok := b.types[name]; !ok {
+		t := Type{
+			Name:    name,
+			Methods: nil,
+		}
+		if s, ok := typ.(*godwarf.StructType); ok {
+			for _, field := range s.Field {
+				t.Fields = append(t.Fields, Field{
+					Name: field.Name,
+					Type: field.Type.Common().Name,
+				})
+			}
+		}
+		b.types[name] = t
+	}
+
+	return typ, nil
+}
+
+// exploreCompileUnit processes a compile unit entry (entry's tag is TagCompileUnit).
+func (b *SymDBBuilder) exploreCompileUnit(entry *dwarf.Entry, reader *dwarf.Reader) (Package, error) {
+	if entry.Tag != dwarf.TagCompileUnit {
+		return Package{}, fmt.Errorf("expected TagCompileUnit, got %s", entry.Tag)
+	}
+
+	b.currentCompileUnit = entry
+	defer func() { b.currentCompileUnit = nil }()
+
+	var res Package
+	name, ok := entry.Val(dwarf.AttrName).(string)
+	if !ok {
+		return Package{}, errors.New("compile unit without name")
+	}
+	res.Name = name
+
+	cuLineReader, err := b.dwarfData.LineReader(entry)
+	if err != nil {
+		return Package{}, fmt.Errorf("could not get file line reader for compile unit %s: %w", name, err)
+	}
+	var files []string
+	if cuLineReader != nil {
+		for i, file := range cuLineReader.Files() {
+			if file == nil {
+				// Each compile unit starts with a nil entry at position 0; 0 is
+				// used as a sentinel by file references to indicate that the
+				// file is not known.
+				if i != 0 {
+					return Package{}, fmt.Errorf(
+						"compile unit %s has invalid nil file entry at index %d", name, i)
+				}
+				files = append(files, "")
+				continue
+			}
+			files = append(files, strings.Clone(file.Name))
+		}
+	}
+	b.filesInCurrentCompileUnit = files
+
+	// We recognize subprograms and types.
+	for child, err := reader.Next(); child != nil; child, err = reader.Next() {
+		if err != nil {
+			return Package{}, err
+		}
+		if IsEntryNull(child) {
+			break // End of children for this compile unit.
+		}
+
+		if child.Tag == dwarf.TagSubprogram {
+			function, err := b.exploreSubprogram(child, reader)
+			if err != nil {
+				return Package{}, err
+			}
+			if !function.empty() {
+				res.Functions = append(res.Functions, function)
+			}
+		} else if child.Tag == dwarf.TagTypedef ||
+			child.Tag == dwarf.TagClassType ||
+			child.Tag == dwarf.TagUnionType ||
+			child.Tag == dwarf.TagPointerType ||
+			child.Tag == dwarf.TagStructType {
+			// TODO: deal with more type tags above
+
+			typeName, ok := child.Val(dwarf.AttrName).(string)
+			if !ok {
+				continue // Skip if no name
+			}
+			t := Type{Name: typeName}
+
+			// TODO: read the struct fields
+			// TODO: deduplicate pointer types and their pointees.
+
+			b.types[typeName] = t
+
+			res.Types = append(res.Types, t)
+		} else {
+			reader.SkipChildren()
+		}
+	}
+
+	// !!! copy the types from this current package to the output (since we now
+	// know all the methods of their types).
+	//for _, t := range b.types {
+	//	res.Types = append(res.Types, t)
+	//}
+
+	return res, nil
+}
+
+// DW_INL_inlined is the value for AttrInline marking the function as inlined.
+const DW_INL_inlined = 1
+
+// exploreSubprogram processes a subprogram entry, corresponding to a Go
+// function (entry's tag is TagSubprogram). It accumulates the function's
+// lexical blocks and variables. If the function is free-standing (not a
+// method), returns the accumulated info. If the function is a method (i.e. has
+// a receiver), it is appended to the types methods in the types collection.
+//
+// Returns a zero Function if the kind of function is currently unsupported and
+// should be ignored.
+//
+// Upon return, the reader is positioned after the subprogram's children.
+func (b *SymDBBuilder) exploreSubprogram(
+	subprogEntry *dwarf.Entry, reader *dwarf.Reader,
+) (Function, error) {
+	earlyExit := func() (Function, error) {
+		reader.SkipChildren()
+		return Function{}, nil
+	}
+
+	if subprogEntry.Tag != dwarf.TagSubprogram {
+		return Function{}, fmt.Errorf("expected TagSubprogram, got %s", subprogEntry.Tag)
+	}
+
+	// If this is a "concrete-out-of-line" instance of a subprogram, the
+	// variables inside it will reference the abstract origin. We don't handle
+	// that at the moment, so skip these functions.
+	// TODO: handle concrete-out-of-line instances of functions.
+	if subprogEntry.AttrField(dwarf.AttrAbstractOrigin) != nil {
+		return earlyExit()
+	}
+
+	funcQualifiedName, ok := subprogEntry.Val(dwarf.AttrName).(string)
+	if !ok {
+		return Function{}, errors.New("subprogram without name")
+	}
+	inline, ok := subprogEntry.Val(dwarf.AttrInline).(int64)
+	if ok {
+		if inline == DW_INL_inlined {
+			// This function is always inlined; its variables don't have
+			// location lists here; instead, each inlined instance will have
+			// them. Nothing to do.
+			return earlyExit()
+		}
+	}
+
+	fileIdx, ok := subprogEntry.Val(dwarf.AttrDeclFile).(int64)
+	if !ok {
+		// No DeclFile means the function is coming from the stdlib.
+		fileIdx = 0
+	}
+	if fileIdx < 0 || int(fileIdx) >= len(b.filesInCurrentCompileUnit) {
+		return Function{}, fmt.Errorf(
+			"subprogram %s has invalid file index %d, expected in range [0, %d)",
+			funcQualifiedName, fileIdx, len(b.filesInCurrentCompileUnit),
+		)
+	}
+	fileName := b.filesInCurrentCompileUnit[fileIdx]
+	// There are some funky auto-generated functions that we can't deal with
+	// because we can't parse their names (e.g.
+	// type:.eq.sync/atomic.Pointer[os.dirInfo]). Skip everything
+	// auto-generated.
+	if fileName == "<autogenerated>" {
+		return earlyExit()
+	}
+
+	// We cannot deal with the auto-generated trampoline functions because they
+	// don't have debug info. The name looks like a method, but there's no info
+	// on the pointer receiver. Also, we don't want to show these functions to
+	// users anyway.
+	if subprogEntry.AttrField(dwarf.AttrTrampoline) != nil {
+		return earlyExit()
+	}
+
+	lowpc, ok := subprogEntry.Val(dwarf.AttrLowpc).(uint64)
+	if !ok {
+		return Function{}, fmt.Errorf("subprogram without lowpc: %s", funcQualifiedName)
+	}
+	highpc, ok := subprogEntry.Val(dwarf.AttrHighpc).(uint64)
+	if !ok {
+		return Function{}, errors.New("subprogram without highpc")
+	}
+
+	// From now on, location lists that reference the current block will
+	// reference this function.
+	b.pushBlock(subprogBlock{lowpc: lowpc, highpc: highpc})
+	defer b.popBlock()
+
+	// Resolve the address range to a function, and use the function's line
+	// table to resolve addresses for all the scopes in the function. We
+	// technically don't need to do this -- b.sym.PCToFunc can be used directly
+	// to resolve any address across all the functions, but resolving the
+	// function first and reusing that is more efficient.
+	funcTable := b.sym.PCToFunc(lowpc)
+
+	startLine := funcTable.LineTable.PCToLine(lowpc)
+	endLine := funcTable.LineTable.PCToLine(highpc)
+
+	// Explore the function's body. Besides collecting the information that we
+	// want to explore to SymDB, this also has the side effect of resolving the
+	// types of all the function arguments; in particular, we rely below on the
+	// type of the receiver having been resolved.
+	inner, err := b.exploreCode(reader, funcTable)
+	if err != nil {
+		return Function{}, err
+	}
+
+	funcName, err := ParseFuncName(funcQualifiedName)
+	if err != nil {
+		return Function{}, err
+	}
+	if funcName.Empty() {
+		return Function{}, err
+	}
+
+	res := Function{
+		Name: funcName.Name,
+		File: fileName,
+		Scope: Scope{
+			StartLine: startLine,
+			EndLine:   endLine,
+			Variables: inner.vars,
+			Scopes:    inner.scopes,
+		},
+	}
+
+	if funcName.GenericFunction {
+		return Function{}, err
+	}
+	// If this function is a method (i.e. it has a receiver), we add it to the
+	// respective type instead of returning it as a stand-alone function.
+	if funcName.Type != "" {
+		typeQualifiedName := funcName.Package + "." + funcName.Type
+		// We expect the type of the receiver to have been populated by the
+		// exploreCode() call above.
+		typ, ok := b.types[typeQualifiedName]
+		if !ok {
+			return Function{}, fmt.Errorf(
+				"%s is a method of type %s, but that type is missing from the cache. DWARF offset: 0x%x",
+				funcQualifiedName, typeQualifiedName, subprogEntry.Offset,
+			)
+		}
+		typ.Methods = append(typ.Methods, res)
+		b.types[typeQualifiedName] = typ
+		return Function{}, nil
+	} else {
+		return res, nil
+	}
+}
+
+func (b *SymDBBuilder) exploreInlinedSubroutine(inlinedEntry *dwarf.Entry, reader *dwarf.Reader) error {
+	if inlinedEntry.Tag != dwarf.TagInlinedSubroutine {
+		return fmt.Errorf("expected TagInlinedSubroutine, got %s", inlinedEntry.Tag)
+	}
+	// TODO: accumulate variable availability data and join it with the other
+	// inlined and out-of-line instances.
+	reader.SkipChildren()
+	return nil
+}
+
+// exploreLexicalBlock processes a lexical block entry. If the block contains
+// any variables, it returns one Scope with those variables and any sub-blocks.
+// If the block does not contain any variables, it returns any sub-blocks that
+// do contain variables (if any).
+func (b *SymDBBuilder) exploreLexicalBlock(
+	blockEntry *dwarf.Entry, reader *dwarf.Reader, funcTable *gosym.Func,
+) ([]Scope, error) {
+	if blockEntry.Tag != dwarf.TagLexDwarfBlock {
+		return nil, fmt.Errorf("expected TagLexDwarfBlock, got %s", blockEntry.Tag)
+	}
+	currentBlock := &dwarfBlock{entry: blockEntry}
+	// From now on, location lists that reference the current block will
+	// reference this block.
+	b.pushBlock(currentBlock)
+	defer b.popBlock()
+
+	inner, err := b.exploreCode(reader, funcTable)
+	if err != nil {
+		return nil, fmt.Errorf("error exploring code in lexical block: %w", err)
+	}
+
+	// If the block has any variables, then we create a scope for it. If it
+	// doesn't, then inner scopes (if any), are returned directly, to be added
+	// as direct children of the caller's block.
+	if len(inner.vars) != 0 {
+		lineRange, err := currentBlock.resolveLines(b.dwarfData, funcTable)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving lines for lexical block: %w (0x%x)",
+				err, currentBlock.entry.Offset)
+		}
+		if lineRange == [2]int{} {
+			// The block has no address ranges; let's ignore it. I've seen a
+			// case where this happens even though the block has variables
+			// inside it; in that case, the variables did not have availability
+			// information either, so the block was useless.
+			return nil, nil
+		}
+		// Replace all the accumulated scopes with a new scope that contains them as
+		// children.
+		return []Scope{{
+			StartLine: lineRange[0],
+			EndLine:   lineRange[1],
+			Scopes:    inner.scopes,
+			Variables: inner.vars,
+		}}, nil
+	} else {
+		return inner.scopes, nil
+	}
+}
+
+func (b *SymDBBuilder) parseVariable(varEntry *dwarf.Entry, funcTable *gosym.Func) (Variable, error) {
+	varName, ok := varEntry.Val(dwarf.AttrName).(string)
+	if !ok {
+		return Variable{}, fmt.Errorf("formal parameter without name at 0x%x", varEntry.Offset)
+	}
+	declLine, ok := varEntry.Val(dwarf.AttrDeclLine).(int64)
+	if !ok {
+		return Variable{}, errors.New("formal parameter without declaration line")
+	}
+	typeOffset, ok := varEntry.Val(dwarf.AttrType).(dwarf.Offset)
+	if !ok {
+		return Variable{}, errors.New("formal parameter without type")
+	}
+	typ, err := b.resolveType(typeOffset)
+	if err != nil {
+		return Variable{}, err
+	}
+
+	// Parse the line availability for the variable.
+	var availableLineRanges [][2]int
+	if locField := varEntry.AttrField(dwarf.AttrLocation); locField != nil {
+		pcRanges, err := b.processLocations(locField, uint32(typ.Size()))
+		if err != nil {
+			return Variable{}, fmt.Errorf(
+				"error processing locations for variable %q: %w", varName, err,
+			)
+		}
+		for _, r := range pcRanges {
+			rangeStartLine := funcTable.LineTable.PCToLine(r[0])
+			rangeEndLine := funcTable.LineTable.PCToLine(r[1])
+			availableLineRanges = append(availableLineRanges, [2]int{rangeStartLine, rangeEndLine})
+		}
+	}
+
+	// Merge the available lines into disjoint ranges.
+	if len(availableLineRanges) > 0 {
+		sort.Slice(availableLineRanges, func(i, j int) bool {
+			return availableLineRanges[i][0] < availableLineRanges[j][0]
+		})
+		merged := make([][2]int, 0, len(availableLineRanges))
+		merged = append(merged, availableLineRanges[0])
+		for _, curr := range availableLineRanges[1:] {
+			last := &merged[len(merged)-1]
+			if curr[0] <= (*last)[1] {
+				if curr[1] > last[1] {
+					// curr extends last.
+					last[1] = curr[1]
+				}
+			} else {
+				// curr is disjoint from last, so add it.
+				merged = append(merged, curr)
+			}
+		}
+		availableLineRanges = merged
+	}
+
+	return Variable{
+		Name:                varName,
+		DeclLine:            int(declLine),
+		TypeName:            typ.Common().Name,
+		FunctionArgument:    false,
+		AvailableLineRanges: availableLineRanges,
+	}, nil
+}
+
+// processLocations goes through a list of location lists and returns the PC
+// ranges for which the whole variable is available. Ranges for which the
+// variable is only partially available are ignored.
+func (b *SymDBBuilder) processLocations(
+	locField *dwarf.Field,
+	// The size of the type that this location list is describing.
+	totalSize uint32,
+) ([]PCRange, error) {
+	// TODO: resolving these PC ranges is only necessary for variables that use
+	// dwarf.ClassExprLoc; it's not necessary for other variables. It might be
+	// worth it to make the computation lazy.
+	pcRanges, err := b.currentBlock().resolvePCRanges(b.dwarfData)
+	if err != nil {
+		return nil, err
+	}
+	loclists, err := dwarfutil.ProcessLocations(locField, b.currentCompileUnit, b.loclistReader, pcRanges, totalSize, uint8(b.pointerSize))
+	if err != nil {
+		return nil, err
+	}
+	loclists = dwarfutil.FilterIncompleteLocationLists(loclists)
+	res := make([]PCRange, len(loclists))
+	for i, loc := range loclists {
+		res[i] = loc.Range
+	}
+	return res, nil
+}
+
+type exploreCodeResult struct {
+	// vars contains all the variables that are defined by the outer scope (i.e.
+	// not inside `scopes`).
+	vars   []Variable
+	scopes []Scope
+}
+
+// exploreCode contains shared logic for exploring blocks, subprograms, and
+// inlined subprograms.
+func (b *SymDBBuilder) exploreCode(
+	reader *dwarf.Reader, funcTable *gosym.Func,
+) (exploreCodeResult, error) {
+	var res exploreCodeResult
+	for child, err := reader.Next(); child != nil; child, err = reader.Next() {
+		if err != nil {
+			return exploreCodeResult{}, err
+		}
+		if IsEntryNull(child) {
+			break // End of children for this subprogram.
+		}
+
+		// We recognize formal parameters, variables, lexical blocks and inlined subroutines.
+		switch child.Tag {
+		case dwarf.TagFormalParameter:
+			v, err := b.parseVariable(child, funcTable)
+			if err != nil {
+				return exploreCodeResult{}, err
+			}
+			v.FunctionArgument = true
+			res.vars = append(res.vars, v)
+		case dwarf.TagVariable:
+			v, err := b.parseVariable(child, funcTable)
+			if err != nil {
+				return exploreCodeResult{}, err
+			}
+			res.vars = append(res.vars, v)
+		case dwarf.TagLexDwarfBlock:
+			scopes, err := b.exploreLexicalBlock(child, reader, funcTable)
+			if err != nil {
+				return exploreCodeResult{}, err
+			}
+			res.scopes = append(res.scopes, scopes...)
+		case dwarf.TagInlinedSubroutine:
+			if err := b.exploreInlinedSubroutine(child, reader); err != nil {
+				return exploreCodeResult{}, err
+			}
+		}
+	}
+	return res, nil
+}
+
+// IsEntryNull determines whether a *dwarf.Entry value is a "null" DIE, which
+// are used to denote the end of sub-trees. See DWARF v4 spec, section 2.3.
+func IsEntryNull(entry *dwarf.Entry) bool {
+	// Every field is 0 in an empty entry.
+	return !entry.Children &&
+		len(entry.Field) == 0 &&
+		entry.Offset == 0 &&
+		entry.Tag == dwarf.Tag(0)
+}

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -1,0 +1,113 @@
+package symdb_test
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymDB(t *testing.T) {
+	cfgs, err := testprogs.GetCommonConfigs()
+	require.NoError(t, err)
+	for _, cfg := range cfgs {
+		binaryPath, err := testprogs.GetBinary("simple", cfg)
+		require.NoError(t, err)
+		elf, err := safeelf.Open(binaryPath)
+		require.NoError(t, err)
+		file, err := object.NewElfObject(elf)
+		require.NoError(t, err)
+		// !!!
+		//obj, err := object.NewElfObject(elf)
+		//require.NoError(t, err)
+		//dwarfData, err := obj.DWARF()
+		//require.NoError(t, err)
+		//
+		//lineTableSect := elf.Section(".gopclntab")
+		//textSect := elf.Section(".text")
+		//if lineTableSect == nil || textSect == nil {
+		//	t.Fatalf("missing required sections in %s", binaryPath)
+		//}
+		//
+		//lineTableData, err := lineTableSect.Data()
+		//if err != nil {
+		//	t.Fatalf("read .gopclntab: %s", err)
+		//}
+		//
+		//textAddr := elf.Section(".text").Addr
+		//lineTable := gosym.NewLineTable(lineTableData, textAddr)
+		//symTable, err := gosym.NewTable([]byte{}, lineTable)
+		//if err != nil {
+		//	t.Fatalf("failed to parse .gosymtab: %s", err)
+		//}
+		//
+		//loclistReader, err := obj.LoclistReader()
+		//if err != nil {
+		//	t.Fatalf("failed to create loclist reader: %s", err)
+		//}
+		//symBuilder := symdb.NewSymDBBuilder(dwarfData, symTable, loclistReader, 8)
+		symBuilder, err := symdb.NewSymDBBuilder(file)
+		require.NoError(t, err)
+		symbols, err := symBuilder.ExtractSymbols()
+		require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
+		require.NotEmpty(t, symbols.Packages)
+
+		pkg, ok := findPackage(symbols, "main")
+		require.Truef(t, ok, "package 'main' not found in %s", binaryPath)
+		fn, ok := findFunction(pkg, "stringArg")
+		require.Truef(t, ok, "function 'stringArg' not found in package 'main' in %s", binaryPath)
+		v, ok := findVariable(fn.Scope, "s")
+		require.Truef(t, ok, "variable 's' not found in function 'stringArg' in package 'main' in %s", binaryPath)
+		require.True(t, v.FunctionArgument)
+		require.NotZero(t, v.DeclLine)
+		require.NotEmpty(t, v.AvailableLineRanges)
+	}
+}
+
+func findPackage(s symdb.Symbols, pkgName string) (symdb.Package, bool) {
+	for _, pkg := range s.Packages {
+		if pkg.Name == pkgName {
+			return pkg, true
+		}
+	}
+	return symdb.Package{}, false
+}
+
+func findFunction(pkg symdb.Package, fnName string) (symdb.Function, bool) {
+	for _, fn := range pkg.Functions {
+		if fn.Name == fnName {
+			return fn, true
+		}
+	}
+	return symdb.Function{}, false
+}
+
+func findType(pkg symdb.Package, typeName string) (symdb.Type, bool) {
+	for _, typ := range pkg.Types {
+		if typ.Name == typeName {
+			return typ, true
+		}
+	}
+	return symdb.Type{}, false
+}
+
+func findMethod(typ symdb.Type, methodName string) (symdb.Function, bool) {
+	for _, method := range typ.Methods {
+		if method.Name == methodName {
+			return method, true
+		}
+	}
+	return symdb.Function{}, false
+}
+
+func findVariable(scope symdb.Scope, varName string) (symdb.Variable, bool) {
+	for _, variable := range scope.Variables {
+		if variable.Name == varName {
+			return variable, true
+		}
+	}
+	return symdb.Variable{}, false
+}


### PR DESCRIPTION
Walk through the DWARF debug info for a Go binary and extract the symbols data that we'll export to SymDB.
