### PR TITLE
[dyninst] Support probe throttling

### DIFF
--- a/pkg/dyninst/compiler/sm/functions.go
+++ b/pkg/dyninst/compiler/sm/functions.go
@@ -42,8 +42,9 @@ func (ChasePointers) String() string {
 // at given injection PC.
 type ProcessEvent struct {
 	baseFunctionID
-	EventRootType *ir.EventRootType
+	ThrottlerIdx  int
 	InjectionPC   uint64
+	EventRootType *ir.EventRootType
 }
 
 // String returns a human-readable identifier for the function.

--- a/pkg/dyninst/compiler/sm/generate.go
+++ b/pkg/dyninst/compiler/sm/generate.go
@@ -22,10 +22,17 @@ type Function struct {
 	Ops []Op
 }
 
+// Throttler corresponds to a throttler instance with specified limits.
+type Throttler struct {
+	PeriodNs uint64
+	Budget   int64
+}
+
 // Program represents stack machine program.
 type Program struct {
-	Functions []Function
-	Types     []ir.Type
+	Functions  []Function
+	Types      []ir.Type
+	Throttlers []Throttler
 }
 
 type generator struct {
@@ -60,14 +67,20 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 	if err != nil {
 		return Program{}, err
 	}
+	throttlers := make([]Throttler, 0, len(program.Probes))
 	for _, probe := range program.Probes {
 		for _, event := range probe.Events {
 			for _, injectionPC := range event.InjectionPCs {
-				err := g.addEventHandler(injectionPC, event.Type)
+				err := g.addEventHandler(len(throttlers), injectionPC, event.Type)
 				if err != nil {
 					return Program{}, err
 				}
 			}
+			// We throttle each event individually, across all its injection points.
+			throttlers = append(throttlers, Throttler{
+				PeriodNs: uint64(probe.ThrottlePeriodMs) * 1000 * 1000,
+				Budget:   probe.ThrottleBudget,
+			})
 		}
 	}
 	for len(g.typeQueue) > 0 {
@@ -82,18 +95,20 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 		types = append(types, t)
 	}
 	return Program{
-		Functions: g.functions,
-		Types:     types,
+		Functions:  g.functions,
+		Types:      types,
+		Throttlers: throttlers,
 	}, nil
 }
 
 // Generates a function called when a probe (represented by the root type)
 // is triggered with a particular event (injectionPC). The function
 // dispatches expression handlers.
-func (g *generator) addEventHandler(injectionPC uint64, rootType *ir.EventRootType) error {
+func (g *generator) addEventHandler(throttlerIdx int, injectionPC uint64, rootType *ir.EventRootType) error {
 	id := ProcessEvent{
-		EventRootType: rootType,
+		ThrottlerIdx:  throttlerIdx,
 		InjectionPC:   injectionPC,
+		EventRootType: rootType,
 	}
 	ops := make([]Op, 0, 2+len(rootType.Expressions))
 	ops = append(ops, PrepareEventRootOp{

--- a/pkg/dyninst/compiler/snapshot_test.go
+++ b/pkg/dyninst/compiler/snapshot_test.go
@@ -36,7 +36,7 @@ const snapshotDir = "testdata/snapshot"
 var cases = []string{"simple"}
 
 func TestSnapshotTesting(t *testing.T) {
-	cfgs := testprogs.GetCommonConfigs(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, caseName := range cases {
 		t.Run(caseName, func(t *testing.T) {
 			for _, cfg := range cfgs {
@@ -53,8 +53,8 @@ func runTest(
 	cfg testprogs.Config,
 	caseName string,
 ) {
-	binPath := testprogs.GetBinary(t, caseName, cfg)
-	probesCfgs := testprogs.GetProbeCfgs(t, caseName)
+	binPath := testprogs.MustGetBinary(t, caseName, cfg)
+	probesCfgs := testprogs.MustGetProbeCfgs(t, caseName)
 	elfFile, err := safeelf.Open(binPath)
 	require.NoError(t, err)
 	obj, err := object.NewElfObject(elfFile)

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
@@ -166,16 +166,16 @@ const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
 const probe_params_t probe_params[] = {
-	{.stack_machine_pc = 0x19, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x50, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x92, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0xbd, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0xff, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x13f, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x15d, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x17b, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x1a0, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x1bf, .stream_id = 0, .frameless = false},
+	{.throttler_idx = 0, .stack_machine_pc = 0x19, .frameless = false},
+	{.throttler_idx = 1, .stack_machine_pc = 0x50, .frameless = false},
+	{.throttler_idx = 2, .stack_machine_pc = 0x92, .frameless = false},
+	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .frameless = false},
+	{.throttler_idx = 4, .stack_machine_pc = 0xff, .frameless = false},
+	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .frameless = false},
+	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .frameless = false},
 };
 const uint32_t num_probe_params = 10;
 typedef enum type {
@@ -303,3 +303,15 @@ const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 
 
 const uint32_t num_types = 57;
 
+const throttler_params_t throttler_params[] = {
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+};
+#define NUM_THROTTLERS 9

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
@@ -166,16 +166,16 @@ const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
 const probe_params_t probe_params[] = {
-	{.stack_machine_pc = 0x19, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x50, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x92, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0xbd, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0xff, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x13f, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x15d, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x17b, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x1a0, .stream_id = 0, .frameless = false},
-	{.stack_machine_pc = 0x1bf, .stream_id = 0, .frameless = false},
+	{.throttler_idx = 0, .stack_machine_pc = 0x19, .frameless = false},
+	{.throttler_idx = 1, .stack_machine_pc = 0x50, .frameless = false},
+	{.throttler_idx = 2, .stack_machine_pc = 0x92, .frameless = false},
+	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .frameless = false},
+	{.throttler_idx = 4, .stack_machine_pc = 0xff, .frameless = false},
+	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .frameless = false},
+	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .frameless = false},
 };
 const uint32_t num_probe_params = 10;
 typedef enum type {
@@ -303,3 +303,15 @@ const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 
 
 const uint32_t num_types = 57;
 
+const throttler_params_t throttler_params[] = {
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
+};
+#define NUM_THROTTLERS 9

--- a/pkg/dyninst/dyninsttest/util.go
+++ b/pkg/dyninst/dyninsttest/util.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package dyninsttest provides utilities for dyninst integration testing.
+package dyninsttest
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler/codegen"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+// PrepTmpDir creates a temporary directory and a suitable cleanup function.
+func PrepTmpDir(t *testing.T, prefix string) (string, func()) {
+	dir, err := os.MkdirTemp(os.TempDir(), prefix)
+	require.NoError(t, err)
+	return dir, func() {
+		preserve, _ := strconv.ParseBool(os.Getenv("KEEP_TEMP"))
+		if preserve || t.Failed() {
+			t.Logf("leaving temp dir %s for inspection", dir)
+		} else {
+			require.NoError(t, os.RemoveAll(dir))
+		}
+	}
+}
+
+// GenerateIr generates an IR program based on a binary and a config files.
+func GenerateIr(t *testing.T, tempDir string, binPath string, cfgName string) (obj *object.ElfFile, irp *ir.Program) {
+	binary, err := safeelf.Open(binPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, binary.Close()) }()
+
+	probes := testprogs.MustGetProbeCfgs(t, cfgName)
+
+	obj, err = object.NewElfObject(binary)
+	require.NoError(t, err)
+
+	irp, err = irgen.GenerateIR(1, obj, probes)
+	require.NoError(t, err)
+
+	irDump, err := os.Create(filepath.Join(tempDir, "probe.ir.yaml"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, irDump.Close()) }()
+	irYaml, err := irprinter.PrintYAML(irp)
+	require.NoError(t, err)
+	_, err = irDump.Write(irYaml)
+	require.NoError(t, err)
+
+	return
+}
+
+// CompileAndLoadBPF compiles an IR program and loads it into the kernel.
+func CompileAndLoadBPF(
+	t *testing.T,
+	tempDir string,
+	irp *ir.Program,
+) (*ebpf.Collection, *ebpf.Program, []codegen.BPFAttachPoint, func()) {
+	codeDump, err := os.Create(filepath.Join(tempDir, "probe.bpf.c"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, codeDump.Close()) }()
+
+	compiledBPF, err := compiler.CompileBPFProgram(irp, codeDump)
+	require.NoError(t, err)
+
+	bpfObjDump, err := os.Create(filepath.Join(tempDir, "probe.bpf.o"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, bpfObjDump.Close()) }()
+	_, err = io.Copy(bpfObjDump, compiledBPF.Obj)
+	require.NoError(t, err)
+
+	spec, err := ebpf.LoadCollectionSpecFromReader(compiledBPF.Obj)
+	require.NoError(t, err)
+
+	bpfCollection, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	require.NoError(t, err)
+
+	bpfProg, ok := bpfCollection.Programs[compiledBPF.ProgramName]
+	require.True(t, ok)
+
+	return bpfCollection, bpfProg, compiledBPF.Attachpoints, func() {
+		compiledBPF.Obj.Close()
+		bpfCollection.Close()
+	}
+}
+
+// StartProcess starts a process and returns a write closer for the stdin.
+func StartProcess(ctx context.Context, t *testing.T, tempDir string, binPath string, args ...string) (*exec.Cmd, io.WriteCloser) {
+	proc := exec.CommandContext(ctx, binPath, args...)
+	sampleStdin, err := proc.StdinPipe()
+	require.NoError(t, err)
+	proc.Stdout, err = os.Create(filepath.Join(tempDir, "sample.out"))
+	require.NoError(t, err)
+	proc.Stderr, err = os.Create(filepath.Join(tempDir, "sample.err"))
+	require.NoError(t, err)
+	err = proc.Start()
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	return proc, sampleStdin
+}
+
+// AttachBPFProbes attaches the BPF program to the running process.
+func AttachBPFProbes(
+	t *testing.T,
+	binPath string,
+	obj *object.ElfFile,
+	pid int,
+	bpfProg *ebpf.Program,
+	attachpoints []codegen.BPFAttachPoint,
+) func() {
+	sampleLink, err := link.OpenExecutable(binPath)
+	require.NoError(t, err)
+	textSection, err := obj.TextSectionHeader()
+	require.NoError(t, err)
+
+	var allAttached []link.Link
+	for _, attachpoint := range attachpoints {
+		// Despite the name, Uprobe expects an offset in the object file, and not the virtual address.
+		addr := attachpoint.PC - textSection.Addr + textSection.Offset
+		t.Logf("attaching @0x%x cookie=%d", addr, attachpoint.Cookie)
+		attached, err := sampleLink.Uprobe(
+			"",
+			bpfProg,
+			&link.UprobeOptions{
+				PID:     pid,
+				Address: addr,
+				Offset:  0,
+				Cookie:  attachpoint.Cookie,
+			},
+		)
+		require.NoError(t, err)
+		allAttached = append(allAttached, attached)
+	}
+	return func() {
+		for _, a := range allAttached {
+			require.NoError(t, a.Close())
+		}
+	}
+}

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -10,14 +10,22 @@
 #include "murmur2.h"
 #include "walk_stack.h"
 #include "scratch.h"
+#include "throttler.h"
 
 char _license[] SEC("license") = "GPL";
 
 extern const probe_params_t probe_params[];
 extern const uint32_t num_probe_params;
 
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, 1);
+  __type(key, uint32_t);
+  __type(value, uint64_t);
+} throttled_events SEC(".maps");
+
 SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
-  uint64_t start = bpf_ktime_get_ns();
+  uint64_t start_ns = bpf_ktime_get_ns();
 
   const uint64_t cookie = bpf_get_attach_cookie(regs);
   if (cookie >= num_probe_params) {
@@ -25,6 +33,14 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   }
   const probe_params_t* params = &probe_params[cookie];
 
+  if (should_throttle(params->throttler_idx, start_ns)) {
+    uint32_t zero = 0;
+    uint64_t* cnt = bpf_map_lookup_elem(&throttled_events, &zero);
+    if (cnt) {
+      ++*cnt;
+    }
+    return 0;
+  }
   global_ctx_t global_ctx;
   global_ctx.stack_machine = stack_machine_ctx_load();
   if (!global_ctx.stack_machine) {
@@ -52,7 +68,7 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   *header = (event_header_t){
       .data_byte_len = sizeof(event_header_t),
       .stack_byte_len = 0, // set this if we collect stacks
-      .ktime_ns = start,
+      .ktime_ns = start_ns,
   };
 
   __maybe_unused int process_steps = 0;
@@ -91,7 +107,6 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
     stack_hash = 0;
   }
   global_ctx.regs = &global_ctx.stack_walk->regs;
-
   frame_data_t frame_data = {
 // Stack layout is slightly different in Go between arm64 and x86_64.
 // Established based on following documentation and machine code reads:

--- a/pkg/dyninst/ebpf/throttler.h
+++ b/pkg/dyninst/ebpf/throttler.h
@@ -1,0 +1,58 @@
+#ifndef __THROTTLER_H__
+#define __THROTTLER_H__
+
+#include "types.h"
+
+typedef struct throttler {
+  uint64_t last_probe_run_ns;
+  int64_t budget;
+} throttler_t;
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, NUM_THROTTLERS);
+  __type(key, uint32_t);
+  __type(value, throttler_t);
+} throttler_buf SEC(".maps");
+
+static bool should_throttle(uint32_t throttler_idx, uint64_t start_ns) {
+  throttler_t* throttler = (throttler_t*)bpf_map_lookup_elem(&throttler_buf, &throttler_idx);
+  if (!throttler) {
+    return true;
+  }
+  // Try twice to determine throttling result.
+  for (int i = 0; i < 2; i++) {
+    // Check if we are within budget. First do only a memory read, to avoid
+    // contention on a most executed (and thus throttled) probes.
+    if (throttler->budget > 0) {
+        if (__sync_fetch_and_sub(&throttler->budget, 1) > 0) {
+            return false;
+        }
+    }
+    // We are out of budget, check if throttling period passed and budget
+    // could be refreshed.
+    if (throttler_idx >= NUM_THROTTLERS) {
+        return true;
+    }
+    if (throttler->last_probe_run_ns > 0 && start_ns - throttler->last_probe_run_ns < throttler_params[throttler_idx].period_ns) {
+        return true;
+    }
+    // Try to refresh the budget. We need to make sure we do it only once
+    // per the throttling period. We make an assumption that ns measurement
+    // is never the same.
+    int64_t budget = throttler_params[throttler_idx].budget;
+    uint64_t local_last_probe_run_ns = throttler->last_probe_run_ns;
+    if (__sync_val_compare_and_swap(&throttler->last_probe_run_ns, local_last_probe_run_ns, start_ns) == local_last_probe_run_ns) {
+        // Note that any probe that reads the budget between the preceeding last_probe_run_ns update and following budget refresh
+        // will be rejected. In practise this results in immaterial over-throttling - it requires probing a hot function, in
+        // which case we will throttle affected call, and instead probe some future call.
+        throttler->budget = budget - 1;
+        return false;
+    }
+    // We failed to refresh the budget, maybe try again.
+  }
+  // We failed to determine throttling result, conservatively reject.
+  return true;
+}
+
+#endif // __THROTTLER_H__

--- a/pkg/dyninst/ebpf/types.h
+++ b/pkg/dyninst/ebpf/types.h
@@ -12,10 +12,15 @@ typedef struct type_info {
 } type_info_t;
 
 typedef struct probe_params {
+  uint32_t throttler_idx;
   uint32_t stack_machine_pc;
-  uint32_t stream_id;
   bool frameless;
 } probe_params_t;
+
+typedef struct throttler_params {
+  uint64_t period_ns;
+  int64_t budget;
+} throttler_params_t;
 
 typedef enum sm_opcode {
   SM_OP_INVALID = 0,
@@ -47,7 +52,6 @@ typedef enum sm_opcode {
   SM_OP_CHASE_POINTERS = 22,
   SM_OP_PREPARE_EVENT_ROOT = 23,
 } sm_opcode_t;
-
 
 #ifdef DYNINST_DEBUG
 static const char* op_code_name(sm_opcode_t op_code) {
@@ -91,6 +95,8 @@ typedef enum type { TYPE_NONE = 0 } type_t;
 const type_info_t type_info[] = {};
 const uint32_t type_ids[] = {};
 const uint32_t num_types = 0;
+const throttler_params_t throttler_params[] = {};
+#define NUM_THROTTLERS 0
 
 #endif
 

--- a/pkg/dyninst/ebpfbench/main.go
+++ b/pkg/dyninst/ebpfbench/main.go
@@ -1,0 +1,206 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Code skeleton for running a manual benchmark of eBPF program cpu overheads.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+func getSampleBinaryPath() (string, error) {
+	return testprogs.GetBinary("busyloop", testprogs.Config{
+		GOARCH:      runtime.GOARCH,
+		GOTOOLCHAIN: "go1.24.3",
+	})
+}
+
+func runBenchmark() error {
+	binPath, err := getSampleBinaryPath()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("loading binary %s\n", binPath)
+	// Load the binary and generate the IR.
+	binary, err := safeelf.Open(binPath)
+	if err != nil {
+		return err
+	}
+	defer func() { binary.Close() }()
+
+	probes, err := testprogs.GetProbeCfgs("busyloop")
+	if err != nil {
+		return err
+	}
+
+	obj, err := object.NewElfObject(binary)
+	if err != nil {
+		return err
+	}
+
+	irp, err := irgen.GenerateIR(1, obj, probes)
+	if err != nil {
+		return err
+	}
+	irp.Probes[0].ThrottlePeriodMs = 1
+	irp.Probes[0].ThrottleBudget = 3
+
+	// Compile the IR and prepare the BPF program.
+	fmt.Println("compiling BPF")
+	compiledBPF, err := compiler.CompileBPFProgram(irp, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { compiledBPF.Obj.Close() }()
+
+	bpfObjDump, err := os.Create("/tmp/probe.bpf.o")
+	if err != nil {
+		return err
+	}
+	defer func() { bpfObjDump.Close() }()
+	_, err = io.Copy(bpfObjDump, compiledBPF.Obj)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("loading BPF")
+	spec, err := ebpf.LoadCollectionSpecFromReader(compiledBPF.Obj)
+	if err != nil {
+		return err
+	}
+
+	bpfCollection, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { bpfCollection.Close() }()
+
+	bpfProg, ok := bpfCollection.Programs[compiledBPF.ProgramName]
+	if !ok {
+		return fmt.Errorf("bpf program %s not found", compiledBPF.ProgramName)
+	}
+
+	sampleLink, err := link.OpenExecutable(binPath)
+	if err != nil {
+		return err
+	}
+
+	// Launch the sample service, inject the BPF program and collect the output.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	fmt.Println("spawning and instrumenting sample")
+	sampleProc := exec.CommandContext(ctx, binPath, "5", "1", "4")
+	sampleStdin, err := sampleProc.StdinPipe()
+	if err != nil {
+		return err
+	}
+	sampleProc.Stdout = os.Stdout
+	sampleProc.Stderr = os.Stderr
+	err = sampleProc.Start()
+	if err != nil {
+		return err
+	}
+
+	textSection, err := obj.TextSectionHeader()
+	if err != nil {
+		return err
+	}
+	var allAttached []link.Link
+	for _, attachpoint := range compiledBPF.Attachpoints {
+		// Despite the name, Uprobe expects an offset in the object file, and not the virtual address.
+		addr := attachpoint.PC - textSection.Addr + textSection.Offset
+		fmt.Printf("attaching @0x%x cookie=%d\n", addr, attachpoint.Cookie)
+		attached, err := sampleLink.Uprobe(
+			"",
+			bpfProg,
+			&link.UprobeOptions{
+				PID:     sampleProc.Process.Pid,
+				Address: addr,
+				Offset:  0,
+				Cookie:  attachpoint.Cookie,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		allAttached = append(allAttached, attached)
+	}
+	defer func() {
+		for _, a := range allAttached {
+			if err := a.Close(); err != nil {
+				fmt.Printf("error closing link: %v\n", err)
+			}
+		}
+	}()
+
+	// Trigger the function calls.
+	fmt.Println("running the sample")
+	_, err = sampleStdin.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+
+	err = sampleProc.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Count events.
+	rd, err := ringbuf.NewReader(bpfCollection.Maps["out_ringbuf"])
+	if err != nil {
+		return err
+	}
+
+	ts := make(map[uint64]struct{})
+	duplicates := 0
+
+	events := 0
+	for rd.AvailableBytes() > 0 {
+		record, err := rd.Read()
+		if err != nil {
+			return err
+		}
+
+		header := (*output.EventHeader)(unsafe.Pointer(&record.RawSample[0]))
+		_, ok := ts[header.Ktime_ns]
+		if ok {
+			duplicates++
+		}
+		ts[header.Ktime_ns] = struct{}{}
+		events++
+	}
+	fmt.Printf("collected %d events with %d ts duplicates\n", events, duplicates)
+
+	return nil
+}
+
+func main() {
+	err := runBenchmark()
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
-	object "github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -47,13 +47,13 @@ func skipIfKernelNotSupported(t *testing.T) {
 
 func TestDyninst(t *testing.T) {
 	skipIfKernelNotSupported(t)
-	cfgs := testprogs.GetCommonConfigs(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, cfg := range cfgs {
 		t.Run(cfg.String(), func(t *testing.T) {
 			if cfg.GOARCH != runtime.GOARCH {
 				t.Skipf("cross-execution is not supported, running on %s", runtime.GOARCH)
 			}
-			bin := testprogs.GetBinary(t, "simple", cfg)
+			bin := testprogs.MustGetBinary(t, "simple", cfg)
 			testDyninst(t, bin)
 		})
 	}
@@ -77,7 +77,7 @@ func testDyninst(t *testing.T, sampleServicePath string) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, binary.Close()) }()
 
-	probes := testprogs.GetProbeCfgs(t, "simple")
+	probes := testprogs.MustGetProbeCfgs(t, "simple")
 
 	obj, err := object.NewElfObject(binary)
 	require.NoError(t, err)

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -9,30 +9,21 @@ package dyninst_test
 
 import (
 	"context"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"testing"
 	"time"
 	"unsafe"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 var MinimumKernelVersion = kernel.VersionCode(5, 17, 0)
@@ -60,112 +51,29 @@ func TestDyninst(t *testing.T) {
 }
 
 func testDyninst(t *testing.T, sampleServicePath string) {
-	t.Logf("loading binary")
-	tempDir, err := os.MkdirTemp(os.TempDir(), "dyninst-integration-test-")
-	require.NoError(t, err)
-	defer func() {
-		preserve, _ := strconv.ParseBool(os.Getenv("KEEP_TEMP"))
-		if preserve || t.Failed() {
-			t.Logf("leaving temp dir %s for inspection", tempDir)
-		} else {
-			require.NoError(t, os.RemoveAll(tempDir))
-		}
-	}()
+	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-integration-test-")
+	defer cleanup()
 
 	// Load the binary and generate the IR.
-	binary, err := safeelf.Open(sampleServicePath)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, binary.Close()) }()
-
-	probes := testprogs.MustGetProbeCfgs(t, "simple")
-
-	obj, err := object.NewElfObject(binary)
-	require.NoError(t, err)
-
-	irp, err := irgen.GenerateIR(1, obj, probes)
-	require.NoError(t, err)
-
-	irDump, err := os.Create(filepath.Join(tempDir, "probe.ir.yaml"))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, irDump.Close()) }()
-	irYaml, err := irprinter.PrintYAML(irp)
-	require.NoError(t, err)
-	_, err = irDump.Write(irYaml)
-	require.NoError(t, err)
+	t.Logf("loading binary")
+	obj, irp := dyninsttest.GenerateIr(t, tempDir, sampleServicePath, "simple")
 
 	// Compile the IR and prepare the BPF program.
 	t.Logf("compiling BPF")
-	codeDump, err := os.Create(filepath.Join(tempDir, "probe.bpf.c"))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, codeDump.Close()) }()
-
-	compiledBPF, err := compiler.CompileBPFProgram(irp, codeDump)
-	require.NoError(t, err)
-	defer func() { compiledBPF.Obj.Close() }()
-
-	bpfObjDump, err := os.Create(filepath.Join(tempDir, "probe.bpf.o"))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, bpfObjDump.Close()) }()
-	_, err = io.Copy(bpfObjDump, compiledBPF.Obj)
-	require.NoError(t, err)
-
-	spec, err := ebpf.LoadCollectionSpecFromReader(compiledBPF.Obj)
-	require.NoError(t, err)
-
-	bpfCollection, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
-	require.NoError(t, err)
-	defer func() { bpfCollection.Close() }()
-
-	bpfProg, ok := bpfCollection.Programs[compiledBPF.ProgramName]
-	require.True(t, ok)
-
-	sampleLink, err := link.OpenExecutable(sampleServicePath)
-	require.NoError(t, err)
+	bpfCollection, bpfProg, attachpoints, cleanup := dyninsttest.CompileAndLoadBPF(t, tempDir, irp)
+	defer cleanup()
 
 	// Launch the sample service, inject the BPF program and collect the output.
 	t.Logf("running and instrumenting sample")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	sampleProc := exec.CommandContext(ctx, sampleServicePath)
-	sampleStdin, err := sampleProc.StdinPipe()
-	require.NoError(t, err)
-	sampleProc.Stdout, err = os.Create(filepath.Join(tempDir, "sample.out"))
-	require.NoError(t, err)
-	sampleProc.Stderr, err = os.Create(filepath.Join(tempDir, "sample.err"))
-	require.NoError(t, err)
-	err = sampleProc.Start()
-	require.NoError(t, err)
+	sampleProc, sampleStdin := dyninsttest.StartProcess(ctx, t, tempDir, sampleServicePath)
+	cleanup = dyninsttest.AttachBPFProbes(t, sampleServicePath, obj, sampleProc.Process.Pid, bpfProg, attachpoints)
+	defer cleanup()
 
-	textSection, err := obj.TextSectionHeader()
-	require.NoError(t, err)
-	var allAttached []link.Link
-	for _, attachpoint := range compiledBPF.Attachpoints {
-		// Despite the name, Uprobe expects an offset in the object file, and not the virtual address.
-		addr := attachpoint.PC - textSection.Addr + textSection.Offset
-		t.Logf("attaching @0x%x cookie=%d", addr, attachpoint.Cookie)
-		attached, err := sampleLink.Uprobe(
-			"",
-			bpfProg,
-			&link.UprobeOptions{
-				PID:     sampleProc.Process.Pid,
-				Address: addr,
-				Offset:  0,
-				Cookie:  attachpoint.Cookie,
-			},
-		)
-		require.NoError(t, err)
-		allAttached = append(allAttached, attached)
-	}
-	defer func() {
-		for _, a := range allAttached {
-			require.NoError(t, a.Close())
-		}
-	}()
-
-	// Trigger the function calls.
+	// Trigger the function calls and wait for the process to exit.
 	sampleStdin.Write([]byte("\n"))
-
-	err = sampleProc.Wait()
+	err := sampleProc.Wait()
 	require.NoError(t, err)
 
 	// Validate the output. For now we just check the total length.
@@ -178,7 +86,7 @@ func testDyninst(t *testing.T, sampleServicePath string) {
 	defer func() { require.NoError(t, bpfOutDump.Close()) }()
 
 	// Inlined function is called twice, hence extra event.
-	for range len(probes) + 1 {
+	for range len(irp.Probes) + 1 {
 		t.Logf("reading ringbuf item")
 		require.Greater(t, rd.AvailableBytes(), 0)
 		record, err := rd.Read()

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -112,6 +112,10 @@ type Probe struct {
 	Events []*Event
 	// Whether the probe should capture a snapshot of the state of the program.
 	Snapshot bool
+	// ThrottlePeriodMs is the resolution of the throttler.
+	ThrottlePeriodMs uint32
+	// ThrottleBudget is the amount of events that can be emitted per ThrottlePeriodMs.
+	ThrottleBudget int64
 	// TODO: Add template support:
 	//	TemplateSegments []TemplateSegment
 }

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -16,19 +16,19 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/config"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
-	object "github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 func TestIRGenAllProbes(t *testing.T) {
-	programs := testprogs.GetPrograms(t)
-	cfgs := testprogs.GetCommonConfigs(t)
+	programs := testprogs.MustGetPrograms(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, pkg := range programs {
 		t.Run(pkg, func(t *testing.T) {
 			for _, cfg := range cfgs {
 				t.Run(cfg.String(), func(t *testing.T) {
-					bin := testprogs.GetBinary(t, pkg, cfg)
+					bin := testprogs.MustGetBinary(t, pkg, cfg)
 					testAllProbes(t, bin)
 				})
 			}

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -34,7 +34,7 @@ const snapshotDir = "testdata/snapshot"
 var cases = []string{"simple"}
 
 func TestSnapshotTesting(t *testing.T) {
-	cfgs := testprogs.GetCommonConfigs(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, caseName := range cases {
 		t.Run(caseName, func(t *testing.T) {
 			for _, cfg := range cfgs {
@@ -51,8 +51,8 @@ func runTest(
 	cfg testprogs.Config,
 	caseName string,
 ) {
-	binPath := testprogs.GetBinary(t, caseName, cfg)
-	probesCfgs := testprogs.GetProbeCfgs(t, caseName)
+	binPath := testprogs.MustGetBinary(t, caseName, cfg)
+	probesCfgs := testprogs.MustGetProbeCfgs(t, caseName)
 	elfFile, err := safeelf.Open(binPath)
 	require.NoError(t, err)
 	obj, err := object.NewElfObject(elfFile)

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,6 +11,8 @@ Probes:
           InjectionPCs: ["0x4a7f0a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: b
       Kind: ProbeKindLog
       Version: 0
@@ -22,6 +24,8 @@ Probes:
           InjectionPCs: ["0x4a7f8a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: c
       Kind: ProbeKindLog
       Version: 0
@@ -33,6 +37,8 @@ Probes:
           InjectionPCs: ["0x4a800a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: d
       Kind: ProbeKindLog
       Version: 0
@@ -44,6 +50,8 @@ Probes:
           InjectionPCs: ["0x4a808a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: e
       Kind: ProbeKindLog
       Version: 0
@@ -55,6 +63,8 @@ Probes:
           InjectionPCs: ["0x4a810a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: f
       Kind: ProbeKindLog
       Version: 0
@@ -66,6 +76,8 @@ Probes:
           InjectionPCs: ["0x4a818a"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: h
       Kind: ProbeKindLog
       Version: 0
@@ -77,6 +89,8 @@ Probes:
           InjectionPCs: ["0x4a82ca"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: i
       Kind: ProbeKindLog
       Version: 0
@@ -88,6 +102,8 @@ Probes:
           InjectionPCs: ["0x4a8333"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: g
       Kind: ProbeKindLog
       Version: 0
@@ -99,6 +115,8 @@ Probes:
           InjectionPCs: ["0x4a820a", "0x4a7da6"]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
 Subprograms:
     - ID: 2
       Name: main.intArg

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,6 +11,8 @@ Probes:
           InjectionPCs: [741596]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: b
       Kind: ProbeKindLog
       Version: 0
@@ -22,6 +24,8 @@ Probes:
           InjectionPCs: [741708]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: c
       Kind: ProbeKindLog
       Version: 0
@@ -33,6 +37,8 @@ Probes:
           InjectionPCs: [741836]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: d
       Kind: ProbeKindLog
       Version: 0
@@ -44,6 +50,8 @@ Probes:
           InjectionPCs: [741964]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: e
       Kind: ProbeKindLog
       Version: 0
@@ -55,6 +63,8 @@ Probes:
           InjectionPCs: [742092]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: f
       Kind: ProbeKindLog
       Version: 0
@@ -66,6 +76,8 @@ Probes:
           InjectionPCs: [742220]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: h
       Kind: ProbeKindLog
       Version: 0
@@ -77,6 +89,8 @@ Probes:
           InjectionPCs: [742540]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: i
       Kind: ProbeKindLog
       Version: 0
@@ -88,6 +102,8 @@ Probes:
           InjectionPCs: [742656]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
     - ID: g
       Kind: ProbeKindLog
       Version: 0
@@ -99,6 +115,8 @@ Probes:
           InjectionPCs: [742348, 741304]
           Condition: null
       Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
 Subprograms:
     - ID: 2
       Name: main.intArg

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -21,9 +21,9 @@ import (
 // This is a very basic test of loading a Go elf object file
 // and that it more or less works and sanely loads dwarf.
 func TestElfObject(t *testing.T) {
-	cfgs := testprogs.GetCommonConfigs(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
 	for _, cfg := range cfgs {
-		binaryPath := testprogs.GetBinary(t, "simple", cfg)
+		binaryPath := testprogs.MustGetBinary(t, "simple", cfg)
 		elf, err := safeelf.Open(binaryPath)
 		require.NoError(t, err)
 		obj, err := object.NewElfObject(elf)

--- a/pkg/dyninst/testprogs/progs/busyloop/main.go
+++ b/pkg/dyninst/testprogs/progs/busyloop/main.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Busyloop is a sample go program that can be used for benchmarking.
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"time"
+)
+
+//go:noinline
+func noop() {}
+
+func busyloop(concurrency int, duration time.Duration) float64 {
+	ready := make(chan struct{})
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	counts := make(chan int)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			iters := 0
+			// Synchronize all goroutines after threads have been spawned.
+			ready <- struct{}{}
+			<-start
+		loop:
+			for {
+				select {
+				case <-stop:
+					break loop
+				default:
+					// Busy loop.
+					noop()
+					iters++
+				}
+			}
+			counts <- iters
+		}()
+	}
+	for i := 0; i < concurrency; i++ {
+		<-ready
+	}
+	close(start)
+	time.Sleep(duration)
+	close(stop)
+	total := 0
+	for i := 0; i < concurrency; i++ {
+		total += <-counts
+	}
+	return 1e6 * float64(concurrency) / float64(total)
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Println("Usage: ./busyloop [round_cnt] [round_sec] [concurrency]")
+		return
+	}
+	// Wait for input signalling that loop should be started.
+	round_cnt, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	round_sec, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	concurrency, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	_, err = fmt.Scanln()
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	results := make([]float64, round_cnt)
+	avg := 0.0
+	for i := 0; i < round_cnt; i++ {
+		results[i] = busyloop(concurrency, time.Duration(round_sec)*time.Second)
+		fmt.Printf("%.6fus\n", results[i])
+		avg += results[i]
+	}
+	avg /= float64(len(results))
+	stddev := 0.0
+	for i := 0; i < round_cnt; i++ {
+		stddev += (results[i] - avg) * (results[i] - avg)
+	}
+	stddev /= float64(len(results))
+	stddev = math.Sqrt(stddev)
+	fmt.Printf("avg=%.6fus stddev=%.6fus\n", avg, stddev)
+}

--- a/pkg/dyninst/testprogs/test_progs.go
+++ b/pkg/dyninst/testprogs/test_progs.go
@@ -310,12 +310,6 @@ func (m *Config) String() string {
 	return fmt.Sprintf("arch=%s,toolchain=%s", m.GOARCH, m.GOTOOLCHAIN)
 }
 
-// Go124 is the go version 1.24.1.
-const Go124 = "go1.24.1"
-
-// Local is the local go version.
-const Local = "local"
-
 const (
 	// Amd64 is the amd64 architecture.
 	Amd64 = "amd64"
@@ -366,5 +360,5 @@ func parseConfig(s string) (Config, error) {
 }
 
 var (
-	goVersionRegex = regexp.MustCompile(`^(go1\.\d+\.\d+|local)$`)
+	goVersionRegex = regexp.MustCompile(`^(go1\.\d+\.\d+)$`)
 )

--- a/pkg/dyninst/testprogs/testdata/probes/busyloop.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/busyloop.yaml
@@ -1,0 +1,6 @@
+binary: busyloop
+probes:
+- id: a
+  type: LOG_PROBE
+  where:
+    method_name: main.noop

--- a/pkg/dyninst/throttler_test.go
+++ b/pkg/dyninst/throttler_test.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+func TestThrottler(t *testing.T) {
+	skipIfKernelNotSupported(t)
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	for _, cfg := range cfgs {
+		t.Run(cfg.String(), func(t *testing.T) {
+			if cfg.GOARCH != runtime.GOARCH {
+				t.Skipf("cross-execution is not supported, running on %s", runtime.GOARCH)
+			}
+			bin := testprogs.MustGetBinary(t, "busyloop", cfg)
+			t.Run("enforcesBudget", func(t *testing.T) {
+				enforcesBudget(t, bin)
+			})
+			t.Run("refreshesBudget", func(t *testing.T) {
+				refreshesBudget(t, bin)
+			})
+		})
+	}
+}
+
+func enforcesBudget(t *testing.T, busyloopPath string) {
+	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-throttler-test-")
+	defer cleanup()
+
+	// Load the binary and generate the IR.
+	t.Logf("loading binary")
+	obj, irp := dyninsttest.GenerateIr(t, tempDir, busyloopPath, "busyloop")
+
+	// Adjust throttling parameters.
+	// Practically infinite period, with specific event count.
+	require.Equal(t, 1, len(irp.Probes))
+	expectedEvents := 7
+	irp.Probes[0].ThrottlePeriodMs = 1000 * 1000
+	irp.Probes[0].ThrottleBudget = int64(expectedEvents)
+
+	// Compile the IR and prepare the BPF program.
+	t.Logf("compiling BPF")
+	bpfCollection, bpfProg, attachpoints, cleanup := dyninsttest.CompileAndLoadBPF(t, tempDir, irp)
+	defer cleanup()
+
+	// Launch the sample service, inject the BPF program and collect the output.
+	t.Logf("running and instrumenting sample")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sampleProc, sampleStdin := dyninsttest.StartProcess(
+		ctx, t, tempDir, busyloopPath,
+		"1" /*round_cnt*/, "20" /*round_sec*/, "3", /*concurrency*/
+	)
+	cleanup = dyninsttest.AttachBPFProbes(
+		t, busyloopPath, obj, sampleProc.Process.Pid, bpfProg, attachpoints,
+	)
+	defer cleanup()
+	defer func() {
+		sampleProc.Process.Kill()
+		sampleProc.Process.Wait()
+	}()
+	sampleStdin.Write([]byte("\n"))
+
+	// Read expected number of events.
+	rd, err := ringbuf.NewReader(bpfCollection.Maps["out_ringbuf"])
+	require.NoError(t, err)
+	rd.SetDeadline(time.Now().Add(10 * time.Second))
+	for range expectedEvents {
+		t.Logf("reading ringbuf item")
+		_, err := rd.Read()
+		require.NoError(t, err)
+	}
+
+	// Check there are no more events after a short delay.
+	rd.SetDeadline(time.Now().Add(10 * time.Millisecond))
+	_, err = rd.Read()
+	log.Printf("err: %v", err)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+}
+
+func refreshesBudget(t *testing.T, busyloopPath string) {
+	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-throttler-test-")
+	defer cleanup()
+
+	// Load the binary and generate the IR.
+	t.Logf("loading binary")
+	obj, irp := dyninsttest.GenerateIr(t, tempDir, busyloopPath, "busyloop")
+
+	// Adjust throttling parameters.
+	// Small period, and budget.
+	require.Equal(t, 1, len(irp.Probes))
+	irp.Probes[0].ThrottlePeriodMs = 1
+	irp.Probes[0].ThrottleBudget = 2
+
+	// Compile the IR and prepare the BPF program.
+	t.Logf("compiling BPF")
+	bpfCollection, bpfProg, attachpoints, cleanup := dyninsttest.CompileAndLoadBPF(t, tempDir, irp)
+	defer cleanup()
+
+	// Launch the sample service, inject the BPF program and collect the output.
+	t.Logf("running and instrumenting sample")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	sampleProc, sampleStdin := dyninsttest.StartProcess(
+		ctx, t, tempDir, busyloopPath,
+		"1" /*round_cnt*/, "20" /*round_sec*/, "3", /*concurrency*/
+	)
+	cleanup = dyninsttest.AttachBPFProbes(t, busyloopPath, obj, sampleProc.Process.Pid, bpfProg, attachpoints)
+	defer cleanup()
+	defer func() {
+		sampleProc.Process.Kill()
+		sampleProc.Process.Wait()
+	}()
+	sampleStdin.Write([]byte("\n"))
+
+	// We should be able to observe multiple events.
+	rd, err := ringbuf.NewReader(bpfCollection.Maps["out_ringbuf"])
+	require.NoError(t, err)
+	rd.SetDeadline(time.Now().Add(10 * time.Second))
+	for range 12 {
+		t.Logf("reading ringbuf item")
+		_, err := rd.Read()
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Introduce per-probe throttling. To prevent needless probe execution, we need to perform throttling inside the eBPF program.

#### Requirements

We want to be able to limit probe execution on roughly 1 second time scale. Practically snapshots are limited to 1ps, no-snapshot logs to 5kps, and metric probes (we don't support these yet) are unlimited.

Most performance sensitive scenario is a probe injected into busyloop, executed on every core. The cheapest eBPF program execution path should be throttler rejection. Acceptance path should be cheap, but it's less of a concern given the cost of executing the probe itself. Both paths must minimize contention, as probes may be executed across cores (and currently, with exception of output ringbuffer, are fully independent).

eBPF programs cannot block nor wait. Limited (less than 1%) over-throttling is allowed.

#### Solution

We introduce following throttling schema. There are two parameters - period and budget. Whenever "budget" probes are executed, we throttle following probes. We refresh the "budget" after "period" elapsed since previous refresh.

Throttle-reject fast path involves checking if budget is non-positive, and whether period has not elapsed since previous refresh. It only involves memory reads, causing no contention.

Throttle-accept fast path involves atomically decrementing budget variable. This should be acceptable, as it will cause no more contention than submitting output to the ringbuf. There is an implementation approach that would eliminate contention, where each core reserves fraction of the budget for itself, but the complexity outweighs the benefits.

Slow path involves refreshing budget variable. It requires compare-and-swap to only refresh the budget once within a period. We make an assumption that ktime_ns reads practically always return different values. Compare-and-swap may fail, in which case we repeat whole throttling evaluation procedure again, and if it fails again, we conservatively make reject decision. Two consecutive compare-and-swap failures imply that budget was expired "immediately" between previous refresh and probe retry. In which case the conservative rejection is correct. We may over-throttle - any probe that checks the budget between the compare-and-swap on the last refresh variable, before budget is refreshed, is rejected. Practically, this requires probing a hot function - to cause a race, in which case incorrectly throttling one call, will allow some future call to stay within probing budget.

To provide throttling metric, eBPF programs has per-cpu throttled_events counter (unsynchronized memory write).

See implementation in ebpf/throttler.h.

Benchmarks, using kmt amd64 ubuntu24 machine, with 4 vcpus. We run busyloops on 4 threads, and apply 500 probes per 100ms limit. We measure number of busyloops iterations in twenty 10s rounds, to calculate busyloop single iteration latency, which is practically the cost of ebpf program execution (the busyloop itself only performs function call, to allow for an easy injection point).

The no-op ebpf program costs (= interrupt latency): 
avg=0.604338us stddev=0.000763us

Ebpf program with only thottler (no stack machine execution, nothing else):
avg=0.623178us stddev=0.002300us 

Giving ~19ns throttling latency. Nota bene, ~15ns of that comes from reading ktime (for ebpf latency expectations, see: https://datadoghq.atlassian.net/wiki/spaces/~712020ffd5f306baa1460395eea88b46dbe046/pages/5111545950/Ebpf+low-level+benchmarks). 

### Motivation

https://datadoghq.atlassian.net/browse/DEBUG-4012