### PR TITLE
fix password prompt during kmt.launch-stack

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -165,7 +165,7 @@
       # Each VM gets 12GB of memory. We have set 8GB as base for the system, and upto 4GB can be used
       # by a ram backed filesystem holding the system-probe test packages
     - dda inv -- -e kmt.gen-config --ci --arch=$ARCH --output-file=$VMCONFIG_FILE --vmconfig-template=$TEST_COMPONENT --memory=12288
-    - dda inv -- -e system-probe.start-microvms --provision-instance --provision-microvms --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-${TEST_COMPONENT}-${ARCH}-${CI_PIPELINE_ID} --run-agent
+    - dda inv -- -e kmt.start-microvms --provision-instance --provision-microvms --vmconfig=$VMCONFIG_FILE $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-${TEST_COMPONENT}-${ARCH}-${CI_PIPELINE_ID} --run-agent
     - jq "." $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -258,7 +258,6 @@ def destroy_stack_pulumi(ctx: Context, stack: str, ssh_key: str | None):
     if remote_vms_in_config(vm_config):
         prefix = "aws-vault exec sso-sandbox-account-admin -- "
 
-
     build_start_microvms_binary(ctx)
     start_cmd = start_microvms_cmd(infra_env="aws/sandbox", stack_name=stack, destroy=True, local=True)
     ctx.run(f"{prefix}{start_cmd}", env=env)

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -205,42 +205,38 @@ def launch_stack(
         ensure_key_in_agent(ctx, ssh_key_obj)
         ensure_key_in_ec2(ctx, ssh_key_obj)
 
-    env = [
-        "TEAM=ebpf-platform",
-        "PULUMI_CONFIG_PASSPHRASE=1234",
-        f"LibvirtSSHKeyX86={stack_dir}/libvirt_rsa-x86_64",
-        f"LibvirtSSHKeyARM={stack_dir}/libvirt_rsa-arm64",
-        f"CI_PROJECT_DIR={stack_dir}",
-    ]
+    env = {
+        "TEAM": "ebpf-platform",
+        "PULUMI_CONFIG_PASSPHRASE": "1234",
+        "LibvirtSSHKeyX86": f"{stack_dir}/libvirt_rsa-x86_64",
+        "LibvirtSSHKeyARM": f"{stack_dir}/libvirt_rsa-arm64",
+        "CI_PROJECT_DIR": stack_dir,
+    }
+
+    provision_instance = remote_vms_in_config(vm_config)
+    local = local_vms_in_config(vm_config)
+    if local:
+        check_env(ctx)
+
+    build_start_microvms_binary(ctx)
+    start_cmd = start_microvms_cmd(
+        provision_instance=provision_instance,
+        provision_microvms=provision_microvms,
+        instance_type_x86=X86_INSTANCE_TYPE,
+        instance_type_arm=ARM_INSTANCE_TYPE,
+        x86_ami_id=x86_ami,
+        arm_ami_id=arm_ami,
+        ssh_key_name=ssh_key_obj['aws_key_name'] if ssh_key_obj is not None else None,
+        infra_env="aws/sandbox",
+        vmconfig=vm_config,
+        stack_name=stack,
+        local=local,
+    )
 
     prefix = ""
-    local = ""
-    if remote_vms_in_config(vm_config):
-        prefix = "aws-vault exec sso-sandbox-account-admin --"
-
-    if local_vms_in_config(vm_config):
-        check_env(ctx)
-        local = "--local"
-
-    provision = ""
-    if remote_vms_in_config(vm_config):
-        provision = "--provision-instance"
-
-    args = [
-        "--provision-microvms" if provision_microvms else "",
-        f"--instance-type-x86={X86_INSTANCE_TYPE}",
-        f"--instance-type-arm={ARM_INSTANCE_TYPE}",
-        f"--x86-ami-id={x86_ami}",
-        f"--arm-ami-id={arm_ami}",
-        f"--ssh-key-name={ssh_key_obj['aws_key_name'] if ssh_key_obj is not None else ''}",
-        "--infra-env=aws/sandbox",
-        f"--vmconfig={vm_config}",
-        f"--stack-name={stack}",
-        local,
-        provision,
-    ]
-    ctx.run(f"{' '.join(env)} {prefix} dda inv -- -e system-probe.start-microvms {' '.join(args)}")
-
+    if provision_instance:
+        prefix = "aws-vault exec sso-sandbox-account-admin -- "
+    ctx.run(f"{prefix}{start_cmd}", env=env)
     info(f"[+] Stack {stack} successfully setup")
 
 
@@ -250,22 +246,69 @@ def destroy_stack_pulumi(ctx: Context, stack: str, ssh_key: str | None):
         ensure_key_in_agent(ctx, ssh_key_obj)
 
     stack_dir = f"{get_kmt_os().stacks_dir}/{stack}"
-    env = [
-        "PULUMI_CONFIG_PASSPHRASE=1234",
-        f"LibvirtSSHKeyX86={stack_dir}/libvirt_rsa-x86_64",
-        f"LibvirtSSHKeyARM={stack_dir}/libvirt_rsa-arm64",
-        f"CI_PROJECT_DIR={stack_dir}",
-    ]
+    env = {
+        "PULUMI_CONFIG_PASSPHRASE": "1234",
+        "LibvirtSSHKeyX86": f"{stack_dir}/libvirt_rsa-x86_64",
+        "LibvirtSSHKeyARM": f"{stack_dir}/libvirt_rsa-arm64",
+        "CI_PROJECT_DIR": stack_dir,
+    }
 
     vm_config = f"{stack_dir}/{VMCONFIG}"
     prefix = ""
     if remote_vms_in_config(vm_config):
-        prefix = "aws-vault exec sso-sandbox-account-admin --"
+        prefix = "aws-vault exec sso-sandbox-account-admin -- "
 
-    env_vars = ' '.join(env)
-    ctx.run(
-        f"{env_vars} {prefix} dda inv -- system-probe.start-microvms --infra-env=aws/sandbox --stack-name={stack} --destroy --local"
-    )
+
+    build_start_microvms_binary(ctx)
+    start_cmd = start_microvms_cmd(infra_env="aws/sandbox", stack_name=stack, destroy=True, local=True)
+    ctx.run(f"{prefix}{start_cmd}", env=env)
+
+
+def build_start_microvms_binary(ctx):
+    # building the binary improves start up time for local usage where we invoke this multiple times.
+    ctx.run("cd ./test/new-e2e && go build -o start-microvms ./scenarios/system-probe/main.go")
+
+
+def start_microvms_cmd(
+    infra_env,
+    instance_type_x86=None,
+    instance_type_arm=None,
+    x86_ami_id=None,
+    arm_ami_id=None,
+    destroy=False,
+    ssh_key_name=None,
+    ssh_key_path=None,
+    dependencies_dir=None,
+    shutdown_period=320,
+    stack_name="kernel-matrix-testing-system",
+    vmconfig=None,
+    local=False,
+    provision_instance=False,
+    provision_microvms=False,
+    run_agent=False,
+    agent_version=None,
+):
+    args = [
+        f"--instance-type-x86 {instance_type_x86}" if instance_type_x86 else "",
+        f"--instance-type-arm {instance_type_arm}" if instance_type_arm else "",
+        f"--x86-ami-id {x86_ami_id}" if x86_ami_id else "",
+        f"--arm-ami-id {arm_ami_id}" if arm_ami_id else "",
+        "--destroy" if destroy else "",
+        f"--ssh-key-path {ssh_key_path}" if ssh_key_path else "",
+        f"--ssh-key-name {ssh_key_name}" if ssh_key_name else "",
+        f"--infra-env {infra_env}",
+        f"--shutdown-period {shutdown_period}",
+        f"--dependencies-dir {dependencies_dir}" if dependencies_dir else "",
+        f"--name {stack_name}",
+        f"--vmconfig {vmconfig}" if vmconfig else "",
+        "--local" if local else "",
+        "--run-agent" if run_agent else "",
+        f"--agent-version {agent_version}" if agent_version else "",
+        "--provision-instance" if provision_instance else "",
+        "--provision-microvms" if provision_microvms else "",
+    ]
+    go_args = ' '.join(filter(lambda x: x != "", args))
+    return f"./test/new-e2e/start-microvms {go_args}"
 
 
 def ec2_instance_ids(ctx: Context, ip_list: list[str]) -> list[str]:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -55,6 +55,7 @@ from tasks.libs.ciproviders.gitlab_api import (
     post_process_gitlab_ci_configuration,
     resolve_gitlab_ci_configuration,
 )
+from tasks.libs.common.color import color_message
 from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.utils import get_build_flags
 from tasks.libs.pipeline.tools import GitlabJobStatus, loop_status
@@ -2472,3 +2473,52 @@ def retry_failed_pipeline(ctx: Context, pipeline_id: int, component: str | None 
             continue
 
     info(f"[+] All jobs retried, job IDs: {retried_jobs}")
+
+
+@task
+def start_microvms(
+    ctx,
+    infra_env,
+    instance_type_x86=None,
+    instance_type_arm=None,
+    x86_ami_id=None,
+    arm_ami_id=None,
+    destroy=False,
+    ssh_key_name=None,
+    ssh_key_path=None,
+    dependencies_dir=None,
+    shutdown_period=320,
+    stack_name="kernel-matrix-testing-system",
+    vmconfig=None,
+    local=False,
+    provision_instance=False,
+    provision_microvms=False,
+    run_agent=False,
+    agent_version=None,
+):
+    stacks.build_start_microvms_binary(ctx)
+    print(
+        color_message(
+            "[+] Creating and provisioning microVMs.\n[+] If you want to see the pulumi progress, set configParams.pulumi.verboseProgressStreams: true in ~/.test_infra_config.yaml",
+            "green",
+        )
+    )
+    ctx.run(stacks.start_microvms_cmd(
+        infra_env=infra_env,
+        instance_type_x86=instance_type_x86,
+        instance_type_arm=instance_type_arm,
+        x86_ami_id=x86_ami_id,
+        arm_ami_id=arm_ami_id,
+        destroy=destroy,
+        ssh_key_name=ssh_key_name,
+        ssh_key_path=ssh_key_path,
+        dependencies_dir=dependencies_dir,
+        shutdown_period=shutdown_period,
+        stack_name=stack_name,
+        vmconfig=vmconfig,
+        local=local,
+        provision_instance=provision_instance,
+        provision_microvms=provision_microvms,
+        run_agent=run_agent,
+        agent_version=agent_version,
+    ))

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -2503,22 +2503,24 @@ def start_microvms(
             "green",
         )
     )
-    ctx.run(stacks.start_microvms_cmd(
-        infra_env=infra_env,
-        instance_type_x86=instance_type_x86,
-        instance_type_arm=instance_type_arm,
-        x86_ami_id=x86_ami_id,
-        arm_ami_id=arm_ami_id,
-        destroy=destroy,
-        ssh_key_name=ssh_key_name,
-        ssh_key_path=ssh_key_path,
-        dependencies_dir=dependencies_dir,
-        shutdown_period=shutdown_period,
-        stack_name=stack_name,
-        vmconfig=vmconfig,
-        local=local,
-        provision_instance=provision_instance,
-        provision_microvms=provision_microvms,
-        run_agent=run_agent,
-        agent_version=agent_version,
-    ))
+    ctx.run(
+        stacks.start_microvms_cmd(
+            infra_env=infra_env,
+            instance_type_x86=instance_type_x86,
+            instance_type_arm=instance_type_arm,
+            x86_ami_id=x86_ami_id,
+            arm_ami_id=arm_ami_id,
+            destroy=destroy,
+            ssh_key_name=ssh_key_name,
+            ssh_key_path=ssh_key_path,
+            dependencies_dir=dependencies_dir,
+            shutdown_period=shutdown_period,
+            stack_name=stack_name,
+            vmconfig=vmconfig,
+            local=local,
+            provision_instance=provision_instance,
+            provision_microvms=provision_microvms,
+            run_agent=run_agent,
+            agent_version=agent_version,
+        )
+    )

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1969,60 +1969,6 @@ def _test_docker_image_list():
 
 
 @task
-def start_microvms(
-    ctx,
-    infra_env,
-    instance_type_x86=None,
-    instance_type_arm=None,
-    x86_ami_id=None,
-    arm_ami_id=None,
-    destroy=False,
-    ssh_key_name=None,
-    ssh_key_path=None,
-    dependencies_dir=None,
-    shutdown_period=320,
-    stack_name="kernel-matrix-testing-system",
-    vmconfig=None,
-    local=False,
-    provision_instance=False,
-    provision_microvms=False,
-    run_agent=False,
-    agent_version=None,
-):
-    args = [
-        f"--instance-type-x86 {instance_type_x86}" if instance_type_x86 else "",
-        f"--instance-type-arm {instance_type_arm}" if instance_type_arm else "",
-        f"--x86-ami-id {x86_ami_id}" if x86_ami_id else "",
-        f"--arm-ami-id {arm_ami_id}" if arm_ami_id else "",
-        "--destroy" if destroy else "",
-        f"--ssh-key-path {ssh_key_path}" if ssh_key_path else "",
-        f"--ssh-key-name {ssh_key_name}" if ssh_key_name else "",
-        f"--infra-env {infra_env}",
-        f"--shutdown-period {shutdown_period}",
-        f"--dependencies-dir {dependencies_dir}" if dependencies_dir else "",
-        f"--name {stack_name}",
-        f"--vmconfig {vmconfig}" if vmconfig else "",
-        "--local" if local else "",
-        "--run-agent" if run_agent else "",
-        f"--agent-version {agent_version}" if agent_version else "",
-        "--provision-instance" if provision_instance else "",
-        "--provision-microvms" if provision_microvms else "",
-    ]
-
-    go_args = ' '.join(filter(lambda x: x != "", args))
-
-    # building the binary improves start up time for local usage where we invoke this multiple times.
-    ctx.run("cd ./test/new-e2e && go build -o start-microvms ./scenarios/system-probe/main.go")
-    print(
-        color_message(
-            "[+] Creating and provisioning microVMs.\n[+] If you want to see the pulumi progress, set configParams.pulumi.verboseProgressStreams: true in ~/.test_infra_config.yaml",
-            "green",
-        )
-    )
-    ctx.run(f"./test/new-e2e/start-microvms {go_args}")
-
-
-@task
 def save_build_outputs(ctx, destfile):
     ignored_extensions = {".bc"}
     ignored_files = {"cws", "integrity", "include_headers"}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a problem with `kmt.launch-stack` where the `Enter Password:` prompt was not visible. This was due to nesting of running an invoke command within an invoke task. Replaced with a direct call instead.

### Motivation

Confusing user experience, thinking the command was hanging.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->