### PR TITLE
Calling SetWithoutSource updates unknown keys

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -287,6 +287,22 @@ customKey2: unused
 		assert.NotContains(t, slices.Collect(maps.Keys(viperConf.GetKnownKeysLowercased())), "customkey2")
 		assert.NotContains(t, slices.Collect(maps.Keys(ntmConf.GetKnownKeysLowercased())), "customkey2")
 	})
+
+	t.Run("SetWithoutSource won't create known key", func(t *testing.T) {
+		dataYaml := `
+port: 8080
+`
+		viperConf, ntmConf := constructBothConfigs(dataYaml, true, func(cfg model.Setup) {
+			cfg.SetKnown("port")
+		})
+		viperConf.SetWithoutSource("unknown_key.unknown_subkey", "true")
+		ntmConf.SetWithoutSource("unknown_key.unknown_subkey", "true")
+
+		wantKeys := []string{"port"}
+		assert.ElementsMatch(t, wantKeys, slices.Collect(maps.Keys(viperConf.GetKnownKeysLowercased())))
+		assert.ElementsMatch(t, wantKeys, slices.Collect(maps.Keys(ntmConf.GetKnownKeysLowercased())))
+	})
+
 }
 
 func TestCompareAllKeysLowercased(t *testing.T) {
@@ -349,6 +365,21 @@ customKey2: unused
 		})
 
 		wantKeys := []string{"port", "host", "customkey1", "customkey2"}
+		assert.ElementsMatch(t, wantKeys, viperConf.AllKeysLowercased())
+		assert.ElementsMatch(t, wantKeys, ntmConf.AllKeysLowercased())
+	})
+
+	t.Run("SetWithoutSource will create unknown key", func(t *testing.T) {
+		dataYaml := `
+port: 8080
+`
+		viperConf, ntmConf := constructBothConfigs(dataYaml, true, func(cfg model.Setup) {
+			cfg.SetKnown("port")
+		})
+		viperConf.SetWithoutSource("unknown_key.unknown_subkey", "true")
+		ntmConf.SetWithoutSource("unknown_key.unknown_subkey", "true")
+
+		wantKeys := []string{"port", "unknown_key.unknown_subkey"}
 		assert.ElementsMatch(t, wantKeys, viperConf.AllKeysLowercased())
 		assert.ElementsMatch(t, wantKeys, ntmConf.AllKeysLowercased())
 	})

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -242,6 +242,14 @@ func (c *ntmConfig) SetWithoutSource(key string, value interface{}) {
 		panic("You cannot set a struct as a value")
 	}
 	c.Set(key, value, model.SourceUnknown)
+	keySet := make(map[string]struct{}, len(c.allSettings))
+	for _, k := range c.allSettings {
+		keySet[k] = struct{}{}
+	}
+	keySet[key] = struct{}{}
+	allKeys := slices.Collect(maps.Keys(keySet))
+	slices.Sort(allKeys)
+	c.allSettings = allKeys
 }
 
 // SetDefault assigns the value to the given key using source Default
@@ -454,10 +462,7 @@ func (c *ntmConfig) computeAllSettings(path string) []string {
 	// 3. Collect all unknown keys, even if they have no value set
 	c.collectKeysFromNode(c.unknown, "", keySet, true)
 
-	var allKeys []string
-	for key := range maps.Keys(keySet) {
-		allKeys = append(allKeys, key)
-	}
+	allKeys := slices.Collect(maps.Keys(keySet))
 	slices.Sort(allKeys)
 	return allKeys
 }


### PR DESCRIPTION
### What does this PR do?

Calling SetWithoutSource with an unknown key will add it to unknown key. Improves compatibility with viper. Running with `DD_CONF_NODETREEMODEL=enable` will fix the unit test `pkg/config/setup.TestUnknownKeysWarning`

### Motivation

Fixing nodetreemodel compatibility with viper

### Describe how you validated your changes

Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
