### PR TITLE
[cluster-agent] Add new cws instrumentation metrics

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -77,20 +77,20 @@ var (
 	LibInjectionErrors = telemetry.NewCounterWithOpts("admission_webhooks", "library_injection_errors",
 		[]string{"language", "auto_detected", "injection_type"}, "Number of library injection failures by language and injection type",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	CWSExecInstrumentationAttempts = telemetry.NewHistogramWithOpts(
-		"admission_webhooks",
-		"cws_exec_instrumentation_attempts",
-		[]string{"mode", "injected", "reason"},
-		"Distribution of exec requests instrumentation attempts by CWS Instrumentation mode",
-		prometheus.LinearBuckets(0, 1, 1),
+	CWSPodMutationAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "cws_pod_mutation_attempts",
+		[]string{"mode", "injected", "reason"}, "Count of pod mutation attempts per CWS instrumentation mode",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	CWSPodInstrumentationAttempts = telemetry.NewHistogramWithOpts(
-		"admission_webhooks",
-		"cws_pod_instrumentation_attempts",
-		[]string{"mode", "injected", "reason"},
-		"Distribution of pod requests instrumentation attempts by CWS Instrumentation mode",
-		prometheus.LinearBuckets(0, 1, 1),
+	CWSExecMutationAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "cws_exec_mutation_attempts",
+		[]string{"mode", "injected", "reason"}, "Count of exec mutation attempts per CWS instrumentation mode",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	CWSResponseDuration = telemetry.NewHistogramWithOpts(
+		"admission_webhooks",
+		"cws_response_duration",
+		[]string{"mode", "webhook_name", "type", "success", "injected"},
+		"CWS Webhook response duration distribution (in seconds).",
+		prometheus.DefBuckets, // The default prometheus buckets are adapted to measure response time
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
 	RemoteConfigs = telemetry.NewGaugeWithOpts("admission_webhooks", "rc_provider_configs",
 		[]string{}, "Number of valid remote configurations.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -404,7 +404,14 @@ func (ci *CWSInstrumentation) WebhookForCommands() *WebhookForCommands {
 }
 
 func (ci *CWSInstrumentation) injectForCommand(request *admission.Request) *admiv1.AdmissionResponse {
-	return common.MutationResponse(mutatePodExecOptions(request.Object, request.Name, request.Namespace, ci.webhookForCommands.Name(), request.UserInfo, ci.injectCWSCommandInstrumentation, request.DynamicClient, request.APIClient))
+	return common.MutationResponse(mutatePodExecOptions(request.Object, request.Name, request.Namespace, ci.webhookForCommands.Name(), request.UserInfo, ci.injectCWSCommandInstrumentationMeasured, request.DynamicClient, request.APIClient))
+}
+
+func (ci *CWSInstrumentation) resolveNodeArchMeasured(nodeName string, apiClient kubernetes.Interface) (string, error) {
+	start := time.Now()
+	arch, err := ci.resolveNodeArch(nodeName, apiClient)
+	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), ci.mode.String(), webhookForCommandsName, "arch_resolution", strconv.FormatBool(len(arch) > 0 && err == nil), "")
+	return arch, err
 }
 
 func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kubernetes.Interface) (string, error) {
@@ -459,16 +466,35 @@ func (ci *CWSInstrumentation) hasReadonlyRootfs(pod *corev1.Pod, container strin
 	return false
 }
 
-func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, _ dynamic.Interface, apiClient kubernetes.Interface) (bool, error) {
+func (ci *CWSInstrumentation) getPod(apiClient kubernetes.Interface, name string, ns string) (*corev1.Pod, error) {
+	start := time.Now()
+	pod, err := apiClient.CoreV1().Pods(ns).Get(context.Background(), name, metav1.GetOptions{})
+	// measure execution time
+	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), ci.mode.String(), webhookForCommandsName, "query_pod", strconv.FormatBool(err == nil), "")
+	return pod, err
+}
+
+func (ci *CWSInstrumentation) injectCWSCommandInstrumentationMeasured(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, _ dynamic.Interface, apiClient kubernetes.Interface) (bool, error) {
+	start := time.Now()
+	injected, err := ci.injectCWSCommandInstrumentation(exec, name, ns, userInfo, apiClient)
+	totalTime := time.Since(start).Seconds()
+	if totalTime > 10 {
+		log.Warnf("Pod exec request to %s/%s (container %s) by %s timed out after %f seconds", ns, name, exec.Container, userInfo.Username, totalTime)
+	}
+	metrics.CWSResponseDuration.Observe(totalTime, ci.mode.String(), webhookForCommandsName, "total", strconv.FormatBool(err == nil), strconv.FormatBool(injected))
+	return injected, err
+}
+
+func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, apiClient kubernetes.Interface) (bool, error) {
 	var injected bool
 
 	if exec == nil || userInfo == nil {
 		log.Errorf("cannot inject CWS instrumentation into nil exec options or nil userInfo")
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsNilInputReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsNilInputReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
 	if len(exec.Command) == 0 {
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsNilCommandReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsNilCommandReason)
 		return false, nil
 	}
 
@@ -476,41 +502,41 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	if ci.mode == RemoteCopy {
 		if userInfo.Username == ci.clusterAgentServiceAccount {
 			log.Debugf("Ignoring exec request to %s from the cluster agent", name)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsClusterAgentServiceAccountReason)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsClusterAgentServiceAccountReason)
 			return false, nil
 		}
 
 		// fall back in case the service account filter somehow didn't work
 		if len(exec.Command) >= len(k8scp.CWSRemoteCopyCommand) && slices.Equal(exec.Command[0:len(k8scp.CWSRemoteCopyCommand)], k8scp.CWSRemoteCopyCommand) {
 			log.Debugf("Ignoring kubectl cp requests to %s from the cluster agent", name)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsClusterAgentKubectlCPReason)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsClusterAgentKubectlCPReason)
 			return false, nil
 		}
 	}
 
 	// is the namespace / container targeted by the instrumentation ?
 	if ci.filter.IsExcluded(nil, exec.Container, "", ns) {
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsExcludedResourceReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedResourceReason)
 		return false, nil
 	}
 
 	// check if the pod has been instrumented
