### PR TITLE
remove debug agent.exe from windows container

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -23,6 +23,9 @@
     - Expand-Archive datadog-agent-latest.amd64.zip
     - Remove-Item datadog-agent-latest.amd64.zip
     - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
+    # Omnibus uses a slightly different path than the actual install
+    # TODO: This overwrites an extra agent.exe, we should also remove it from the zip
+    - mv "Datadog Agent\bin\agent\agent.exe" "Datadog Agent\bin\agent.exe"
     - popd
 
     - get-childitem ${BUILD_CONTEXT}

--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -25,7 +25,7 @@
     - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
     # Omnibus uses a slightly different path than the actual install
     # TODO: This overwrites an extra agent.exe, we should also remove it from the zip
-    - mv "Datadog Agent\bin\agent\agent.exe" "Datadog Agent\bin\agent.exe"
+    - mv "Datadog Agent\bin\agent\agent.exe" "Datadog Agent\bin\agent.exe" -Force
     - popd
 
     - get-childitem ${BUILD_CONTEXT}

--- a/releasenotes/notes/remove-debug-agent-from-windows-container-11d28a6a2ea9e204.yaml
+++ b/releasenotes/notes/remove-debug-agent-from-windows-container-11d28a6a2ea9e204.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Removes an extra copy of ``agent.exe`` from the Windows container


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replaces the duplicate, debug build, `bin/agent.exe` with the actual, release/stripped, `bin/agent/agent.exe` in the Windows container.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1352
Reduce container size to pass static size checks.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
check windows container size is reduced, view static size check report

check agent still runs in container
```
docker run --rm -it -e "DD_API_KEY=XXX" -e "DD_HOSTNAME=XXX" --isolation process datadog/agent-dev:branden-clark-remove-debug-agent-py3-win-servercore-ltsc2022
```
### Possible Drawbacks / Trade-offs
the duplicate `agent.exe` is coming from the zip package, so this is a bandaid just for the container to get the static size check to pass. We should fix it in the zip package itself, but we have to investigate what else depends on it first.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->