### PR TITLE
In serverless tests using env vars, init the configmock

### DIFF
--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger/events"
@@ -486,6 +487,7 @@ func TestStartExecutionSpan(t *testing.T) {
 }
 
 func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
+	configmock.SetDefaultConfigType(t, "yaml")
 	currentExecutionInfo := &ExecutionStartInfo{}
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
@@ -536,6 +538,7 @@ func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
 }
 
 func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
+	configmock.SetDefaultConfigType(t, "yaml")
 	currentExecutionInfo := &ExecutionStartInfo{}
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
@@ -593,6 +596,7 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 			triggerTags:   make(map[string]string),
 		},
 	}
+	configmock.SetDefaultConfigType(t, "yaml")
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
 	testString := `{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}`
@@ -654,6 +658,7 @@ func TestEndExecutionSpanProactInit(t *testing.T) {
 			triggerTags:   make(map[string]string),
 		},
 	}
+	configmock.SetDefaultConfigType(t, "yaml")
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
 	testString := `{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}`
@@ -704,6 +709,7 @@ func TestEndExecutionSpanProactInit(t *testing.T) {
 }
 
 func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
+	configmock.SetDefaultConfigType(t, "yaml")
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "INVALID_INPUT")
 	testString := `{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}`

--- a/pkg/serverless/trace/inferredspan/inferred_span_test.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span_test.go
@@ -107,6 +107,7 @@ func TestIsInferredSpansEnabledWhileInvalid(t *testing.T) {
 }
 
 func setEnvVars(t *testing.T, trace string, managedServices string) {
+	configmock.SetDefaultConfigType(t, "yaml")
 	t.Setenv("DD_TRACE_ENABLED", trace)
 	t.Setenv("DD_TRACE_MANAGED_SERVICES", managedServices)
 }

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -72,6 +73,7 @@ func TestStartEnabledTrueValidConfigInvalidPath(t *testing.T) {
 
 	lambdaSpanChan := make(chan *pb.Span)
 
+	configmock.SetDefaultConfigType(t, "yaml")
 	t.Setenv("DD_API_KEY", "x")
 	agent := StartServerlessTraceAgent(StartServerlessTraceAgentArgs{
 		Enabled:         true,


### PR DESCRIPTION
### What does this PR do?

Fix tests in serverless when run using the nodetreemodel implementation of the config.

### Motivation

For the new nodetreemodel implementation of the config, env vars have to be handled specially by the configmock. Fix this tests when run using `DD_CONF_NODETREEMODEL=enable` by calling configmock.SetDefaultConfigType. The reason this is needed is that nodetreemodel doesn't see env vars assigned after the config has been constructed. Using the configmock fixes this by reloading all env vars whenever the config is accessed.

### Describe how you validated your changes

Run unit tests with `DD_CONF_NODETREEMODEL=enable`

### Possible Drawbacks / Trade-offs

### Additional Notes
