### PR TITLE
[pkg/dyninst] Support pointer chasing limit

### DIFF
--- a/pkg/dyninst/compiler/codegen/code.go
+++ b/pkg/dyninst/compiler/codegen/code.go
@@ -86,7 +86,10 @@ func GenerateCCode(program sm.Program, out io.Writer) (attachpoints []BPFAttachP
 				PC:     f.InjectionPC,
 				Cookie: uint64(len(attachpoints)),
 			})
-			mustFprintf(out, "\t{.throttler_idx = %d, .stack_machine_pc = 0x%x, .frameless = false},\n", f.ThrottlerIdx, metadata.FunctionLoc[f])
+			mustFprintf(
+				out, "\t{.throttler_idx = %d, .stack_machine_pc = 0x%x, .pointer_chasing_limit = %d, .frameless = false},\n",
+				f.ThrottlerIdx, metadata.FunctionLoc[f], f.PointerChasingLimit,
+			)
 		}
 	}
 	mustFprintf(out, "};\n")

--- a/pkg/dyninst/compiler/sm/functions.go
+++ b/pkg/dyninst/compiler/sm/functions.go
@@ -42,9 +42,10 @@ func (ChasePointers) String() string {
 // at given injection PC.
 type ProcessEvent struct {
 	baseFunctionID
-	ThrottlerIdx  int
-	InjectionPC   uint64
-	EventRootType *ir.EventRootType
+	InjectionPC         uint64
+	ThrottlerIdx        int
+	PointerChasingLimit uint32
+	EventRootType       *ir.EventRootType
 }
 
 // String returns a human-readable identifier for the function.

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
@@ -5,22 +5,22 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CHASE_POINTERS, 
 		SM_OP_RETURN, 
 
-	// 0x3: ProcessExpression[Probe[main.intArg]@0x4a7f0a.expr[0]]
+	// 0x3: ProcessExpression[Probe[main.intArg]@0x4a804a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x19: ProcessEvent[Probe[main.intArg]@4a7f0a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x31, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0x4a7f0a.expr[0]]
+	// 0x19: ProcessEvent[Probe[main.intArg]@4a804a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0x4a804a.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x28: ProcessType[string]
-		SM_OP_PROCESS_STRING, 0x27, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_STRING, 0x2b, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x2e: ProcessExpression[Probe[main.stringArg]@0x4a7f8a.expr[0]]
+	// 0x2e: ProcessExpression[Probe[main.stringArg]@0x4a80ca.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -28,16 +28,16 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_RETURN, 
 
-	// 0x50: ProcessEvent[Probe[main.stringArg]@4a7f8a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x32, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0x4a7f8a.expr[0]]
+	// 0x50: ProcessEvent[Probe[main.stringArg]@4a80ca]
+		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0x4a80ca.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x5f: ProcessType[[]int]
-		SM_OP_PROCESS_SLICE, 0x29, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_SLICE, 0x2d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0x4a800a.expr[0]]
+	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0x4a814a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -46,27 +46,27 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x5f, 0x00, 0x00, 0x00, // ProcessType[[]int]
 		SM_OP_RETURN, 
 
-	// 0x92: ProcessEvent[Probe[main.intSliceArg]@4a800a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x33, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0x4a800a.expr[0]]
+	// 0x92: ProcessEvent[Probe[main.intSliceArg]@4a814a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0x4a814a.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0x4a808a.expr[0]]
+	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0x4a81ca.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@4a808a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x34, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0x4a808a.expr[0]]
+	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@4a81ca]
+		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0x4a81ca.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0xcc: ProcessType[[]string]
-		SM_OP_PROCESS_SLICE, 0x2b, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_SLICE, 0x2f, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0x4a810a.expr[0]]
+	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0x4a824a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -75,9 +75,9 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0xcc, 0x00, 0x00, 0x00, // ProcessType[[]string]
 		SM_OP_RETURN, 
 
-	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@4a810a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0x4a810a.expr[0]]
+	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@4a824a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0x4a824a.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x10e: ProcessType[[3]string]
@@ -86,47 +86,47 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0x4a818a.expr[0]]
+	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0x4a82ca.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
 		SM_OP_RETURN, 
 
-	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@4a818a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0x4a818a.expr[0]]
+	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@4a82ca]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3a, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0x4a82ca.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x14e: ProcessExpression[Probe[main.mapArg]@0x4a82ca.expr[0]]
+	// 0x14e: ProcessExpression[Probe[main.mapArg]@0x4a840a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x15d: ProcessEvent[Probe[main.mapArg]@4a82ca]
-		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0x4a82ca.expr[0]]
+	// 0x15d: ProcessEvent[Probe[main.mapArg]@4a840a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0x4a840a.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0x4a8333.expr[0]]
+	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0x4a8473.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@4a8333]
-		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0x4a8333.expr[0]]
+	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@4a8473]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0x4a8473.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x18a: ProcessExpression[Probe[main.inlined]@0x4a820a.expr[0]]
+	// 0x18a: ProcessExpression[Probe[main.inlined]@0x4a834a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1a0: ProcessEvent[Probe[main.inlined]@4a820a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a820a.expr[0]]
+	// 0x1a0: ProcessEvent[Probe[main.inlined]@4a834a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a834a.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x1af: ProcessExpression[Probe[main.inlined]@0x4a7da6.expr[0]]
@@ -136,14 +136,46 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_RETURN, 
 
 	// 0x1bf: ProcessEvent[Probe[main.inlined]@4a7da6]
-		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0xaf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a7da6.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1ce: ProcessType[[]string.array]
+	// 0x1ce: ProcessType[*****int]
+		SM_OP_PROCESS_POINTER, 0x03, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x1d4: ProcessExpression[Probe[main.PointerChainArg]@0x4a7fe6.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xce, 0x01, 0x00, 0x00, // ProcessType[*****int]
+		SM_OP_RETURN, 
+
+	// 0x1ef: ProcessEvent[Probe[main.PointerChainArg]@4a7fe6]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xd4, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0x4a7fe6.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x1fe: ProcessType[[]string.array]
 		SM_OP_PROCESS_SLICE_DATA_PREP, 
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x20a: ProcessType[****int]
+		SM_OP_PROCESS_POINTER, 0x04, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x210: ProcessType[***int]
+		SM_OP_PROCESS_POINTER, 0x05, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x216: ProcessType[**int]
+		SM_OP_PROCESS_POINTER, 0x06, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x21c: ProcessType[*int]
+		SM_OP_PROCESS_POINTER, 0x01, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
 	// Extra illegal ops to simplify code bound checks
@@ -161,147 +193,158 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_ILLEGAL, 
 		SM_OP_ILLEGAL, 
 };
-const uint64_t stack_machine_code_len = 487;
+const uint64_t stack_machine_code_len = 559;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
 const probe_params_t probe_params[] = {
-	{.throttler_idx = 0, .stack_machine_pc = 0x19, .frameless = false},
-	{.throttler_idx = 1, .stack_machine_pc = 0x50, .frameless = false},
-	{.throttler_idx = 2, .stack_machine_pc = 0x92, .frameless = false},
-	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .frameless = false},
-	{.throttler_idx = 4, .stack_machine_pc = 0xff, .frameless = false},
-	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .frameless = false},
-	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .frameless = false},
-	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .frameless = false},
+	{.throttler_idx = 0, .stack_machine_pc = 0x19, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 1, .stack_machine_pc = 0x50, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 2, .stack_machine_pc = 0x92, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 4, .stack_machine_pc = 0xff, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 3, .frameless = false},
 };
