### PR TITLE
usm: kafka: Change customer facing terminology from fetch to consume

### DIFF
--- a/pkg/network/protocols/kafka/debugging/debugging.go
+++ b/pkg/network/protocols/kafka/debugging/debugging.go
@@ -49,7 +49,7 @@ func Kafka(stats map[kafka.Key]*kafka.RequestStats) []RequestSummary {
 		if key.RequestAPIKey == kafka.ProduceAPIKey {
 			operationName = "produce"
 		} else if key.RequestAPIKey == kafka.FetchAPIKey {
-			operationName = "fetch"
+			operationName = "consume"
 		}
 
 		debug := RequestSummary{

--- a/pkg/network/protocols/kafka/kernel_telemetry.go
+++ b/pkg/network/protocols/kafka/kernel_telemetry.go
@@ -46,7 +46,7 @@ func newKernelTelemetry() *kernelTelemetry {
 	kafkaKernelTel.produceNoRequiredAcks = metricGroup.NewCounter("produce_no_required_acks")
 
 	for bucketIndex := range kafkaKernelTel.classifiedFetchAPIVersionHits {
-		kafkaKernelTel.classifiedFetchAPIVersionHits[bucketIndex] = metricGroup.NewCounter("classified_hits", "operation:fetch", "protocol_version:"+strconv.Itoa(bucketIndex))
+		kafkaKernelTel.classifiedFetchAPIVersionHits[bucketIndex] = metricGroup.NewCounter("classified_hits", "operation:consume", "protocol_version:"+strconv.Itoa(bucketIndex))
 	}
 	for bucketIndex := range kafkaKernelTel.classifiedProduceAPIVersionHits {
 		kafkaKernelTel.classifiedProduceAPIVersionHits[bucketIndex] = metricGroup.NewCounter("classified_hits", "operation:produce", "protocol_version:"+strconv.Itoa(bucketIndex))

--- a/pkg/network/protocols/kafka/model_linux.go
+++ b/pkg/network/protocols/kafka/model_linux.go
@@ -92,7 +92,7 @@ RawKernelTelemetry{
 		"in range [91, 255]": %d,
 	}
 	"produce no required acks": %d,
-	"classified fetch api version hits": %s,
+	"classified consume api version hits": %s,
 	"classified produce api version hits": %s
 }`, t.Topic_name_size_buckets[0], t.Topic_name_size_buckets[1], t.Topic_name_size_buckets[2], t.Topic_name_size_buckets[3],
 		t.Topic_name_size_buckets[4], t.Topic_name_size_buckets[5], t.Topic_name_size_buckets[6], t.Topic_name_size_buckets[7],

--- a/pkg/network/protocols/kafka/telemetry.go
+++ b/pkg/network/protocols/kafka/telemetry.go
@@ -29,7 +29,7 @@ func NewTelemetry() *Telemetry {
 	return &Telemetry{
 		metricGroup:    metricGroup,
 		produceHits:    newAPIVersionCounter(metricGroup, "total_hits", ClassificationMinSupportedProduceRequestApiVersion, ClassificationMaxSupportedProduceRequestApiVersion, "operation:produce", libtelemetry.OptStatsd),
-		fetchHits:      newAPIVersionCounter(metricGroup, "total_hits", ClassificationMinSupportedFetchRequestApiVersion, ClassificationMaxSupportedFetchRequestApiVersion, "operation:fetch", libtelemetry.OptStatsd),
+		fetchHits:      newAPIVersionCounter(metricGroup, "total_hits", ClassificationMinSupportedFetchRequestApiVersion, ClassificationMaxSupportedFetchRequestApiVersion, "operation:consume", libtelemetry.OptStatsd),
 		dropped:        metricGroup.NewCounter("dropped", libtelemetry.OptStatsd),
 		invalidLatency: metricGroup.NewCounter("malformed", "type:invalid-latency", libtelemetry.OptStatsd),
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes customer facing terminology from 'fetch' to 'consume'

### Motivation

We use the term 'consume' in our public metrics, the internal metrics and customer facing terminology should be aligned as well

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->