### PR TITLE
[DEBUG-4070] dyninst/object: improve decompression efficiency

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -335,22 +335,15 @@ func generateIR(
 	executable Executable,
 	probes []ir.ProbeDefinition,
 ) (*ir.Program, error) {
-	elfFile, err := safeelf.Open(executable.Path)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to open executable %s: %w", executable.Path, err,
-		)
-	}
-	defer elfFile.Close()
-
-	objFile, err := object.NewElfObject(elfFile)
+	elfFile, err := object.OpenElfFile(executable.Path)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to read object file for %s: %w", executable.Path, err,
 		)
 	}
+	defer elfFile.Close()
 
-	ir, err := irGenerator.GenerateIR(programID, objFile, probes)
+	ir, err := irGenerator.GenerateIR(programID, elfFile, probes)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to generate IR for %s: %w", executable.Path, err,

--- a/pkg/dyninst/actuator/actuator_test.go
+++ b/pkg/dyninst/actuator/actuator_test.go
@@ -60,7 +60,7 @@ func TestIrGenFailed(t *testing.T) {
 	msg, ok := <-reporter.ch
 	require.True(t, ok)
 	require.Equal(t, pid, msg.processID)
-	require.Regexp(t, "failed to open executable", msg.err.Error())
+	require.Regexp(t, "failed to load elf file", msg.err.Error())
 	require.ErrorIs(t, msg.err, os.ErrNotExist)
 }
 

--- a/pkg/dyninst/compiler/snapshot_test.go
+++ b/pkg/dyninst/compiler/snapshot_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var rewriteFromEnv = func() bool {
@@ -55,11 +54,9 @@ func runTest(
 ) {
 	binPath := testprogs.MustGetBinary(t, caseName, cfg)
 	probeDefs := testprogs.MustGetProbeDefinitions(t, caseName)
-	elfFile, err := safeelf.Open(binPath)
+	obj, err := object.OpenElfFile(binPath)
 	require.NoError(t, err)
-	obj, err := object.NewElfObject(elfFile)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, elfFile.Close()) }()
+	defer func() { _ = obj.Close() }()
 	ir, err := irgen.GenerateIR(1, obj, probeDefs)
 	require.NoError(t, err)
 	require.Empty(t, ir.Issues)

--- a/pkg/dyninst/ebpfbench/main.go
+++ b/pkg/dyninst/ebpfbench/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 func getSampleBinaryPath() (string, error) {
@@ -63,17 +62,13 @@ func runBenchmark() error {
 
 	fmt.Printf("loading binary %s\n", binPath)
 	// Load the binary and generate the IR.
-	binary, err := safeelf.Open(binPath)
+	obj, err := object.OpenElfFile(binPath)
 	if err != nil {
 		return err
 	}
-	defer func() { binary.Close() }()
+	defer func() { _ = obj.Close() }()
 
 	probes, err := testprogs.GetProbeDefinitions("busyloop")
-	if err != nil {
-		return err
-	}
-	obj, err := object.NewElfObject(binary)
 	if err != nil {
 		return err
 	}
@@ -126,7 +121,7 @@ func runBenchmark() error {
 		return err
 	}
 
-	textSection, err := object.FindTextSectionHeader(obj.File)
+	textSection, err := object.FindTextSectionHeader(obj.Underlying.Elf)
 	if err != nil {
 		return err
 	}

--- a/pkg/dyninst/gosym/cli/symbol.go
+++ b/pkg/dyninst/gosym/cli/symbol.go
@@ -19,7 +19,7 @@ import (
 )
 
 func run(binary string, pc uint64) error {
-	mef, err := object.NewMMappingElfFile(binary)
+	mef, err := object.OpenMMappingElfFile(binary)
 	if err != nil {
 		return err
 	}

--- a/pkg/dyninst/gosym/symtab_benchmark_test.go
+++ b/pkg/dyninst/gosym/symtab_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	mef, err := object.NewMMappingElfFile(binPath)
+	mef, err := object.OpenMMappingElfFile(binPath)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/dyninst/gosym/symtab_test.go
+++ b/pkg/dyninst/gosym/symtab_test.go
@@ -54,23 +54,20 @@ func runTest(
 ) {
 	binPath := testprogs.MustGetBinary(t, caseName, cfg)
 	probesCfgs := testprogs.MustGetProbeDefinitions(t, caseName)
-	mef, err := object.NewMMappingElfFile(binPath)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, mef.Close()) }()
-	obj, err := object.NewElfObject(mef.Elf)
+	obj, err := object.OpenElfFile(binPath)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, obj.Close()) }()
 	ir, err := irgen.GenerateIR(1, obj, probesCfgs)
 	require.NoError(t, err)
 	require.Empty(t, ir.Issues)
 
