### PR TITLE
[clusteragent/autoscaling] Add indexing to autoscaling workload store

### DIFF
--- a/pkg/clusteragent/autoscaling/store.go
+++ b/pkg/clusteragent/autoscaling/store.go
@@ -9,8 +9,6 @@ package autoscaling
 
 import (
 	"sync"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -118,10 +116,8 @@ func (s *Store[T]) GetFiltered(filter func(T) bool) []T {
 	return objects
 }
 
-// GetFilteredByOwner returns a copy of all store values matched by the owner index key
-func (s *Store[T]) GetFilteredByOwner(indexKey any) []T {
-	log.Debugf("Getting filtered by owner: %+v", indexKey)
-	log.Debugf("Indexer: %+v", s.indexer)
+// GetFilteredByIndexKey returns a copy of all store values matched by the index key
+func (s *Store[T]) GetFilteredByIndexKey(indexKey any) []T {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -122,7 +122,7 @@ func NewController(
 	store.RegisterObserver(autoscaling.Observer{
 		DeleteFunc: unsetTelemetry,
 	})
-	store.SetIndexer(NewMapIndexer())
+	store.SetIndexer(newMapIndexer())
 
 	c.store = store
 	c.podWatcher = podWatcher

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -122,6 +122,8 @@ func NewController(
 	store.RegisterObserver(autoscaling.Observer{
 		DeleteFunc: unsetTelemetry,
 	})
+	store.SetIndexer(NewMapIndexer())
+
 	c.store = store
 	c.podWatcher = podWatcher
 

--- a/pkg/clusteragent/autoscaling/workload/map_indexer.go
+++ b/pkg/clusteragent/autoscaling/workload/map_indexer.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package workload
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
+)
+
+type MapIndexer struct {
+	indexMap map[any]map[string]bool
+}
+
+func NewMapIndexer() *MapIndexer {
+	return &MapIndexer{
+		indexMap: make(map[any]map[string]bool),
+	}
+}
+
+func (m *MapIndexer) GetIDs(key any) []string {
+	ids := make([]string, 0, len(m.indexMap[key]))
+	for id := range m.indexMap[key] {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (m *MapIndexer) GetIndexKey(obj any) any {
+	podAutoscaler, ok := obj.(model.PodAutoscalerInternal)
+	if !ok {
+		return nil
+	}
+
+	return model.OwnerReference{
+		Namespace:  podAutoscaler.Namespace(),
+		Name:       podAutoscaler.Spec().TargetRef.Name,
+		Kind:       podAutoscaler.Spec().TargetRef.Kind,
+		APIVersion: podAutoscaler.Spec().TargetRef.APIVersion,
+	}
+}
+
+func (m *MapIndexer) AddToIndex(key any, id string) {
+	if key == nil {
+		return
+	}
+
+	if m.indexMap[key] == nil {
+		m.indexMap[key] = make(map[string]bool)
+	}
+
+	m.indexMap[key][id] = true
+}
+
+func (m *MapIndexer) RemoveFromIndex(key any, id string) {
+	if key == nil {
+		return
+	}
+
+	delete(m.indexMap[key], id)
+	if len(m.indexMap[key]) == 0 {
+		delete(m.indexMap, key)
+	}
+}

--- a/pkg/clusteragent/autoscaling/workload/map_indexer.go
+++ b/pkg/clusteragent/autoscaling/workload/map_indexer.go
@@ -11,17 +11,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 )
 
-type MapIndexer struct {
+type mapIndexer struct {
 	indexMap map[any]map[string]bool
 }
 
-func NewMapIndexer() *MapIndexer {
-	return &MapIndexer{
+func newMapIndexer() *mapIndexer {
+	return &mapIndexer{
 		indexMap: make(map[any]map[string]bool),
 	}
 }
 
-func (m *MapIndexer) GetIDs(key any) []string {
+// GetIDs returns all IDs for a given key
+func (m *mapIndexer) GetIDs(key any) []string {
 	ids := make([]string, 0, len(m.indexMap[key]))
 	for id := range m.indexMap[key] {
 		ids = append(ids, id)
@@ -29,21 +30,18 @@ func (m *MapIndexer) GetIDs(key any) []string {
 	return ids
 }
 
-func (m *MapIndexer) GetIndexKey(obj any) any {
+// GetIndexKey returns the index key for a given object
+func (m *mapIndexer) GetIndexKey(obj any) any {
 	podAutoscaler, ok := obj.(model.PodAutoscalerInternal)
 	if !ok {
 		return nil
 	}
 
-	return model.OwnerReference{
-		Namespace:  podAutoscaler.Namespace(),
-		Name:       podAutoscaler.Spec().TargetRef.Name,
-		Kind:       podAutoscaler.Spec().TargetRef.Kind,
-		APIVersion: podAutoscaler.Spec().TargetRef.APIVersion,
-	}
+	return podAutoscaler.GetOwnerReference()
 }
 
-func (m *MapIndexer) AddToIndex(key any, id string) {
+// AddToIndex adds an ID to the index for a given key
+func (m *mapIndexer) AddToIndex(key any, id string) {
 	if key == nil {
 		return
 	}
@@ -55,7 +53,8 @@ func (m *MapIndexer) AddToIndex(key any, id string) {
 	m.indexMap[key][id] = true
 }
 
-func (m *MapIndexer) RemoveFromIndex(key any, id string) {
+// RemoveFromIndex removes an ID from the index for a given key
+func (m *mapIndexer) RemoveFromIndex(key any, id string) {
 	if key == nil {
 		return
 	}

--- a/pkg/clusteragent/autoscaling/workload/map_indexer_test.go
+++ b/pkg/clusteragent/autoscaling/workload/map_indexer_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
+)
+
+func TestMapIndexer(t *testing.T) {
+	indexer := NewMapIndexer()
+
+	// Check adding works
+	ownerRef := model.OwnerReference{
+		Namespace:  "test",
+		Name:       "test",
+		Kind:       "PodAutoscaler",
+		APIVersion: "v1alpha2",
+	}
+
+	ownerRef2 := model.OwnerReference{
+		Namespace:  "test2",
+		Name:       "test2",
+		Kind:       "PodAutoscaler",
+		APIVersion: "v1alpha2",
+	}
+
+	// Check adding works
+	indexer.AddToIndex(ownerRef, "test/test")
+	assert.Equal(t, []string{"test/test"}, indexer.GetIDs(ownerRef))
+	indexer.AddToIndex(ownerRef2, "test2/test2")
+	assert.Equal(t, []string{"test2/test2"}, indexer.GetIDs(ownerRef2))
+
+	// Check adding to the same key works
+	indexer.AddToIndex(ownerRef, "test/test2")
+	assert.Equal(t, []string{"test/test", "test/test2"}, indexer.GetIDs(ownerRef))
+
+	// Check removing works
+	indexer.RemoveFromIndex(ownerRef, "test/test")
+	assert.Equal(t, []string{"test/test2"}, indexer.GetIDs(ownerRef))
+
+	// Check removing a	non-existing ID does not error
+	indexer.RemoveFromIndex(ownerRef, "test/test")
+	assert.Equal(t, []string{"test/test2"}, indexer.GetIDs(ownerRef))
+
+	// Check removing the last ID from the key works
+	indexer.RemoveFromIndex(ownerRef, "test/test2")
+	assert.Equal(t, []string{}, indexer.GetIDs(ownerRef))
+}
+
+func TestMapIndexer_GetIndexKey(t *testing.T) {
+	indexer := NewMapIndexer()
+
+	podAutoscaler := model.NewFakePodAutoscalerInternal("test", "test", &model.FakePodAutoscalerInternal{
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: autoscalingv2.CrossVersionObjectReference{
+				Kind:       "PodAutoscaler",
+				Name:       "test",
+				APIVersion: "v1alpha2",
+			},
+		},
+	})
+
+	assert.Equal(t, model.OwnerReference{
+		Namespace:  "test",
+		Name:       "test",
+		Kind:       "PodAutoscaler",
+		APIVersion: "v1alpha2",
+	}, indexer.GetIndexKey(podAutoscaler))
+}

--- a/pkg/clusteragent/autoscaling/workload/map_indexer_test.go
+++ b/pkg/clusteragent/autoscaling/workload/map_indexer_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMapIndexer(t *testing.T) {
-	indexer := NewMapIndexer()
+	indexer := newMapIndexer()
 
 	// Check adding works
 	ownerRef := model.OwnerReference{
@@ -60,7 +60,7 @@ func TestMapIndexer(t *testing.T) {
 }
 
 func TestMapIndexer_GetIndexKey(t *testing.T) {
-	indexer := NewMapIndexer()
+	indexer := newMapIndexer()
 
 	podAutoscaler := model.NewFakePodAutoscalerInternal("test", "test", &model.FakePodAutoscalerInternal{
 		Spec: &datadoghq.DatadogPodAutoscalerSpec{

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -457,6 +457,23 @@ func (p *PodAutoscalerInternal) CustomRecommenderConfiguration() *RecommenderCon
 	return p.customRecommenderConfiguration
 }
 
+// OwnerReference represents a reference to an owner object
+type OwnerReference struct {
+	Namespace  string
+	Name       string
+	Kind       string
+	APIVersion string
+}
+
+func (p *PodAutoscalerInternal) GetOwnerReference() OwnerReference {
+	return OwnerReference{
+		Namespace:  p.namespace,
+		Name:       p.spec.TargetRef.Name,
+		Kind:       p.spec.TargetRef.Kind,
+		APIVersion: p.spec.TargetRef.APIVersion,
+	}
+}
+
 //
 // Helpers
 //

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -465,6 +465,7 @@ type OwnerReference struct {
 	APIVersion string
 }
 
+// GetOwnerReference returns the OwnerReference for a given PodAutoscalerInternal object
 func (p *PodAutoscalerInternal) GetOwnerReference() OwnerReference {
 	return OwnerReference{
 		Namespace:  p.namespace,

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -153,7 +153,7 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 		}
 	}
 
-	podAutoscalers := pa.store.GetFilteredByOwner(model.OwnerReference{
+	podAutoscalers := pa.store.GetFilteredByIndexKey(model.OwnerReference{
 		Namespace:  pod.Namespace,
 		Name:       ownerRef.Name,
 		Kind:       ownerRef.Kind,

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -153,17 +153,6 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 		}
 	}
 
-	// TODO: Implementation is slow
-	// podAutoscalers := pa.store.GetFiltered(func(podAutoscaler model.PodAutoscalerInternal) bool {
-	// 	if podAutoscaler.Namespace() == pod.Namespace &&
-	// 		podAutoscaler.Spec().TargetRef.Name == ownerRef.Name &&
-	// 		podAutoscaler.Spec().TargetRef.Kind == ownerRef.Kind &&
-	// 		podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion {
-	// 		return true
-	// 	}
-	// 	return false
-	// })
-
 	podAutoscalers := pa.store.GetFilteredByOwner(model.OwnerReference{
 		Namespace:  pod.Namespace,
 		Name:       ownerRef.Name,
@@ -176,7 +165,7 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 	}
 
 	if len(podAutoscalers) > 1 {
-		return nil, log.Errorf("Multiple autoscaler found for POD %s/%s, ownerRef: %s/%s, cannot update POD", pod.Namespace, pod.Name, ownerRef.Kind, ownerRef.Name)
+		return nil, log.Errorf("Multiple autoscalers found for POD %s/%s, ownerRef: %s/%s, cannot update POD", pod.Namespace, pod.Name, ownerRef.Kind, ownerRef.Name)
 	}
 
 	return &podAutoscalers[0], nil

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -154,14 +154,21 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 	}
 
 	// TODO: Implementation is slow
-	podAutoscalers := pa.store.GetFiltered(func(podAutoscaler model.PodAutoscalerInternal) bool {
-		if podAutoscaler.Namespace() == pod.Namespace &&
-			podAutoscaler.Spec().TargetRef.Name == ownerRef.Name &&
-			podAutoscaler.Spec().TargetRef.Kind == ownerRef.Kind &&
-			podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion {
-			return true
-		}
-		return false
+	// podAutoscalers := pa.store.GetFiltered(func(podAutoscaler model.PodAutoscalerInternal) bool {
+	// 	if podAutoscaler.Namespace() == pod.Namespace &&
+	// 		podAutoscaler.Spec().TargetRef.Name == ownerRef.Name &&
+	// 		podAutoscaler.Spec().TargetRef.Kind == ownerRef.Kind &&
+	// 		podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion {
+	// 		return true
+	// 	}
+	// 	return false
+	// })
+
+	podAutoscalers := pa.store.GetFilteredByOwner(model.OwnerReference{
+		Namespace:  pod.Namespace,
+		Name:       ownerRef.Name,
+		Kind:       ownerRef.Kind,
+		APIVersion: ownerRef.APIVersion,
 	})
 
 	if len(podAutoscalers) == 0 {

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -28,6 +28,7 @@ import (
 
 func patcherTestStoreWithData() *store {
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
+	store.SetIndexer(NewMapIndexer())
 
 	// ns1/autoscaler1 targets "test-deployment" and has vertical recommendations for 2 containers and from automatic source
 	store.Set("ns1/autoscaler1", model.FakePodAutoscalerInternal{
@@ -399,7 +400,7 @@ func TestFindAutoscaler(t *testing.T) {
 				},
 			},
 			expectedAutoscalerID: "",
-			expectedError:        errors.New("Multiple autoscaler found for POD ns2/pod2, ownerRef: ReplicaSet/duplicate-target, cannot update POD"),
+			expectedError:        errors.New("Multiple autoscalers found for POD ns2/pod2, ownerRef: ReplicaSet/duplicate-target, cannot update POD"),
 		},
 		{
 			name: "Pod without owner",

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -28,7 +28,7 @@ import (
 
 func patcherTestStoreWithData() *store {
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
-	store.SetIndexer(NewMapIndexer())
+	store.SetIndexer(newMapIndexer())
 
 	// ns1/autoscaler1 targets "test-deployment" and has vertical recommendations for 2 containers and from automatic source
 	store.Set("ns1/autoscaler1", model.FakePodAutoscalerInternal{

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -47,7 +47,9 @@ func StartWorkloadAutoscaling(
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "datadog-workload-autoscaler"})
 
-	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
+	store := autoscaling.NewStore[model.PodAutoscalerInternal](func(obj *model.PodAutoscalerInternal) any {
+		return obj.GetOwnerReference()
+	})
 	workload.InitDumper(store)
 
 	podPatcher := workload.NewPodPatcher(store, isLeaderFunc, apiCl.DynamicCl, eventRecorder)

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -47,9 +47,7 @@ func StartWorkloadAutoscaling(
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "datadog-workload-autoscaler"})
 
-	store := autoscaling.NewStore[model.PodAutoscalerInternal](func(obj *model.PodAutoscalerInternal) any {
-		return obj.GetOwnerReference()
-	})
+	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
 	workload.InitDumper(store)
 
 	podPatcher := workload.NewPodPatcher(store, isLeaderFunc, apiCl.DynamicCl, eventRecorder)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds support for indexers to the autoscaling store and implements a map indexer on the workload store

### Motivation

The call to get the autoscaler prior to patching it was slow:
```
	podAutoscalers := pa.store.GetFiltered(func(podAutoscaler model.PodAutoscalerInternal) bool {
		if podAutoscaler.Namespace() == pod.Namespace &&
			podAutoscaler.Spec().TargetRef.Name == ownerRef.Name &&
			podAutoscaler.Spec().TargetRef.Kind == ownerRef.Kind &&
			podAutoscaler.Spec().TargetRef.APIVersion == ownerRef.APIVersion {
			return true
		}
		return false
	})
```
in large clusters with many workload (e.g. 1000+), we also had a memory overhead as we allocated a slice with the size of the number of workloads in the store to filter on. In most cases, we expect this to only return one autoscaler (i.e. one autoscaler<>one workload); adding indexing allows us to easily search through and quickly return the autoscaler we want to scale on.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Deploy these changes
2. Verify that recommendations are being applied as usual

Also added unit tests to verify the change.

### Possible Drawbacks / Trade-offs

To allow for indexing, we are allocating a map of owner=>pod autoscaler IDs for each autoscaler. In large clusters with many autoscalers this can cause a memory overhead. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Do we want to allow for 