-	pod, err := apiClient.CoreV1().Pods(ns).Get(context.Background(), name, metav1.GetOptions{})
+	pod, err := ci.getPod(apiClient, name, ns)
 	if err != nil || pod == nil {
 		log.Errorf("couldn't describe pod %s in namespace %s from the API server: %v", name, ns, err)
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsDescribePodErrorReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsDescribePodErrorReason)
 		return false, errors.New(metrics.InternalError)
 	}
 
 	// is the pod excluded explicitly ? (we can filter out with labels in the webhook selector on pods / exec creation)
 	if pod.Labels != nil && pod.Labels[PodLabelEnabled] == "false" {
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsExcludedByLabelReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedByLabelReason)
 		return false, nil
 	}
 
 	// is the pod targeted by the instrumentation ?
 	if ci.filter.IsExcluded(pod.Annotations, "", "", "") {
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsExcludedByAnnotationReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedByAnnotationReason)
 		return false, nil
 	}
 
@@ -523,7 +549,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		if !isPodCWSInstrumentationReady(pod.Annotations) {
 			// pod isn't instrumented, do not attempt to override the pod exec command
 			log.Debugf("Ignoring exec request into %s, pod not instrumented yet", mutatecommon.PodString(pod))
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsPodNotInstrumentedReason)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsPodNotInstrumentedReason)
 			return false, nil
 		}
 	case RemoteCopy:
@@ -534,7 +560,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			if !isPodCWSInstrumentationReady(pod.Annotations) {
 				// pod isn't instrumented, do not attempt to override the pod exec command
 				log.Debugf("Ignoring exec request into %s, pod not instrumented yet", mutatecommon.PodString(pod))
-				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsPodNotInstrumentedReason)
+				metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsPodNotInstrumentedReason)
 				return false, nil
 			}
 			cwsInstrumentationRemotePath = filepath.Join(cwsMountPath, cwsInstrumentationRemotePath)
@@ -543,7 +569,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 			if readOnly := ci.hasReadonlyRootfs(pod, exec.Container); readOnly {
 				// readonly rootfs containers can't be instrumented
 				log.Errorf("Ignoring exec request into %s, container %s has read only rootfs. Try enabling admission_controller.cws_instrumentation.remote_copy.mount_volume", mutatecommon.PodString(pod), exec.Container)
-				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsReadonlyFilesystemReason)
+				metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsReadonlyFilesystemReason)
 				return false, errors.New(metrics.InvalidInput)
 			}
 		}
@@ -552,14 +578,14 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		// remote health command from the cluster-agent (in which case we should simply ignore this request)
 		if len(exec.Command) >= 2 && slices.Equal(exec.Command[0:2], []string{cwsInstrumentationRemotePath, k8sexec.CWSHealthCommand}) {
 			log.Debugf("Ignoring kubectl health check exec requests to %s from the cluster agent", name)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsClusterAgentKubectlExecHealthReason)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsClusterAgentKubectlExecHealthReason)
 			return false, nil
 		}
 
