### PR TITLE
feat(renovate): Create an independent rule for windows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
         "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}"
       },
       {
-        "matchDepNames": ["buildimages"],
+        "matchDepNames": ["buildimages", "windows"],
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main"
       }
     ],
@@ -28,11 +28,22 @@
         "customType": "regex",
         "fileMatch": [".gitlab-ci.yml"],
         "matchStrings": [
-          "  CI_IMAGE_[^:]*: (?<currentValue>v.*)"
+          "  CI_IMAGE_[^W][^:]*: (?<currentValue>v.*)"
         ],
         "depNameTemplate": "buildimages",
         "versioningTemplate": "loose",
         "datasourceTemplate": "custom.buildimages"
+      },
+      {
+        "customType": "regex",
+        "fileMatch": [".gitlab-ci.yml"],
+        "matchStrings": [
+          "  CI_IMAGE_WIN_[^:]*: (?<currentValue>v.*)"
+        ],
+        "depNameTemplate": "windows",
+        "versioningTemplate": "regex:^(ltsc2022-)?v(?<major>\\d+)-.*$",
+        "datasourceTemplate": "custom.windows",
+        "extractVersionTemplate": "^(ltsc2022-)?(?<version>.*)$"
       },
       {
         "customType": "regex",
@@ -71,6 +82,12 @@
         "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-deb_x64/tags",
         "transformTemplates": [
           "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
+        ]
+      },
+      "windows": {
+        "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-windows_x64/tags",
+        "transformTemplates": [
+          "{\"releases\": $map(results, function($v) { {\"version\": $replace($replace($v.name, \"lstc2022-\", \"\"), \"lstc2022\", \"latest\"), \"releaseTimestamp\": $v.last_updated, \"digest\": $v.digest } }) }"
         ]
       }
     }

--- a/renovate.json
+++ b/renovate.json
@@ -87,7 +87,7 @@
       "windows": {
         "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-windows_x64/tags",
         "transformTemplates": [
-          "{\"releases\": $map(results, function($v) { {\"version\": $replace($replace($v.name, \"lstc2022-\", \"\"), \"lstc2022\", \"latest\"), \"releaseTimestamp\": $v.last_updated, \"digest\": $v.digest } }) }"
+          "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
         ]
       }
     }

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
         "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}"
       },
       {
-        "matchDepNames": ["buildimages", "windows"],
+        "matchDepNames": ["linux-images", "windows-images"],
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main"
       }
     ],
@@ -30,9 +30,9 @@
         "matchStrings": [
           "  CI_IMAGE_[^W][^:]*: (?<currentValue>v.*)"
         ],
-        "depNameTemplate": "buildimages",
+        "depNameTemplate": "linux-images",
         "versioningTemplate": "loose",
-        "datasourceTemplate": "custom.buildimages"
+        "datasourceTemplate": "custom.linux-images"
       },
       {
         "customType": "regex",
@@ -40,9 +40,9 @@
         "matchStrings": [
           "  CI_IMAGE_WIN_[^:]*: (?<currentValue>v.*)"
         ],
-        "depNameTemplate": "windows",
+        "depNameTemplate": "windows-images",
         "versioningTemplate": "regex:^(ltsc2022-)?v(?<major>\\d+)-.*$",
-        "datasourceTemplate": "custom.windows",
+        "datasourceTemplate": "custom.windows-images",
         "extractVersionTemplate": "^(ltsc2022-)?(?<version>.*)$"
       },
       {
@@ -78,13 +78,13 @@
       }
     ],
     "customDatasources": {
-      "buildimages": {
+      "linux-images": {
         "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-deb_x64/tags",
         "transformTemplates": [
           "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
         ]
       },
-      "windows": {
+      "windows-images": {
         "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-windows_x64/tags",
         "transformTemplates": [
           "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Split the update between linux and windows images. 
### Motivation
The windows image pull is costly and we don't want to update this when it is not changed


### Describe how you validated your changes
Tested on a personal repo:
- [configuration](https://github.com/chouetz/psychic-guacamole/blob/main/renovate.json)
- [windows pr](https://github.com/chouetz/psychic-guacamole/pull/167)
- [linux one](https://github.com/chouetz/psychic-guacamole/pull/166)  
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
https://datadoghq.atlassian.net/browse/ACIX-878
Relates to https://github.com/DataDog/datadog-agent-buildimages/pull/867
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->