### PR TITLE
[SYNTH-19906] Add UDP IPv6 support

### DIFF
--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -203,11 +203,9 @@ func ParseUDPFirstBytes(buffer []byte) (UDPInfo, error) {
 	}
 	// Check for minimum payload length for NSMNC + 2-byte ID
 	if len(buffer) >= 16 && string(buffer[8:13]) == "NSMNC" {
-		if len(buffer) >= 16 { // 8-byte header + 8-byte payload
-			idHigh := buffer[14]
-			idLow := buffer[15]
-			udp.ID = (uint16(idHigh) << 8) | uint16(idLow)
-		}
+		idHigh := buffer[14]
+		idLow := buffer[15]
+		udp.ID = (uint16(idHigh) << 8) | uint16(idLow)
 	}
 
 	return udp, nil
@@ -307,7 +305,6 @@ func (p *FrameParser) GetICMPInfo() (ICMPInfo, error) {
 		}
 		return icmpInfo, nil
 	default:
-		// TODO IPv6
 		return ICMPInfo{}, fmt.Errorf("GetICMPInfo: unexpected layer type %s", p.Layers[1])
 	}
 }

--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -40,7 +40,6 @@ const expectedLayerCount = 2
 func NewFrameParser() *FrameParser {
 	p := &FrameParser{}
 	p.parserv4 = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &p.IP4, &p.TCP, &p.ICMP4, &p.Payload)
-	// TODO: IPv6 is not actually implemented yet
 	p.parserv6 = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv6, &p.IP6, &p.TCP, &p.ICMP6, &p.Payload)
 
 	return p