-		arch, err := ci.resolveNodeArch(pod.Spec.NodeName, apiClient)
+		arch, err := ci.resolveNodeArchMeasured(pod.Spec.NodeName, apiClient)
 		if err != nil {
-			log.Errorf("Ignoring exec request into %s: %v", mutatecommon.PodString(pod), err)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsMissingArchReason)
+			log.Errorf("Ignoring exec request into %s: failed to resolve arch: %v", mutatecommon.PodString(pod), err)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsMissingArchReason)
 			return false, errors.New(metrics.InternalError)
 		}
 		cwsInstrumentationLocalPath := filepath.Join(cwsInstrumentationEmbeddedPath, "cws-instrumentation."+arch)
@@ -567,27 +593,27 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 		// check if the pod is ready to be exec-ed into
 		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 			log.Errorf("Ignoring exec request into %s: cannot exec into a container in a completed pod; current phase is %s", mutatecommon.PodString(pod), pod.Status.Phase)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsCompletedPodReason)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsCompletedPodReason)
 			return false, errors.New(metrics.InvalidInput)
 		}
 
 		// check if the input container exists, or select the default one to which the user will be redirected
 		container, err := podcmd.FindOrDefaultContainerByName(pod, exec.Container, true, nil)
 		if err != nil {
-			log.Errorf("Ignoring exec request into %s, invalid container: %v", mutatecommon.PodString(pod), err)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsInvalidInputContainerReason)
+			log.Errorf("Ignoring exec request into %s: invalid container: %v", mutatecommon.PodString(pod), err)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsInvalidInputContainerReason)
 			return false, errors.New(metrics.InvalidInput)
 		}
 
 		// copy CWS instrumentation directly to the target container
 		if err := ci.injectCWSCommandInstrumentationRemoteCopy(pod, container.Name, cwsInstrumentationLocalPath, cwsInstrumentationRemotePath); err != nil {
-			log.Warnf("Ignoring exec request into %s, remote copy failed: %v", mutatecommon.PodString(pod), err)
-			metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsRemoteCopyFailedReason)
+			log.Warnf("Ignoring exec request into %s: remote copy failed: %v", mutatecommon.PodString(pod), err)
+			metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsRemoteCopyFailedReason)
 			return false, errors.New(metrics.InternalError)
 		}
 	default:
-		log.Errorf("Ignoring exec request into %s, unknown CWS Instrumentation mode %v", mutatecommon.PodString(pod), ci.mode)
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsUnknownModeReason)
+		log.Errorf("Ignoring exec request into %s: unknown CWS Instrumentation mode %v", mutatecommon.PodString(pod), ci.mode)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsUnknownModeReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
 
@@ -595,7 +621,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	userSessionCtx, err := k8sutils.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
 	if err != nil {
 		log.Debugf("ignoring instrumentation of %s: %v", mutatecommon.PodString(pod), err)
-		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsCredentialsSerializationErrorReason)
+		metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsCredentialsSerializationErrorReason)
 		return false, errors.New(metrics.InternalError)
 	}
 
@@ -610,7 +636,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 
 			if exec.Command[5] == string(userSessionCtx) {
 				log.Debugf("Exec request into %s is already instrumented, ignoring", mutatecommon.PodString(pod))
-				metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsAlreadyInstrumentedReason)
+				metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "false", cwsAlreadyInstrumentedReason)
 				return true, nil
 			}
 		}
@@ -628,7 +654,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	}, exec.Command...)
 
 	log.Debugf("Pod exec request to %s by %s is now instrumented for CWS", mutatecommon.PodString(pod), userInfo.Username)
-	metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "true", "")
+	metrics.CWSExecMutationAttempts.Inc(ci.mode.String(), "true", "")
 	injected = true
 
 	return injected, nil
@@ -641,13 +667,13 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentationRemoteCopy(pod *cor
 	}
 
 	cp := k8scp.NewCopy(apiclient)
