### PR TITLE
Support setting defaults in OTLP Ingest in agent

### DIFF
--- a/comp/otelcol/otlp/configcheck/configcheck.go
+++ b/comp/otelcol/otlp/configcheck/configcheck.go
@@ -76,18 +76,17 @@ var intConfigs = map[string]struct{}{
 // IsEnabled checks if OTLP pipeline is enabled in a given config.
 func IsEnabled(cfg config.Reader) bool {
 	for _, key := range cfg.AllKeysLowercased() {
-		if strings.HasPrefix(key, "otlp_config.receiver") {
+		if key == "otlp_config.receiver" {
 			// otlp_config.receiver key does not exist. If it is present in AllKeysLowercased,
 			// this means that otlp_config.receiver was set in agent config
 			// to an empty section, in which case OTLP Ingest is enabled.
-			if key == "otlp_config.receiver" {
+			return true
+		}
+		if strings.HasPrefix(key, "otlp_config.receiver") {
+			if cfg.IsConfigured(key) {
+				// if any of the otlp_config.receiver.* keys are configured,
+				// enable the OTLP ingest.
 				return true
-			} else {
-				if cfg.IsConfigured(key) {
-					// if any of the otlp_config.receiver.* keys are configured,
-					// enable the OTLP ingest.
-					return true
-				}
 			}
 		}
 	}

--- a/comp/otelcol/otlp/configcheck/configcheck.go
+++ b/comp/otelcol/otlp/configcheck/configcheck.go
@@ -9,7 +9,6 @@
 package configcheck
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/mohae/deepcopy"
@@ -79,14 +78,14 @@ func IsEnabled(cfg config.Reader) bool {
 	for _, key := range cfg.AllKeysLowercased() {
 		if strings.HasPrefix(key, "otlp_config.receiver") {
 			// otlp_config.receiver key does not exist. If it is present in AllKeysLowercased,
-			// this means that otlp_config.receiver was set in agent config 
+			// this means that otlp_config.receiver was set in agent config
 			// to an empty section, in which case OTLP Ingest is enabled.
 			if key == "otlp_config.receiver" {
 				return true
 			} else {
 				if cfg.IsConfigured(key) {
 					// if any of the otlp_config.receiver.* keys are configured,
-					// enable the OTLP ingest.					
+					// enable the OTLP ingest.
 					return true
 				}
 			}

--- a/comp/otelcol/otlp/configcheck/configcheck.go
+++ b/comp/otelcol/otlp/configcheck/configcheck.go
@@ -106,7 +106,6 @@ func hasSection(cfg config.Reader, section string) bool {
 	//
 	// IsSet won't work here: it will return false if the section is present but empty.
 	// To work around this, we check if the receiver key is present in the string map, which does the 'correct' thing.
-	fmt.Println("SECTION: \n", ReadConfigSection(cfg, coreconfig.OTLPSection).ToStringMap())
 	_, ok := ReadConfigSection(cfg, coreconfig.OTLPSection).ToStringMap()[section]
 	return ok
 }

--- a/pkg/config/setup/otlp.go
+++ b/pkg/config/setup/otlp.go
@@ -49,7 +49,7 @@ func OTLP(config pkgconfigmodel.Setup) {
 	// gRPC settings
 	config.BindEnv("otlp_config.receiver.protocols.grpc.endpoint")
 	config.BindEnv("otlp_config.receiver.protocols.grpc.transport")
-	config.BindEnv("otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib")
+	config.BindEnvAndSetDefault("otlp_config.receiver.protocols.grpc.max_recv_msg_size_mib", 10)
 	config.BindEnv("otlp_config.receiver.protocols.grpc.max_concurrent_streams")
 	config.BindEnv("otlp_config.receiver.protocols.grpc.read_buffer_size")
 	config.BindEnv("otlp_config.receiver.protocols.grpc.write_buffer_size")

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -94,10 +94,8 @@ func NewOTLPReceiver(out chan<- *Payload, cfg *config.AgentConfig, statsd statsd
 		enableReceiveResourceSpansV2Val = 0.0
 	}
 	_ = statsd.Gauge("datadog.trace_agent.otlp.enable_receive_resource_spans_v2", enableReceiveResourceSpansV2Val, nil, 1)
-	grpcMaxRecvMsgSize := 10 * 1024 * 1024
-	if cfg.OTLPReceiver.GrpcMaxRecvMsgSizeMib > 0 {
-		grpcMaxRecvMsgSize = cfg.OTLPReceiver.GrpcMaxRecvMsgSizeMib * 1024 * 1024
-	}
+	grpcMaxRecvMsgSize := cfg.OTLPReceiver.GrpcMaxRecvMsgSizeMib * 1024 * 1024
+
 	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo), statsd: statsd, timing: timing, grpcMaxRecvMsgSize: grpcMaxRecvMsgSize}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently, the OTLP ingest in agent can be enabled in one of two ways:
- Any settings in `otlp_config.receiver` being set. This can be done via config or env var.
- `otlp_config.receiver` being set with nothing in the section in the config file, in which the OTLP ingest in the agent is enabled. e.g.
```
otlp_config:
  receiver:
```

Previously, we were unable to set defaults, as this would trigger the section to be enabled. In this PR, we change the behaviour.
- For the first bullet point, we iterate over each key in `otlp_config.receiver.*`, and use `IsConfigured` (returns `false` in case of default), and if any key is configured the OTLP ingest is enabled
- For the second bullet point, we iterate over the result of `AllKeysLowercased`. Because the key `otlp_config.receiver`
 does not exist, if this key is present in `AllKeysLowercased` this means the user set this to an empty section. In this case, the OTLP ingest is enabled.

### Motivation
OTAGENT-378

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->