### PR TITLE
[EBPF] enable gpu host tags collection by default

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -498,8 +498,8 @@ api_key:
 #
 # gce_metadata_timeout: 1000
 
-## @param collect_gpu_tags - boolean - optional - default: false
-## @env DD_COLLECT_GPU_TAGS - boolean - optional - default: false
+## @param collect_gpu_tags - boolean - optional - default: true
+## @env DD_COLLECT_GPU_TAGS - boolean - optional - default: true
 ## Collect GPU related host tags
 #
 # collect_gpu_tags: false
@@ -4751,10 +4751,10 @@ api_key:
 ##
 ## Settings can be configured via environment variables or the application_monitoring.yaml file.
 ## Configuration precedence (highest to lowest priority):
-##   1. Fleet-managed config file 
+##   1. Fleet-managed config file
 ##      (etc/datadog-agent/managed/datadog-agent/stable/application_monitoring.yaml)
 ##   2. Environment variables
-##   3. Local config file 
+##   3. Local config file
 ##      (etc/datadog-agent/application_monitoring.yaml)
 # apm_configuration_rules:
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -615,7 +615,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
 	// GPU
-	config.BindEnvAndSetDefault("collect_gpu_tags", false)
+	config.BindEnvAndSetDefault("collect_gpu_tags", true)
 	config.BindEnvAndSetDefault("nvml_lib_path", "")
 	config.BindEnvAndSetDefault("enable_nvml_detection", false)
 

--- a/releasenotes/notes/enable-gpu-host-tags-collection-by-default-f3734b26d31068e8.yaml
+++ b/releasenotes/notes/enable-gpu-host-tags-collection-by-default-f3734b26d31068e8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    changed `collect_gpu_tags` config flag to be enabled by default. Now the agent will collect an additional `gpu_host` host tag for all hosts that have Nvidia GPUs

--- a/releasenotes/notes/enable-gpu-host-tags-collection-by-default-f3734b26d31068e8.yaml
+++ b/releasenotes/notes/enable-gpu-host-tags-collection-by-default-f3734b26d31068e8.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    changed `collect_gpu_tags` config flag to be enabled by default. Now the agent will collect an additional `gpu_host` host tag for all hosts that have Nvidia GPUs
+    Change `collect_gpu_tags` config flag to be enabled by default. Now the Agent collects an additional `gpu_host` host tag for all hosts that have Nvidia GPUs.


### PR DESCRIPTION
### What does this PR do?

changes the feature flag to collect an extra host tag `gpu_host`

### Motivation

simplify onboarding for the customers

### Describe how you validated your changes
this flag was [introduced](https://github.com/DataDog/datadog-agent/pull/35402) in agent version 7.66 and enabled on staging and prod for a while

### Possible Drawbacks / Trade-offs

### Additional Notes

updated release notes
