### PR TITLE
[CWS] fix fentry tail call detection by looking at kernel BTF

### DIFF
--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -47,3 +47,8 @@ func GetHasVFSRenameStructArgs() (bool, error) {
 func GetBTFFunctionArgCount(_ string) (int, error) {
 	return 0, errors.New("unsupported BTF request")
 }
+
+// AreFentryTailCallsBroken not available
+func AreFentryTailCallsBroken() (bool, error) {
+	return false, errors.New("unsupported BTF request")
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -242,7 +242,9 @@ func (p *EBPFProbe) selectFentryMode() {
 		p.useFentry = false
 		seclog.Errorf("fentry enabled but not supported, falling back to kprobe mode")
 		return
-	} else if p.kernelVersion.Code != 0 && p.kernelVersion.Code >= kernel.Kernel6_11 {
+	}
+
+	if p.kernelVersion.Code != 0 && p.kernelVersion.Code >= kernel.Kernel6_11 {
 		p.useFentry = false
 		seclog.Errorf("fentry disabled on kernels >= 6.11, falling back to kprobe mode")
 		return

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/gopacket/layers"
 
 	lib "github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/sys/mountinfo"
 	"github.com/vishvananda/netlink"
@@ -245,7 +244,7 @@ func (p *EBPFProbe) selectFentryMode() {
 		return
 	}
 
-	tailCallsBroken, err := areFentryTailCallsBroken()
+	tailCallsBroken, err := constantfetch.AreFentryTailCallsBroken()
 	if err != nil {
 		p.useFentry = false
 		seclog.Errorf("fentry enabled but failed to verify tail call support: %v, falling back to kprobe mode", err)
@@ -284,43 +283,6 @@ func (p *EBPFProbe) selectFentryMode() {
 	}
 
 	p.useFentry = true
-}
-
-func areFentryTailCallsBroken() (bool, error) {
-	spec, err := ddebpf.GetKernelSpec()
-	if err != nil {
-		return false, err
-	}
-
-	var bpfMap *btf.Struct
-	if err := spec.TypeByName("bpf_map", &bpfMap); err != nil {
-		return false, err
-	}
-
-	/*
-		we are checking for the presence of the bpf_map.owner.attach_func_proto field
-		if it exists, fentry tail calls are broken
-		https://github.com/torvalds/linux/commit/28ead3eaabc16ecc907cfb71876da028080f6356
-	*/
-
-	for _, member := range bpfMap.Members {
-		if member.Name != "owner" {
-			continue
-		}
-
-		ty, ok := member.Type.(*btf.Struct)
-		if !ok {
-			return false, fmt.Errorf("bpf_map.owner is not a struct")
-		}
-
-		for _, ownerMember := range ty.Members {
-			if ownerMember.Name == "attach_func_proto" {
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
 }
 
 func (p *EBPFProbe) isCgroupSysCtlNotSupported() bool {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In kernel 6.11 and higher, [fentry had a breaking change](https://github.com/torvalds/linux/commit/28ead3eaabc16ecc907cfb71876da028080f6356) around tail calls that break our support. We merged https://github.com/DataDog/datadog-agent/pull/36918 to detect this, but since the breaking change is getting backported ( :( ) this PR improves the detection by using BTF kernel data.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->