### PR TITLE
[process] Never run the process component in the cluster worker

### DIFF
--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/process/types"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
@@ -33,6 +34,11 @@ var (
 )
 
 func enabledHelper(config config.Component, checkComponents []types.CheckComponent, l log.Component) bool {
+	// never run the process component in the cluster worker
+	if setup.IsCLCRunner(config) {
+		return false
+	}
+
 	runInCoreAgent := config.GetBool("process_config.run_in_core_agent.enabled")
 
 	var npmEnabled bool

--- a/comp/process/agent/agent_linux_test.go
+++ b/comp/process/agent/agent_linux_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/process/types"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+)
+
+func TestEnabledHelper(t *testing.T) {
+	tests := []struct {
+		name           string
+		agentFlavor    string
+		isCLCRunner    bool
+		runInCoreAgent bool
+		checks         []types.CheckComponent
+		expected       bool
+	}{
+		{
+			name:           "process agent with connections check enabled and run_in_core_agent disabled",
+			agentFlavor:    flavor.ProcessAgent,
+			runInCoreAgent: false,
+			checks: []types.CheckComponent{
+				types.NewMockCheckComponent(t, checks.ConnectionsCheckName, true),
+				types.NewMockCheckComponent(t, checks.ProcessCheckName, true),
+			},
+			expected: true,
+		},
+		{
+			name:           "process agent with connections check enabled and run_in_core_agent enabled",
+			agentFlavor:    flavor.ProcessAgent,
+			runInCoreAgent: true,
+			checks: []types.CheckComponent{
+				types.NewMockCheckComponent(t, checks.ConnectionsCheckName, true),
+				types.NewMockCheckComponent(t, checks.ProcessCheckName, true),
+			},
+			expected: true,
+		},
+		{
+			name:           "process agent with connections check disabled and run_in_core_agent disabled",
+			agentFlavor:    flavor.ProcessAgent,
+			runInCoreAgent: false,
+			checks: []types.CheckComponent{
+				types.NewMockCheckComponent(t, checks.ProcessCheckName, true),
+			},
+			expected: true,
+		},
+		{
+			name:           "process agent with connections check disabled and run_in_core_agent enabled",
+			agentFlavor:    flavor.ProcessAgent,
+			runInCoreAgent: true,
+			checks: []types.CheckComponent{
+				types.NewMockCheckComponent(t, checks.ProcessCheckName, true),
+			},
+			expected: false,
+		},
+		{
+			name:           "default agent with run_in_core_agent enabled",
+			agentFlavor:    flavor.DefaultAgent,
+			runInCoreAgent: true,
+			expected:       true,
+		},
+		{
+			name:           "default agent with run_in_core_agent disabled",
+			agentFlavor:    flavor.DefaultAgent,
+			runInCoreAgent: false,
+			expected:       false,
+		},
+		{
+			name:           "CLC runner should always return false",
+			agentFlavor:    flavor.DefaultAgent,
+			isCLCRunner:    true,
+			runInCoreAgent: true,
+			checks: []types.CheckComponent{
+				types.NewMockCheckComponent(t, checks.ConnectionsCheckName, true),
+				types.NewMockCheckComponent(t, checks.ProcessCheckName, true),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set agent flavor for this test
+			originalFlavor := flavor.GetFlavor()
+			flavor.SetFlavor(tc.agentFlavor)
+			defer func() {
+				flavor.SetFlavor(originalFlavor)
+			}()
+
+			// Create mock config
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("process_config.run_in_core_agent.enabled", tc.runInCoreAgent)
+			mockConfig.SetWithoutSource("clc_runner_enabled", tc.isCLCRunner)
+
+			if tc.isCLCRunner {
+				// Add the clusterchecks config provider to the config
+				mockConfig.SetWithoutSource("config_providers", []map[string]interface{}{
+					{"name": "clusterchecks"},
+				})
+			}
+
+			// Call the function under test and assert the result
+			result := enabledHelper(mockConfig, tc.checks, logmock.New(t))
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/comp/process/types/mock.go
+++ b/comp/process/types/mock.go
@@ -9,6 +9,8 @@
 package types
 
 import (
+	"testing"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
@@ -20,4 +22,22 @@ type MockCheckParams[T checks.Check] struct {
 	fx.In
 
 	OrchestrateMock func(mock *checkMocks.Check) `optional:"true"`
+}
+
+type mockCheck struct {
+	mock *checkMocks.Check
+}
+
+func (m *mockCheck) Object() checks.Check {
+	return m.mock
+}
+
+func NewMockCheckComponent(t *testing.T, name string, isEnabled bool) CheckComponent {
+	mock := checkMocks.NewCheck(t)
+	mock.On("Name").Return(name).Maybe()
+	mock.On("IsEnabled").Return(isEnabled).Maybe()
+
+	return &mockCheck{
+		mock: mock,
+	}
 }

--- a/releasenotes/notes/process-component-in-clc-runner-55732ff35b74368a.yaml
+++ b/releasenotes/notes/process-component-in-clc-runner-55732ff35b74368a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Prevent the process component from running in the cluster worker.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a check in the process component's `Enabled()` function that always disables the component for the cluster worker.

### Motivation

Process, container, and process discovery checks should only run in the node agent. However, the cluster worker's agent flavor is also `DefaultAgent` so we need to use the `IsCLCRunner()` helper to check if we are in the cluster worker.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests for enablement check

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Related to incident-39390