-const uint32_t num_probe_params = 10;
+const uint32_t num_probe_params = 11;
 typedef enum type {
 	TYPE_NONE = 0,
 	TYPE_1 = 1, // int
-	TYPE_2 = 2, // string
-	TYPE_3 = 3, // *uint8
-	TYPE_4 = 4, // uint8
-	TYPE_5 = 5, // []int
+	TYPE_2 = 2, // *****int
+	TYPE_3 = 3, // ****int
+	TYPE_4 = 4, // ***int
+	TYPE_5 = 5, // **int
 	TYPE_6 = 6, // *int
-	TYPE_7 = 7, // [3]int
-	TYPE_8 = 8, // []string
-	TYPE_9 = 9, // *string
-	TYPE_10 = 10, // [3]string
-	TYPE_11 = 11, // map[string]int
-	TYPE_12 = 12, // *map<string,int>
-	TYPE_13 = 13, // map<string,int>
-	TYPE_14 = 14, // uint64
-	TYPE_15 = 15, // uintptr
-	TYPE_16 = 16, // **table<string,int>
-	TYPE_17 = 17, // *table<string,int>
-	TYPE_18 = 18, // table<string,int>
-	TYPE_19 = 19, // uint16
-	TYPE_20 = 20, // groupReference<string,int>
-	TYPE_21 = 21, // *noalg.map.group[string]int
-	TYPE_22 = 22, // noalg.map.group[string]int
-	TYPE_23 = 23, // noalg.[8]struct { key string; elem int }
-	TYPE_24 = 24, // noalg.struct { key string; elem int }
-	TYPE_25 = 25, // map[string]main.bigStruct
-	TYPE_26 = 26, // *map<string,main.bigStruct>
-	TYPE_27 = 27, // map<string,main.bigStruct>
-	TYPE_28 = 28, // **table<string,main.bigStruct>
-	TYPE_29 = 29, // *table<string,main.bigStruct>
-	TYPE_30 = 30, // table<string,main.bigStruct>
-	TYPE_31 = 31, // groupReference<string,main.bigStruct>
-	TYPE_32 = 32, // *noalg.map.group[string]main.bigStruct
-	TYPE_33 = 33, // noalg.map.group[string]main.bigStruct
-	TYPE_34 = 34, // noalg.[8]struct { key string; elem *main.bigStruct }
-	TYPE_35 = 35, // noalg.struct { key string; elem *main.bigStruct }
-	TYPE_36 = 36, // *main.bigStruct
-	TYPE_37 = 37, // main.bigStruct
-	TYPE_38 = 38, // [128]uint8
-	TYPE_39 = 39, // string.str
-	TYPE_40 = 40, // *string.str
-	TYPE_41 = 41, // []int.array
-	TYPE_42 = 42, // *[]int.array
-	TYPE_43 = 43, // []string.array
-	TYPE_44 = 44, // *[]string.array
-	TYPE_45 = 45, // []*table<string,int>.array
-	TYPE_46 = 46, // []noalg.map.group[string]int.array
-	TYPE_47 = 47, // []*table<string,main.bigStruct>.array
-	TYPE_48 = 48, // []noalg.map.group[string]main.bigStruct.array
-	TYPE_49 = 49, // Probe[main.intArg]
-	TYPE_50 = 50, // Probe[main.stringArg]
-	TYPE_51 = 51, // Probe[main.intSliceArg]
-	TYPE_52 = 52, // Probe[main.intArrayArg]
-	TYPE_53 = 53, // Probe[main.stringSliceArg]
-	TYPE_54 = 54, // Probe[main.stringArrayArg]
-	TYPE_55 = 55, // Probe[main.mapArg]
-	TYPE_56 = 56, // Probe[main.bigMapArg]
-	TYPE_57 = 57, // Probe[main.inlined]
+	TYPE_7 = 7, // string
+	TYPE_8 = 8, // *uint8
+	TYPE_9 = 9, // uint8
+	TYPE_10 = 10, // []int
+	TYPE_11 = 11, // [3]int
+	TYPE_12 = 12, // []string
+	TYPE_13 = 13, // *string
+	TYPE_14 = 14, // [3]string
+	TYPE_15 = 15, // map[string]int
+	TYPE_16 = 16, // *map<string,int>
+	TYPE_17 = 17, // map<string,int>
+	TYPE_18 = 18, // uint64
+	TYPE_19 = 19, // uintptr
+	TYPE_20 = 20, // **table<string,int>
+	TYPE_21 = 21, // *table<string,int>
+	TYPE_22 = 22, // table<string,int>
+	TYPE_23 = 23, // uint16
+	TYPE_24 = 24, // groupReference<string,int>
+	TYPE_25 = 25, // *noalg.map.group[string]int
+	TYPE_26 = 26, // noalg.map.group[string]int
+	TYPE_27 = 27, // noalg.[8]struct { key string; elem int }
+	TYPE_28 = 28, // noalg.struct { key string; elem int }
+	TYPE_29 = 29, // map[string]main.bigStruct
+	TYPE_30 = 30, // *map<string,main.bigStruct>
+	TYPE_31 = 31, // map<string,main.bigStruct>
+	TYPE_32 = 32, // **table<string,main.bigStruct>
+	TYPE_33 = 33, // *table<string,main.bigStruct>
+	TYPE_34 = 34, // table<string,main.bigStruct>
+	TYPE_35 = 35, // groupReference<string,main.bigStruct>
+	TYPE_36 = 36, // *noalg.map.group[string]main.bigStruct
+	TYPE_37 = 37, // noalg.map.group[string]main.bigStruct
+	TYPE_38 = 38, // noalg.[8]struct { key string; elem *main.bigStruct }
+	TYPE_39 = 39, // noalg.struct { key string; elem *main.bigStruct }
+	TYPE_40 = 40, // *main.bigStruct
+	TYPE_41 = 41, // main.bigStruct
+	TYPE_42 = 42, // [128]uint8
+	TYPE_43 = 43, // string.str
+	TYPE_44 = 44, // *string.str
+	TYPE_45 = 45, // []int.array
+	TYPE_46 = 46, // *[]int.array
+	TYPE_47 = 47, // []string.array
+	TYPE_48 = 48, // *[]string.array
+	TYPE_49 = 49, // []*table<string,int>.array
+	TYPE_50 = 50, // []noalg.map.group[string]int.array
+	TYPE_51 = 51, // []*table<string,main.bigStruct>.array
+	TYPE_52 = 52, // []noalg.map.group[string]main.bigStruct.array
+	TYPE_53 = 53, // Probe[main.intArg]
+	TYPE_54 = 54, // Probe[main.stringArg]
+	TYPE_55 = 55, // Probe[main.intSliceArg]
+	TYPE_56 = 56, // Probe[main.intArrayArg]
+	TYPE_57 = 57, // Probe[main.stringSliceArg]
+	TYPE_58 = 58, // Probe[main.stringArrayArg]
+	TYPE_59 = 59, // Probe[main.mapArg]
+	TYPE_60 = 60, // Probe[main.bigMapArg]
+	TYPE_61 = 61, // Probe[main.inlined]
+	TYPE_62 = 62, // Probe[main.PointerChainArg]
 } type_t;
 
 const type_info_t type_info[] = {
 	/* 1: int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 2: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
-	/* 3: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 4: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 5: []int	*/{.byte_len = 24, .enqueue_pc = 0x5f},
-	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 7: [3]int	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 8: []string	*/{.byte_len = 24, .enqueue_pc = 0xcc},
-	/* 9: *string	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 10: [3]string	*/{.byte_len = 48, .enqueue_pc = 0x10e},
-	/* 11: map[string]int	*/{.byte_len = 0, .enqueue_pc = 0x0},
-	/* 12: *map<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 13: map<string,int>	*/{.byte_len = 48, .enqueue_pc = 0x0},
-	/* 14: uint64	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 15: uintptr	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 16: **table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 17: *table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 18: table<string,int>	*/{.byte_len = 32, .enqueue_pc = 0x0},
-	/* 19: uint16	*/{.byte_len = 2, .enqueue_pc = 0x0},
-	/* 20: groupReference<string,int>	*/{.byte_len = 16, .enqueue_pc = 0x0},
-	/* 21: *noalg.map.group[string]int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 22: noalg.map.group[string]int	*/{.byte_len = 200, .enqueue_pc = 0x0},
-	/* 23: noalg.[8]struct { key string; elem int }	*/{.byte_len = 192, .enqueue_pc = 0x0},
-	/* 24: noalg.struct { key string; elem int }	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 25: map[string]main.bigStruct	*/{.byte_len = 0, .enqueue_pc = 0x0},
-	/* 26: *map<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 27: map<string,main.bigStruct>	*/{.byte_len = 48, .enqueue_pc = 0x0},
-	/* 28: **table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 29: *table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 30: table<string,main.bigStruct>	*/{.byte_len = 32, .enqueue_pc = 0x0},
-	/* 31: groupReference<string,main.bigStruct>	*/{.byte_len = 16, .enqueue_pc = 0x0},
-	/* 32: *noalg.map.group[string]main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 33: noalg.map.group[string]main.bigStruct	*/{.byte_len = 200, .enqueue_pc = 0x0},
-	/* 34: noalg.[8]struct { key string; elem *main.bigStruct }	*/{.byte_len = 192, .enqueue_pc = 0x0},
-	/* 35: noalg.struct { key string; elem *main.bigStruct }	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 36: *main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 37: main.bigStruct	*/{.byte_len = 184, .enqueue_pc = 0x0},
-	/* 38: [128]uint8	*/{.byte_len = 128, .enqueue_pc = 0x0},
-	/* 39: string.str	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 40: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 41: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 42: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 43: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1ce},
-	/* 44: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 45: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
-	/* 46: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 47: []*table<string,main.bigStruct>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
-	/* 48: []noalg.map.group[string]main.bigStruct.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 49: Probe[main.intArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
-	/* 50: Probe[main.stringArg]	*/{.byte_len = 17, .enqueue_pc = 0x0},
-	/* 51: Probe[main.intSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 52: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 53: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 54: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
-	/* 55: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 56: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 57: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1ce},
+	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x20a},
+	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x210},
+	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x216},
+	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x21c},
+	/* 7: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
+	/* 8: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 9: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 10: []int	*/{.byte_len = 24, .enqueue_pc = 0x5f},
+	/* 11: [3]int	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 12: []string	*/{.byte_len = 24, .enqueue_pc = 0xcc},
+	/* 13: *string	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 14: [3]string	*/{.byte_len = 48, .enqueue_pc = 0x10e},
+	/* 15: map[string]int	*/{.byte_len = 0, .enqueue_pc = 0x0},
+	/* 16: *map<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 17: map<string,int>	*/{.byte_len = 48, .enqueue_pc = 0x0},
+	/* 18: uint64	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 19: uintptr	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 20: **table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 21: *table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 22: table<string,int>	*/{.byte_len = 32, .enqueue_pc = 0x0},
+	/* 23: uint16	*/{.byte_len = 2, .enqueue_pc = 0x0},
+	/* 24: groupReference<string,int>	*/{.byte_len = 16, .enqueue_pc = 0x0},
+	/* 25: *noalg.map.group[string]int	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 26: noalg.map.group[string]int	*/{.byte_len = 200, .enqueue_pc = 0x0},
+	/* 27: noalg.[8]struct { key string; elem int }	*/{.byte_len = 192, .enqueue_pc = 0x0},
+	/* 28: noalg.struct { key string; elem int }	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 29: map[string]main.bigStruct	*/{.byte_len = 0, .enqueue_pc = 0x0},
+	/* 30: *map<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 31: map<string,main.bigStruct>	*/{.byte_len = 48, .enqueue_pc = 0x0},
+	/* 32: **table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 33: *table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 34: table<string,main.bigStruct>	*/{.byte_len = 32, .enqueue_pc = 0x0},
+	/* 35: groupReference<string,main.bigStruct>	*/{.byte_len = 16, .enqueue_pc = 0x0},
+	/* 36: *noalg.map.group[string]main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 37: noalg.map.group[string]main.bigStruct	*/{.byte_len = 200, .enqueue_pc = 0x0},
+	/* 38: noalg.[8]struct { key string; elem *main.bigStruct }	*/{.byte_len = 192, .enqueue_pc = 0x0},
+	/* 39: noalg.struct { key string; elem *main.bigStruct }	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 40: *main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 41: main.bigStruct	*/{.byte_len = 184, .enqueue_pc = 0x0},
+	/* 42: [128]uint8	*/{.byte_len = 128, .enqueue_pc = 0x0},
+	/* 43: string.str	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 44: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 45: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 46: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1fe},
+	/* 48: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 49: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
+	/* 50: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 51: []*table<string,main.bigStruct>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
+	/* 52: []noalg.map.group[string]main.bigStruct.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 53: Probe[main.intArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 54: Probe[main.stringArg]	*/{.byte_len = 17, .enqueue_pc = 0x0},
+	/* 55: Probe[main.intSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 56: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 57: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 58: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
+	/* 59: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 60: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 61: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 62: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
 };
 
-const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, };
+const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, };
 
-const uint32_t num_types = 57;
+const uint32_t num_types = 62;
 
 const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
@@ -313,5 +356,6 @@ const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
 };
-#define NUM_THROTTLERS 9
+#define NUM_THROTTLERS 10

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
@@ -5,22 +5,22 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CHASE_POINTERS, 
 		SM_OP_RETURN, 
 
-	// 0x3: ProcessExpression[Probe[main.intArg]@0xb50dc.expr[0]]
+	// 0x3: ProcessExpression[Probe[main.intArg]@0xb51ec.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x19: ProcessEvent[Probe[main.intArg]@b50dc]
-		SM_OP_PREPARE_EVENT_ROOT, 0x31, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0xb50dc.expr[0]]
+	// 0x19: ProcessEvent[Probe[main.intArg]@b51ec]
+		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0xb51ec.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x28: ProcessType[string]
-		SM_OP_PROCESS_STRING, 0x27, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_STRING, 0x2b, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x2e: ProcessExpression[Probe[main.stringArg]@0xb514c.expr[0]]
+	// 0x2e: ProcessExpression[Probe[main.stringArg]@0xb525c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -28,16 +28,16 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_RETURN, 
 
-	// 0x50: ProcessEvent[Probe[main.stringArg]@b514c]
-		SM_OP_PREPARE_EVENT_ROOT, 0x32, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0xb514c.expr[0]]
+	// 0x50: ProcessEvent[Probe[main.stringArg]@b525c]
+		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0xb525c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x5f: ProcessType[[]int]
-		SM_OP_PROCESS_SLICE, 0x29, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_SLICE, 0x2d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0xb51cc.expr[0]]
+	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0xb52dc.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -46,27 +46,27 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x5f, 0x00, 0x00, 0x00, // ProcessType[[]int]
 		SM_OP_RETURN, 
 
-	// 0x92: ProcessEvent[Probe[main.intSliceArg]@b51cc]
-		SM_OP_PREPARE_EVENT_ROOT, 0x33, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0xb51cc.expr[0]]
+	// 0x92: ProcessEvent[Probe[main.intSliceArg]@b52dc]
+		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0xb52dc.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0xb524c.expr[0]]
+	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0xb535c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x08, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@b524c]
-		SM_OP_PREPARE_EVENT_ROOT, 0x34, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0xb524c.expr[0]]
+	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@b535c]
+		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0xb535c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0xcc: ProcessType[[]string]
-		SM_OP_PROCESS_SLICE, 0x2b, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
+		SM_OP_PROCESS_SLICE, 0x2f, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0xb52cc.expr[0]]
+	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0xb53dc.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -75,9 +75,9 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0xcc, 0x00, 0x00, 0x00, // ProcessType[[]string]
 		SM_OP_RETURN, 
 
-	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@b52cc]
-		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0xb52cc.expr[0]]
+	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@b53dc]
+		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0xb53dc.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x10e: ProcessType[[3]string]
@@ -86,47 +86,47 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0xb534c.expr[0]]
+	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0xb545c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x08, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
 		SM_OP_RETURN, 
 
-	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@b534c]
-		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0xb534c.expr[0]]
+	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@b545c]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3a, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0xb545c.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x14e: ProcessExpression[Probe[main.mapArg]@0xb548c.expr[0]]
+	// 0x14e: ProcessExpression[Probe[main.mapArg]@0xb559c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x15d: ProcessEvent[Probe[main.mapArg]@b548c]
-		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0xb548c.expr[0]]
+	// 0x15d: ProcessEvent[Probe[main.mapArg]@b559c]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0xb559c.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0xb5500.expr[0]]
+	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0xb5610.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@b5500]
-		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0xb5500.expr[0]]
+	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@b5610]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0xb5610.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x18a: ProcessExpression[Probe[main.inlined]@0xb53cc.expr[0]]
+	// 0x18a: ProcessExpression[Probe[main.inlined]@0xb54dc.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1a0: ProcessEvent[Probe[main.inlined]@b53cc]
-		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb53cc.expr[0]]
+	// 0x1a0: ProcessEvent[Probe[main.inlined]@b54dc]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb54dc.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x1af: ProcessExpression[Probe[main.inlined]@0xb4fb8.expr[0]]
@@ -136,14 +136,46 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_RETURN, 
 
 	// 0x1bf: ProcessEvent[Probe[main.inlined]@b4fb8]
-		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0xaf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb4fb8.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1ce: ProcessType[[]string.array]
+	// 0x1ce: ProcessType[*****int]
+		SM_OP_PROCESS_POINTER, 0x03, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x1d4: ProcessExpression[Probe[main.PointerChainArg]@0xb5198.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xce, 0x01, 0x00, 0x00, // ProcessType[*****int]
+		SM_OP_RETURN, 
+
+	// 0x1ef: ProcessEvent[Probe[main.PointerChainArg]@b5198]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xd4, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0xb5198.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x1fe: ProcessType[[]string.array]
 		SM_OP_PROCESS_SLICE_DATA_PREP, 
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x20a: ProcessType[****int]
+		SM_OP_PROCESS_POINTER, 0x04, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x210: ProcessType[***int]
+		SM_OP_PROCESS_POINTER, 0x05, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x216: ProcessType[**int]
+		SM_OP_PROCESS_POINTER, 0x06, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x21c: ProcessType[*int]
+		SM_OP_PROCESS_POINTER, 0x01, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
 	// Extra illegal ops to simplify code bound checks
@@ -161,147 +193,158 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_ILLEGAL, 
 		SM_OP_ILLEGAL, 
 };
-const uint64_t stack_machine_code_len = 487;
+const uint64_t stack_machine_code_len = 559;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
 const probe_params_t probe_params[] = {
-	{.throttler_idx = 0, .stack_machine_pc = 0x19, .frameless = false},
-	{.throttler_idx = 1, .stack_machine_pc = 0x50, .frameless = false},
-	{.throttler_idx = 2, .stack_machine_pc = 0x92, .frameless = false},
-	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .frameless = false},
-	{.throttler_idx = 4, .stack_machine_pc = 0xff, .frameless = false},
-	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .frameless = false},
-	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .frameless = false},
-	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .frameless = false},
+	{.throttler_idx = 0, .stack_machine_pc = 0x19, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 1, .stack_machine_pc = 0x50, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 2, .stack_machine_pc = 0x92, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 4, .stack_machine_pc = 0xff, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 3, .frameless = false},
 };
-const uint32_t num_probe_params = 10;
+const uint32_t num_probe_params = 11;
 typedef enum type {
 	TYPE_NONE = 0,
 	TYPE_1 = 1, // int
-	TYPE_2 = 2, // string
-	TYPE_3 = 3, // *uint8
-	TYPE_4 = 4, // uint8
-	TYPE_5 = 5, // []int
+	TYPE_2 = 2, // *****int
+	TYPE_3 = 3, // ****int
+	TYPE_4 = 4, // ***int
+	TYPE_5 = 5, // **int
 	TYPE_6 = 6, // *int
-	TYPE_7 = 7, // [3]int
-	TYPE_8 = 8, // []string
-	TYPE_9 = 9, // *string
-	TYPE_10 = 10, // [3]string
-	TYPE_11 = 11, // map[string]int
-	TYPE_12 = 12, // *map<string,int>
-	TYPE_13 = 13, // map<string,int>
-	TYPE_14 = 14, // uint64
-	TYPE_15 = 15, // uintptr
-	TYPE_16 = 16, // **table<string,int>
-	TYPE_17 = 17, // *table<string,int>
-	TYPE_18 = 18, // table<string,int>
-	TYPE_19 = 19, // uint16
-	TYPE_20 = 20, // groupReference<string,int>
-	TYPE_21 = 21, // *noalg.map.group[string]int
-	TYPE_22 = 22, // noalg.map.group[string]int
-	TYPE_23 = 23, // noalg.[8]struct { key string; elem int }
-	TYPE_24 = 24, // noalg.struct { key string; elem int }
-	TYPE_25 = 25, // map[string]main.bigStruct
-	TYPE_26 = 26, // *map<string,main.bigStruct>
-	TYPE_27 = 27, // map<string,main.bigStruct>
-	TYPE_28 = 28, // **table<string,main.bigStruct>
-	TYPE_29 = 29, // *table<string,main.bigStruct>
-	TYPE_30 = 30, // table<string,main.bigStruct>
-	TYPE_31 = 31, // groupReference<string,main.bigStruct>
-	TYPE_32 = 32, // *noalg.map.group[string]main.bigStruct
-	TYPE_33 = 33, // noalg.map.group[string]main.bigStruct
-	TYPE_34 = 34, // noalg.[8]struct { key string; elem *main.bigStruct }
-	TYPE_35 = 35, // noalg.struct { key string; elem *main.bigStruct }
-	TYPE_36 = 36, // *main.bigStruct
-	TYPE_37 = 37, // main.bigStruct
-	TYPE_38 = 38, // [128]uint8
-	TYPE_39 = 39, // string.str
-	TYPE_40 = 40, // *string.str
-	TYPE_41 = 41, // []int.array
-	TYPE_42 = 42, // *[]int.array
-	TYPE_43 = 43, // []string.array
-	TYPE_44 = 44, // *[]string.array
-	TYPE_45 = 45, // []*table<string,int>.array
-	TYPE_46 = 46, // []noalg.map.group[string]int.array
-	TYPE_47 = 47, // []*table<string,main.bigStruct>.array
-	TYPE_48 = 48, // []noalg.map.group[string]main.bigStruct.array
-	TYPE_49 = 49, // Probe[main.intArg]
-	TYPE_50 = 50, // Probe[main.stringArg]
-	TYPE_51 = 51, // Probe[main.intSliceArg]
-	TYPE_52 = 52, // Probe[main.intArrayArg]
-	TYPE_53 = 53, // Probe[main.stringSliceArg]
-	TYPE_54 = 54, // Probe[main.stringArrayArg]
-	TYPE_55 = 55, // Probe[main.mapArg]
-	TYPE_56 = 56, // Probe[main.bigMapArg]
-	TYPE_57 = 57, // Probe[main.inlined]
+	TYPE_7 = 7, // string
+	TYPE_8 = 8, // *uint8
+	TYPE_9 = 9, // uint8
+	TYPE_10 = 10, // []int
+	TYPE_11 = 11, // [3]int
+	TYPE_12 = 12, // []string
+	TYPE_13 = 13, // *string
+	TYPE_14 = 14, // [3]string
+	TYPE_15 = 15, // map[string]int
+	TYPE_16 = 16, // *map<string,int>
+	TYPE_17 = 17, // map<string,int>
+	TYPE_18 = 18, // uint64
+	TYPE_19 = 19, // uintptr
+	TYPE_20 = 20, // **table<string,int>
+	TYPE_21 = 21, // *table<string,int>
+	TYPE_22 = 22, // table<string,int>
+	TYPE_23 = 23, // uint16
+	TYPE_24 = 24, // groupReference<string,int>
+	TYPE_25 = 25, // *noalg.map.group[string]int
+	TYPE_26 = 26, // noalg.map.group[string]int
+	TYPE_27 = 27, // noalg.[8]struct { key string; elem int }
+	TYPE_28 = 28, // noalg.struct { key string; elem int }
+	TYPE_29 = 29, // map[string]main.bigStruct
+	TYPE_30 = 30, // *map<string,main.bigStruct>
+	TYPE_31 = 31, // map<string,main.bigStruct>
+	TYPE_32 = 32, // **table<string,main.bigStruct>
+	TYPE_33 = 33, // *table<string,main.bigStruct>
+	TYPE_34 = 34, // table<string,main.bigStruct>
+	TYPE_35 = 35, // groupReference<string,main.bigStruct>
+	TYPE_36 = 36, // *noalg.map.group[string]main.bigStruct
+	TYPE_37 = 37, // noalg.map.group[string]main.bigStruct
+	TYPE_38 = 38, // noalg.[8]struct { key string; elem *main.bigStruct }
+	TYPE_39 = 39, // noalg.struct { key string; elem *main.bigStruct }
+	TYPE_40 = 40, // *main.bigStruct
+	TYPE_41 = 41, // main.bigStruct
+	TYPE_42 = 42, // [128]uint8
+	TYPE_43 = 43, // string.str
+	TYPE_44 = 44, // *string.str
+	TYPE_45 = 45, // []int.array
+	TYPE_46 = 46, // *[]int.array
+	TYPE_47 = 47, // []string.array
+	TYPE_48 = 48, // *[]string.array
+	TYPE_49 = 49, // []*table<string,int>.array
+	TYPE_50 = 50, // []noalg.map.group[string]int.array
+	TYPE_51 = 51, // []*table<string,main.bigStruct>.array
+	TYPE_52 = 52, // []noalg.map.group[string]main.bigStruct.array
+	TYPE_53 = 53, // Probe[main.intArg]
+	TYPE_54 = 54, // Probe[main.stringArg]
+	TYPE_55 = 55, // Probe[main.intSliceArg]
+	TYPE_56 = 56, // Probe[main.intArrayArg]
+	TYPE_57 = 57, // Probe[main.stringSliceArg]
+	TYPE_58 = 58, // Probe[main.stringArrayArg]
+	TYPE_59 = 59, // Probe[main.mapArg]
+	TYPE_60 = 60, // Probe[main.bigMapArg]
+	TYPE_61 = 61, // Probe[main.inlined]
+	TYPE_62 = 62, // Probe[main.PointerChainArg]
 } type_t;
 
 const type_info_t type_info[] = {
 	/* 1: int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 2: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
-	/* 3: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 4: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 5: []int	*/{.byte_len = 24, .enqueue_pc = 0x5f},
-	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 7: [3]int	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 8: []string	*/{.byte_len = 24, .enqueue_pc = 0xcc},
-	/* 9: *string	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 10: [3]string	*/{.byte_len = 48, .enqueue_pc = 0x10e},
-	/* 11: map[string]int	*/{.byte_len = 0, .enqueue_pc = 0x0},
-	/* 12: *map<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 13: map<string,int>	*/{.byte_len = 48, .enqueue_pc = 0x0},
-	/* 14: uint64	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 15: uintptr	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 16: **table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 17: *table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 18: table<string,int>	*/{.byte_len = 32, .enqueue_pc = 0x0},
-	/* 19: uint16	*/{.byte_len = 2, .enqueue_pc = 0x0},
-	/* 20: groupReference<string,int>	*/{.byte_len = 16, .enqueue_pc = 0x0},
-	/* 21: *noalg.map.group[string]int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 22: noalg.map.group[string]int	*/{.byte_len = 200, .enqueue_pc = 0x0},
-	/* 23: noalg.[8]struct { key string; elem int }	*/{.byte_len = 192, .enqueue_pc = 0x0},
-	/* 24: noalg.struct { key string; elem int }	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 25: map[string]main.bigStruct	*/{.byte_len = 0, .enqueue_pc = 0x0},
-	/* 26: *map<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 27: map<string,main.bigStruct>	*/{.byte_len = 48, .enqueue_pc = 0x0},
-	/* 28: **table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 29: *table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 30: table<string,main.bigStruct>	*/{.byte_len = 32, .enqueue_pc = 0x0},
-	/* 31: groupReference<string,main.bigStruct>	*/{.byte_len = 16, .enqueue_pc = 0x0},
-	/* 32: *noalg.map.group[string]main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 33: noalg.map.group[string]main.bigStruct	*/{.byte_len = 200, .enqueue_pc = 0x0},
-	/* 34: noalg.[8]struct { key string; elem *main.bigStruct }	*/{.byte_len = 192, .enqueue_pc = 0x0},
-	/* 35: noalg.struct { key string; elem *main.bigStruct }	*/{.byte_len = 24, .enqueue_pc = 0x0},
-	/* 36: *main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 37: main.bigStruct	*/{.byte_len = 184, .enqueue_pc = 0x0},
-	/* 38: [128]uint8	*/{.byte_len = 128, .enqueue_pc = 0x0},
-	/* 39: string.str	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 40: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 41: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 42: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 43: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1ce},
-	/* 44: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 45: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
-	/* 46: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 47: []*table<string,main.bigStruct>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
-	/* 48: []noalg.map.group[string]main.bigStruct.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
-	/* 49: Probe[main.intArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
-	/* 50: Probe[main.stringArg]	*/{.byte_len = 17, .enqueue_pc = 0x0},
-	/* 51: Probe[main.intSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 52: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 53: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
-	/* 54: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
-	/* 55: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 56: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 57: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1ce},
+	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x20a},
+	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x210},
+	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x216},
+	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x21c},
+	/* 7: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
+	/* 8: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 9: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 10: []int	*/{.byte_len = 24, .enqueue_pc = 0x5f},
+	/* 11: [3]int	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 12: []string	*/{.byte_len = 24, .enqueue_pc = 0xcc},
+	/* 13: *string	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 14: [3]string	*/{.byte_len = 48, .enqueue_pc = 0x10e},
+	/* 15: map[string]int	*/{.byte_len = 0, .enqueue_pc = 0x0},
+	/* 16: *map<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 17: map<string,int>	*/{.byte_len = 48, .enqueue_pc = 0x0},
+	/* 18: uint64	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 19: uintptr	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 20: **table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 21: *table<string,int>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 22: table<string,int>	*/{.byte_len = 32, .enqueue_pc = 0x0},
+	/* 23: uint16	*/{.byte_len = 2, .enqueue_pc = 0x0},
+	/* 24: groupReference<string,int>	*/{.byte_len = 16, .enqueue_pc = 0x0},
+	/* 25: *noalg.map.group[string]int	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 26: noalg.map.group[string]int	*/{.byte_len = 200, .enqueue_pc = 0x0},
+	/* 27: noalg.[8]struct { key string; elem int }	*/{.byte_len = 192, .enqueue_pc = 0x0},
+	/* 28: noalg.struct { key string; elem int }	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 29: map[string]main.bigStruct	*/{.byte_len = 0, .enqueue_pc = 0x0},
+	/* 30: *map<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 31: map<string,main.bigStruct>	*/{.byte_len = 48, .enqueue_pc = 0x0},
+	/* 32: **table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 33: *table<string,main.bigStruct>	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 34: table<string,main.bigStruct>	*/{.byte_len = 32, .enqueue_pc = 0x0},
+	/* 35: groupReference<string,main.bigStruct>	*/{.byte_len = 16, .enqueue_pc = 0x0},
+	/* 36: *noalg.map.group[string]main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 37: noalg.map.group[string]main.bigStruct	*/{.byte_len = 200, .enqueue_pc = 0x0},
+	/* 38: noalg.[8]struct { key string; elem *main.bigStruct }	*/{.byte_len = 192, .enqueue_pc = 0x0},
+	/* 39: noalg.struct { key string; elem *main.bigStruct }	*/{.byte_len = 24, .enqueue_pc = 0x0},
+	/* 40: *main.bigStruct	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 41: main.bigStruct	*/{.byte_len = 184, .enqueue_pc = 0x0},
+	/* 42: [128]uint8	*/{.byte_len = 128, .enqueue_pc = 0x0},
+	/* 43: string.str	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 44: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 45: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 46: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1fe},
+	/* 48: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
+	/* 49: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
+	/* 50: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 51: []*table<string,main.bigStruct>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
+	/* 52: []noalg.map.group[string]main.bigStruct.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
+	/* 53: Probe[main.intArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 54: Probe[main.stringArg]	*/{.byte_len = 17, .enqueue_pc = 0x0},
+	/* 55: Probe[main.intSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 56: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 57: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
+	/* 58: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
+	/* 59: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 60: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 61: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 62: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
 };
 
-const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, };
+const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, };
 
-const uint32_t num_types = 57;
+const uint32_t num_types = 62;
 
 const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
@@ -313,5 +356,6 @@ const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
 };
-#define NUM_THROTTLERS 9
+#define NUM_THROTTLERS 10

--- a/pkg/dyninst/ebpf/context.h
+++ b/pkg/dyninst/ebpf/context.h
@@ -10,7 +10,13 @@
 #include "queue.h"
 #include "scratch.h"
 
-DEFINE_QUEUE(pointers, data_item_header_t, 128 << 10);
+typedef struct pointers_queue_item {
+  data_item_header_t di;
+  uint32_t ttl;
+  uint32_t __padding[3];
+} pointers_queue_item_t;
+
+DEFINE_QUEUE(pointers, pointers_queue_item_t, 128);
 
 #define MAX_CHASED_POINTERS 128
 typedef struct chased_pointers {
@@ -35,6 +41,10 @@ typedef struct stack_machine {
 
   pointers_queue_t pointers_queue;
   chased_pointers_t chased;
+  // Remaining pointer chasing limit, given currently processed data item.
+  // Maybe 0, in which case data might still be processed (i.e. interface type rewrite),
+  // but no further pointers will be chased.
+  uint32_t pointer_chasing_ttl;
 
   // Offset of currently visited context object, or zero.
   buf_offset_t go_context_offset;
@@ -65,7 +75,7 @@ struct {
   __type(value, stack_machine_t);
 } stack_machine_buf SEC(".maps");
 
-static stack_machine_t* stack_machine_ctx_load() {
+static stack_machine_t* stack_machine_ctx_load(uint32_t pointer_chasing_limit) {
   const unsigned long zero = 0;
   stack_machine_t* stack_machine =
       (stack_machine_t*)bpf_map_lookup_elem(&stack_machine_buf, &zero);
@@ -75,6 +85,7 @@ static stack_machine_t* stack_machine_ctx_load() {
   stack_machine->pc_stack_pointer = 0;
   stack_machine->data_stack_pointer = 0;
   stack_machine->chased.n = 0;
+  stack_machine->pointer_chasing_ttl = pointer_chasing_limit;
   return stack_machine;
 }
 

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -42,7 +42,7 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
     return 0;
   }
   global_ctx_t global_ctx;
-  global_ctx.stack_machine = stack_machine_ctx_load();
+  global_ctx.stack_machine = stack_machine_ctx_load(params->pointer_chasing_limit);
   if (!global_ctx.stack_machine) {
     return 0;
   }

--- a/pkg/dyninst/ebpf/queue.h
+++ b/pkg/dyninst/ebpf/queue.h
@@ -14,7 +14,9 @@
     prefix##_queue_max_length = max_length,                                    \
     prefix##_queue_entries_per_shard =                                         \
         ((uint32_t)(32 << 10) / sizeof(elem_t)),                               \
-    prefix##_queue_shards = max_length / prefix##_queue_entries_per_shard,     \
+    prefix##_queue_shards =                                                    \
+        (max_length + prefix##_queue_entries_per_shard - 1) /                  \
+        prefix##_queue_entries_per_shard,                                      \
   };                                                                           \
                                                                                \
   typedef struct prefix##_queue_shard {                                        \
@@ -49,19 +51,42 @@
     return &shard->entries[entry_idx];                                         \
   }                                                                            \
                                                                                \
-  static elem_t* prefix##_queue_push(prefix##_queue_t* queue) {                \
+  static elem_t* prefix##_queue_push_back(prefix##_queue_t* queue) {           \
     if (!queue) {                                                              \
       return NULL;                                                             \
     }                                                                          \
     if (queue->len >= prefix##_queue_max_length) {                             \
       return NULL;                                                             \
     }                                                                          \
-    elem_t* ret = prefix##_queue_element_at(queue, queue->head + queue->len);  \
+    elem_t* ret = prefix##_queue_element_at(                                   \
+      queue,                                                                   \
+      (queue->head + queue->len) % prefix##_queue_max_length                   \
+    );                                                                         \
     queue->len++;                                                              \
     return ret;                                                                \
   }                                                                            \
                                                                                \
-  static elem_t* prefix##_queue_pop(prefix##_queue_t* queue) {                 \
+  static elem_t* prefix##_queue_push_front(prefix##_queue_t* queue) {          \
+    if (!queue) {                                                              \
+      return NULL;                                                             \
+    }                                                                          \
+    if (queue->len >= prefix##_queue_max_length) {                             \
+      return NULL;                                                             \
+    }                                                                          \
+    queue->len++;                                                              \
+    if (queue->head == 0) {                                                    \
+      queue->head = prefix##_queue_max_length - 1;                             \
+    } else {                                                                   \
+      queue->head--;                                                           \
+    }                                                                          \
+    elem_t* ret = prefix##_queue_element_at(                                   \
+      queue,                                                                   \
+      queue->head                                                              \
+    );                                                                         \
+    return ret;                                                                \
+  }                                                                            \
+                                                                               \
+  static elem_t* prefix##_queue_pop_front(prefix##_queue_t* queue) {           \
     if (!queue) {                                                              \
       return NULL;                                                             \
     }                                                                          \

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -214,29 +214,37 @@ inline __attribute__((always_inline)) bool sm_return(stack_machine_t* sm) {
   return true;
 }
 
-static bool sm_enqueue_pointer(global_ctx_t* ctx,
-                               data_item_header_t data_item) {
-  data_item_header_t* elem =
-      pointers_queue_push(&ctx->stack_machine->pointers_queue);
-  if (elem == NULL) {
-    return false;
-  }
-  *elem = data_item;
-  return true;
-}
-
-// Call the enqueue function for the given type. If the type has no enqueue an
-// enqueue function, returns false and is otherwise a no-op.
 inline __attribute__((always_inline)) bool
-sm_call_enqueue_for_type(stack_machine_t* sm, const type_info_t* t) {
-  if (!t->enqueue_pc) {
+sm_chase_pointer(global_ctx_t* ctx, pointers_queue_item_t item) {
+  stack_machine_t* sm = ctx->stack_machine;
+
+  // Serialize object entry.
+  const type_info_t* info;
+  if (!get_type_info((type_t)item.di.type, &info)) {
+    return true;
+  }
+  LOG(4, "chase: :%d !%d >%x", item.di.type, info->byte_len, info->enqueue_pc);
+  if (info->byte_len == 0) {
+    return true;
+  }
+  sm->offset = scratch_buf_serialize(ctx->buf, &item.di, info->byte_len);
+  if (!sm->offset) {
+    LOG(3, "chase: failed to serialize type %d", item.di.type);
+    return true;
+  }
+
+  // Recurse if there is more to capture object of this type.
+  sm->pointer_chasing_ttl = item.ttl;
+  sm->di_0 = item.di;
+  sm->di_0.length = info->byte_len;
+  if (!info->enqueue_pc) {
     return false;
   }
-  if (t->enqueue_pc >= stack_machine_code_len) {
+  if (info->enqueue_pc >= stack_machine_code_len) {
     LOG(1,
         "chase: enqueue_pc out of "
         "bounds %ld >= %ld",
-        t->enqueue_pc, stack_machine_code_len);
+        info->enqueue_pc, stack_machine_code_len);
     return false;
   }
   if (sm->pc_stack_pointer >= ENQUEUE_STACK_DEPTH) {
@@ -245,33 +253,8 @@ sm_call_enqueue_for_type(stack_machine_t* sm, const type_info_t* t) {
   }
   sm->pc_stack[sm->pc_stack_pointer] = sm->pc;
   sm->pc_stack_pointer++;
-  sm->pc = t->enqueue_pc;
+  sm->pc = info->enqueue_pc;
   return true;
-}
-
-inline __attribute__((always_inline)) bool
-sm_chase_pointer(global_ctx_t* ctx, data_item_header_t data_item) {
-  stack_machine_t* sm = ctx->stack_machine;
-
-  // Serialize object entry.
-  const type_info_t* info;
-  if (!get_type_info((type_t)data_item.type, &info)) {
-    return true;
-  }
-  LOG(4, "chase: :%d !%d >%x", data_item.type, info->byte_len, info->enqueue_pc);
-  if (info->byte_len == 0) {
-    return true;
-  }
-  sm->offset = scratch_buf_serialize(ctx->buf, &data_item, info->byte_len);
-  if (!sm->offset) {
-    LOG(3, "chase: failed to serialize type %d", data_item.type);
-    return true;
-  }
-
-  // Recurse if there is more to capture object of this type.
-  sm->di_0 = data_item;
-  sm->di_0.length = info->byte_len;
-  return sm_call_enqueue_for_type(sm, info);
 }
 
 // Returns false if the pointer has already been memoized.
@@ -285,20 +268,36 @@ sm_memoize_pointer(__maybe_unused global_ctx_t* ctx, type_t type,
 
 inline __attribute__((always_inline)) bool
 sm_record_pointer(global_ctx_t* ctx, type_t type, target_ptr_t addr,
+                  bool decrease_ttl,
                   uint32_t maybe_len) {
   stack_machine_t* sm = ctx->stack_machine;
   if (addr == 0) {
     return true;
   }
+  if (decrease_ttl && sm->pointer_chasing_ttl == 0) {
+    return true;
+  }
   if (!sm_memoize_pointer(ctx, type, addr)) {
     return true;
   }
-  data_item_header_t data_item = {
+  pointers_queue_item_t* item;
+  if (decrease_ttl) {
+    item = pointers_queue_push_back(&ctx->stack_machine->pointers_queue);
+  } else {
+    item = pointers_queue_push_front(&ctx->stack_machine->pointers_queue);
+  }
+  if (item == NULL) {
+    return false;
+  }
+  *item = (pointers_queue_item_t){
+    .di = {
       .type = type,
       .length = maybe_len,
       .address = addr,
+    },
+    .ttl = sm->pointer_chasing_ttl - (decrease_ttl ? 1 : 0),
   };
-  return sm_enqueue_pointer(ctx, data_item);
+  return true;
 }
 
 // inline __attribute__((always_inline)) bool
@@ -739,7 +738,7 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     }
     target_ptr_t addr = *(target_ptr_t*)&((*buf)[sm->offset]);
 
-    if (!sm_record_pointer(ctx, elem_type, addr, ENQUEUE_LEN_SENTINEL)) {
+    if (!sm_record_pointer(ctx, elem_type, addr, /*decrease_ttl=*/true, ENQUEUE_LEN_SENTINEL)) {
       LOG(3, "enqueue: failed pointer chase");
     }
   } break;
