### PR TITLE
CONTINT-4707/bug_fix_ksm_customresource_take2

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
@@ -79,7 +79,10 @@ func GetCustomMetricNamesMapper(resources []customresourcestate.Resource) (mappe
 		for _, generator := range customResource.Metrics {
 			if generator.Each.Type == metric.Gauge ||
 				generator.Each.Type == metric.StateSet {
-				mapper[customResource.GetMetricNamePrefix()+"_"+generator.Name] = "customresource." + generator.Name
+				if customResource.GetMetricNamePrefix() == "kube_customresource" {
+					mapper[customResource.GetMetricNamePrefix()+"_"+generator.Name] = "customresource." + generator.Name
+				} else {
+					mapper[customResource.GetMetricNamePrefix()+"_"+generator.Name] = "customresource." + customResource.GetMetricNamePrefix() + "_" + generator.Name
 			}
 		}
 	}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/cr.go
@@ -83,6 +83,7 @@ func GetCustomMetricNamesMapper(resources []customresourcestate.Resource) (mappe
 					mapper[customResource.GetMetricNamePrefix()+"_"+generator.Name] = "customresource." + generator.Name
 				} else {
 					mapper[customResource.GetMetricNamePrefix()+"_"+generator.Name] = "customresource." + customResource.GetMetricNamePrefix() + "_" + generator.Name
+				}
 			}
 		}
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -696,7 +696,7 @@ func (k *KSMCheck) processMetrics(sender sender.Sender, metrics map[string][]ksm
 				continue
 			}
 			metricPrefix := ksmMetricPrefix
-			if strings.HasPrefix(metricFamily.Name, "kube_customresource_") {
+			if ddname, found := k.metricNamesMapper[metricFamily.Name]; found && strings.HasPrefix(ddname, "customresource.") {
 				metricPrefix = metricPrefix[:len(metricPrefix)-1] + "_"
 			}
 			if ddname, found := k.metricNamesMapper[metricFamily.Name]; found {

--- a/releasenotes-dca/notes/bugfix-ksm-customresource-1c1609115846ef62.yaml
+++ b/releasenotes-dca/notes/bugfix-ksm-customresource-1c1609115846ef62.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug in the Kubernetes State Metrics (KSM) check where custom resource
+    metrics were incorrectly named using the `kubernetes_state.customresource.<name>`
+    pattern instead of the intended `kubernetes_state_customresource.<prefix>_<name>` format.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes the metric naming logic for custom resources is the Kubernetes State Metrics (KSM) check. Before, custom resource metrics were emitted under the incorrect prefix `kubernetes_state.customresource.<name>` which bypasses the custom metric billing logic. With this change, the correct naming format `kubernetes_state_customresource.<prefix>_<name>` is used.
### Motivation
The motivation is to ensure that metrics for Kubernetes custom resources are correctly prefixed and billed as custom metrics. 
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I used debugging log statements in `kubernetes_state.go` and `cr.go` to trace the metric generation logic:

* Verified that metricFamily.name outputs gotk_csinode

* Confirmed that k.metricNamesMapper contains the mapping gotk_csinode → customresource.gotk_csinode

* Confirmed that the updated conditional logic now matches the customresource. prefix correctly

* Verified the final emitted metric name is kubernetes_state_customresource.gotk_csinode
<img width="771" alt="Screenshot 2025-06-10 at 10 43 17 AM" src="https://github.com/user-attachments/assets/8a86b9a9-61e3-4067-a5b0-d61f514fcb98" />


### Possible Drawbacks / Trade-offs
If new entries are introduced in metricNamesMapper without the customresource. prefix, they may be skipped by this logic and continue to be incorrectly named.
