### PR TITLE
[AGENTRUN-477] Fix wrong provided TLS configuration in TraceAgent

### DIFF
--- a/comp/trace/config/hostname.go
+++ b/comp/trace/config/hostname.go
@@ -50,7 +50,7 @@ func acquireHostname(c *config.AgentConfig) error {
 		return err
 	}
 
-	client, err := grpc.GetDDAgentClient(ctx, ipcAddress, pkgconfigsetup.GetIPCPort(), c.IPCTLSServerConfig)
+	client, err := grpc.GetDDAgentClient(ctx, ipcAddress, pkgconfigsetup.GetIPCPort(), c.IPCTLSClientConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes a bug happening during the hostname fetching in the TraceAgent at startup.
The wrong TLS configuration was provided to gRPC client, which was preventing it to verify the CoreAgent CMD API identity, leading to failing TLS handshake.

### Motivation
This was leading to a lot of error logs in the core Agent such as:
```
2025-06-10 11:48:01 UTC | CORE | ERROR | (/usr/local/go/src/net/http/server.go:1983 in serve) | Error from the Agent HTTP server 'CMD API Server': http: TLS handshake error from 127.0.0.1:37618: remote error: tls: bad certificate
``` 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This change was manually tested on a VM with ubuntu.