-	if err = cp.CopyToPod(cwsInstrumentationLocalPath, cwsInstrumentationRemotePath, pod, container, ci.timeout); err != nil {
+	if err = cp.CopyToPod(cwsInstrumentationLocalPath, cwsInstrumentationRemotePath, pod, container, ci.mode.String(), webhookForCommandsName, ci.timeout); err != nil {
 		return err
 	}
 
 	// check cws-instrumentation was properly copied by running "cws-instrumentation health"
 	health := k8sexec.NewHealthCommand(apiclient)
-	return health.Run(cwsInstrumentationRemotePath, pod, container, ci.timeout)
+	return health.Run(cwsInstrumentationRemotePath, pod, container, ci.mode.String(), webhookForCommandsName, ci.timeout)
 }
 
 func (ci *CWSInstrumentation) injectForPod(request *admission.Request) *admiv1.AdmissionResponse {
@@ -657,19 +683,19 @@ func (ci *CWSInstrumentation) injectForPod(request *admission.Request) *admiv1.A
 func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool, error) {
 	if pod == nil {
 		log.Errorf("cannot inject CWS instrumentation into nil pod")
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsNilInputReason)
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsNilInputReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
 
 	// is the pod targeted by the instrumentation ?
 	if ci.filter.IsExcluded(pod.Annotations, "", "", ns) {
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsExcludedResourceReason)
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsExcludedResourceReason)
 		return false, nil
 	}
 
 	// check if the pod has already been instrumented
 	if isPodCWSInstrumentationReady(pod.Annotations) {
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsAlreadyInstrumentedReason)
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsAlreadyInstrumentedReason)
 		// nothing to do, return
 		return true, nil
 	}
@@ -684,7 +710,7 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 		instrumented = ci.injectCWSPodInstrumentationRemoteCopy(pod)
 	default:
 		log.Errorf("Ignoring Pod %s admission request: unknown CWS Instrumentation mode %v", mutatecommon.PodString(pod), ci.mode)
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsUnknownModeReason)
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsUnknownModeReason)
 		return false, errors.New(metrics.InvalidInput)
 	}
 
@@ -695,9 +721,9 @@ func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns st
 		}
 		pod.Annotations[cwsInstrumentationPodAnotationStatus] = cwsInstrumentationPodAnotationReady
 		log.Debugf("Pod %s is now instrumented for CWS", mutatecommon.PodString(pod))
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "true", "")
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "true", "")
 	} else {
-		metrics.CWSPodInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsNoInstrumentationNeededReason)
+		metrics.CWSPodMutationAttempts.Inc(ci.mode.String(), "false", cwsNoInstrumentationNeededReason)
 	}
 
 	return true, nil

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -500,7 +500,7 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 				if tt.args.exec != nil {
 					apiClient.containerName = tt.args.exec.Container
 				}
-				injected, err := ci.injectCWSCommandInstrumentation(tt.args.exec, tt.args.name, tt.args.ns, tt.args.userInfo, nil, apiClient)
+				injected, err := ci.injectCWSCommandInstrumentationMeasured(tt.args.exec, tt.args.name, tt.args.ns, tt.args.userInfo, nil, apiClient)
 
 				if tt.wantErr {
 					assert.False(t, injected)

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
@@ -14,11 +14,13 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
@@ -52,8 +54,16 @@ func (o *Copy) prepareCommand(destFile string) []string {
 	return cmdArr
 }
 
-// CopyToPod copies the provided local file to the provided container
-func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
+// CopyToPod copies the provided local file to the provided container while observing the execution time
+func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, mode string, webhookName string, timeout time.Duration) error {
+	start := time.Now()
+	err := o.copyToPod(localFile, remoteFile, pod, container, timeout)
+	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), mode, webhookName, "copy_to_pod", strconv.FormatBool(err == nil), "")
+	return err
+}
+
+// copyToPod copies the provided local file to the provided container
+func (o *Copy) copyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
 	o.Container = container
 	localFile = path.Clean(localFile)
 	remoteFile = path.Clean(remoteFile)

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
@@ -59,7 +59,7 @@ func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOpt
 		serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("new REST client error: %v", err)
 	}
 
 	req := restClient.Post().
@@ -83,7 +83,7 @@ func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOpt
 		req.URL(),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("new SPDY executor error: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reworks the metrics we use to track the CWS instrumentation mutating webhook. With this PR, the CWS instrumentation webhook exports 3 metrics:
- `cws_exec_mutation_attempts`: a count of exec mutation attempts, tagged by `mode`, `injected`, `reason`
- `cws_pod_mutation_attempts`: a count of pod mutation attempts, tagged by `mode`, `injected`, `reason`
- `cws_response_duration`: a histogram of response duration for the cws instrumentation webhooks, tagged by `mode`, `webhook_name`, `type`, `success` and `injected`.

### Motivation

This will help debug regressions a investigate longer than usual response time of the CWS mutating webhook.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Make a test deployment of the agent & cluster-agent with the datadog-cluster-agent check enabled. Exec into pods (the containers of the agent will do), wait a bit. You should see the 3 metrics pop up in Datadog.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->