### PR TITLE
[OTAGENT-426] Set logs agent compression to gzip in DDOT

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgdatadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 	"go.opentelemetry.io/collector/confmap"
@@ -161,6 +162,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	pkgconfig.Set("logs_config.batch_wait", ddc.Logs.BatchWait, pkgconfigmodel.SourceFile)
 	pkgconfig.Set("logs_config.use_compression", ddc.Logs.UseCompression, pkgconfigmodel.SourceFile)
 	pkgconfig.Set("logs_config.compression_level", ddc.Logs.CompressionLevel, pkgconfigmodel.SourceFile)
+	pkgconfig.Set("logs_config.compression_kind", logConfig.GzipCompressionKind, pkgconfigmodel.SourceDefault)
 
 	// APM & OTel trace configs
 	pkgconfig.Set("apm_config.enabled", true, pkgconfigmodel.SourceDefault)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Sets logs agent compression kind to gzip in DDOT. 

### Motivation
The default log compression kind was [recently changed](https://github.com/DataDog/datadog-agent/commit/db09bbc371b18d3eab5d57b470b8f374a1195da4#diff-a7b6619528f155e64cefe12cc4ba753eb7688c87fdf9d96e1052a12eeb519df5L85) from gzip to zstd in agent v7.67.0. As a result, there is now an error message when starting DDOT:

```
2025-06-05 15:21:19 EDT | OTELCOL | ERROR | (pkg/util/compression/selector/no-zlib-no-zstd.go:29 in NewCompressor) | invalid compression set
```

To avoid this error in 7.67, we manually set logs_config.compression_kind to gzip.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Build otel-agent locally and verified that error is gone:
```
2025-06-12 12:18:33 EDT | OTELCOL | DEBUG | (comp/logs/agent/config/config_keys.go:152 in compressionLevel) | Logs pipeline is using compression gzip atlevel: 6
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->