### PR TITLE
[CWS] create the ruleset loaded event before setting the current ruleset

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -141,14 +141,12 @@ type RuleSetLoadedReport struct {
 }
 
 // ReportRuleSetLoaded reports to Datadog that a new ruleset was loaded
-func ReportRuleSetLoaded(acc *events.AgentContainerContext, sender events.EventSender, statsdClient statsd.ClientInterface, rs *rules.RuleSet, policies []*PolicyState, filterReport *kfilters.FilterReport) {
-	rule, event := newRuleSetLoadedEvent(acc, rs, policies, filterReport)
-
+func ReportRuleSetLoaded(bundle RulesetLoadedEventBundle, sender events.EventSender, statsdClient statsd.ClientInterface) {
 	if err := statsdClient.Count(metrics.MetricRuleSetLoaded, 1, []string{}, 1.0); err != nil {
 		log.Error(fmt.Errorf("failed to send ruleset_loaded metric: %w", err))
 	}
 
-	sender.SendEvent(rule, event, nil, "")
+	sender.SendEvent(bundle.Rule, bundle.Event, nil, "")
 }
 
 // PolicyMetadata contains the basic information about a policy
@@ -423,8 +421,14 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 	return policies
 }
 
-// newRuleSetLoadedEvent returns the rule (e.g. ruleset_loaded) and a populated custom event for a new_rules_loaded event
-func newRuleSetLoadedEvent(acc *events.AgentContainerContext, rs *rules.RuleSet, policies []*PolicyState, filterReport *kfilters.FilterReport) (*rules.Rule, *events.CustomEvent) {
+// RulesetLoadedEventBundle is used to report a ruleset loaded event
+type RulesetLoadedEventBundle struct {
+	Rule  *rules.Rule
+	Event *events.CustomEvent
+}
+
+// NewRuleSetLoadedEvent returns the rule (e.g. ruleset_loaded) and a populated custom event for a new_rules_loaded event
+func NewRuleSetLoadedEvent(acc *events.AgentContainerContext, rs *rules.RuleSet, policies []*PolicyState, filterReport *kfilters.FilterReport) RulesetLoadedEventBundle {
 	evt := RulesetLoadedEvent{
 		Policies:       policies,
 		Filters:        filterReport,
@@ -432,8 +436,10 @@ func newRuleSetLoadedEvent(acc *events.AgentContainerContext, rs *rules.RuleSet,
 	}
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.RulesetLoadedRuleID, events.RulesetLoadedRuleDesc),
-		events.NewCustomEvent(model.CustomEventType, evt)
+	return RulesetLoadedEventBundle{
+		Rule:  events.NewCustomRule(events.RulesetLoadedRuleID, events.RulesetLoadedRuleDesc),
+		Event: events.NewCustomEvent(model.CustomEventType, evt),
+	}
 }
 
 // newHeartbeatEvents returns the rule (e.g. heartbeat) and a populated custom event for a heartbeat event


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We currently have a race between:
- regular event triggering some partial evaluation/creation
- the collection of file monitored when emitting the ruleset loaded event, computing some partials as well

To fix this race, this PR moves the creation of the ruleset loaded event before the ruleset is set as the current active ruleset. This will allow the collection of monitored files to be done when the ruleset is still "in preparation", and not race with regular events.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->