-	moduledata, err := object.ParseModuleData(mef)
+	moduledata, err := object.ParseModuleData(obj.Underlying)
 	require.NoError(t, err)
 
-	goVersion, err := object.ParseGoVersion(mef)
+	goVersion, err := object.ParseGoVersion(obj.Underlying)
 	require.NoError(t, err)
 
-	goDebugSections, err := moduledata.GoDebugSections(mef)
+	goDebugSections, err := moduledata.GoDebugSections(obj.Underlying)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, goDebugSections.Close()) }()
 

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -240,20 +240,17 @@ func testDyninst(
 
 	t.Logf("processing output")
 	// TODO: we should intercept raw ringbuf bytes and dump them into tmp dir.
-	mef, err := object.NewMMappingElfFile(servicePath)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, mef.Close()) }()
-	obj, err := object.NewElfObject(mef.Elf)
+	obj, err := object.OpenElfFile(servicePath)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, obj.Close()) }()
 
-	moduledata, err := object.ParseModuleData(mef)
+	moduledata, err := object.ParseModuleData(obj.Underlying)
 	require.NoError(t, err)
 
-	goVersion, err := object.ParseGoVersion(mef)
+	goVersion, err := object.ParseGoVersion(obj.Underlying)
 	require.NoError(t, err)
 
-	goDebugSections, err := moduledata.GoDebugSections(mef)
+	goDebugSections, err := moduledata.GoDebugSections(obj.Underlying)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, goDebugSections.Close()) }()
 

--- a/pkg/dyninst/irgen/issues_test.go
+++ b/pkg/dyninst/irgen/issues_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 func TestMissingProbeIssue(t *testing.T) {
@@ -26,10 +25,7 @@ func TestMissingProbeIssue(t *testing.T) {
 	bin := testprogs.MustGetBinary(t, testProg, cfg)
 	probes := testprogs.MustGetProbeDefinitions(t, testProg)
 
-	f, err := safeelf.Open(bin)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, f.Close()) }()
-	obj, err := object.NewElfObject(f)
+	obj, err := object.OpenElfFile(bin)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, obj.Close()) }()
 	probes = probes[:len(probes):len(probes)] // so appends realloc

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var rewriteFromEnv = func() bool {
@@ -53,11 +52,9 @@ func runTest(
 ) {
 	binPath := testprogs.MustGetBinary(t, caseName, cfg)
 	probesCfgs := testprogs.MustGetProbeDefinitions(t, caseName)
-	elfFile, err := safeelf.Open(binPath)
+	obj, err := object.OpenElfFile(binPath)
 	require.NoError(t, err)
-	obj, err := object.NewElfObject(elfFile)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, elfFile.Close()) }()
+	defer func() { require.NoError(t, obj.Close()) }()
 	ir, err := irgen.GenerateIR(1, obj, probesCfgs)
 	require.NoError(t, err)
 	require.Empty(t, ir.Issues)

--- a/pkg/dyninst/module/symbol.go
+++ b/pkg/dyninst/module/symbol.go
@@ -45,7 +45,7 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ i
 			_ = closer.Close()
 		}
 	}()
-	mef, err := object.NewMMappingElfFile(executable.Path)
+	mef, err := object.OpenMMappingElfFile(executable.Path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating mmapping elf file: %w", err)
 	}

