### PR TITLE
[CWS] fix container id from unknown container runtime

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -197,9 +197,10 @@ static __attribute__((always_inline)) u64 get_imds_ip() {
 #define CGROUP_MANAGER_CRI 4
 #define CGROUP_MANAGER_SYSTEMD 5
 
-#define CGROUP_MANAGER_MASK 0b111
-#define CGROUP_SYSTEMD_SERVICE (0 << 8)
-#define CGROUP_SYSTEMD_SCOPE   (1 << 8)
+#define CGROUP_MANAGER_MASK 0xff
+
+#define CGROUP_SYSTEMD_SERVICE (1 << 8)
+#define CGROUP_SYSTEMD_SCOPE (1 << 8) + 1
 
 #define ACTIVE_FLOWS_MAX_SIZE 128
 

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -537,7 +537,7 @@ func (fh *EBPFFieldHandlers) ResolveCGroupID(ev *model.Event, e *model.CGroupCon
 // ResolveCGroupManager resolves the manager of the cgroup
 func (fh *EBPFFieldHandlers) ResolveCGroupManager(ev *model.Event, _ *model.CGroupContext) string {
 	if entry, _ := fh.ResolveProcessCacheEntry(ev, nil); entry != nil {
-		if manager := containerutils.CGroupManager(entry.CGroup.CGroupFlags); manager != 0 {
+		if manager := entry.CGroup.CGroupFlags.GetCGroupManager(); manager != 0 {
 			return manager.String()
 		}
 	}

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1531,11 +1531,8 @@ func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *mod
 	// Assume that the container runtime from the kernel side may be incorrect or missing
 	// In that case fallback to the userland container runtime.
 	if !cgroupContext.CGroupFlags.IsSystemd() && cgroupContext.CGroupID != "" {
-		containerID, cgroupFlags := containerutils.FindContainerID(cgroupContext.CGroupID)
-		cgroupContext.CGroupFlags = cgroupFlags
-
-		pce.ContainerID = containerID
-		pce.Process.ContainerID = containerID
+		pce.Process.ContainerID, cgroupContext.CGroupFlags = containerutils.FindContainerID(cgroupContext.CGroupID)
+		pce.ContainerID = pce.Process.ContainerID
 	}
 
 	pce.Process.CGroup = *cgroupContext

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -24,7 +24,7 @@ const (
 	CGroupManagerSystemd                          // systemd
 	CGroupManagerECS                              // ecs
 
-	CgroupManagerUndefined CGroupManager = 255
+	CgroupManagerUndefined CGroupManager = 255 // undefined
 )
 
 // CGroup flags

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -23,12 +23,14 @@ const (
 	CGroupManagerCRI                              // containerd
 	CGroupManagerSystemd                          // systemd
 	CGroupManagerECS                              // ecs
+
+	CgroupManagerUndefined CGroupManager = 255
 )
 
 // CGroup flags
 const (
-	SystemdService CGroupFlags = (0 << 8)
-	SystemdScope   CGroupFlags = (1 << 8)
+	SystemdService CGroupFlags = iota + (1 << 8)
+	SystemdScope
 )
 
 // RuntimeToken holds the cgroup token used by the different runtimes
@@ -42,13 +44,16 @@ var RuntimeToken = []struct {
 	{"crio-", CGroupManagerCRIO},
 	{"libpod-", CGroupManagerPodman},
 	{"ecs/", CGroupManagerECS},
+
+	// default to containerd in case of kubepods
+	{"kubepods", CGroupManagerCRI},
 }
 
-func getContainerRuntime(cgroupID CGroupID) CGroupFlags {
+func getCGroupManager(cgroupID CGroupID) CGroupManager {
 	for _, rt := range RuntimeToken {
 		if strings.Contains(string(cgroupID), rt.token) {
-			return CGroupFlags(rt.flags)
+			return rt.flags
 		}
 	}
-	return 0
+	return CgroupManagerUndefined
 }

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -17,14 +17,13 @@ type CGroupManager uint64
 
 // CGroup managers
 const (
-	CGroupManagerDocker  CGroupManager = iota + 1 // docker
-	CGroupManagerCRIO                             // cri-o
-	CGroupManagerPodman                           // podman
-	CGroupManagerCRI                              // containerd
-	CGroupManagerSystemd                          // systemd
-	CGroupManagerECS                              // ecs
-
-	CgroupManagerUndefined CGroupManager = 255 // undefined
+	CgroupManagerUndefined CGroupManager = iota // unknown
+	CGroupManagerDocker                         // docker
+	CGroupManagerCRIO                           // cri-o
+	CGroupManagerPodman                         // podman
+	CGroupManagerCRI                            // containerd
+	CGroupManagerSystemd                        // systemd
+	CGroupManagerECS                            // ecs
 )
 
 // CGroup flags
@@ -45,7 +44,7 @@ var RuntimeToken = []struct {
 	{"libpod-", CGroupManagerPodman},
 	{"ecs/", CGroupManagerECS},
 
-	// default to containerd in case of kubepods
+	// fallback to containerd in case of kubepods a
 	{"kubepods", CGroupManagerCRI},
 }
 

--- a/pkg/security/secl/containerutils/cgroup_strings.go
+++ b/pkg/security/secl/containerutils/cgroup_strings.go
@@ -8,32 +8,22 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[CgroupManagerUndefined-0]
 	_ = x[CGroupManagerDocker-1]
 	_ = x[CGroupManagerCRIO-2]
 	_ = x[CGroupManagerPodman-3]
 	_ = x[CGroupManagerCRI-4]
 	_ = x[CGroupManagerSystemd-5]
 	_ = x[CGroupManagerECS-6]
-	_ = x[CgroupManagerUndefined-255]
 }
 
-const (
-	_CGroupManager_name_0 = "dockercri-opodmancontainerdsystemdecs"
-	_CGroupManager_name_1 = "undefined"
-)
+const _CGroupManager_name = "unknowndockercri-opodmancontainerdsystemdecs"
 
-var (
-	_CGroupManager_index_0 = [...]uint8{0, 6, 11, 17, 27, 34, 37}
-)
+var _CGroupManager_index = [...]uint8{0, 7, 13, 18, 24, 34, 41, 44}
 
 func (i CGroupManager) String() string {
-	switch {
-	case 1 <= i && i <= 6:
-		i -= 1
-		return _CGroupManager_name_0[_CGroupManager_index_0[i]:_CGroupManager_index_0[i+1]]
-	case i == 255:
-		return _CGroupManager_name_1
-	default:
+	if i >= CGroupManager(len(_CGroupManager_index)-1) {
 		return "CGroupManager(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
+	return _CGroupManager_name[_CGroupManager_index[i]:_CGroupManager_index[i+1]]
 }

--- a/pkg/security/secl/containerutils/cgroup_strings.go
+++ b/pkg/security/secl/containerutils/cgroup_strings.go
@@ -14,16 +14,26 @@ func _() {
 	_ = x[CGroupManagerCRI-4]
 	_ = x[CGroupManagerSystemd-5]
 	_ = x[CGroupManagerECS-6]
+	_ = x[CgroupManagerUndefined-255]
 }
 
-const _CGroupManager_name = "dockercri-opodmancontainerdsystemdecs"
+const (
+	_CGroupManager_name_0 = "dockercri-opodmancontainerdsystemdecs"
+	_CGroupManager_name_1 = "CgroupManagerUndefined"
+)
 
-var _CGroupManager_index = [...]uint8{0, 6, 11, 17, 27, 34, 37}
+var (
+	_CGroupManager_index_0 = [...]uint8{0, 6, 11, 17, 27, 34, 37}
+)
 
 func (i CGroupManager) String() string {
-	i -= 1
-	if i >= CGroupManager(len(_CGroupManager_index)-1) {
-		return "CGroupManager(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	switch {
+	case 1 <= i && i <= 6:
+		i -= 1
+		return _CGroupManager_name_0[_CGroupManager_index_0[i]:_CGroupManager_index_0[i+1]]
+	case i == 255:
+		return _CGroupManager_name_1
+	default:
+		return "CGroupManager(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _CGroupManager_name[_CGroupManager_index[i]:_CGroupManager_index[i+1]]
 }

--- a/pkg/security/secl/containerutils/cgroup_strings.go
+++ b/pkg/security/secl/containerutils/cgroup_strings.go
@@ -19,7 +19,7 @@ func _() {
 
 const (
 	_CGroupManager_name_0 = "dockercri-opodmancontainerdsystemdecs"
-	_CGroupManager_name_1 = "CgroupManagerUndefined"
+	_CGroupManager_name_1 = "undefined"
 )
 
 var (

--- a/pkg/security/secl/containerutils/helpers_test.go
+++ b/pkg/security/secl/containerutils/helpers_test.go
@@ -17,7 +17,7 @@ import (
 type testCase struct {
 	input  string
 	output string
-	flags  CGroupManager
+	flags  CGroupFlags
 }
 
 func TestFindContainerID(t *testing.T) {
@@ -25,76 +25,89 @@ func TestFindContainerID(t *testing.T) {
 		{ // classic decimal
 			input:  "0123456789012345678901234567890123456789012345678901234567890123",
 			output: "0123456789012345678901234567890123456789012345678901234567890123",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // classic hexa
 			input:  "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
 			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // classic hexa as present in proc
 			input:  "/docker/aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
 			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
-			flags:  CGroupManagerDocker,
+			flags:  CGroupFlags(CGroupManagerDocker),
 		},
 		{ // another proc based
 			input:  "/kubepods.slice/kubepods-pod48d25824_cbe2_4fdc_9928_5bb49e05473d.slice/cri-containerd-c40dff48f1d53c3f07a50aa12bb9ae0e58c0927dc6b1d77e3f166784722642ad.scope",
 			output: "c40dff48f1d53c3f07a50aa12bb9ae0e58c0927dc6b1d77e3f166784722642ad",
-			flags:  CGroupManagerCRI,
+			flags:  CGroupFlags(CGroupManagerCRI),
 		},
 		{ // with prefix/suffix
 			input:  "prefixaAbBcCdDeEfF2345678901234567890123456789012345678901234567890123suffix",
 			output: "aAbBcCdDeEfF2345678901234567890123456789012345678901234567890123",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // path reducer test
 			input:  "/var/run/docker/overlay2/47c1f1930c1831f2359c6d276912c583be1cda5924233cf273022b91763a20f7/merged/etc/passwd",
 			output: "47c1f1930c1831f2359c6d276912c583be1cda5924233cf273022b91763a20f7",
-			flags:  CGroupManagerDocker,
+			flags:  CGroupFlags(CGroupManagerDocker),
 		},
 		{ // GARDEN
 			input:  "01234567-0123-4567-890a-bcde",
 			output: "01234567-0123-4567-890a-bcde",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // GARDEN as present in proc
 			input:  "/docker/01234567-0123-4567-890a-bcde",
 			output: "01234567-0123-4567-890a-bcde",
-			flags:  CGroupManagerDocker,
+			flags:  CGroupFlags(CGroupManagerDocker),
 		},
-		{ // Some random path which could match garden format
+		{ // incorrect container id format
 			input:  "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-f9176c6a-2a34-4ce2-86af-60d16888ed8e.scope",
 			output: "",
-			flags:  CGroupManagerSystemd | CGroupManager(SystemdScope),
+			flags:  CGroupFlags(CGroupManagerSystemd) | SystemdScope,
 		},
 		{ // GARDEN with prefix / suffix
 			input:  "prefix01234567-0123-4567-890a-bcdesuffix",
 			output: "01234567-0123-4567-890a-bcde",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // double with first having a bad format
 			input:  "0123456789aAbBcCdDeEfF0123456789-abcdef6789/0123456789aAbBcCdDeEfF0123456789-0123456789",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // Docker as present in proc
 			input:  "/docker/0123456789aAbBcCdDeEfF0123456789-0123456789",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
-			flags:  CGroupManagerDocker,
+			flags:  CGroupFlags(CGroupManagerDocker),
 		},
 		{ // prefix / suffix
 			input:  "prefix0123456789aAbBcCdDeEfF0123456789-0123456789suffix",
 			output: "0123456789aAbBcCdDeEfF0123456789-0123456789",
+			flags:  CGroupFlags(CgroupManagerUndefined),
 		},
 		{ // ECS
 			input:  "/ecs/0123456789aAbBcCdDeEfF0123456789/0123456789aAbBcCdDeEfF0123456789-012345678",
 			output: "0123456789aAbBcCdDeEfF0123456789-012345678",
-			flags:  CGroupManagerECS,
+			flags:  CGroupFlags(CGroupManagerECS),
 		},
 		{ // EKS
 			input:  "/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981",
 			output: "7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981",
-			flags:  CGroupManagerECS,
+			flags:  CGroupFlags(CGroupManagerECS),
+		},
+		{ // containerd
+			input:  "/kubepods/besteffort/pod8bbdd97b-f902-4e16-8235-4ac18307cef6/09d3f62464b8761e9106350bacc609deb0dc639403888bdf2112033cb30e1bf6",
+			output: "09d3f62464b8761e9106350bacc609deb0dc639403888bdf2112033cb30e1bf6",
+			flags:  CGroupFlags(CGroupManagerCRI),
 		},
 	}
 
 	for _, test := range testCases {
-		containerID, containerFlags := FindContainerID(CGroupID(test.input))
+		containerID, flags := FindContainerID(CGroupID(test.input))
 		assert.Equal(t, test.output, string(containerID))
-		assert.Equal(t, uint64(test.flags), containerFlags, "wrong flags for container %s", containerID)
+		assert.Equal(t, test.flags, flags, "wrong flags for container %s", containerID)
+		assert.Equal(t, test.flags.GetCGroupManager(), flags.GetCGroupManager(), "wrong flags for container %s", containerID)
 	}
 }

--- a/pkg/security/secl/containerutils/types.go
+++ b/pkg/security/secl/containerutils/types.go
@@ -16,9 +16,19 @@ type CGroupID string
 type CGroupFlags uint64
 
 // CGroupManagerMask holds the bitmask for the cgroup manager
-const CGroupManagerMask CGroupFlags = 0b111
+const CGroupManagerMask CGroupFlags = 0xff
 
 // IsContainer returns whether a cgroup maps to a container
 func (f CGroupFlags) IsContainer() bool {
 	return (f&CGroupManagerMask != 0) && ((f & CGroupManagerMask) != CGroupFlags(CGroupManagerSystemd))
+}
+
+// IsSystemd returns whether a cgroup maps to a systemd cgroup
+func (f CGroupFlags) IsSystemd() bool {
+	return CGroupManager(f&CGroupManagerMask) == CGroupManagerSystemd
+}
+
+// GetCGroupManager returns the cgroup manager from the flags
+func (f CGroupFlags) GetCGroupManager() CGroupManager {
+	return CGroupManager(f & CGroupManagerMask)
 }

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -44,8 +44,7 @@ type ControlGroup struct {
 
 // GetContainerContext returns both the container ID and its flags
 func (cg ControlGroup) GetContainerContext() (containerutils.ContainerID, containerutils.CGroupFlags) {
-	id, flags := containerutils.FindContainerID(containerutils.CGroupID(cg.Path))
-	return containerutils.ContainerID(id), containerutils.CGroupFlags(flags)
+	return containerutils.FindContainerID(containerutils.CGroupID(cg.Path))
 }
 
 func parseCgroupLine(line string) (string, string, string, error) {

--- a/pkg/security/utils/cgroup_test.go
+++ b/pkg/security/utils/cgroup_test.go
@@ -31,7 +31,7 @@ type testCgroup struct {
 	cgroupContent string
 	error         bool
 	containerID   string
-	runtime       containerutils.CGroupFlags
+	flags         containerutils.CGroupFlags
 	path          string
 }
 
@@ -56,7 +56,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerCRI),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerCRI),
 			path:        "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope",
 		},
 		{
@@ -78,7 +78,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
 			path:        "/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182",
 		},
 		{
@@ -100,7 +100,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd) | containerutils.SystemdService,
 			path:        "/system.slice/cups.service",
 		},
 		{
@@ -122,7 +122,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd) | containerutils.SystemdService,
 			path:        "/user.slice/user-1000.slice/user@1000.service/xdg-desktop-portal-gtk.service",
 		},
 		{
@@ -144,7 +144,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
 			path:        "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-1d0750f1-4e83-4b26-81ae-e3770394b7f3.scope",
 		},
 		{
@@ -165,7 +165,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     0,
+			flags:       0,
 			path:        "",
 		},
 		{
@@ -187,7 +187,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
 			path:        "/init.scope",
 		},
 		{
@@ -196,7 +196,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
 			path:        "/system.slice/docker-473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47.scope",
 		},
 		{
@@ -205,7 +205,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd) | containerutils.SystemdService,
 			path:        "/system.slice/ssh.service",
 		},
 		{
@@ -214,7 +214,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
 			path:        "/user.slice/user-1000.slice/session-4.scope",
 		},
 		{
@@ -223,7 +223,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
 			path:        "/init.scope",
 		},
 		{
@@ -232,7 +232,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "",
-			runtime:     0,
+			flags:       0,
 			path:        "",
 		},
 		{
@@ -251,7 +251,7 @@ func TestCGroup(t *testing.T) {
 `,
 			error:       false,
 			containerID: "7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerECS),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerECS),
 			path:        "/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981",
 		},
 		{
@@ -262,7 +262,7 @@ func TestCGroup(t *testing.T) {
 1:name=systemd:/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770`,
 			error:       false,
 			containerID: "8a28a84664034325be01ca46b33d1dd3-4092616770",
-			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerECS),
+			flags:       containerutils.CGroupFlags(containerutils.CGroupManagerECS),
 			path:        "/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770",
 		},
 	}
@@ -270,7 +270,7 @@ func TestCGroup(t *testing.T) {
 	for _, test := range testsCgroup {
 		var (
 			containerID   containerutils.ContainerID
-			runtime       containerutils.CGroupFlags
+			flags         containerutils.CGroupFlags
 			cgroupContext CGroupContext
 			cgroupPath    string
 		)
@@ -287,16 +287,16 @@ func TestCGroup(t *testing.T) {
 					return false
 				}
 
-				containerID, runtime = cgroup.GetContainerContext()
+				containerID, flags = cgroup.GetContainerContext()
 				cgroupContext.CGroupID = containerutils.CGroupID(cgroup.Path)
-				cgroupContext.CGroupFlags = runtime
+				cgroupContext.CGroupFlags = flags
 				cgroupPath = path
 				return true
 			})
 
 			assert.Equal(t, test.error, err != nil)
 			assert.Equal(t, containerutils.ContainerID(test.containerID), containerID)
-			assert.Equal(t, test.runtime, runtime)
+			assert.Equal(t, test.flags, flags)
 			assert.Equal(t, test.path, cgroupPath)
 		})
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use the user space container id/container manager userspace side when the manager is not systemd. Recent versions of containerd break the container runtime kernel side detection.

Add unit tests.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->