### PR TITLE
do not recursively set perms on installer data directory

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -920,12 +920,12 @@ func checkAvailableDiskSpace(repositories *repository.Repositories, pkg *oci.Dow
 // ensureRepositoriesExist creates the temp, packages and configs directories if they don't exist
 func ensureRepositoriesExist() error {
 	// TODO: should we call paths.EnsureInstallerDataDir() here?
-	//       It should probably be anywhere that the below directories must be created,
-	//       but it feels wrong to have the constructor perform work like this.
-	//       For example, "read only" subcommands like `get-states` will end up
-	//       iterating the filesystem tree to apply permissions, and every
-	//       subprocess during experiments will repeat the work, even though it should
-	//       only be needed at install/setup time.
+	//       It should probably be anywhere that the below directories must be
+	//       created, but it feels wrong to have the constructor perform work
+	//       like this. For example, "read only" subcommands like `get-states`
+	//       will end up iterating the filesystem tree to apply permissions,
+	//       and every subprocess during experiments will repeat the work,
+	//       even though it should only be needed at install/setup time.
 	err := os.MkdirAll(paths.PackagesPath, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating packages directory: %w", err)

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -919,7 +919,11 @@ func checkAvailableDiskSpace(repositories *repository.Repositories, pkg *oci.Dow
 
 // ensureRepositoriesExist creates the temp, packages and configs directories if they don't exist
 func ensureRepositoriesExist() error {
-	err := os.MkdirAll(paths.PackagesPath, 0755)
+	err := paths.EnsureInstallerDataDir()
+	if err != nil {
+		return fmt.Errorf("error ensuring repositories exist: %w", err)
+	}
+	err = os.MkdirAll(paths.PackagesPath, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating packages directory: %w", err)
 	}

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -919,11 +919,14 @@ func checkAvailableDiskSpace(repositories *repository.Repositories, pkg *oci.Dow
 
 // ensureRepositoriesExist creates the temp, packages and configs directories if they don't exist
 func ensureRepositoriesExist() error {
-	err := paths.EnsureInstallerDataDir()
-	if err != nil {
-		return fmt.Errorf("error ensuring repositories exist: %w", err)
-	}
-	err = os.MkdirAll(paths.PackagesPath, 0755)
+	// TODO: should we call paths.EnsureInstallerDataDir() here?
+	//       It should probably be anywhere that the below directories must be created,
+	//       but it feels wrong to have the constructor perform work like this.
+	//       For example, "read only" subcommands like `get-states` will end up
+	//       iterating the filesystem tree to apply permissions, and every
+	//       subprocess during experiments will repeat the work, even though it should
+	//       only be needed at install/setup time.
+	err := os.MkdirAll(paths.PackagesPath, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating packages directory: %w", err)
 	}

--- a/releasenotes/notes/fix-installer-data-permissions-2a7df94e7da444d2.yaml
+++ b/releasenotes/notes/fix-installer-data-permissions-2a7df94e7da444d2.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Permissions are no longer applied recursively to the Datadog installer
+    data directory on Windows.
+
+    This fixes an issue that causes Agent updates to restrict access to the
+    .NET APM tracer libraries that were previously installed by the
+    ``DD_APM_INSTRUMENTATION_LIBRARIES`` option, preventing them from being
+    loaded by IIS.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
 Permissions are no longer applied recursively to the Datadog installer data directory on Windows.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1556
Fixes an issue that causes Agent updates to restrict access to the .NET APM tracer libraries that were previously installed by the ``DD_APM_INSTRUMENTATION_LIBRARIES`` option, preventing them from being loaded by IIS.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Reproduce the issue
- Install Agent 7.65 or later with APM SSI for IIS
- Update the Agent to another stable version
- Verify tracer libraries are no longer globally readable

Install new version to apply fix
- Install the version from this PR (MSI, or install script, or remotely, it doesn't matter)
- Verify the tracer libraries are globally readable again

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
workaround until update is available:
Option 1:
update the permissions
```PowerShell
icacls.exe C:\ProgramData\Datadog\Installer\packages /inheritance:d /grant Everyone:"(OI)(CI)(RX,S)"
```
Option 2:
Remotely update the .NET tracer libraries using Fleet Automation