### PR TITLE
[AMCC-53] metrics: use the same function to get `histogram_aggregates` & `histogram_percentiles`

### DIFF
--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
-	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.60.0
 	github.com/DataDog/datadog-agent/pkg/tagset v0.60.0
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.64.1
@@ -27,6 +26,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -79,15 +78,11 @@ func NewHistogram(interval int64, config pkgconfigmodel.Config) *Histogram {
 	if defaultAggregates == nil {
 		defaultAggregates = config.GetStringSlice("histogram_aggregates")
 	}
+
 	if defaultPercentiles == nil {
-		c := []string{}
-		err := structure.UnmarshalKey(config, "histogram_percentiles", &c)
-		if err != nil {
-			log.Errorf("Could not Unmarshal histogram configuration: %s", err)
-		} else {
-			defaultPercentiles = ParsePercentiles(c)
-			sort.Ints(defaultPercentiles)
-		}
+		c := config.GetStringSlice("histogram_percentiles")
+		defaultPercentiles = ParsePercentiles(c)
+		sort.Ints(defaultPercentiles)
 	}
 
 	return &Histogram{


### PR DESCRIPTION
### What does this PR do?

Use the same function to get `histogram_aggregates` & `histogram_percentiles` from the configuration.

### Motivation

Simplifying the codebase.

### Describe how you validated your changes

Unit tests.