@@ -755,7 +754,7 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     target_ptr_t addr = *(target_ptr_t*)&((*buf)[sm->offset]);
     int64_t len = *(int64_t*)(&(*buf)[sm->offset + 8]);
     if (len > 0) {
-      if (!sm_record_pointer(ctx, slice_data_type, addr, len * elem_byte_len)) {
+      if (!sm_record_pointer(ctx, slice_data_type, addr, /*decrease_ttl=*/false, len * elem_byte_len)) {
         LOG(3, "enqueue: failed slice chase");
       }
     }
@@ -814,7 +813,7 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     target_ptr_t addr = *(target_ptr_t*)&((*buf)[sm->offset]);
     int64_t len = *(int64_t*)(&(*buf)[sm->offset + 8]);
     if (len > 0) {
-      if (!sm_record_pointer(ctx, string_data_type, addr, len)) {
+      if (!sm_record_pointer(ctx, string_data_type, addr, /*decrease_ttl=*/false, len)) {
         LOG(3, "enqueue: failed string chase");
       }
     }
@@ -837,11 +836,11 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
   // } break;
 
   case SM_OP_CHASE_POINTERS: {
-    data_item_header_t* elem = pointers_queue_pop(&sm->pointers_queue);
-    if (elem != NULL) {
+    pointers_queue_item_t* item = pointers_queue_pop_front(&sm->pointers_queue);
+    if (item != NULL) {
       // Loop as long as there are more pointers to chase.
       sm->pc--;
-      sm_chase_pointer(ctx, *elem);
+      sm_chase_pointer(ctx, *item);
     }
   } break;
 

--- a/pkg/dyninst/ebpf/types.h
+++ b/pkg/dyninst/ebpf/types.h
@@ -14,6 +14,7 @@ typedef struct type_info {
 typedef struct probe_params {
   uint32_t throttler_idx;
   uint32_t stack_machine_pc;
+  uint32_t pointer_chasing_limit;
   bool frameless;
 } probe_params_t;
 

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -116,6 +116,8 @@ type Probe struct {
 	ThrottlePeriodMs uint32
 	// ThrottleBudget is the amount of events that can be emitted per ThrottlePeriodMs.
 	ThrottleBudget int64
+	// PointerChasingDepth is the depth of pointer chasing to perform.
+	PointerChasingLimit uint32
 	// TODO: Add template support:
 	//	TemplateSegments []TemplateSegment
 }

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -704,8 +704,12 @@ func (v *rootVisitor) newProbe(
 		return nil, fmt.Errorf("failed to get probe kind: %w", err)
 	}
 	var captureSnapshot bool
+	pointerChasingLimit := uint32(math.MaxUint32)
 	if lp, ok := probeCfg.(*config.LogProbe); ok {
 		captureSnapshot = lp.CaptureSnapshot
+		if lp.Capture != nil {
+			pointerChasingLimit = uint32(lp.Capture.MaxReferenceDepth)
+		}
 	}
 
 	lineReader, err := v.dwarf.LineReader(unit)
@@ -761,15 +765,16 @@ func (v *rootVisitor) newProbe(
 		throttleBudget = math.MaxInt
 	}
 	probe := &ir.Probe{
-		ID:               probeCfg.GetID(),
-		Subprogram:       subprogram,
-		Kind:             kind,
-		Version:          probeCfg.GetVersion(),
-		Tags:             probeCfg.GetTags(),
-		Events:           events,
-		Snapshot:         captureSnapshot,
-		ThrottlePeriodMs: throttlePeriodMs,
-		ThrottleBudget:   throttleBudget,
+		ID:                  probeCfg.GetID(),
+		Subprogram:          subprogram,
+		Kind:                kind,
+		Version:             probeCfg.GetVersion(),
+		Tags:                probeCfg.GetTags(),
+		Events:              events,
+		Snapshot:            captureSnapshot,
+		ThrottlePeriodMs:    throttlePeriodMs,
+		ThrottleBudget:      throttleBudget,
+		PointerChasingLimit: pointerChasingLimit,
 	}
 	return probe, nil
 }

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -4,106 +4,114 @@ Probes:
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 2}
-      Events:
-        - ID: 1
-          Type: 49 EventRootType Probe[main.intArg]
-          InjectionPCs: ["0x4a7f0a"]
-          Condition: null
-      Snapshot: false
-      ThrottlePeriodMs: 100
-      ThrottleBudget: 500
-    - ID: b
-      Kind: ProbeKindLog
-      Version: 0
-      Tags: []
       Subprogram: {subprogram: 3}
       Events:
-        - ID: 2
-          Type: 50 EventRootType Probe[main.stringArg]
-          InjectionPCs: ["0x4a7f8a"]
+        - ID: 1
+          Type: 53 EventRootType Probe[main.intArg]
+          InjectionPCs: ["0x4a804a"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: c
+      PointerChasingLimit: 4.294967295e+09
+    - ID: b
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 4}
       Events:
-        - ID: 3
-          Type: 51 EventRootType Probe[main.intSliceArg]
-          InjectionPCs: ["0x4a800a"]
+        - ID: 2
+          Type: 54 EventRootType Probe[main.stringArg]
+          InjectionPCs: ["0x4a80ca"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: d
+      PointerChasingLimit: 4.294967295e+09
+    - ID: c
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 5}
       Events:
-        - ID: 4
-          Type: 52 EventRootType Probe[main.intArrayArg]
-          InjectionPCs: ["0x4a808a"]
+        - ID: 3
+          Type: 55 EventRootType Probe[main.intSliceArg]
+          InjectionPCs: ["0x4a814a"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: e
+      PointerChasingLimit: 4.294967295e+09
+    - ID: d
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 6}
       Events:
-        - ID: 5
-          Type: 53 EventRootType Probe[main.stringSliceArg]
-          InjectionPCs: ["0x4a810a"]
+        - ID: 4
+          Type: 56 EventRootType Probe[main.intArrayArg]
+          InjectionPCs: ["0x4a81ca"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: f
+      PointerChasingLimit: 4.294967295e+09
+    - ID: e
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 7}
       Events:
-        - ID: 6
-          Type: 54 EventRootType Probe[main.stringArrayArg]
-          InjectionPCs: ["0x4a818a"]
+        - ID: 5
+          Type: 57 EventRootType Probe[main.stringSliceArg]
+          InjectionPCs: ["0x4a824a"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: h
+      PointerChasingLimit: 4.294967295e+09
+    - ID: f
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 8}
       Events:
-        - ID: 7
-          Type: 55 EventRootType Probe[main.mapArg]
+        - ID: 6
+          Type: 58 EventRootType Probe[main.stringArrayArg]
           InjectionPCs: ["0x4a82ca"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: i
+      PointerChasingLimit: 4.294967295e+09
+    - ID: h
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 9}
       Events:
-        - ID: 8
-          Type: 56 EventRootType Probe[main.bigMapArg]
-          InjectionPCs: ["0x4a8333"]
+        - ID: 7
+          Type: 59 EventRootType Probe[main.mapArg]
+          InjectionPCs: ["0x4a840a"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: i
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 10}
+      Events:
+        - ID: 8
+          Type: 60 EventRootType Probe[main.bigMapArg]
+          InjectionPCs: ["0x4a8473"]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
     - ID: g
       Kind: ProbeKindLog
       Version: 0
@@ -111,54 +119,49 @@ Probes:
       Subprogram: {subprogram: 1}
       Events:
         - ID: 9
-          Type: 57 EventRootType Probe[main.inlined]
-          InjectionPCs: ["0x4a820a", "0x4a7da6"]
+          Type: 61 EventRootType Probe[main.inlined]
+          InjectionPCs: ["0x4a834a", "0x4a7da6"]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: j
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 2}
+      Events:
+        - ID: 10
+          Type: 62 EventRootType Probe[main.PointerChainArg]
+          InjectionPCs: ["0x4a7fe6"]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 3
 Subprograms:
-    - ID: 2
+    - ID: 3
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a7f00..0x4a7f62]
+      OutOfLinePCRanges: [0x4a8040..0x4a80a2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x4a7f00..0x4a7f19
+            - Range: 0x4a8040..0x4a8059
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
-      Name: main.stringArg
-      OutOfLinePCRanges: [0x4a7f80..0x4a7ff1]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 2 GoStringHeaderType string
-          Locations:
-            - Range: 0x4a7f80..0x4a7f9e
-              Pieces:
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 0
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 3
-          IsParameter: true
-          IsReturn: false
     - ID: 4
-      Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a8000..0x4a807a]
+      Name: main.stringArg
+      OutOfLinePCRanges: [0x4a80c0..0x4a8131]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 5 GoSliceHeaderType []int
+          Type: 7 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8000..0x4a801e
+            - Range: 0x4a80c0..0x4a80de
               Pieces:
                 - Size: 8
                   InReg: true
