### PR TITLE
[CWS] fix nlink for exec event

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -204,6 +204,18 @@ struct dentry *__attribute__((always_inline)) get_path_dentry(struct path *path)
     return dentry;
 }
 
+u32  __attribute__((always_inline)) get_dentry_nlink(struct dentry* dentry) {
+    struct inode *d_inode = get_dentry_inode(dentry);
+
+    u64 inode_nlink_offset;
+    LOAD_CONSTANT("inode_nlink_offset", inode_nlink_offset);
+
+    int nlink = 0;
+    bpf_probe_read(&nlink, sizeof(nlink), (void *)d_inode + inode_nlink_offset);
+
+    return nlink;
+}
+
 struct dentry *__attribute__((always_inline)) get_file_dentry(struct file *file) {
     return get_path_dentry(get_file_f_path_addr(file));
 }

--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -7,9 +7,9 @@
 #include "process.h"
 
 int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_cache_t *syscall, struct file *file, struct inode *inode) {
-    if (syscall->exec.is_parsed) {
+    struct dentry *dentry  = get_file_dentry(file);
+    if (syscall->exec.dentry) {
         // handle nlink that needs to be collected in the second pass
-        struct dentry *dentry  = get_file_dentry(file);
         if (dentry) {
             u32 nlink = get_dentry_nlink(dentry);
             if (nlink > syscall->exec.file.metadata.nlink) {
@@ -18,9 +18,7 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
         }
         return 0;
     }
-    syscall->exec.is_parsed = 1;
-
-    syscall->exec.dentry = get_file_dentry(file);
+    syscall->exec.dentry = dentry;
 
     struct path *path = get_file_f_path_addr(file);
 

--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -8,6 +8,14 @@
 
 int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_cache_t *syscall, struct file *file, struct inode *inode) {
     if (syscall->exec.is_parsed) {
+        // handle nlink that needs to be collected in the second pass
+        struct dentry *dentry  = get_file_dentry(file);
+        if (dentry) {
+            u32 nlink = get_dentry_nlink(dentry);
+            if (nlink > syscall->exec.file.metadata.nlink) {
+                syscall->exec.file.metadata.nlink = nlink;
+            }
+        }
         return 0;
     }
     syscall->exec.is_parsed = 1;

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -112,11 +112,13 @@ void __attribute__((always_inline)) fill_file(struct dentry *dentry, struct file
     file->dev = get_dentry_dev(dentry);
 
     // nlink is mostly used userspace side to invalidate cache. use the higher value found
-    if (!file->metadata.nlink) {
-        u64 inode_nlink_offset;
-        LOAD_CONSTANT("inode_nlink_offset", inode_nlink_offset);
+    u64 inode_nlink_offset;
+    LOAD_CONSTANT("inode_nlink_offset", inode_nlink_offset);
 
-        bpf_probe_read(&file->metadata.nlink, sizeof(file->metadata.nlink), (void *)d_inode + inode_nlink_offset);
+    u32 nlink = 0;
+    bpf_probe_read(&nlink, sizeof(nlink), (void *)d_inode + inode_nlink_offset);
+    if (nlink > file->metadata.nlink) {
+      file->metadata.nlink = nlink;
     }
 
     u64 inode_gid_offset;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -689,7 +689,11 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
                     .mount_id = syscall->exec.file.path_key.mount_id,
                     .path_id = syscall->exec.file.path_key.path_id,
                 },
-                .flags = syscall->exec.file.flags },
+                .flags = syscall->exec.file.flags,
+                .metadata = {
+                    .nlink = syscall->exec.file.metadata.nlink
+                },
+            },
             .exec_timestamp = now,
         },
         .container = {},

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -141,7 +141,6 @@ struct syscall_cache_t {
             struct args_envs_parsing_context_t args_envs_ctx;
             struct span_context_t span_context;
             struct linux_binprm_t linux_binprm;
-            u8 is_parsed;
         } exec;
 
         struct {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -41,8 +41,12 @@ var dockerImageLibrary = map[string][]string{
 		"public.ecr.aws/docker/library/centos:7",
 	},
 	"alpine": {
-		"alpine",
-		"public.ecr.aws/docker/library/alpine:latest",
+		"alpine:3.18.2",
+		"public.ecr.aws/docker/library/alpine:3.18.2", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
+	},
+	"busybox": {
+		"busybox:1.36.1",
+		"docker.io/busybox:1.36.1", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
 	},
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a dentry cache issue with hardlink. nlink wasn't reported correctly causing the wrong entry cache to be used in case of busybox command line for instance.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->