### PR TITLE
bininspect: switch pointer to value receiver

### DIFF
--- a/pkg/network/go/bininspect/types.go
+++ b/pkg/network/go/bininspect/types.go
@@ -90,8 +90,8 @@ const (
 )
 
 // PointerSize gets the size, in bytes, of pointers on the architecture
-func (a *GoArch) PointerSize() uint {
-	switch *a {
+func (a GoArch) PointerSize() uint {
+	switch a {
 	case GoArchX86_64:
 		return 8
 	case GoArchARM64:


### PR DESCRIPTION
GoArch is a string type that had a pointer receiver method. I don't see any point to the pointer, and it having a pointer receiver precludes the method from being called on temporaries. We have code returning GoArch by value (as is natural), so the pointer receiver forced you to give a name to such return values. This patch switches it to value receiver.