--- a/pkg/dyninst/object/elf.go
+++ b/pkg/dyninst/object/elf.go
@@ -8,11 +8,14 @@
 package object
 
 import (
+	"compress/zlib"
 	"debug/dwarf"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"unsafe"
 
 	dlvdwarf "github.com/go-delve/delve/pkg/dwarf"
 
@@ -45,6 +48,16 @@ type ElfFile struct {
 	// Maps the compile unit entry offset to the version of the DWARF spec
 	// that was used to parse it.
 	unitVersions map[dwarf.Offset]uint8
+}
+
+// TextSectionHeader implements File.
+func (e *ElfFile) TextSectionHeader() (*safeelf.SectionHeader, error) {
+	for _, s := range e.Underlying.Elf.Sections {
+		if s.Name == ".text" {
+			return &s.SectionHeader, nil
+		}
+	}
+	return nil, fmt.Errorf("text section not found")
 }
 
 // Architecture implements File.
@@ -136,7 +149,7 @@ func newElfObject(mmf *MMappingElfFile) (_ *ElfFile, retErr error) {
 	if err != nil {
 		return nil, err
 	}
-	ds, err := loadDebugSections(mmf.Elf)
+	ds, err := loadDebugSections(mmf.Elf, mmf.f)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +191,7 @@ func newElfObject(mmf *MMappingElfFile) (_ *ElfFile, retErr error) {
 // which could be used to load the section into a file we then mmap or something
 // like that.
 
-func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
+func loadDebugSections(elfFile *safeelf.File, f io.ReaderAt) (*DebugSections, error) {
 	dwarfSuffix := func(s *safeelf.Section) string {
 		const debug = ".debug_"
 		const zdebug = ".zdebug_"
@@ -194,7 +207,7 @@ func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
 	// There are many DWARf sections, but these are the ones
 	// the debug/dwarf package started with.
 	var ds DebugSections
-	for _, s := range f.Sections {
+	for _, s := range elfFile.Sections {
 		suffix := dwarfSuffix(s)
 		if suffix == "" {
 			continue
@@ -207,6 +220,11 @@ func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
 			return nil, fmt.Errorf("section %s already loaded", s.Name)
 		}
 
+		cr, err := sectionData(s, elfFile, f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get section data for %s: %w", s.Name, err)
+		}
+
 		// TODO: Figure out whether it is important that we aren't applying
 		// relocations here. The elf code that loads dwarf in `f.DWARF()` does
 		// apply relocations, so it's possible that we're not getting the same
@@ -214,7 +232,7 @@ func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
 		// like the stdlib when loading this data.
 		//
 		// 0: https://github.com/golang/go/blob/db55b83c/src/debug/elf/file.go#L1351-L1377
-		data, err := s.Data()
+		data, err := cr.data(f)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to get section data for %s: %w", s.Name, err,
@@ -223,4 +241,170 @@ func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
 		*sd = data
 	}
 	return &ds, nil
+}
+
+type compressionFormat uint8
+
+const (
+	compressionFormatUnknown compressionFormat = iota
+	compressionFormatNone
+	compressionFormatZlib
+)
+
+type compressedFileRange struct {
+	format compressionFormat
+	// The offset of the compressed data in the file.
+	// Note that this takes into account any compression header.
+	offset int64
+	// The length of the compressed data.
+	compressedLength int64
+	// The length of the uncompressed data.
+	uncompressedLength int64
+}
+
+func (r compressedFileRange) data(fileReaderAt io.ReaderAt) ([]byte, error) {
+	// We don't want to let an invalid section header cause us to load
+	// too much data into memory.
+	const maxSectionSize = 512 << 20 // 512MiB
+
+	if r.uncompressedLength > maxSectionSize {
+		return nil, fmt.Errorf(
+			"section has a decompressed size of %d bytes, "+
+				"exceeding the maximum of %d bytes",
+			r.uncompressedLength,
+			maxSectionSize,
+		)
+	}
+
+	var reader io.Reader
+	switch r.format {
+	case compressionFormatUnknown:
+		return nil, fmt.Errorf("unknown compression format")
+	case compressionFormatNone:
+		reader = io.NewSectionReader(fileReaderAt, r.offset, r.compressedLength)
+	case compressionFormatZlib:
+		input := io.NewSectionReader(
+			fileReaderAt,
+			r.offset,
+			r.compressedLength,
+		)
+
+		zrd, err := zlib.NewReader(input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create zlib reader: %w", err)
+		}
+		reader = zrd
+	}
+
+	data := make([]byte, r.uncompressedLength)
+	_, err := io.ReadFull(reader, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read section data: %w", err)
+	}
+	return data, nil
+}
+
+func sectionData(
+	s *safeelf.Section,
+	elfFile *safeelf.File,
+	fileReaderAt io.ReaderAt,
+) (compressedFileRange, error) {
+	var r compressedFileRange
+	if s.Type == elf_SHT_NOBITS {
+		return r, nil
+	}
+
+	// If the section doesn't have the compressed flag set, it still might
+	// be compressed with the "gnu" compression scheme. This is somewhat
+	// outdated for elf binaries produced by a modern Go toolchain, but it's
+	// the scheme used for compression in Mach-O binaries on macos.
+	//
+	// See https://github.com/golang/go/blob/d166a0b0/src/debug/elf/file.go#L134-L149
+	if s.Flags&elf_SHF_COMPRESSED == 0 {
+		if !strings.HasPrefix(s.Name, ".zdebug") {
+			return compressedFileRange{
+				format:             compressionFormatNone,
+				offset:             int64(s.Offset),
+				compressedLength:   int64(s.Size),
+				uncompressedLength: int64(s.Size),
+			}, nil
+		}
+		sr := io.NewSectionReader(fileReaderAt, int64(s.Offset), int64(s.Size))
+
+		const gnuCompressionMagic = "ZLIB\x00\x00\x00\x00"
+		const gnuCompressionHeaderLength = 12 // magic + 4-byte big endian uncompressed length
+		b := make([]byte, gnuCompressionHeaderLength)
+		n, _ := sr.ReadAt(b, 0)
+		if n != 12 || string(b[:8]) != gnuCompressionMagic {
+			return compressedFileRange{
+				format:             compressionFormatUnknown,
+				offset:             int64(s.Offset + gnuCompressionHeaderLength),
+				compressedLength:   int64(s.Size),
+				uncompressedLength: int64(s.Size),
+			}, nil
+		}
+
+		r.format = compressionFormatZlib
+		r.uncompressedLength = int64(binary.BigEndian.Uint32(b[8:12]))
+		r.compressedLength = int64(s.Size) - gnuCompressionHeaderLength
+		r.offset = int64(s.Offset) + gnuCompressionHeaderLength
+		return r, nil
+	}
+
+	// Parse out the compression header.
+	//
+	// See https://github.com/golang/go/blob/d166a0b0/src/debug/elf/file.go#L557-L579
+	if s.Flags&elf_SHF_ALLOC != 0 {
+		return r, fmt.Errorf("SHF_COMPRESSED applies only to non-allocable sections")
+	}
+	sr := io.NewSectionReader(fileReaderAt, int64(s.Offset), int64(s.FileSize))
+
+	var bo binary.ByteOrder
+	switch elfFile.File.Data {
+	case elf_ELFDATA2LSB:
+		bo = binary.LittleEndian
+	case elf_ELFDATA2MSB:
+		bo = binary.BigEndian
+	default:
+		return r, fmt.Errorf("unknown elf data encoding: %#v", elfFile.File.Data)
+	}
+	// Read the compression header.
+	switch elfFile.File.Class {
+	case elf_ELFCLASS32:
+		var ch elf_Chdr32
+		chdata := make([]byte, unsafe.Sizeof(ch))
+		if _, err := sr.ReadAt(chdata, 0); err != nil {
+			return r, fmt.Errorf("failed to read compression header: %w", err)
+		}
+		ct := elf_CompressionType(bo.Uint32(chdata[unsafe.Offsetof(ch.Type):]))
+		switch ct {
+		case elf_COMPRESS_ZLIB:
+			r.format = compressionFormatZlib
+			r.offset = int64(s.Offset) + int64(unsafe.Sizeof(ch))
+			r.compressedLength = int64(s.SectionHeader.FileSize) - int64(unsafe.Sizeof(ch))
+			r.uncompressedLength = int64(bo.Uint64(chdata[unsafe.Offsetof(ch.Size):]))
+			return r, nil
+		default:
+			return r, fmt.Errorf("unknown compression type: %#v %x", ct, ct)
+		}
+	case elf_ELFCLASS64:
+		var ch elf_Chdr64
+		chdata := make([]byte, unsafe.Sizeof(ch))
+		if _, err := sr.ReadAt(chdata, 0); err != nil {
+			return r, err
+		}
+		ct := elf_CompressionType(bo.Uint32(chdata[unsafe.Offsetof(ch.Type):]))
+		switch ct {
+		case elf_COMPRESS_ZLIB:
+			r.format = compressionFormatZlib
+			r.offset = int64(s.Offset) + int64(unsafe.Sizeof(ch))
+			r.compressedLength = int64(s.SectionHeader.FileSize) - int64(unsafe.Sizeof(ch))
+			r.uncompressedLength = int64(bo.Uint64(chdata[unsafe.Offsetof(ch.Size):]))
+			return r, nil
+		default:
+			return r, fmt.Errorf("unknown compression type: %#v %x", ct, chdata)
+		}
+	default:
+		return r, fmt.Errorf("unknown elf class: %#v", elfFile.File.Class)
+	}
 }

--- a/pkg/dyninst/object/elf.go
+++ b/pkg/dyninst/object/elf.go
@@ -199,8 +199,8 @@ func loadDebugSections(f *safeelf.File) (*DebugSections, error) {
 		if suffix == "" {
 			continue
 		}
-		sd, ok := ds.getSection(suffix)
-		if !ok {
+		sd := ds.getSection(suffix)
+		if sd == nil {
 			continue
 		}
 		if *sd != nil {

--- a/pkg/dyninst/object/elf_constants.go
+++ b/pkg/dyninst/object/elf_constants.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package object
+
+// Normally the debug/elf package is not allowed to be used because
+// it doesn't automatically recover from panics. Here we allow it just to
+// get at some constants.
+//
+//nolint:depguard
+import "debug/elf"
+
+//nolint:revive
+const (
+	elf_COMPRESS_ZLIB = elf.COMPRESS_ZLIB
+	elf_ELFCLASS32    = elf.ELFCLASS32
+	elf_ELFCLASS64    = elf.ELFCLASS64
+
+	elf_SHF_COMPRESSED = elf.SHF_COMPRESSED
+	elf_SHT_NOBITS     = elf.SHT_NOBITS
+	elf_SHF_ALLOC      = elf.SHF_ALLOC
+
+	elf_ELFDATA2LSB = elf.ELFDATA2LSB
+	elf_ELFDATA2MSB = elf.ELFDATA2MSB
+)
+
+//nolint:revive
+type (
+	elf_Chdr32          = elf.Chdr32
+	elf_Chdr64          = elf.Chdr64
+	elf_CompressionType = elf.CompressionType
+)

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // This is a very basic test of loading a Go elf object file
@@ -24,15 +23,11 @@ func TestElfObject(t *testing.T) {
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, cfg := range cfgs {
 		binaryPath := testprogs.MustGetBinary(t, "simple", cfg)
-		elf, err := safeelf.Open(binaryPath)
-		require.NoError(t, err)
-		obj, err := object.NewElfObject(elf)
-		require.NoError(t, err)
-		dd, err := obj.DWARF()
+		obj, err := object.OpenElfFile(binaryPath)
 		require.NoError(t, err)
 		// Assert that some symbol we expect to exist is in there.
 		const targetFunction = "main.main"
-		findTargetSubprogram(t, dd, targetFunction)
+		findTargetSubprogram(t, obj.DwarfData(), targetFunction)
 	}
 }
 

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -110,6 +110,7 @@ func benchmarkLoadElfFile(b *testing.B, binaryPath string) *object.DebugSections
 			total += len(data)
 		}
 		b.SetBytes(int64(total))
+		require.NoError(b, obj.Close())
 	}
 	b.StopTimer()
 	return ds

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -8,8 +8,15 @@
 package object_test
 
 import (
+	"bufio"
+	"bytes"
 	"debug/dwarf"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
 	"testing"
+	"text/tabwriter"
 
 	"github.com/stretchr/testify/require"
 
@@ -52,4 +59,81 @@ func findTargetSubprogram(
 			return
 		}
 	}
+}
+
+type testBinary struct {
+	name string
+	path string
+}
+
+func parseBinaries(s string) ([]testBinary, error) {
+	var binaries []testBinary
+	parts := strings.Split(s, ",")
+	for _, part := range parts {
+		parts := strings.Split(part, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid test binary: %s", part)
+		}
+		binaries = append(binaries, testBinary{name: parts[0], path: parts[1]})
+	}
+	return binaries, nil
+}
+func BenchmarkLoadElfFile(b *testing.B) {
+	binaries, err := parseBinaries(os.Getenv("TEST_BINARIES"))
+	require.NoError(b, err, "failed to parse TEST_BINARIES")
+	if len(binaries) == 0 {
+		b.Skip("no binaries provided via TEST_BINARIES")
+	}
+	for _, binary := range binaries {
+		var logOnce sync.Once
+		b.Run(binary.name, func(b *testing.B) {
+			ds := benchmarkLoadElfFile(b, binary.path)
+			logOnce.Do(func() {
+				logDebugSections(b, ds)
+			})
+		})
+	}
+}
+
+func benchmarkLoadElfFile(b *testing.B, binaryPath string) *object.DebugSections {
+	f, err := os.Open(binaryPath)
+	require.NoError(b, err)
+	defer f.Close()
+	var ds *object.DebugSections
+	b.ResetTimer()
+	for b.Loop() {
+		obj, err := object.OpenElfFile(binaryPath)
+		require.NoError(b, err)
+		ds = obj.DwarfSections()
+		var total int
+		for _, data := range ds.Sections() {
+			total += len(data)
+		}
+		b.SetBytes(int64(total))
+	}
+	b.StopTimer()
+	return ds
+}
+
+func logDebugSections(b *testing.B, ds *object.DebugSections) {
+	var tab bytes.Buffer
+	tw := tabwriter.NewWriter(&tab, 0, 0, 1, ' ', 0)
+	total := 0
+	var maxNameLen int
+	for name, data := range ds.Sections() {
+		if len(data) == 0 {
+			continue
+		}
+		maxNameLen = max(maxNameLen, len(name))
+		fmt.Fprintf(tw, "%s\t%d\n", name, len(data))
+		total += len(data)
+	}
+	fmt.Fprintf(tw, "----\t----\n")
+	fmt.Fprintf(tw, "\t%d\n", total)
+	require.NoError(b, tw.Flush())
+	scanner := bufio.NewScanner(&tab)
+	for scanner.Scan() {
+		b.Log(scanner.Text())
+	}
+	require.NoError(b, scanner.Err())
 }

--- a/pkg/dyninst/object/mmap.go
+++ b/pkg/dyninst/object/mmap.go
@@ -70,7 +70,8 @@ func (m *MMappingElfFile) Close() error {
 
 // MMap mmaps a portion of the file into memory.
 func (m *MMappingElfFile) MMap(
-	section *safeelf.Section, offset, size uint64) (*MMappedData, error) {
+	section *safeelf.Section, offset, size uint64,
+) (*MMappedData, error) {
 	if section.Flags&safeelf.SHF_COMPRESSED != 0 {
 		return nil, fmt.Errorf("mmapping compressed sections is not supported")
 	}
@@ -79,6 +80,10 @@ func (m *MMappingElfFile) MMap(
 	}
 	offset += section.Offset
 
+	return m.mmap(offset, size)
+}
+
+func (m *MMappingElfFile) mmap(offset uint64, size uint64) (*MMappedData, error) {
 	// The offset must be page-aligned for mmap to work
 	pageSize := uint64(syscall.Getpagesize())
 	alignedOffset := (offset / pageSize) * pageSize

--- a/pkg/dyninst/object/object.go
+++ b/pkg/dyninst/object/object.go
@@ -11,6 +11,7 @@ package object
 
 import (
 	"debug/dwarf"
+	"io"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
@@ -21,6 +22,8 @@ type Architecture = bininspect.GoArch
 
 // File is an interface that represents an object file.
 type File interface {
+	io.Closer
+
 	// Access to the DWARF sections.
 	DwarfSections() *DebugSections
 	// Access to the DWARF data.

--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -192,7 +192,7 @@ var goSections = map[string]struct{}{
 // version of the trace agent that we care about, but for now we leave
 // that to later analysis of dwarf.
 func isGoElfBinaryWithDDTraceGo(f *os.File) (bool, error) {
-	elfFile, err := object.NewMMappingElfFile(f.Name())
+	elfFile, err := object.OpenMMappingElfFile(f.Name())
 	if err != nil {
 		log.Tracef("isGoElfBinary(%s): not an ELF file: %v", f.Name(), err)
 		return false, nil

--- a/pkg/dyninst/rcscrape/ir_generator.go
+++ b/pkg/dyninst/rcscrape/ir_generator.go
@@ -46,7 +46,7 @@ func (irGenerator) GenerateIR(
 		ID: programID,
 	}
 	// TODO: We could use less memory if we had a better symbol table parser.
-	symbols, err := executable.Symbols()
+	symbols, err := executable.Underlying.Elf.Symbols()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get symbols: %w", err)
 	}


### PR DESCRIPTION
### dyninst/object: refactor ElfFile to sit on top of MMappingElfFile

### dyninst/object: add a simple benchmark

This benchmark measures the time it takes to decompress the debug sections
from a binary provided by the TEST_BINARIES env var.

### dyninst/object: parse compression header to size buffer

This commit adds manual parsing of section compression headers outside
of the debug/elf library in order to compute the correct format, size,
and file offset of the compressed data. This allows up to create a
buffer of the correct size. This helps avoid allocating too much
memory and improves the throughput meaningfully.

A sad truth is that the debug/elf library *almost* gives us everything
we'd need here to do this type of thing without having to reparse
data structures, but it doesn't expose compressionFormat or
compressionOffset.

This acheives meaningfully beffer performance, but still around 4x
slower than rust:
```
name                      old time/op    new time/op    delta
LoadElfFile/cockroach-10     1.78s ± 4%     1.42s ± 3%  -20.16%  (p=0.000 n=10+10)
LoadElfFile/dd-agent-10      448ms ± 3%     385ms ± 2%  -14.01%  (p=0.000 n=8+10)

name                      old speed      new speed      delta
LoadElfFile/cockroach-10   148MB/s ± 4%   185MB/s ± 3%  +25.23%  (p=0.000 n=10+10)
LoadElfFile/dd-agent-10    159MB/s ± 2%   186MB/s ± 2%  +16.83%  (p=0.000 n=7+10)

name                      old alloc/op   new alloc/op   delta
LoadElfFile/cockroach-10    1.11GB ± 0%    0.28GB ± 0%  -75.08%  (p=0.000 n=8+8)
LoadElfFile/dd-agent-10      210MB ± 0%      75MB ± 0%  -64.19%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
LoadElfFile/cockroach-10      121k ± 0%      121k ± 0%   -0.03%  (p=0.000 n=9+9)
LoadElfFile/dd-agent-10      32.1k ± 0%     32.1k ± 0%   -0.06%  (p=0.000 n=9+10)
```

### dyninst/object: mmap compressed data

This primarily is important because the zlib implementations are
able to utilize the `ReadByte` method on the underlying bytes.Reader.

```
name                      old time/op    new time/op    delta
LoadElfFile/cockroach-10     1.42s ± 3%     0.96s ± 8%  -32.45%  (p=0.000 n=10+9)
LoadElfFile/dd-agent-10      385ms ± 2%     253ms ± 1%  -34.38%  (p=0.000 n=10+9)

name                      old speed      new speed      delta
LoadElfFile/cockroach-10   185MB/s ± 3%   274MB/s ± 8%  +48.15%  (p=0.000 n=10+9)
LoadElfFile/dd-agent-10    186MB/s ± 2%   284MB/s ± 1%  +52.37%  (p=0.000 n=10+9)

name                      old alloc/op   new alloc/op   delta
LoadElfFile/cockroach-10     276MB ± 0%     276MB ± 0%   -0.01%  (p=0.000 n=8+10)
LoadElfFile/dd-agent-10     75.3MB ± 0%    75.3MB ± 0%   -0.03%  (p=0.000 n=10+10)

name                      old allocs/op  new allocs/op  delta
LoadElfFile/cockroach-10      121k ± 0%      121k ± 0%   -0.01%  (p=0.000 n=9+10)
LoadElfFile/dd-agent-10      32.1k ± 0%     32.1k ± 0%   -0.02%  (p=0.000 n=10+10)
```