@@ -168,33 +171,17 @@ Subprograms:
                   InReg: true
                   StackOffset: 0
                   Register: 3
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 2
           IsParameter: true
           IsReturn: false
     - ID: 5
-      Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a8080..0x4a80e7]
+      Name: main.intSliceArg
+      OutOfLinePCRanges: [0x4a8140..0x4a81ba]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 ArrayType [3]int
+          Type: 10 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a8080..0x4a80e7
-              Pieces: [{Size: 24, InReg: false, StackOffset: 0, Register: 0}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 6
-      Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a8100..0x4a817a]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 8 GoSliceHeaderType []string
-          Locations:
-            - Range: 0x4a8100..0x4a811e
+            - Range: 0x4a8140..0x4a815e
               Pieces:
                 - Size: 8
                   InReg: true
@@ -210,47 +197,83 @@ Subprograms:
                   Register: 2
           IsParameter: true
           IsReturn: false
-    - ID: 7
-      Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a8180..0x4a81e7]
+    - ID: 6
+      Name: main.intArrayArg
+      OutOfLinePCRanges: [0x4a81c0..0x4a8227]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 ArrayType [3]string
+          Type: 11 ArrayType [3]int
           Locations:
-            - Range: 0x4a8180..0x4a81e7
-              Pieces: [{Size: 48, InReg: false, StackOffset: 0, Register: 0}]
+            - Range: 0x4a81c0..0x4a8227
+              Pieces: [{Size: 24, InReg: false, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 7
+      Name: main.stringSliceArg
+      OutOfLinePCRanges: [0x4a8240..0x4a82ba]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 12 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x4a8240..0x4a825e
+              Pieces:
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 0
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 3
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 2
           IsParameter: true
           IsReturn: false
     - ID: 8
-      Name: main.mapArg
-      OutOfLinePCRanges: [0x4a82c0..0x4a8316]
+      Name: main.stringArrayArg
+      OutOfLinePCRanges: [0x4a82c0..0x4a8327]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 11 GoMapType map[string]int
+        - Name: s
+          Type: 14 ArrayType [3]string
           Locations:
-            - Range: 0x4a82c0..0x4a82ed
-              Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
+            - Range: 0x4a82c0..0x4a8327
+              Pieces: [{Size: 48, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 9
-      Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a8320..0x4a83db]
+      Name: main.mapArg
+      OutOfLinePCRanges: [0x4a8400..0x4a8456]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 25 GoMapType map[string]main.bigStruct
+          Type: 15 GoMapType map[string]int
           Locations:
-            - Range: 0x4a8320..0x4a8353
+            - Range: 0x4a8400..0x4a842d
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x4a8353..0x4a83db
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.bigMapArg
+      OutOfLinePCRanges: [0x4a8460..0x4a851b]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 29 GoMapType map[string]main.bigStruct
+          Locations:
+            - Range: 0x4a8460..0x4a8493
+              Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
+            - Range: 0x4a8493..0x4a851b
               Pieces: [{Size: 0, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a8200..0x4a8262]
+      OutOfLinePCRanges: [0x4a8340..0x4a83a2]
       InlinePCRanges: [[0x4a7da6..0x4a7df3]]
       Variables:
         - Name: x
@@ -258,7 +281,19 @@ Subprograms:
           Locations:
             - Range: 0x4a7da6..0x4a7df3
               Pieces: []
-            - Range: 0x4a8200..0x4a8219
+            - Range: 0x4a8340..0x4a8359
+              Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0x4a7fe6..0x4a8025]]
+      Variables:
+        - Name: ptr
+          Type: 2 PointerType *****int
+          Locations:
+            - Range: 0x4a7fbf..0x4a800b
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
@@ -267,40 +302,75 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41664
+      GoRuntimeType: 41952
       GoKind: 2
-    - __kind: GoStringHeaderType
+    - __kind: PointerType
       ID: 2
+      Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 35264
+      GoKind: 22
+      Pointee: 3 PointerType ****int
+    - __kind: PointerType
+      ID: 3
+      Name: '****int'
+      ByteSize: 8
+      GoRuntimeType: 35200
+      GoKind: 22
+      Pointee: 4 PointerType ***int
+    - __kind: PointerType
+      ID: 4
+      Name: '***int'
+      ByteSize: 8
+      GoRuntimeType: 35136
+      GoKind: 22
+      Pointee: 5 PointerType **int
+    - __kind: PointerType
+      ID: 5
+      Name: '**int'
+      ByteSize: 8
+      GoRuntimeType: 35072
+      GoKind: 22
+      Pointee: 6 PointerType *int
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29120
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41088
+      GoRuntimeType: 41376
       GoKind: 24
       Fields:
         - Name: str
           Offset: 0
-          Type: 40 PointerType *string.str
+          Type: 44 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 39 GoStringDataType string.str
+      Data: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 3
+      ID: 8
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28640
+      GoRuntimeType: 28672
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 9 BaseType uint8
     - __kind: BaseType
-      ID: 4
+      ID: 9
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41216
+      GoRuntimeType: 41504
       GoKind: 8
     - __kind: GoSliceHeaderType
-      ID: 5
+      ID: 10
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37408
+      GoRuntimeType: 37696
       GoKind: 23
       Fields:
         - Name: array
@@ -312,348 +382,341 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 41 GoSliceDataType []int.array
-    - __kind: PointerType
-      ID: 6
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29088
-      GoKind: 22
-      Pointee: 1 BaseType int
+      Data: 45 GoSliceDataType []int.array
     - __kind: ArrayType
-      ID: 7
+      ID: 11
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45664
+      GoRuntimeType: 45952
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 8
+      ID: 12
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37664
+      GoRuntimeType: 37952
       GoKind: 23
       Fields:
         - Name: array
           Offset: 0
-          Type: 9 PointerType *string
+          Type: 13 PointerType *string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 43 GoSliceDataType []string.array
+      Data: 47 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 9
+      ID: 13
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28512
+      GoRuntimeType: 28544
       GoKind: 22
-      Pointee: 2 GoStringHeaderType string
+      Pointee: 7 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 10
+      ID: 14
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 45760
+      GoRuntimeType: 46048
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 2 GoStringHeaderType string
+      Element: 7 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 11
+      ID: 15
       Name: map[string]int
-      GoRuntimeType: 66976
+      GoRuntimeType: 67264
       GoKind: 21
-      HeaderType: 13 GoSwissMapHeaderType map<string,int>
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 12
+      ID: 16
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 13 GoSwissMapHeaderType map<string,int>
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 13
+      ID: 17
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 15 BaseType uintptr
+          Type: 19 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 16 PointerType **table<string,int>
+          Type: 20 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 14 BaseType uint64
-      TablePtrSliceType: 45 GoSliceDataType []*table<string,int>.array
-      GroupType: 22 StructureType noalg.map.group[string]int
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 49 GoSliceDataType []*table<string,int>.array
+      GroupType: 26 StructureType noalg.map.group[string]int
     - __kind: BaseType
-      ID: 14
+      ID: 18
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41600
+      GoRuntimeType: 41888
       GoKind: 11
     - __kind: BaseType
-      ID: 15
+      ID: 19
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 41792
+      GoRuntimeType: 42080
       GoKind: 12
     - __kind: PointerType
-      ID: 16
+      ID: 20
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 17 PointerType *table<string,int>
+      Pointee: 21 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 17
+      ID: 21
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 18 StructureType table<string,int>
+      Pointee: 22 StructureType table<string,int>
     - __kind: StructureType
-      ID: 18
+      ID: 22
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 20 GoSwissMapGroupsType groupReference<string,int>
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
     - __kind: BaseType
-      ID: 19
+      ID: 23
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41344
+      GoRuntimeType: 41632
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 20
+      ID: 24
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       Fields:
         - Name: data
           Offset: 0
-          Type: 21 PointerType *noalg.map.group[string]int
+          Type: 25 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 14 BaseType uint64
-      GroupType: 22 StructureType noalg.map.group[string]int
-      GroupSliceType: 46 GoSliceDataType []noalg.map.group[string]int.array
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 50 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 21
+      ID: 25
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 22 StructureType noalg.map.group[string]int
+      Pointee: 26 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 22
+      ID: 26
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74368
+      GoRuntimeType: 74656
       GoKind: 25
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 23 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 23
+      ID: 27
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 45856
+      GoRuntimeType: 46144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 24 StructureType noalg.struct { key string; elem int }
+      Element: 28 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 24
+      ID: 28
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74240
+      GoRuntimeType: 74528
       GoKind: 25
       Fields:
         - Name: key
           Offset: 0
-          Type: 2 GoStringHeaderType string
+          Type: 7 GoStringHeaderType string
         - Name: elem
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 25
+      ID: 29
       Name: map[string]main.bigStruct
-      GoRuntimeType: 67104
+      GoRuntimeType: 67392
       GoKind: 21
-      HeaderType: 27 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 26
+      ID: 30
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 27 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 27
+      ID: 31
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 15 BaseType uintptr
+          Type: 19 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 28 PointerType **table<string,main.bigStruct>
+          Type: 32 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 14 BaseType uint64
-      TablePtrSliceType: 47 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 33 StructureType noalg.map.group[string]main.bigStruct
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 51 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 28
+      ID: 32
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 29 PointerType *table<string,main.bigStruct>
+      Pointee: 33 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 29
+      ID: 33
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 30 StructureType table<string,main.bigStruct>
+      Pointee: 34 StructureType table<string,main.bigStruct>
     - __kind: StructureType
-      ID: 30
+      ID: 34
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 31 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 31
+      ID: 35
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       Fields:
         - Name: data
           Offset: 0
-          Type: 32 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 14 BaseType uint64
-      GroupType: 33 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 48 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+          Type: 18 BaseType uint64
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 52 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
-      ID: 32
+      ID: 36
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 33 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: StructureType
-      ID: 33
+      ID: 37
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74624
+      GoRuntimeType: 74912
       GoKind: 25
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 34 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 34
+      ID: 38
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46048
+      GoRuntimeType: 46336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 35 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 35
+      ID: 39
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74496
+      GoRuntimeType: 74784
       GoKind: 25
       Fields:
         - Name: key
           Offset: 0
-          Type: 2 GoStringHeaderType string
+          Type: 7 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 36 PointerType *main.bigStruct
+          Type: 40 PointerType *main.bigStruct
     - __kind: PointerType
-      ID: 36
+      ID: 40
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 26944
       GoKind: 22
-      Pointee: 37 StructureType main.bigStruct
+      Pointee: 41 StructureType main.bigStruct
     - __kind: StructureType
-      ID: 37
+      ID: 41
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119456
+      GoRuntimeType: 119744
       GoKind: 25
       Fields:
         - Name: Field1
@@ -679,67 +742,67 @@ Types:
           Type: 1 BaseType int
         - Name: data
           Offset: 56
-          Type: 38 ArrayType [128]uint8
+          Type: 42 ArrayType [128]uint8
     - __kind: ArrayType
-      ID: 38
+      ID: 42
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 45952
+      GoRuntimeType: 46240
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 9 BaseType uint8
     - __kind: GoStringDataType
-      ID: 39
+      ID: 43
       Name: string.str
       ByteSize: 512
     - __kind: PointerType
-      ID: 40
+      ID: 44
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 39 GoStringDataType string.str
+      Pointee: 43 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 41
+      ID: 45
       Name: '[]int.array'
       ByteSize: 512
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 42
+      ID: 46
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 41 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 43
-      Name: '[]string.array'
-      ByteSize: 512
-      Element: 2 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 44
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 43 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 45
-      Name: '[]*table<string,int>.array'
-      ByteSize: 2048
-      Element: 17 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 46
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 512
-      Element: 22 StructureType noalg.map.group[string]int
+      Pointee: 45 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 47
+      Name: '[]string.array'
+      ByteSize: 512
+      Element: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 48
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 47 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 49
+      Name: '[]*table<string,int>.array'
+      ByteSize: 2048
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 50
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 512
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 51
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 29 PointerType *table<string,main.bigStruct>
+      Element: 33 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 48
+      ID: 52
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 512
-      Element: 33 StructureType noalg.map.group[string]main.bigStruct
+      Element: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
-      ID: 49
+      ID: 53
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -750,11 +813,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 50
+      ID: 54
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenseBitsetSize: 1
@@ -762,14 +825,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 2 GoStringHeaderType string
+            Type: 7 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 51
+      ID: 55
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -777,14 +840,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 5 GoSliceHeaderType []int
+            Type: 10 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 52
+      ID: 56
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -792,14 +855,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 ArrayType [3]int
+            Type: 11 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 53
+      ID: 57
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -807,14 +870,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 8 GoSliceHeaderType []string
+            Type: 12 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 54
+      ID: 58
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenseBitsetSize: 1
@@ -822,14 +885,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 ArrayType [3]string
+            Type: 14 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 8, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 55
+      ID: 59
       Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -837,14 +900,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 11 GoMapType map[string]int
+            Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 56
+      ID: 60
       Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -852,14 +915,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 25 GoMapType map[string]main.bigStruct
+            Type: 29 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: m}
+                  Variable: {subprogram: 10, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 57
+      ID: 61
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -873,4 +936,19 @@ Types:
                   Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 57
+    - __kind: EventRootType
+      ID: 62
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 62

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -4,106 +4,114 @@ Probes:
       Kind: ProbeKindLog
       Version: 0
       Tags: []
-      Subprogram: {subprogram: 2}
-      Events:
-        - ID: 1
-          Type: 49 EventRootType Probe[main.intArg]
-          InjectionPCs: [741596]
-          Condition: null
-      Snapshot: false
-      ThrottlePeriodMs: 100
-      ThrottleBudget: 500
-    - ID: b
-      Kind: ProbeKindLog
-      Version: 0
-      Tags: []
       Subprogram: {subprogram: 3}
       Events:
-        - ID: 2
-          Type: 50 EventRootType Probe[main.stringArg]
-          InjectionPCs: [741708]
+        - ID: 1
+          Type: 53 EventRootType Probe[main.intArg]
+          InjectionPCs: [741868]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: c
+      PointerChasingLimit: 4.294967295e+09
+    - ID: b
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 4}
       Events:
-        - ID: 3
-          Type: 51 EventRootType Probe[main.intSliceArg]
-          InjectionPCs: [741836]
+        - ID: 2
+          Type: 54 EventRootType Probe[main.stringArg]
+          InjectionPCs: [741980]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: d
+      PointerChasingLimit: 4.294967295e+09
+    - ID: c
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 5}
       Events:
