### PR TITLE
[fleet] telem - fix unsupported type

### DIFF
--- a/pkg/fleet/installer/telemetry/span.go
+++ b/pkg/fleet/installer/telemetry/span.go
@@ -128,7 +128,7 @@ func (s *Span) SetTag(key string, value interface{}) {
 	case float64:
 		s.span.Metrics[key] = v
 	default:
-		s.span.Meta[key] = fmt.Sprintf("%v", v)
+		s.span.Meta[key] = fmt.Sprint(v)
 	}
 }
 

--- a/pkg/fleet/installer/telemetry/span.go
+++ b/pkg/fleet/installer/telemetry/span.go
@@ -128,7 +128,7 @@ func (s *Span) SetTag(key string, value interface{}) {
 	case float64:
 		s.span.Metrics[key] = v
 	default:
-		s.span.Meta[key] = fmt.Sprintf("not_supported_type %T", v)
+		s.span.Meta[key] = fmt.Sprintf("%v", v)
 	}
 }
 


### PR DESCRIPTION
Add a default value instead of unsupported type, this works with []string, []int, types that implement string method

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->