### PR TITLE
[CWS] report approvers-only when used

### DIFF
--- a/pkg/security/probe/kfilters/report.go
+++ b/pkg/security/probe/kfilters/report.go
@@ -8,6 +8,7 @@ package kfilters
 
 import (
 	"encoding/json"
+	"slices"
 	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
@@ -98,9 +99,14 @@ func computeApprovers(config *config.Config, rs *rules.RuleSet, capabilities map
 		if values, exists := approvers[eventType]; exists {
 			report.Approvers = values
 
+			// report approvers that are marked as approver only
 			for _, evtCapability := range capabilities[eventType] {
-				if evtCapability.FilterMode == rules.ApproverOnlyMode {
-					report.ApproversOnly = append(report.ApproversOnly, evtCapability.Field)
+				for field := range values {
+					if evtCapability.Field == field && evtCapability.FilterMode == rules.ApproverOnlyMode {
+						if !slices.Contains(report.ApproversOnly, evtCapability.Field) {
+							report.ApproversOnly = append(report.ApproversOnly, evtCapability.Field)
+						}
+					}
 				}
 			}
 		} else {

--- a/pkg/security/probe/kfilters/report_test.go
+++ b/pkg/security/probe/kfilters/report_test.go
@@ -43,7 +43,8 @@ func TestDiscarderReport(t *testing.T) {
 			t.Errorf("expected 1 supported discarder, got %d", len(report.DiscardersReport.Supported))
 		}
 	})
-	t.Run("no-discarder-ok", func(t *testing.T) {
+
+	t.Run("no-discarder-ok-1", func(t *testing.T) {
 		rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 
 		// The first rule can generate a discarder, the second one can't
@@ -65,8 +66,36 @@ func TestDiscarderReport(t *testing.T) {
 			t.Errorf("expected 0 invalid discarder, got %d", len(report.DiscardersReport.Invalid))
 		}
 
+		if len(report.ApproverReports["open"].ApproversOnly) != 1 {
+			t.Errorf("expected 1 approvers only, got %+v", report.ApproverReports["open"].ApproversOnly)
+		}
+	})
+
+	t.Run("no-discarder-ok-2", func(t *testing.T) {
+		rs := rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+
+		// The first rule can generate a discarder, the second one can't
+		// As the second can be in approver only, we can generate discarders for the first one
+		// if we convert the second one to approver only
+		rules.AddTestRuleExpr(t, rs, `open.file.path =~ "/etc/**" && open.file.name == "cron"`)
+		rules.AddTestRuleExpr(t, rs, `open.file.name == "group"`)
+		rules.AddTestRuleExpr(t, rs, `open.file.name =~ "group*" && process.auid == 244`)
+
+		report, err := ComputeFilters(cfg, rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(report.DiscardersReport.Supported) != 1 {
+			t.Errorf("expected 1 supported discarder, got %d", len(report.DiscardersReport.Supported))
+		}
+
+		if len(report.DiscardersReport.Invalid) != 0 {
+			t.Errorf("expected 0 invalid discarder, got %d", len(report.DiscardersReport.Invalid))
+		}
+
 		if len(report.ApproverReports["open"].ApproversOnly) != 2 {
-			t.Errorf("expected 0 approvers only, got %+v", report.ApproverReports["open"].ApproversOnly)
+			t.Errorf("expected 2 approvers only, got %+v", report.ApproverReports["open"].ApproversOnly)
 		}
 	})
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Before all the approver only were reported whatever they were used or not

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->