-        - ID: 4
-          Type: 52 EventRootType Probe[main.intArrayArg]
-          InjectionPCs: [741964]
+        - ID: 3
+          Type: 55 EventRootType Probe[main.intSliceArg]
+          InjectionPCs: [742108]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: e
+      PointerChasingLimit: 4.294967295e+09
+    - ID: d
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 6}
       Events:
-        - ID: 5
-          Type: 53 EventRootType Probe[main.stringSliceArg]
-          InjectionPCs: [742092]
+        - ID: 4
+          Type: 56 EventRootType Probe[main.intArrayArg]
+          InjectionPCs: [742236]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: f
+      PointerChasingLimit: 4.294967295e+09
+    - ID: e
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 7}
       Events:
-        - ID: 6
-          Type: 54 EventRootType Probe[main.stringArrayArg]
-          InjectionPCs: [742220]
+        - ID: 5
+          Type: 57 EventRootType Probe[main.stringSliceArg]
+          InjectionPCs: [742364]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: h
+      PointerChasingLimit: 4.294967295e+09
+    - ID: f
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 8}
       Events:
-        - ID: 7
-          Type: 55 EventRootType Probe[main.mapArg]
-          InjectionPCs: [742540]
+        - ID: 6
+          Type: 58 EventRootType Probe[main.stringArrayArg]
+          InjectionPCs: [742492]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
-    - ID: i
+      PointerChasingLimit: 4.294967295e+09
+    - ID: h
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 9}
       Events:
