### PR TITLE
chore(fleet): Skip daemon Start if remote_updates is false

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -270,6 +270,12 @@ func (d *daemonImpl) SetConfigCatalog(configs map[string]installerConfig) {
 func (d *daemonImpl) Start(_ context.Context) error {
 	d.m.Lock()
 	defer d.m.Unlock()
+
+	if !d.env.RemoteUpdates {
+		// If remote updates are disabled, we don't need to start the daemon
+		return nil
+	}
+
 	go func() {
 		gcTicker := time.NewTicker(gcInterval)
 		defer gcTicker.Stop()
@@ -306,6 +312,12 @@ func (d *daemonImpl) Start(_ context.Context) error {
 func (d *daemonImpl) Stop(_ context.Context) error {
 	d.m.Lock()
 	defer d.m.Unlock()
+
+	if !d.env.RemoteUpdates {
+		// If remote updates are disabled, we don't need to stop the daemon as it was never started
+		return nil
+	}
+
 	d.rc.Close()
 	close(d.stopChan)
 	d.requestsWG.Wait()


### PR DESCRIPTION
### What does this PR do?
We're seeing a lot of failures for `get_states` when running DJM install scripts. This happens because while the installer setup is running the DB is locked; but the daemon still tries to call `get_states`; causing it to fail because of the lock. The core issue is that we call `get_states` while we're still in the installation phase.

This PR only alleviates it by making sure the daemon doesn't start calling `get_states` when it should in fact be disabled: there can be a first call between the installer process startup & the moment it is deactivated because `remote_updates` is disabled. Thus this PR makes sure the daemon component doesn't even start if `remote_updates: false`

### Motivation
Less errors in telemetry

### Describe how you validated your changes
E2E

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->