@@ -52,10 +51,7 @@ func (p *FrameParser) Parse(buffer []byte) error {
 	if err != nil {
 		return err
 	}
-	// TODO: currently we don't support ipv6
-	if parser == p.parserv6 {
-		return ignoredLayerErr
-	}
+
 	err = parser.DecodeLayers(buffer, &p.Layers)
 	var unsupportedErr gopacket.UnsupportedLayerType
 	if errors.As(err, &unsupportedErr) {
@@ -91,9 +87,8 @@ func (p *FrameParser) GetTransportLayer() gopacket.LayerType {
 	return p.Layers[1]
 }
 
-// TODO IPv6
-var ipLayers = []gopacket.LayerType{layers.LayerTypeIPv4}
-var transportLayers = []gopacket.LayerType{layers.LayerTypeTCP, layers.LayerTypeUDP, layers.LayerTypeICMPv4}
+var ipLayers = []gopacket.LayerType{layers.LayerTypeIPv4, layers.LayerTypeIPv6}
+var transportLayers = []gopacket.LayerType{layers.LayerTypeTCP, layers.LayerTypeUDP, layers.LayerTypeICMPv4, layers.LayerTypeICMPv6}
 
 // checkLayers sanity checks the layers of the parse.
 func (p *FrameParser) checkLayers() error {
@@ -132,11 +127,25 @@ func getIPv4Pair(ip4 *layers.IPv4) IPPair {
 	return IPPair{SrcAddr: srcAddr, DstAddr: dstAddr}
 }
 
+func getIPv6Pair(ip6 *layers.IPv6) IPPair {
+	srcAddr, ok := netip.AddrFromSlice(ip6.SrcIP)
+	if !ok {
+		return IPPair{}
+	}
+	dstAddr, ok := netip.AddrFromSlice(ip6.DstIP)
+	if !ok {
+		return IPPair{}
+	}
+	return IPPair{srcAddr, dstAddr}
+}
+
 // GetIPPair gets the IPPair of the IP layer
 func (p *FrameParser) GetIPPair() (IPPair, error) {
 	switch p.GetIPLayer() {
 	case layers.LayerTypeIPv4:
 		return getIPv4Pair(&p.IP4), nil
+	case layers.LayerTypeIPv6:
+		return getIPv6Pair(&p.IP6), nil
 	default:
 		// TODO IPv6
 		return IPPair{}, fmt.Errorf("GetIPPair: unexpected IP layer type %s", p.Layers[0])
@@ -174,6 +183,7 @@ func SerializeTCPFirstBytes(tcp TCPInfo) []byte {
 
 // UDPInfo is the info we get back from ICMP exceeded payload in a UDP probe.
 type UDPInfo struct {
+	ID       uint16
 	SrcPort  uint16
 	DstPort  uint16
 	Length   uint16
@@ -191,7 +201,36 @@ func ParseUDPFirstBytes(buffer []byte) (UDPInfo, error) {
 		Length:   binary.BigEndian.Uint16(buffer[4:6]),
 		Checksum: binary.BigEndian.Uint16(buffer[6:8]),
 	}
+	// Check for minimum payload length for NSMNC + 2-byte ID
+	if len(buffer) >= 16 && string(buffer[8:13]) == "NSMNC" {
+		if len(buffer) >= 16 { // 8-byte header + 8-byte payload
+			idHigh := buffer[14]
+			idLow := buffer[15]
+			udp.ID = (uint16(idHigh) << 8) | uint16(idLow)
+		}
+	}
+
 	return udp, nil
+}
+
+// WriteUDPFirstBytes writes the first 8 bytes of a UDP packet and optional "NSMNC" payload with ID.
+func WriteUDPFirstBytes(udp UDPInfo) []byte {
+	buffer := make([]byte, 8)
+
+	binary.BigEndian.PutUint16(buffer[0:2], udp.SrcPort)
+	binary.BigEndian.PutUint16(buffer[2:4], udp.DstPort)
+	binary.BigEndian.PutUint16(buffer[4:6], udp.Length)
+	binary.BigEndian.PutUint16(buffer[6:8], udp.Checksum)
+
+	// If ID is set, append "NSMNC" and the ID as 2 bytes
+	if udp.ID != 0 {
+		payload := []byte("NSMNC\x00")             // pad to 6 bytes first
+		payload = append(payload, byte(udp.ID>>8)) // high byte
+		payload = append(payload, byte(udp.ID))    // low byte
+		buffer = append(buffer, payload...)
+	}
+
+	return buffer
 }
 
 // ICMPInfo encodes the information relevant to traceroutes from an ICMP response
@@ -251,9 +290,37 @@ func (p *FrameParser) GetICMPInfo() (ICMPInfo, error) {
 			Payload:         slices.Clone(innerPkt.Payload),
 		}
 		return icmpInfo, nil
+	case layers.LayerTypeICMPv6:
+		embedded, err := extractEmbeddedIPv6(p.ICMP6.Payload)
+		if err != nil {
+			return ICMPInfo{}, fmt.Errorf("GetICMPInfo failed to decode inner packet: %w", err)
+		}
+		var innerPkt layers.IPv6
+		err = (&innerPkt).DecodeFromBytes(embedded, gopacket.NilDecodeFeedback)
+		if err != nil {
+			return ICMPInfo{}, fmt.Errorf("GetICMPInfo failed to decode inner packet: %w", err)
+		}
+		icmpInfo := ICMPInfo{
+			IPPair:   ipPair,
+			ICMPPair: getIPv6Pair(&innerPkt),
+			Payload:  slices.Clone(innerPkt.Payload),
+		}
+		return icmpInfo, nil
 	default:
 		// TODO IPv6
 		return ICMPInfo{}, fmt.Errorf("GetICMPInfo: unexpected layer type %s", p.Layers[1])
+	}
+}
+
+func extractEmbeddedIPv6(payload []byte) ([]byte, error) {
+	switch {
+	// skip 4-byte prefix if IPv6 follows
+	// trim off the first 4 bytes always in a Time Exceeded response
+	// https://en.wikipedia.org/wiki/ICMPv6#Format
+	case len(payload) >= 5 && payload[4]>>4 == 6:
+		return payload[4:], nil
+	default:
+		return nil, fmt.Errorf("cannot locate IPv6 header in payload")
 	}
 }
 

--- a/pkg/networkpath/traceroute/udp/udp_driver_test.go
+++ b/pkg/networkpath/traceroute/udp/udp_driver_test.go
@@ -1,0 +1,435 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package udp
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+)
+
+func initTest(t *testing.T, ipv6 bool) (*UDPv4, *udpDriver, *packets.MockSink, *packets.MockSource) {
+	packets.RandomizePacketIDBase()
+
+	ctrl := gomock.NewController(t)
+	mockSource := packets.NewMockSource(ctrl)
+	mockSink := packets.NewMockSink(ctrl)
+
+	ipAddress := net.ParseIP("1.2.3.4")
+	if ipv6 {
+		ipAddress = net.ParseIP("2001:0db8:abcd:0012::0a00:fffe")
+	}
+	config := NewUDPv4(
+		ipAddress,
+		80,
+		1,
+		1,
+		30,
+		10*time.Millisecond,
+		100*time.Second,
+	)
+	config.srcIP = net.ParseIP("5.6.7.8")
+	if ipv6 {
+		config.srcIP = net.ParseIP("2001:0db8:1234:5678:0000:0000:9abc:def0")
+	}
+	config.srcPort = 12345
+
+	driver := newUDPDriver(config, mockSink, mockSource)
+
+	return config, driver, mockSink, mockSource
+}
+
+func expectIDs(t *testing.T, config *UDPv4, buf []byte, ipv6 bool) {
+	var IP4 layers.IPv4
+	var IP6 layers.IPv6
+	var UDP layers.UDP
+	var Payload gopacket.Payload
+
+	parser := gopacket.NewDecodingLayerParser(
+		layers.LayerTypeIPv4,
+		&IP4, &UDP, &Payload, // include UDP here
+	)
+	if ipv6 {
+		parser = gopacket.NewDecodingLayerParser(
+			layers.LayerTypeIPv6,
+			&IP6, &UDP, &Payload, // include UDP here
+		)
+	}
+	decoded := []gopacket.LayerType{}
+	err := parser.DecodeLayers(buf, &decoded)
+	require.NoError(t, err)
+
+	if ipv6 {
+		require.True(t, config.srcIP.Equal(IP6.SrcIP))
+		require.True(t, config.Target.Equal(IP6.DstIP))
+	} else {
+		require.True(t, config.srcIP.Equal(IP4.SrcIP))
+		require.True(t, config.Target.Equal(IP4.DstIP))
+	}
+	require.Equal(t, config.srcPort, uint16(UDP.SrcPort))
+	require.Equal(t, config.TargetPort, uint16(UDP.DstPort))
+}
+
+func mockICMPResp(t *testing.T, config *UDPv4, hopIP net.IP, ttl uint8, udpInfo packets.UDPInfo, timeExceeded bool) []byte {
+	ipLayer := &layers.IPv4{
+		Version:  4,
+		Length:   20,
+		TTL:      ttl,
+		Protocol: layers.IPProtocolICMPv4,
+		DstIP:    config.srcIP,
+		SrcIP:    hopIP,
+	}
+
+	var icmpLayer *layers.ICMPv4
+	if timeExceeded {
+		icmpLayer = &layers.ICMPv4{
+			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeTimeExceeded, layers.ICMPv4CodeTTLExceeded),
+		}
+	} else {
+		icmpLayer = &layers.ICMPv4{
+			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeDestinationUnreachable, layers.ICMPv4CodePort),
+		}
+	}
+	innerIPLayer := &layers.IPv4{
+		Version:  4,
+		Length:   20,
+		TTL:      ttl,
+		Id:       41821,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    config.srcIP,
+		DstIP:    config.Target,
+	}
+
+	payload := packets.WriteUDPFirstBytes(udpInfo)
+
+	// clear the gopacket.SerializeBuffer
+	buf := gopacket.NewSerializeBuffer()
+
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	err := gopacket.SerializeLayers(buf, opts,
+		ipLayer,
+		icmpLayer,
+		innerIPLayer,
+		gopacket.Payload(payload),
+	)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+func mockICMPRespIPv6(t *testing.T, config *UDPv4, hopIP net.IP, ttl uint8, udpInfo packets.UDPInfo, timeExceeded bool) []byte {
+	ipLayer := &layers.IPv6{
+		Version:      6,
+		TrafficClass: 0,
+		FlowLabel:    0,
+		NextHeader:   layers.IPProtocolICMPv6,
+		HopLimit:     ttl,
+		SrcIP:        hopIP,
+		DstIP:        config.srcIP,
+	}
+
+	var icmpLayer *layers.ICMPv6
+	if timeExceeded {
+		icmpLayer = &layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeTimeExceeded, 0),
+		}
+	} else {
+		icmpLayer = &layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeDestinationUnreachable, layers.ICMPv6CodePortUnreachable),
+		}
+	}
+
+	err := icmpLayer.SetNetworkLayerForChecksum(ipLayer)
+	require.NoError(t, err)
+
+	innerIPLayer := &layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolUDP,
+		HopLimit:   64,
+		SrcIP:      config.srcIP,
+		DstIP:      config.Target,
+	}
+
+	payload := packets.WriteUDPFirstBytes(udpInfo)
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+
+	err = gopacket.SerializeLayers(buf, opts,
+		ipLayer,
+		icmpLayer,
+		// there are 4 unused bytes in the ICMP payload before the message body
+		// https://en.wikipedia.org/wiki/ICMPv6#Format
+		gopacket.Payload([]byte{0, 0, 0, 0}),
+		innerIPLayer,
+		gopacket.Payload(payload),
+	)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+func mockRead(mockSource *packets.MockSource, packet []byte) {
+	mockSource.EXPECT().Read(gomock.Any()).DoAndReturn(func(buf []byte) (int, error) {
+		n := copy(buf, packet)
+		return n, nil
+	})
+}
+
+func TestUDPDriverTwoHops(t *testing.T) {
+	config, driver, mockSink, mockSource := initTest(t, false)
+
+	// *** TTL=1 -- get back an ICMP TTL exceeded
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, config, buf, false)
+		require.True(t, config.Target.Equal(addrPort.Addr().AsSlice()))
+		require.Equal(t, config.TargetPort, addrPort.Port())
+		return nil
+	})
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+	var checksum uint16
+	for k := range driver.sentProbes {
+		checksum = k.checksum
+		break
+	}
+	// make the source return an ICMP TTL exceeded
+	hopIP := net.ParseIP("42.42.42.42")
+	icmpResp := mockICMPResp(t, config, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		Checksum: checksum,
+	}, true)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).DoAndReturn(func(deadline time.Time) error {
+		require.True(t, deadline.After(time.Now().Add(500*time.Millisecond)))
+		return nil
+	})
+	mockRead(mockSource, icmpResp)
+
+	// should get back the ICMP hop IP
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), probeResp.TTL)
+	require.True(t, hopIP.Equal(probeResp.IP.AsSlice()))
+	require.False(t, probeResp.IsDest)
+
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, config, buf, false)
+		require.True(t, config.Target.Equal(addrPort.Addr().AsSlice()))
+		require.Equal(t, config.TargetPort, addrPort.Port())
+		return nil
+	})
+
+	// send the second packet
+	driver.SendProbe(2)
+
+	for k := range driver.sentProbes {
+		if checksum != k.checksum {
+			checksum = k.checksum
+			break
+		}
+	}
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+	icmpResp = mockICMPResp(t, config, config.Target, 2, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		Checksum: checksum,
+	}, false)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(2), probeResp.TTL)
+	require.True(t, config.Target.Equal(probeResp.IP.AsSlice()))
+	require.True(t, probeResp.IsDest)
+}
+
+func TestUDPDriverTwoHopsIPV6(t *testing.T) {
+	config, driver, mockSink, mockSource := initTest(t, true)
+
+	// *** TTL=1 -- get back an ICMP TTL exceeded
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, config, buf, true)
+		require.True(t, config.Target.Equal(addrPort.Addr().AsSlice()))
+		require.Equal(t, config.TargetPort, addrPort.Port())
+		return nil
+	})
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+	var checksum uint16
+	for k := range driver.sentProbes {
+		checksum = k.checksum
+		break
+	}
+	// make the source return an ICMP TTL exceeded
+	hopIP := net.ParseIP("2001:0db8:85a3::8a2e:0370:7334")
+	icmpResp := mockICMPRespIPv6(t, config, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		ID:       uint16(1) + config.TargetPort,
+		Checksum: checksum,
+	}, true)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).DoAndReturn(func(deadline time.Time) error {
+		require.True(t, deadline.After(time.Now().Add(500*time.Millisecond)))
+		return nil
+	})
+	mockRead(mockSource, icmpResp)
+
+	// should get back the ICMP hop IP
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), probeResp.TTL)
+	require.True(t, hopIP.Equal(probeResp.IP.AsSlice()))
+	require.False(t, probeResp.IsDest)
+
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, config, buf, true)
+		require.True(t, config.Target.Equal(addrPort.Addr().AsSlice()))
+		require.Equal(t, config.TargetPort, addrPort.Port())
+		return nil
+	})
+
+	// send the second packet
+	driver.SendProbe(2)
+
+	for k := range driver.sentProbes {
+		if checksum != k.checksum {
+			checksum = k.checksum
+			break
+		}
+	}
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+	icmpResp = mockICMPRespIPv6(t, config, config.Target, 2, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		ID:       uint16(2) + config.TargetPort,
+		Checksum: checksum,
+	}, false)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(2), probeResp.TTL)
+	require.True(t, config.Target.Equal(probeResp.IP.AsSlice()))
+	require.True(t, probeResp.IsDest)
+}
+
+func TestUDPDriverICMPMismatchedIP(t *testing.T) {
+	config, driver, mockSink, mockSource := initTest(t, false)
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil)
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+
+	// *** CASE 1: mismatched src IP
+	hopIP := net.ParseIP("42.42.42.42")
+	badConfig := *config
+	badConfig.srcIP = net.ParseIP("8.8.8.8")
+
+	var checksum uint16
+	for k := range driver.sentProbes {
+		checksum = k.checksum
+		break
+	}
+	icmpResp := mockICMPResp(t, &badConfig, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		Checksum: checksum,
+	}, true)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+
+	// *** CASE 2: mismatched dest IP
+	hopIP = net.ParseIP("42.42.42.42")
+	badConfig = *config
+	badConfig.Target = net.ParseIP("8.8.8.8")
+	for k := range driver.sentProbes {
+		checksum = k.checksum
+		break
+	}
+	icmpResp = mockICMPResp(t, &badConfig, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		Checksum: checksum,
+	}, true)
+
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+}
+
+func TestUDPDriverICMPMismatchedUDPInfo(t *testing.T) {
+	config, driver, mockSink, mockSource := initTest(t, false)
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil)
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+
+	// *** get back an ICMP TTL exceeded, but for the wrong seq num
+	hopIP := net.ParseIP("42.42.42.42")
+	var checksum uint16
+	for k := range driver.sentProbes {
+		checksum = k.checksum
+		break
+	}
+	icmpResp := mockICMPResp(t, config, hopIP, 2, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort,
+		Checksum: checksum + 1,
+	}, true)
+
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+
+	// *** get back an ICMP TTL exceeded, but for the wrong srcPort
+	icmpResp = mockICMPResp(t, config, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort + 1,
+		DstPort:  config.TargetPort,
+		Checksum: checksum,
+	}, true)
+
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+
+	// *** get back an ICMP TTL exceeded, but for the wrong dstPort
+	icmpResp = mockICMPResp(t, config, hopIP, 1, packets.UDPInfo{
+		SrcPort:  config.srcPort,
+		DstPort:  config.TargetPort + 1,
+		Checksum: checksum,
+	}, true)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+}