-        - ID: 8
-          Type: 56 EventRootType Probe[main.bigMapArg]
-          InjectionPCs: [742656]
+        - ID: 7
+          Type: 59 EventRootType Probe[main.mapArg]
+          InjectionPCs: [742812]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: i
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 10}
+      Events:
+        - ID: 8
+          Type: 60 EventRootType Probe[main.bigMapArg]
+          InjectionPCs: [742928]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
     - ID: g
       Kind: ProbeKindLog
       Version: 0
@@ -111,54 +119,49 @@ Probes:
       Subprogram: {subprogram: 1}
       Events:
         - ID: 9
-          Type: 57 EventRootType Probe[main.inlined]
-          InjectionPCs: [742348, 741304]
+          Type: 61 EventRootType Probe[main.inlined]
+          InjectionPCs: [742620, 741304]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: j
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 2}
+      Events:
+        - ID: 10
+          Type: 62 EventRootType Probe[main.PointerChainArg]
+          InjectionPCs: [741784]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 3
 Subprograms:
-    - ID: 2
+    - ID: 3
       Name: main.intArg
-      OutOfLinePCRanges: [0xb50d0..0xb5140]
+      OutOfLinePCRanges: [0xb51e0..0xb5250]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xb50d0..0xb50f0
+            - Range: 0xb51e0..0xb5200
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-    - ID: 3
-      Name: main.stringArg
-      OutOfLinePCRanges: [0xb5140..0xb51c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 2 GoStringHeaderType string
-          Locations:
-            - Range: 0xb5140..0xb5164
-              Pieces:
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 0
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 1
-          IsParameter: true
-          IsReturn: false
     - ID: 4
-      Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb51c0..0xb5240]
+      Name: main.stringArg
+      OutOfLinePCRanges: [0xb5250..0xb52d0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 5 GoSliceHeaderType []int
+          Type: 7 GoStringHeaderType string
           Locations:
-            - Range: 0xb51c0..0xb51e4
+            - Range: 0xb5250..0xb5274
               Pieces:
                 - Size: 8
                   InReg: true
@@ -168,33 +171,17 @@ Subprograms:
                   InReg: true
                   StackOffset: 0
                   Register: 1
-                - Size: 8
-                  InReg: true
-                  StackOffset: 0
-                  Register: 2
           IsParameter: true
           IsReturn: false
     - ID: 5
-      Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb5240..0xb52c0]
+      Name: main.intSliceArg
+      OutOfLinePCRanges: [0xb52d0..0xb5350]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 7 ArrayType [3]int
+          Type: 10 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5240..0xb52c0
-              Pieces: [{Size: 24, InReg: false, StackOffset: 8, Register: 0}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 6
-      Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb52c0..0xb5340]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 8 GoSliceHeaderType []string
-          Locations:
-            - Range: 0xb52c0..0xb52e4
+            - Range: 0xb52d0..0xb52f4
               Pieces:
                 - Size: 8
                   InReg: true
