### PR TITLE
Add peak memory reporting when using containerd metrics collector

### DIFF
--- a/pkg/util/containers/metrics/containerd/collector_cgroupv2.go
+++ b/pkg/util/containers/metrics/containerd/collector_cgroupv2.go
@@ -62,6 +62,7 @@ func getMemoryStatsCgroupV2(memStat *v2.MemoryStat, memEvents *v2.MemoryEvents) 
 		Swap:         pointer.Ptr(float64(memStat.SwapUsage)),
 		Pgfault:      pointer.Ptr(float64(memStat.Pgfault)),
 		Pgmajfault:   pointer.Ptr(float64(memStat.Pgmajfault)),
+		Peak:         pointer.Ptr(float64(memStat.MaxUsage)),
 	}
 
 	if memEvents != nil {

--- a/pkg/util/containers/metrics/containerd/collector_linux_test.go
+++ b/pkg/util/containers/metrics/containerd/collector_linux_test.go
@@ -145,6 +145,7 @@ func TestGetContainerStats_Containerd(t *testing.T) {
 			KernelStack:  100,
 			Pgfault:      2,
 			Pgmajfault:   1,
+			MaxUsage:     1000,
 		},
 		Io: &v2.IOStat{
 			Usage: []*v2.IOEntry{
@@ -252,6 +253,7 @@ func TestGetContainerStats_Containerd(t *testing.T) {
 					Swap:         pointer.Ptr(10.0),
 					Pgfault:      pointer.Ptr(2.0),
 					Pgmajfault:   pointer.Ptr(1.0),
+					Peak:         pointer.Ptr(1000.0),
 				},
 				IO: &provider.ContainerIOStats{
 					ReadBytes:       pointer.Ptr(60.0),


### PR DESCRIPTION
### What does this PR do?

Add peak memory reporting when using containerd metrics collector. Useful for Kata containers.

### Motivation

Provide more metrics for Kata containers.

### Describe how you validated your changes

Run a container with Kata containers and containerd, the `container.memory.usage.peak` metric should be reported.

### Possible Drawbacks / Trade-offs

### Additional Notes