### PR TITLE
fix(installer): Install agent before adding the user to additional groups

### DIFF
--- a/pkg/fleet/installer/setup/common/packages.go
+++ b/pkg/fleet/installer/setup/common/packages.go
@@ -7,9 +7,6 @@ package common
 
 import (
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 )
@@ -96,55 +93,4 @@ func (p *Packages) Install(pkg string, version string) {
 // Use this when installing SSI without the agent, so that the installer can be used later to remove the packages.
 func (p *Packages) WriteSSIInstaller() {
 	p.copyInstallerSSI = true
-}
-
-func copyInstallerSSI() error {
-	destinationPath := "/opt/datadog-packages/run/datadog-installer-ssi"
-
-	// Get the current executable path
-	currentExecutable, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get current executable: %w", err)
-	}
-
-	// Open the current executable file
-	sourceFile, err := os.Open(currentExecutable)
-	if err != nil {
-		return fmt.Errorf("failed to open current executable: %w", err)
-	}
-	defer sourceFile.Close()
-
-	// Create /usr/bin directory if it doesn't exist (unlikely)
-	err = os.MkdirAll(filepath.Dir(destinationPath), 0755)
-	if err != nil {
-		return fmt.Errorf("failed to create installer directory: %w", err)
-	}
-
-	// Check if the destination file already exists and remove it if it does (we don't want to overwrite a symlink)
-	if _, err := os.Stat(destinationPath); err == nil {
-		if err := os.Remove(destinationPath); err != nil {
-			return fmt.Errorf("failed to remove existing destination file: %w", err)
-		}
-	}
-
-	// Create the destination file
-	destinationFile, err := os.Create(destinationPath)
-	if err != nil {
-		return fmt.Errorf("failed to create destination file: %w", err)
-	}
-	defer destinationFile.Close()
-
-	// Copy the current executable to the destination file
-	_, err = io.Copy(destinationFile, sourceFile)
-	if err != nil {
-		return fmt.Errorf("failed to copy executable: %w", err)
-	}
-
-	// Set the permissions on the destination file to be executable
-	err = destinationFile.Chmod(0755)
-	if err != nil {
-		return fmt.Errorf("failed to set permissions on destination file: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -130,7 +130,7 @@ func (s *Setup) Run() (err error) {
 		}
 	}
 	if err = s.postInstallPackages(); err != nil {
-		return fmt.Errorf("failed during pre-package installation: %w", err)
+		return fmt.Errorf("failed during post-package installation: %w", err)
 	}
 	if s.Packages.copyInstallerSSI {
 		if err := copyInstallerSSI(); err != nil {

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -122,15 +122,15 @@ func (s *Setup) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to write install info: %w", err)
 	}
-	if err = s.preInstallPackages(); err != nil {
-		return fmt.Errorf("failed during pre-package installation: %w", err)
-	}
 	for _, p := range packages {
 		url := oci.PackageURL(s.Env, p.name, p.version)
 		err = s.installPackage(p.name, url)
 		if err != nil {
 			return fmt.Errorf("failed to install package %s: %w", url, err)
 		}
+	}
+	if err = s.postInstallPackages(); err != nil {
+		return fmt.Errorf("failed during pre-package installation: %w", err)
 	}
 	if s.Packages.copyInstallerSSI {
 		if err := copyInstallerSSI(); err != nil {

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -8,12 +8,16 @@
 package common
 
 import (
+	"fmt"
+	"io"
+	"os"
 	"os/user"
+	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func (s *Setup) preInstallPackages() (err error) {
+func (s *Setup) postInstallPackages() (err error) {
 	s.addAgentToAdditionalGroups()
 
 	return nil
@@ -32,4 +36,55 @@ func (s *Setup) addAgentToAdditionalGroups() {
 			log.Warnf("failed to add dd-agent to group %s:  %v", group, err)
 		}
 	}
+}
+
+func copyInstallerSSI() error {
+	destinationPath := "/opt/datadog-packages/run/datadog-installer-ssi"
+
+	// Get the current executable path
+	currentExecutable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get current executable: %w", err)
+	}
+
+	// Open the current executable file
+	sourceFile, err := os.Open(currentExecutable)
+	if err != nil {
+		return fmt.Errorf("failed to open current executable: %w", err)
+	}
+	defer sourceFile.Close()
+
+	// Create /usr/bin directory if it doesn't exist (unlikely)
+	err = os.MkdirAll(filepath.Dir(destinationPath), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create installer directory: %w", err)
+	}
+
+	// Check if the destination file already exists and remove it if it does (we don't want to overwrite a symlink)
+	if _, err := os.Stat(destinationPath); err == nil {
+		if err := os.Remove(destinationPath); err != nil {
+			return fmt.Errorf("failed to remove existing destination file: %w", err)
+		}
+	}
+
+	// Create the destination file
+	destinationFile, err := os.Create(destinationPath)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer destinationFile.Close()
+
+	// Copy the current executable to the destination file
+	_, err = io.Copy(destinationFile, sourceFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy executable: %w", err)
+	}
+
+	// Set the permissions on the destination file to be executable
+	err = destinationFile.Chmod(0755)
+	if err != nil {
+		return fmt.Errorf("failed to set permissions on destination file: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/fleet/installer/setup/common/setup_windows.go
+++ b/pkg/fleet/installer/setup/common/setup_windows.go
@@ -7,7 +7,12 @@
 
 package common
 
-func (s *Setup) preInstallPackages() (err error) {
+func (s *Setup) postInstallPackages() (err error) {
+	// nothing to do on windows
+	return nil
+}
+
+func copyInstallerSSI() error {
 	// nothing to do on windows
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
This PR installs the agent before adding the user to additional groups in the installer install scripts.
It also moves the copyInstallerToBin method to be unix-only.

### Motivation
Some installs for EMR with logs failed because we were trying to add the dd-agent user to additional groups before that user was even created.

### Describe how you validated your changes
E2E, manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->