### PR TITLE
otlp: do not try to enrich tags if OriginID is empty

### DIFF
--- a/comp/otelcol/otlp/collector.go
+++ b/comp/otelcol/otlp/collector.go
@@ -70,16 +70,18 @@ func (t *tagEnricher) Enrich(_ context.Context, extraTags []string, dimensions *
 	enrichedTags := make([]string, 0, len(extraTags)+len(dimensions.Tags()))
 	enrichedTags = append(enrichedTags, extraTags...)
 	enrichedTags = append(enrichedTags, dimensions.Tags()...)
-	prefix, id, err := types.ExtractPrefixAndID(dimensions.OriginID())
-	if err != nil {
-		log.Tracef("Cannot get tags for entity %s: %s", dimensions.OriginID(), err)
-	} else {
-		entityID := types.NewEntityID(prefix, id)
-		entityTags, err := t.tagger.Tag(entityID, t.cardinality)
+	if originID := dimensions.OriginID(); originID != "" {
+		prefix, id, err := types.ExtractPrefixAndID(originID)
 		if err != nil {
-			log.Tracef("Cannot get tags for entity %s: %s", dimensions.OriginID(), err)
+			log.Tracef("Cannot get tags for entity %s: %s", originID, err)
 		} else {
-			enrichedTags = append(enrichedTags, entityTags...)
+			entityID := types.NewEntityID(prefix, id)
+			entityTags, err := t.tagger.Tag(entityID, t.cardinality)
+			if err != nil {
+				log.Tracef("Cannot get tags for entity %s: %s", originID, err)
+			} else {
+				enrichedTags = append(enrichedTags, entityTags...)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

When `dimensions.OriginID()` is empty, a pretty common case especially in SMP, `types.ExtractPrefixAndID` ends up returning an error that the code ends up passing to `log.Tracef`.
```
2025-06-18 09:06:42 UTC | CORE | TRACE | (comp/otelcol/otlp/collector.go:75 in Enrich) | Cannot get tags for entity : unsupported tagger entity id format "", correct format is `{prefix}://{id}`
```

The issue with `log.Tracef` is that this function has a huge cost compared to what it brings based on multiple factors:
- the default log level doesn't include trace logs, meaning that those logs are often hidden, and thus they can be super spammy without anyone really noticing
- `log.*` actually take a lock deep in the mutex, causing some lock contention (reported by the profiling product)
- `log.Tracef` is a variadic function, calling another function taking a closure making all of this difficult to inline for the compiler

This PR adds an early check for emptyness skipping the whole enrichment part.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->