--- a/pkg/networkpath/traceroute/udp/udpv4.go
+++ b/pkg/networkpath/traceroute/udp/udpv4.go
@@ -8,13 +8,13 @@ package udp
 
 import (
 	"fmt"
+	"golang.org/x/net/ipv4"
 	"net"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/icmp"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"golang.org/x/net/ipv4"
 )
 
 type (
@@ -70,19 +70,9 @@ func (u *UDPv4) Close() error {
 // createRawUDPBuffer creates a raw UDP packet with the specified parameters
 //
 // the nolint:unused is necessary because we don't yet use this outside the Windows implementation
-func (u *UDPv4) createRawUDPBuffer(sourceIP net.IP, sourcePort uint16, destIP net.IP, destPort uint16, ttl int) (*ipv4.Header, []byte, uint16, int, error) { //nolint:unused
+func (u *UDPv4) createRawUDPBuffer(sourceIP net.IP, sourcePort uint16, destIP net.IP, destPort uint16, ttl int) (uint16, []byte, uint16, error) { //nolint:unused
 	// if this function is modified in a way that changes the size,
 	// update the NewSerializeBufferExpectedSize call in NewUDPv4
-	ipLayer := &layers.IPv4{
-		Version:  4,
-		Length:   20,
-		TTL:      uint8(ttl),
-		Id:       uint16(41821),
-		Protocol: 17, // hard code UDP so other OSs can use it
-		DstIP:    destIP,
-		SrcIP:    sourceIP,
-		Flags:    layers.IPv4DontFragment, // needed for dublin-traceroute-like NAT detection
-	}
 	udpLayer := &layers.UDP{
 		SrcPort: layers.UDPPort(sourcePort),
 		DstPort: layers.UDPPort(destPort),
@@ -97,32 +87,61 @@ func (u *UDPv4) createRawUDPBuffer(sourceIP net.IP, sourcePort uint16, destIP ne
 	// as is done in dublin-traceroute. Gopacket doesn't expose
 	// the checksum computations and modifying the IP header after
 	// serialization would change its checksum
-	err := udpLayer.SetNetworkLayerForChecksum(ipLayer)
-	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("failed to create packet checksum: %w", err)
+	var ipLayer gopacket.SerializableLayer
+	if destIP.To4() != nil {
+		ipv4Layer := &layers.IPv4{
+			Version:  4,
+			Length:   20,
+			TTL:      uint8(ttl),
+			Id:       uint16(41821),
+			Protocol: layers.IPProtocolUDP, // hard code UDP so other OSs can use it
+			DstIP:    destIP,
+			SrcIP:    sourceIP,
+			Flags:    layers.IPv4DontFragment, // needed for dublin-traceroute-like NAT detection
+		}
+		err := udpLayer.SetNetworkLayerForChecksum(ipv4Layer)
+		if err != nil {
+			return 0, nil, 0, fmt.Errorf("failed to create packet checksum: %w", err)
+		}
+		ipLayer = ipv4Layer
+	} else {
+		// Create IPv6 header
+		ipv6Layer := &layers.IPv6{
+			Version:    6,
+			HopLimit:   uint8(ttl),
+			NextHeader: layers.IPProtocolUDP,
+			SrcIP:      sourceIP,
+			DstIP:      destIP,
+		}
+		err := udpLayer.SetNetworkLayerForChecksum(ipv6Layer)
+		if err != nil {
+			return 0, nil, 0, fmt.Errorf("failed to create packet checksum: %w", err)
+		}
+		ipLayer = ipv6Layer
 	}
-
 	// clear the gopacket.SerializeBuffer
 	if len(u.buffer.Bytes()) > 0 {
-		if err = u.buffer.Clear(); err != nil {
+		if err := u.buffer.Clear(); err != nil {
 			u.buffer = gopacket.NewSerializeBuffer()
 		}
 	}
 	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
-	err = gopacket.SerializeLayers(u.buffer, opts,
+	err := gopacket.SerializeLayers(u.buffer, opts,
 		ipLayer,
 		udpLayer,
 		gopacket.Payload(udpPayload),
 	)
 	if err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("failed to serialize packet: %w", err)
+		return 0, nil, 0, fmt.Errorf("failed to serialize packet: %w", err)
 	}
+
 	packet := u.buffer.Bytes()
-
-	var ipHdr ipv4.Header
-	if err := ipHdr.Parse(packet[:20]); err != nil {
-		return nil, nil, 0, 0, fmt.Errorf("failed to parse IP header: %w", err)
+	if destIP.To4() != nil {
+		var ipHdr ipv4.Header
+		if err := ipHdr.Parse(packet[:20]); err != nil {
+			return 0, nil, 0, fmt.Errorf("failed to parse IP header: %w", err)
+		}
+		id = uint16(ipHdr.ID)
 	}
-
-	return &ipHdr, packet, udpLayer.Checksum, 20, nil
+	return id, packet, udpLayer.Checksum, nil
 }

--- a/pkg/networkpath/traceroute/udp/udpv4_test.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_test.go
@@ -57,11 +57,10 @@ func TestCreateRawUDPBuffer(t *testing.T) {
 	// based on bytes 26-27 of expectedPktBytes
 	expectedChecksum := uint16(0xdba6)
 
-	ipHeader, pktBytes, actualChecksum, headerLength, err := udp.createRawUDPBuffer(udp.srcIP, udp.srcPort, udp.Target, udp.TargetPort, ttl)
+	ipHeader, pktBytes, actualChecksum, err := udp.createRawUDPBuffer(udp.srcIP, udp.srcPort, udp.Target, udp.TargetPort, ttl)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedIPHeader, ipHeader)
-	assert.Equal(t, 20, headerLength)
 	assert.Equal(t, expectedPktBytes, pktBytes)
 	assert.Equal(t, expectedChecksum, actualChecksum)
 }

--- a/pkg/networkpath/traceroute/udp/udpv4_test.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_test.go
@@ -57,10 +57,10 @@ func TestCreateRawUDPBuffer(t *testing.T) {
 	// based on bytes 26-27 of expectedPktBytes
 	expectedChecksum := uint16(0xdba6)
 
-	ipHeader, pktBytes, actualChecksum, err := udp.createRawUDPBuffer(udp.srcIP, udp.srcPort, udp.Target, udp.TargetPort, ttl)
+	ipHeaderID, pktBytes, actualChecksum, err := udp.createRawUDPBuffer(udp.srcIP, udp.srcPort, udp.Target, udp.TargetPort, ttl)
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedIPHeader, ipHeader)
+	assert.Equal(t, uint16(expectedIPHeader.ID), ipHeaderID)
 	assert.Equal(t, expectedPktBytes, pktBytes)
 	assert.Equal(t, expectedChecksum, actualChecksum)
 }

--- a/pkg/networkpath/traceroute/udp/udpv4_windows.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_windows.go
@@ -66,7 +66,7 @@ func (u *UDPv4) TracerouteSequential() (*common.Results, error) {
 }
 
 func (u *UDPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, timeout time.Duration) (*common.Hop, error) {
-	ipHdr, buffer, udpChecksum, _, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
+	ipHdr, buffer, udpChecksum, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
 	if err != nil {
 		log.Errorf("failed to create UDP packet with TTL: %d, error: %s", ttl, err.Error())
 		return nil, err

--- a/pkg/networkpath/traceroute/udp/udpv4_windows.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_windows.go
@@ -66,7 +66,7 @@ func (u *UDPv4) TracerouteSequential() (*common.Results, error) {
 }
 
 func (u *UDPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, timeout time.Duration) (*common.Hop, error) {
-	ipHdr, buffer, udpChecksum, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
+	ipHdrID, buffer, udpChecksum, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
 	if err != nil {
 		log.Errorf("failed to create UDP packet with TTL: %d, error: %s", ttl, err.Error())
 		return nil, err
@@ -82,7 +82,7 @@ func (u *UDPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, timeout time.
 		windows.IPPROTO_ICMP: u.icmpParser.Match,
 	}
 	start := time.Now() // TODO: is this the best place to start?
-	hopIP, end, err := rs.ListenPackets(timeout, u.srcIP, u.srcPort, u.Target, u.TargetPort, uint32(udpChecksum), uint16(ipHdr.ID), matcherFuncs)
+	hopIP, end, err := rs.ListenPackets(timeout, u.srcIP, u.srcPort, u.Target, u.TargetPort, uint32(udpChecksum), ipHdrID, matcherFuncs)
 	if err != nil {
 		log.Errorf("failed to listen for packets: %s", err.Error())
 		return nil, err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a UDP traceroute driver for IPv6 and tests for both IPv4 and IPv6 
### Motivation
This PR adds IPv6 support on udp for the existing traceroute methods

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Build for an ec2 box with IPv6 enabled:
```
GOARCH=amd64 go build github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/udp/portable_udp
```
2. `scp` it to the ec2 box
3. Traceroute to Google's public DNS servers: `sudo -E ./portable_udp [2001:4860:4860::8888]:33434`


### Possible Drawbacks / Trade-offs
Also this isn't tested like the TCP driver yet

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->