### PR TITLE
Revert "[incident-39523] Revert "(fleet) support upgrades on deb/rpm""

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -262,6 +262,7 @@ elsif do_package
     dependency "package-artifact"
   end
   dependency "init-scripts-agent"
+  dependency 'datadog-agent-installer-symlinks'
 end
 
 # version manifest is based on the built softwares.

--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -1,0 +1,21 @@
+name 'datadog-agent-installer-symlinks'
+
+description "Create symlinks for the datadog-agent installer to track deb/rpm packages as installed"
+
+always_build true
+
+build do
+  license :project_license
+
+  block do
+    if linux_target? and install_dir == '/opt/datadog-agent'
+      version = project.build_version
+      mkdir '/opt/datadog-packages/datadog-agent'
+      link "/opt/datadog-agent", "/opt/datadog-packages/datadog-agent/#{version}"
+      link "/opt/datadog-packages/datadog-agent/#{version}", "/opt/datadog-packages/datadog-agent/stable"
+      link "/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent/experiment"
+      project.extra_package_file "/opt/datadog-packages/datadog-agent"
+    end
+  end
+end
+

--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -7,13 +7,19 @@
 #                                                                        #
 ##########################################################################
 
-INSTALL_DIR=/opt/datadog-agent
+INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
 
 # Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
