### PR TITLE
Avoid bazel symlinks in modules.validate task

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -171,6 +171,10 @@ def validate(ctx: Context, base_dir='.', fix_format=False):
 
     # Backward check for go.mod (ensure there is a module for each go.mod)
     for go_mod in glob(str(base_dir / '**/go.mod'), recursive=True):
+        # Ignore bazel generated symlinks
+        if go_mod.startswith(str(base_dir / 'bazel')):
+            continue
+
         path = Path(go_mod).parent.relative_to(base_dir).as_posix()
         assert path in config.modules or path in config.ignored_modules, f"Configuration is missing a module for {path}"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`glob` follows symlinks and makes this task to fail when using bazel, ignored bazel directories.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->