@@ -210,47 +197,83 @@ Subprograms:
                   Register: 2
           IsParameter: true
           IsReturn: false
-    - ID: 7
-      Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5340..0xb53c0]
+    - ID: 6
+      Name: main.intArrayArg
+      OutOfLinePCRanges: [0xb5350..0xb53d0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 10 ArrayType [3]string
+          Type: 11 ArrayType [3]int
           Locations:
-            - Range: 0xb5340..0xb53c0
-              Pieces: [{Size: 48, InReg: false, StackOffset: 8, Register: 0}]
+            - Range: 0xb5350..0xb53d0
+              Pieces: [{Size: 24, InReg: false, StackOffset: 8, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 7
+      Name: main.stringSliceArg
+      OutOfLinePCRanges: [0xb53d0..0xb5450]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 12 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xb53d0..0xb53f4
+              Pieces:
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 0
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 1
+                - Size: 8
+                  InReg: true
+                  StackOffset: 0
+                  Register: 2
           IsParameter: true
           IsReturn: false
     - ID: 8
-      Name: main.mapArg
-      OutOfLinePCRanges: [0xb5480..0xb54f0]
+      Name: main.stringArrayArg
+      OutOfLinePCRanges: [0xb5450..0xb54d0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 11 GoMapType map[string]int
+        - Name: s
+          Type: 14 ArrayType [3]string
           Locations:
-            - Range: 0xb5480..0xb54b8
-              Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
+            - Range: 0xb5450..0xb54d0
+              Pieces: [{Size: 48, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 9
-      Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb54f0..0xb55b0]
+      Name: main.mapArg
+      OutOfLinePCRanges: [0xb5590..0xb5600]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 25 GoMapType map[string]main.bigStruct
+          Type: 15 GoMapType map[string]int
           Locations:
-            - Range: 0xb54f0..0xb5528
+            - Range: 0xb5590..0xb55c8
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0xb5528..0xb55b0
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.bigMapArg
+      OutOfLinePCRanges: [0xb5600..0xb56c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 29 GoMapType map[string]main.bigStruct
+          Locations:
+            - Range: 0xb5600..0xb5638
+              Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
+            - Range: 0xb5638..0xb56c0
               Pieces: [{Size: 0, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.inlined
-      OutOfLinePCRanges: [0xb53c0..0xb5430]
+      OutOfLinePCRanges: [0xb54d0..0xb5540]
       InlinePCRanges: [[0xb4fb8..0xb4ff4]]
       Variables:
         - Name: x
@@ -258,7 +281,19 @@ Subprograms:
           Locations:
             - Range: 0xb4fb8..0xb4ff4
               Pieces: []
-            - Range: 0xb53c0..0xb53e0
+            - Range: 0xb54d0..0xb54f0
+              Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0xb5198..0xb51c8]]
+      Variables:
+        - Name: ptr
+          Type: 2 PointerType *****int
+          Locations:
+            - Range: 0xb5170..0xb51b8
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
@@ -267,40 +302,75 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 41632
+      GoRuntimeType: 41920
       GoKind: 2
-    - __kind: GoStringHeaderType
+    - __kind: PointerType
       ID: 2
+      Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 35232
+      GoKind: 22
+      Pointee: 3 PointerType ****int
+    - __kind: PointerType
+      ID: 3
+      Name: '****int'
+      ByteSize: 8
+      GoRuntimeType: 35168
+      GoKind: 22
+      Pointee: 4 PointerType ***int
+    - __kind: PointerType
+      ID: 4
+      Name: '***int'
+      ByteSize: 8
+      GoRuntimeType: 35104
+      GoKind: 22
+      Pointee: 5 PointerType **int
+    - __kind: PointerType
+      ID: 5
+      Name: '**int'
+      ByteSize: 8
+      GoRuntimeType: 35040
+      GoKind: 22
+      Pointee: 6 PointerType *int
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 29088
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
       Name: string
       ByteSize: 16
-      GoRuntimeType: 41056
+      GoRuntimeType: 41344
       GoKind: 24
       Fields:
         - Name: str
           Offset: 0
-          Type: 40 PointerType *string.str
+          Type: 44 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 39 GoStringDataType string.str
+      Data: 43 GoStringDataType string.str
     - __kind: PointerType
-      ID: 3
+      ID: 8
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 28608
+      GoRuntimeType: 28640
       GoKind: 22
-      Pointee: 4 BaseType uint8
+      Pointee: 9 BaseType uint8
     - __kind: BaseType
-      ID: 4
+      ID: 9
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 41184
+      GoRuntimeType: 41472
       GoKind: 8
     - __kind: GoSliceHeaderType
-      ID: 5
+      ID: 10
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 37376
+      GoRuntimeType: 37664
       GoKind: 23
       Fields:
         - Name: array
@@ -312,348 +382,341 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 41 GoSliceDataType []int.array
-    - __kind: PointerType
-      ID: 6
-      Name: '*int'
-      ByteSize: 8
-      GoRuntimeType: 29056
-      GoKind: 22
-      Pointee: 1 BaseType int
+      Data: 45 GoSliceDataType []int.array
     - __kind: ArrayType
-      ID: 7
+      ID: 11
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 45632
+      GoRuntimeType: 45920
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoSliceHeaderType
-      ID: 8
+      ID: 12
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 37632
+      GoRuntimeType: 37920
       GoKind: 23
       Fields:
         - Name: array
           Offset: 0
-          Type: 9 PointerType *string
+          Type: 13 PointerType *string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 43 GoSliceDataType []string.array
+      Data: 47 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 9
+      ID: 13
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28480
+      GoRuntimeType: 28512
       GoKind: 22
-      Pointee: 2 GoStringHeaderType string
+      Pointee: 7 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 10
+      ID: 14
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 45728
+      GoRuntimeType: 46016
       GoKind: 17
       Count: 3
       HasCount: true
-      Element: 2 GoStringHeaderType string
+      Element: 7 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 11
+      ID: 15
       Name: map[string]int
-      GoRuntimeType: 66848
+      GoRuntimeType: 67136
       GoKind: 21
-      HeaderType: 13 GoSwissMapHeaderType map<string,int>
+      HeaderType: 17 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 12
+      ID: 16
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 13 GoSwissMapHeaderType map<string,int>
+      Pointee: 17 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 13
+      ID: 17
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 15 BaseType uintptr
+          Type: 19 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 16 PointerType **table<string,int>
+          Type: 20 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 14 BaseType uint64
-      TablePtrSliceType: 45 GoSliceDataType []*table<string,int>.array
-      GroupType: 22 StructureType noalg.map.group[string]int
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 49 GoSliceDataType []*table<string,int>.array
+      GroupType: 26 StructureType noalg.map.group[string]int
     - __kind: BaseType
-      ID: 14
+      ID: 18
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 41568
+      GoRuntimeType: 41856
       GoKind: 11
     - __kind: BaseType
-      ID: 15
+      ID: 19
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 41760
+      GoRuntimeType: 42048
       GoKind: 12
     - __kind: PointerType
-      ID: 16
+      ID: 20
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 17 PointerType *table<string,int>
+      Pointee: 21 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 17
+      ID: 21
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 18 StructureType table<string,int>
+      Pointee: 22 StructureType table<string,int>
     - __kind: StructureType
-      ID: 18
+      ID: 22
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 20 GoSwissMapGroupsType groupReference<string,int>
+          Type: 24 GoSwissMapGroupsType groupReference<string,int>
     - __kind: BaseType
-      ID: 19
+      ID: 23
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 41312
+      GoRuntimeType: 41600
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 20
+      ID: 24
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       Fields:
         - Name: data
           Offset: 0
-          Type: 21 PointerType *noalg.map.group[string]int
+          Type: 25 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 14 BaseType uint64
-      GroupType: 22 StructureType noalg.map.group[string]int
-      GroupSliceType: 46 GoSliceDataType []noalg.map.group[string]int.array
+          Type: 18 BaseType uint64
+      GroupType: 26 StructureType noalg.map.group[string]int
+      GroupSliceType: 50 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 21
+      ID: 25
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 22 StructureType noalg.map.group[string]int
+      Pointee: 26 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 22
+      ID: 26
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 74240
+      GoRuntimeType: 74528
       GoKind: 25
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 23 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 27 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 23
+      ID: 27
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 45824
+      GoRuntimeType: 46112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 24 StructureType noalg.struct { key string; elem int }
+      Element: 28 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 24
+      ID: 28
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 74112
+      GoRuntimeType: 74400
       GoKind: 25
       Fields:
         - Name: key
           Offset: 0
-          Type: 2 GoStringHeaderType string
+          Type: 7 GoStringHeaderType string
         - Name: elem
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 25
+      ID: 29
       Name: map[string]main.bigStruct
-      GoRuntimeType: 66976
+      GoRuntimeType: 67264
       GoKind: 21
-      HeaderType: 27 GoSwissMapHeaderType map<string,main.bigStruct>
+      HeaderType: 31 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 26
+      ID: 30
       Name: '*map<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 27 GoSwissMapHeaderType map<string,main.bigStruct>
+      Pointee: 31 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 27
+      ID: 31
       Name: map<string,main.bigStruct>
       ByteSize: 48
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 15 BaseType uintptr
+          Type: 19 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 28 PointerType **table<string,main.bigStruct>
+          Type: 32 PointerType **table<string,main.bigStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 14 BaseType uint64
-      TablePtrSliceType: 47 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 33 StructureType noalg.map.group[string]main.bigStruct
+          Type: 18 BaseType uint64
+      TablePtrSliceType: 51 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 28
+      ID: 32
       Name: '**table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 29 PointerType *table<string,main.bigStruct>
+      Pointee: 33 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 29
+      ID: 33
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 30 StructureType table<string,main.bigStruct>
+      Pointee: 34 StructureType table<string,main.bigStruct>
     - __kind: StructureType
-      ID: 30
+      ID: 34
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
       Fields:
         - Name: used
           Offset: 0
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 19 BaseType uint16
+          Type: 23 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 4 BaseType uint8
+          Type: 9 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 31 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 35 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 31
+      ID: 35
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       Fields:
         - Name: data
           Offset: 0
-          Type: 32 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 36 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
-          Type: 14 BaseType uint64
-      GroupType: 33 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 48 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+          Type: 18 BaseType uint64
+      GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 52 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
-      ID: 32
+      ID: 36
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 33 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: StructureType
-      ID: 33
+      ID: 37
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 74496
+      GoRuntimeType: 74784
       GoKind: 25
       Fields:
         - Name: ctrl
           Offset: 0
-          Type: 14 BaseType uint64
+          Type: 18 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 34 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 38 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 34
+      ID: 38
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 46016
+      GoRuntimeType: 46304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 35 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 39 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 35
+      ID: 39
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 74368
+      GoRuntimeType: 74656
       GoKind: 25
       Fields:
         - Name: key
           Offset: 0
-          Type: 2 GoStringHeaderType string
+          Type: 7 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 36 PointerType *main.bigStruct
+          Type: 40 PointerType *main.bigStruct
     - __kind: PointerType
-      ID: 36
+      ID: 40
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 26880
+      GoRuntimeType: 26912
       GoKind: 22
-      Pointee: 37 StructureType main.bigStruct
+      Pointee: 41 StructureType main.bigStruct
     - __kind: StructureType
-      ID: 37
+      ID: 41
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 119328
+      GoRuntimeType: 119616
       GoKind: 25
       Fields:
         - Name: Field1
@@ -679,67 +742,67 @@ Types:
           Type: 1 BaseType int
         - Name: data
           Offset: 56
-          Type: 38 ArrayType [128]uint8
+          Type: 42 ArrayType [128]uint8
     - __kind: ArrayType
-      ID: 38
+      ID: 42
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 45920
+      GoRuntimeType: 46208
       GoKind: 17
       Count: 128
       HasCount: true
-      Element: 4 BaseType uint8
+      Element: 9 BaseType uint8
     - __kind: GoStringDataType
-      ID: 39
+      ID: 43
       Name: string.str
       ByteSize: 512
     - __kind: PointerType
-      ID: 40
+      ID: 44
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 39 GoStringDataType string.str
+      Pointee: 43 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 41
+      ID: 45
       Name: '[]int.array'
       ByteSize: 512
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 42
+      ID: 46
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 41 GoSliceDataType []int.array
-    - __kind: GoSliceDataType
-      ID: 43
-      Name: '[]string.array'
-      ByteSize: 512
-      Element: 2 GoStringHeaderType string
-    - __kind: PointerType
-      ID: 44
-      Name: '*[]string.array'
-      ByteSize: 8
-      Pointee: 43 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 45
-      Name: '[]*table<string,int>.array'
-      ByteSize: 2048
-      Element: 17 PointerType *table<string,int>
-    - __kind: GoSliceDataType
-      ID: 46
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 512
-      Element: 22 StructureType noalg.map.group[string]int
+      Pointee: 45 GoSliceDataType []int.array
     - __kind: GoSliceDataType
       ID: 47
+      Name: '[]string.array'
+      ByteSize: 512
+      Element: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 48
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 47 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 49
+      Name: '[]*table<string,int>.array'
+      ByteSize: 2048
+      Element: 21 PointerType *table<string,int>
+    - __kind: GoSliceDataType
+      ID: 50
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 512
+      Element: 26 StructureType noalg.map.group[string]int
+    - __kind: GoSliceDataType
+      ID: 51
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 2048
-      Element: 29 PointerType *table<string,main.bigStruct>
+      Element: 33 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 48
+      ID: 52
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 512
-      Element: 33 StructureType noalg.map.group[string]main.bigStruct
+      Element: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
-      ID: 49
+      ID: 53
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -750,11 +813,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 2, index: 0, name: x}
+                  Variable: {subprogram: 3, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 50
+      ID: 54
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenseBitsetSize: 1
@@ -762,14 +825,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 2 GoStringHeaderType string
+            Type: 7 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: s}
+                  Variable: {subprogram: 4, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 51
+      ID: 55
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -777,14 +840,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 5 GoSliceHeaderType []int
+            Type: 10 GoSliceHeaderType []int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: s}
+                  Variable: {subprogram: 5, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 52
+      ID: 56
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -792,14 +855,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 7 ArrayType [3]int
+            Type: 11 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: s}
+                  Variable: {subprogram: 6, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 53
+      ID: 57
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenseBitsetSize: 1
@@ -807,14 +870,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 8 GoSliceHeaderType []string
+            Type: 12 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: s}
+                  Variable: {subprogram: 7, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 54
+      ID: 58
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenseBitsetSize: 1
@@ -822,14 +885,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 10 ArrayType [3]string
+            Type: 14 ArrayType [3]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: s}
+                  Variable: {subprogram: 8, index: 0, name: s}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 55
+      ID: 59
       Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -837,14 +900,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 11 GoMapType map[string]int
+            Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: m}
+                  Variable: {subprogram: 9, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 56
+      ID: 60
       Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -852,14 +915,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 25 GoMapType map[string]main.bigStruct
+            Type: 29 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: m}
+                  Variable: {subprogram: 10, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 57
+      ID: 61
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -873,4 +936,19 @@ Types:
                   Variable: {subprogram: 1, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 57
+    - __kind: EventRootType
+      ID: 62
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 62

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -27,6 +27,13 @@ func main() {
 	funcArg(inlined)
 	mapArg(map[string]int{"a": 1})
 	bigMapArg(map[string]bigStruct{"b": {Field1: 1}})
+	val := 17
+	ptr1 := &val
+	ptr2 := &ptr1
+	ptr3 := &ptr2
+	ptr4 := &ptr3
+	ptr5 := &ptr4
+	PointerChainArg(ptr5)
 }
 
 //go:noinline
@@ -92,4 +99,8 @@ func bigMapArg(m map[string]bigStruct) {
 		v.data[0] = 1 // use data
 	}
 	fmt.Println(m)
+}
+
+func PointerChainArg(ptr *****int) {
+	fmt.Println(ptr)
 }

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -36,3 +36,9 @@ probes:
   type: LOG_PROBE
   where:
     method_name: main.bigMapArg
+- id: j
+  type: LOG_PROBE
+  where:
+    method_name: main.PointerChainArg
+  capture:
+    max_reference_depth: 3


### PR DESCRIPTION
### What does this PR do?

Respect MaxReferenceDepth as a pointer chasing limit. Pointers (and interfaces in the futures) count towards the limit. Strings, slices (and maps in the future) do not count towards the limit.

### Motivation

https://datadoghq.atlassian.net/browse/DEBUG-4066
