### PR TITLE
[ AGNTLOG-170 ] Agent status page contains a warning about open files limit

### DIFF
--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -153,7 +153,8 @@ func (p *FileProvider) addFilesToTailList(validatePodContainerID bool, inputFile
 		status.AddGlobalWarning(
 			openFilesLimitWarningType,
 			fmt.Sprintf(
-				"The limit on the maximum number of files in use (%d) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+				"The limit on the maximum number of files in use (%d) has been reached. If you aren't tailing the files you want to be tailing, increase this limit ("+
+					"logs_config.open_files_limit in datadog.yaml), decrease the number of files you are tailing, or alter the logs_config.file_wildcard_selection_mode setting to by_modification_time.",
 				p.filesLimit,
 			),
 		)

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -25,6 +25,10 @@ import (
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"
 )
 
+const (
+	fileLimitWarning = "The limit on the maximum number of files in use (%d) has been reached. If you aren't tailing the files you want to be tailing, increase this limit (logs_config.open_files_limit in datadog.yaml), decrease the number of files you are tailing, or alter the logs_config.file_wildcard_selection_mode setting to by_modification_time."
+)
+
 type tempFs struct {
 	tempDir string
 	t       testing.TB
@@ -151,7 +155,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	suite.Equal([]string{"3 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, suite.filesLimit),
 		},
 		status.Get(false).Warnings,
 	)
@@ -215,7 +219,7 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 	suite.Equal([]string{"3 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, suite.filesLimit),
 		},
 		status.Get(false).Warnings,
 	)
@@ -250,7 +254,7 @@ func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
 	suite.Equal([]string{"3 files tailed out of 5 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (3) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, suite.filesLimit),
 		},
 		status.Get(false).Warnings,
 	)
@@ -270,14 +274,14 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	suite.Equal([]string{"2 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, filesLimit),
 		},
 		status.Get(false).Warnings,
 	)
 	suite.Equal([]string{"0 files tailed out of 2 files matching"}, logSources[1].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, filesLimit),
 		},
 		status.Get(false).Warnings,
 	)
@@ -292,7 +296,7 @@ func (suite *ProviderTestSuite) TestAllWildcardPathsAreUpdated() {
 	suite.Equal([]string{"1 files tailed out of 1 files matching"}, logSources[1].Messages.GetMessages())
 	suite.Equal(
 		[]string{
-			"The limit on the maximum number of files in use (2) has been reached. Increase this limit (thanks to the attribute logs_config.open_files_limit in datadog.yaml) or decrease the number of tailed file.",
+			fmt.Sprintf(fileLimitWarning, filesLimit),
 		},
 		status.Get(false).Warnings,
 	)

--- a/releasenotes/notes/tailer-limit-warning-49e8f3730d3670d5.yaml
+++ b/releasenotes/notes/tailer-limit-warning-49e8f3730d3670d5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Generate a more detailed warning when the Logs Agent tailer limit is reached.


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Customers who hit the log agent's open_files_limit currently receive an error message in the agent status that advises them to change the setting or tail less files. While these solutions do solve a subset of issues, it has been noted that altering the file_wildcard_selection_mode was often the actual desired solution for users who contacted support regarding this issue. As such, this PR modifies the warning message to draw attention to this as a possible solution.
```
==========
Logs Agent
==========

    Reliable: Sending compressed logs in HTTPS to testserver.com on port 443
    BytesSent: 206
    EncodedBytesSent: 183
    LogsProcessed: 1
    LogsSent: 1
    LogsTruncated: 0
    RetryCount: 0
    RetryTimeSpent: 0s

  Warnings
  ========
    The limit on the maximum number of files in use (1) has been reached. If you aren't tailing the files you want to be tailing, increase this limit (logs_config.open_files_limit in datadog.yaml), decrease the number of files you are tailing, or alter the logs_config.file_wildcard_selection_mode setting to by_modification_time.
  ============
  Integrations
  ============

  logs
  ----
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->