### PR TITLE
Go DI: Surface program ID in events 

### DIFF
--- a/pkg/dyninst/compiler/codegen/code.go
+++ b/pkg/dyninst/compiler/codegen/code.go
@@ -78,6 +78,7 @@ func GenerateCCode(program sm.Program, out io.Writer) (attachpoints []BPFAttachP
 	mustFprintf(out, "const uint64_t stack_machine_code_len = %d;\n", metadata.Len)
 	mustFprintf(out, "const uint32_t stack_machine_code_max_op = %d;\n", metadata.MaxOpLen)
 	mustFprintf(out, "const uint32_t chase_pointers_entrypoint = 0x%x;\n\n", metadata.FunctionLoc[sm.ChasePointers{}])
+	mustFprintf(out, "const uint32_t prog_id = %d;\n\n", program.ID)
 
 	mustFprintf(out, "const probe_params_t probe_params[] = {\n")
 	for _, f := range program.Functions {

--- a/pkg/dyninst/compiler/sm/generate.go
+++ b/pkg/dyninst/compiler/sm/generate.go
@@ -30,6 +30,7 @@ type Throttler struct {
 
 // Program represents stack machine program.
 type Program struct {
+	ID         uint32
 	Functions  []Function
 	Types      []ir.Type
 	Throttlers []Throttler
@@ -100,6 +101,7 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 		types = append(types, t)
 	}
 	return Program{
+		ID:         uint32(program.ID),
 		Functions:  g.functions,
 		Types:      types,
 		Throttlers: throttlers,

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
@@ -197,6 +197,8 @@ const uint64_t stack_machine_code_len = 559;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
+const uint32_t prog_id = 1;
+
 const probe_params_t probe_params[] = {
 	{.throttler_idx = 0, .stack_machine_pc = 0x19, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 1, .stack_machine_pc = 0x50, .pointer_chasing_limit = 4294967295, .frameless = false},

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
@@ -197,6 +197,8 @@ const uint64_t stack_machine_code_len = 559;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
+const uint32_t prog_id = 1;
+
 const probe_params_t probe_params[] = {
 	{.throttler_idx = 0, .stack_machine_pc = 0x19, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 1, .stack_machine_pc = 0x50, .pointer_chasing_limit = 4294967295, .frameless = false},

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -98,6 +98,20 @@ func (d *Decoder) Decode(event output.Event, out io.Writer) error {
 		return err
 	}
 
+	header, err := event.Header()
+	if err != nil {
+		return err
+	}
+
+	err = enc.WriteToken(jsontext.String("prog_id"))
+	if err != nil {
+		return err
+	}
+	err = enc.WriteToken(jsontext.Uint(uint64(header.Prog_id)))
+	if err != nil {
+		return err
+	}
+
 	err = enc.WriteToken(jsontext.String("stack_frames"))
 	if err != nil {
 		return err

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -73,16 +73,6 @@ func (d *Decoder) Decode(event output.Event, out io.Writer) error {
 		return err
 	}
 
-	err = enc.WriteToken(jsontext.String("event_id"))
-	if err != nil {
-		return err
-	}
-
-	err = enc.WriteToken(jsontext.Uint(uint64(eventHeader.Event_id)))
-	if err != nil {
-		return err
-	}
-
 	err = enc.WriteToken(jsontext.String("program_id"))
 	if err != nil {
 		return err

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -69,6 +69,7 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
       .data_byte_len = sizeof(event_header_t),
       .stack_byte_len = 0, // set this if we collect stacks
       .ktime_ns = start_ns,
+      .prog_id = prog_id,
   };
 
   __maybe_unused int process_steps = 0;

--- a/pkg/dyninst/ebpf/framing.h
+++ b/pkg/dyninst/ebpf/framing.h
@@ -21,12 +21,9 @@ typedef struct event_header {
   // The ID of the program that produced this event.
   uint32_t prog_id;
 
-  // The ID of the event within a probe of the program that produced this event.
-  uint32_t event_id;
-
   // The number of bytes for a stack trace that follows this header.
   uint16_t stack_byte_len;
-  char __padding[2];
+  char __padding[6];
  
   // Hash of the stack trace that follows this header.
   uint64_t stack_hash;

--- a/pkg/dyninst/output/framing_linux.go
+++ b/pkg/dyninst/output/framing_linux.go
@@ -6,9 +6,8 @@ package output
 type EventHeader struct {
 	Data_byte_len  uint32
 	Prog_id        uint32
-	Event_id       uint32
 	Stack_byte_len uint16
-	X__padding     [2]int8
+	X__padding     [6]int8
 	Stack_hash     uint64
 	Ktime_ns       uint64
 }


### PR DESCRIPTION
### What does this PR do?

Program and event IDs were not being surfaced in events off the ringbuffer in Go DI. This fixes this.

### Motivation

We need these IDs to correlate events with the IR definitions.

### Describe how you validated your changes

Ran tests locally.

### Possible Drawbacks / Trade-offs

### Additional Notes
