### PR TITLE
Revert changes for cws-instrumentation and dca image publish jobs

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -21,14 +21,6 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
-.deploy_mutable_cws-instrumentation_tags_base:
-  extends: .docker_publish_job_definition
-  stage: deploy_cws_instrumentation
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
-
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
@@ -36,13 +28,10 @@ deploy_containers-cws-instrumentation-rc-versioned:
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
+  extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-cws-instrumentation-rc-versioned
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: rc
+    VERSION: rc
 
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
@@ -51,10 +40,7 @@ deploy_containers-cws-instrumentation-final-versioned:
 
 # will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
+  extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-cws-instrumentation-final-versioned
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: latest
+    VERSION: latest

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -6,7 +6,6 @@ include:
 # DCA image tagging & manifest publication
 #
 
-# Basic flavor
 .deploy_containers-dca-base:
   extends: .docker_publish_job_definition
   stage: deploy_dca
@@ -22,59 +21,38 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
 
-.deploy_mutable_dca_tags-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
-
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
-  extends: .deploy_mutable_dca_tags-base
+  extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: rc
+    VERSION: rc
 
 deploy_containers-dca-latest:
-  extends: .deploy_mutable_dca_tags-base
+  extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: latest
+    VERSION: latest
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_manual_final]
 
 deploy_containers-dca_internal-rc:
-  extends: .deploy_mutable_dca_tags-base
+  extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: rc
+    VERSION: rc
 
 deploy_containers-dca_internal-latest:
-  extends: .deploy_mutable_dca_tags-base
+  extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: latest
+    VERSION: latest
 
-# Fips flavor
 .deploy_containers-dca-fips-base:
   extends: .docker_publish_job_definition
   stage: deploy_dca
@@ -90,54 +68,34 @@ deploy_containers-dca_internal-latest:
     - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips"
 
-.deploy_mutable_dca_tags-fips-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
+deploy_containers-dca-fips-latest:
+  extends: .deploy_containers-dca-fips-base
+  rules: !reference [.on_deploy_manual_final]
+  variables:
+    VERSION: latest
+
+deploy_containers-dca-fips-rc:
+  extends: .deploy_containers-dca-fips-base
+  rules: !reference [.on_deploy_rc]
+  variables:
+    VERSION: rc
 
 deploy_containers-dca-fips:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
-
-deploy_containers-dca-fips-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest-fips
-
-deploy_containers-dca-fips-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc-fips
 
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_manual_final]
 
 deploy_containers-dca-fips_internal-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
+  extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: rc-fips
+    VERSION: rc
 
 deploy_containers-dca-fips_internal-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
+  extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
   variables:
-    IMG_NEW_TAGS: latest-fips
+    VERSION: latest


### PR DESCRIPTION
What does this PR do?
Revert https://github.com/DataDog/datadog-agent/pull/37846 and https://github.com/DataDog/datadog-agent/pull/37852. The gitlab job cannot have a jobs needing each other in the same stage.

Motivation
Fix pipeline.