-if [ "$1" = "remove" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent deb || true
-elif [ "$1" = "upgrade" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent deb || true
+if [ -f ${INSTALLER_DEB} ] && [ "$1" = "remove" ]; then
+    ${INSTALLER_DEB} prerm datadog-agent deb || true
+elif [ -f ${INSTALLER_DEB} ] && [ "$1" = "upgrade" ]; then
+    ${INSTALLER_DEB} prerm --upgrade datadog-agent deb || true
+fi
+
+# Remove the agent if it was upgraded using the installer
+if [ -f ${INSTALLER_OCI} ] && [ "$1" = "remove" ]; then
+    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
 fi
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -7,12 +7,18 @@
 #                                                                        #
 ##########################################################################
 
-INSTALL_DIR=/opt/datadog-agent
+INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
 
 # Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 # Note: the upgrade prerm is handled in the preinst script of the new package on rpm.
-if [ "$*" = "0" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent rpm || true
+if [ -f ${INSTALLER_DEB} ] && [ "$*" = "0" ]; then
+    ${INSTALLER_DEB} prerm datadog-agent rpm || true
+fi
+
+# Remove the agent if it was upgraded using the installer
+if [ -f ${INSTALLER_OCI} ] && [ "$*" = "0" ]; then
+    ${INSTALLER_OCI} remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
 fi
 
 exit 0

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -85,6 +85,14 @@ func getAggregator(t *testing.T) *BufferedAggregator {
 	return deps.Demultiplexer.Aggregator()
 }
 
+func versionTags() []string {
+	tags := []string{"version:" + version.AgentVersion}
+	if version.AgentPackageVersion != "" {
+		tags = append(tags, "package_version:"+version.AgentPackageVersion)
+	}
+	return tags
+}
+
 func TestRegisterCheckSampler(t *testing.T) {
 	// this test IS USING globals
 	// -
@@ -256,7 +264,7 @@ func TestDefaultData(t *testing.T) {
 	series := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{fmt.Sprintf("version:%s", version.AgentVersion)}),
+		Tags:           tagset.CompositeTagsFromSlice(versionTags()),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -307,14 +315,10 @@ func TestDefaultSeries(t *testing.T) {
 	})
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
 
-	runningTags := []string{"version:" + version.AgentVersion, "config_id:config123"}
-	if version.AgentPackageVersion != "" {
-		runningTags = append(runningTags, "package_version:"+version.AgentPackageVersion)
-	}
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice(runningTags),
+		Tags:           tagset.CompositeTagsFromSlice(append(versionTags(), "config_id:config123")),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -528,7 +532,7 @@ func TestRecurrentSeries(t *testing.T) {
 	}, &metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{fmt.Sprintf("version:%s", version.AgentVersion)}),
+		Tags:           tagset.CompositeTagsFromSlice(versionTags()),
 		Host:           demux.Aggregator().hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -598,7 +602,7 @@ func TestTags(t *testing.T) {
 			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
 			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
-			want:                    []string{"version:" + version.AgentVersion},
+			want:                    versionTags(),
 		},
 		{
 			name:                    "tags disabled, without version",
@@ -616,7 +620,7 @@ func TestTags(t *testing.T) {
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
 			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
-			want:                    []string{"container_name:agent", "version:" + version.AgentVersion},
+			want:                    append(versionTags(), "container_name:agent"),
 		},
 		{
 			name:                    "tags enabled, without version",
@@ -634,7 +638,7 @@ func TestTags(t *testing.T) {
 			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("no tags") },
 			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             true,
-			want:                    []string{"version:" + version.AgentVersion},
+			want:                    versionTags(),
 		},
 		{
 			name:                    "tags enabled, with version, with global tags (no hostname)",
@@ -643,7 +647,7 @@ func TestTags(t *testing.T) {
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
 			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
-			want:                    []string{"container_name:agent", "version:" + version.AgentVersion, "kube_cluster_name:foo"},
+			want:                    append(versionTags(), "container_name:agent", "kube_cluster_name:foo"),
 		},
 		{
 			name:                    "tags enabled, with version, with global tags (hostname present)",
@@ -652,7 +656,7 @@ func TestTags(t *testing.T) {
 			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
 			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
-			want:                    []string{"container_name:agent", "version:" + version.AgentVersion, "kube_cluster_name:foo"},
+			want:                    append(versionTags(), "container_name:agent", "kube_cluster_name:foo"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -307,10 +307,14 @@ func TestDefaultSeries(t *testing.T) {
 	})
 	s.On("SendServiceChecks", agentUpMatcher).Return(nil).Times(1)
 
+	runningTags := []string{"version:" + version.AgentVersion, "config_id:config123"}
+	if version.AgentPackageVersion != "" {
+		runningTags = append(runningTags, "package_version:"+version.AgentPackageVersion)
+	}
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "config_id:config123"}),
+		Tags:           tagset.CompositeTagsFromSlice(runningTags),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",

--- a/pkg/fleet/installer/repository/link.go
+++ b/pkg/fleet/installer/repository/link.go
@@ -8,11 +8,10 @@ package repository
 import (
 	"errors"
 	"os"
-	"path/filepath"
 )
 
 func linkRead(linkPath string) (string, error) {
-	return filepath.EvalSymlinks(linkPath)
+	return os.Readlink(linkPath)
 }
 
 func linkExists(linkPath string) (bool, error) {

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -271,7 +271,7 @@ func (r *Repository) PromoteExperiment(ctx context.Context) error {
 	if !repository.experiment.Exists() {
 		return fmt.Errorf("experiment link does not exist, invalid state")
 	}
-	if repository.stable.Target() == repository.experiment.Target() {
+	if repository.experiment.Target() == "" || repository.stable.Target() == repository.experiment.Target() {
 		return fmt.Errorf("no experiment to promote")
 	}
 	err = repository.stable.Set(*repository.experiment.packagePath)
@@ -449,6 +449,13 @@ func (r *repositoryFiles) cleanup(ctx context.Context) error {
 		}
 
 		log.Debugf("Removing package %s", pkgRepositoryPath)
+		realPkgRepositoryPath, err := filepath.EvalSymlinks(pkgRepositoryPath)
+		if err != nil {
+			log.Errorf("could not evaluate symlinks for package %s: %v", pkgRepositoryPath, err)
+		}
+		if err := os.RemoveAll(realPkgRepositoryPath); err != nil {
+			log.Errorf("could not remove package %s directory, will retry: %v", realPkgRepositoryPath, err)
+		}
 		if err := os.RemoveAll(pkgRepositoryPath); err != nil {
 			log.Errorf("could not remove package %s directory, will retry: %v", pkgRepositoryPath, err)
 		}
@@ -493,7 +500,11 @@ func (l *link) Exists() bool {
 
 func (l *link) Target() string {
 	if l.Exists() {
-		return filepath.Base(*l.packagePath)
+		packagePath := filepath.Base(*l.packagePath)
+		if packagePath == stableVersionLink {
+			return ""
+		}
+		return packagePath
 	}
 	return ""
 }

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -387,11 +387,11 @@ def get_version_ldflags(ctx, major_version='7', install_path=None):
 
     payload_v = get_payload_version()
     commit = get_commit_sha(ctx, short=True)
+    version = get_version(ctx, include_git=True, major_version=major_version)
+    package_version = os.getenv('PACKAGE_VERSION', version)
 
     ldflags = f"-X {REPO_PATH}/pkg/version.Commit={commit} "
-    ldflags += (
-        f"-X {REPO_PATH}/pkg/version.AgentVersion={get_version(ctx, include_git=True, major_version=major_version)} "
-    )
+    ldflags += f"-X {REPO_PATH}/pkg/version.AgentVersion={version} "
     ldflags += f"-X {REPO_PATH}/pkg/version.AgentPayloadVersion={payload_v} "
     if install_path:
         if sys.platform == 'win32':
@@ -407,9 +407,10 @@ def get_version_ldflags(ctx, major_version='7', install_path=None):
             #       it's also hardcoded in Generate-OCIPackage.ps1
             package_version = f"{package_version}-1"
         else:
-            package_version = os.path.basename(install_path)
-        if package_version != "datadog-agent":
-            ldflags += f"-X {REPO_PATH}/pkg/version.AgentPackageVersion={package_version} "
+            install_dir = os.path.basename(install_path)
+            if install_dir != "datadog-agent":
+                package_version = install_dir
+    ldflags += f"-X {REPO_PATH}/pkg/version.AgentPackageVersion={package_version} "
     return ldflags
 
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -251,7 +251,12 @@ func (h *Host) AssertPackageInstalledByInstaller(pkgs ...string) {
 func (h *Host) AssertPackageNotInstalledByInstaller(pkgs ...string) {
 	for _, pkg := range pkgs {
 		_, err := h.remote.ReadDir(fmt.Sprintf("/opt/datadog-packages/%s/stable/", pkg))
-		require.Error(h.t(), err, "package %s installed by the installer", pkg)
+		if err == nil {
+			installPath := strings.TrimSpace(h.remote.MustExecute(fmt.Sprintf("sudo readlink -f /opt/datadog-packages/%s/stable", pkg)))
+			if strings.HasPrefix(installPath, "/opt/datadog-packages/") {
+				h.t().Errorf("package %s installed by the installer", pkg)
+			}
+		}
 	}
 }
 

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -225,7 +225,7 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 
 	// Act
 	_, err := s.StartExperimentCurrentVersion()
-	s.Require().ErrorContains(err, "cannot set new experiment to the same version as the current experiment")
+	s.Require().ErrorContains(err, "cannot set new experiment to the same version as stable")
 
 	// Assert
 	s.assertDaemonStaysRunning(func() {


### PR DESCRIPTION
Reverts DataDog/datadog-agent#37909

A bug in the CI led to some unit test not running and they failed in main. Those tests only needed updating to include the `package_version` tag on the `datadog.agent.running` metric used in new contexts (before: OCI, now: OCI,DEB,RPM).