### PR TITLE
Split cws-instrumentation and dca publish jobs to two stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,17 +440,6 @@ workflow:
   - <<: *if_deploy_installer
     when: on_failure
 
-.on_deploy_rc:
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_deploy_on_rc_tag_on_beta_repo_branch
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
-      OTEL_AGENT_REPOSITORY: ddot-collector
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
 # rule to trigger job for internal image deployment if deploy is set or
 # manually if not
 .on_deploy_internal_or_manual:
@@ -462,95 +451,6 @@ workflow:
     allow_failure: true
     variables:
       RELEASE_PROD: "false"
-
-# Same as on_deploy_manual, except the job would not run on pipelines
-# using beta branch, it would only run for the final release.
-.on_deploy_manual_final:
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_deploy_on_beta_repo_branch
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      OTEL_AGENT_REPOSITORY: ddot-collector-dev
-      DSD_REPOSITORY: dogstatsd-dev
-      IMG_REGISTRIES: dev
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      OTEL_AGENT_REPOSITORY: ddot-collector
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-# This rule is a variation of on_deploy_manual where
-# the job is usually run manually, except when the pipeline
-# builds an RC: in this case, the job is run automatically.
-# This is done to reduce the number of manual steps that have
-# to be done when creating RCs.
-.on_deploy_manual_auto_on_rc:
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      OTEL_AGENT_REPOSITORY: ddot-collector-dev
-      DSD_REPOSITORY: dogstatsd-dev
-      IMG_REGISTRIES: dev
-  - <<: *if_deploy_on_rc_tag_on_beta_repo_branch
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
-      OTEL_AGENT_REPOSITORY: ddot-collector
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      OTEL_AGENT_REPOSITORY: ddot-collector
-      DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-# This is used for image vulnerability scanning. Because agent 6
-# uses python 2, which has many vulnerabilities that will not get
-# patched, we do not wish to scan this image. For this reason, only
-# agent 7 versions should be published internally using these
-# configurations.
-.on_deploy_internal_rc:
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_deploy_on_rc_tag_on_beta_repo_branch
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: ci/datadog-agent/agent-release
-      CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
-      OTEL_AGENT_REPOSITORY: ci/datadog-agent/otel-agent-release
-      DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
-      IMG_REGISTRIES: internal-aws-ddbuild
-
-# Same as on_deploy_manual_final, except the job is used to publish images
-# to our internal registries.
-.on_deploy_internal_manual_final:
-  - <<: *if_not_deploy
-    when: never
-  - <<: *if_deploy_on_beta_repo_branch
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: ci/datadog-agent/agent-release
-      OTEL_AGENT_REPOSITORY: ci/datadog-agent/otel-agent-release
-      CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
-      DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
-      IMG_REGISTRIES: internal-aws-ddbuild
 
 .on_deploy_nightly_repo_branch:
   - <<: *if_not_nightly_or_dev_repo_branch

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -1,60 +1,24 @@
 ---
-include:
-  - .gitlab/common/container_publish_job_templates.yml
+# deploy cws-instrumentation stage
+# Contains jobs which create child pipelines to deploy CWS Instrumentation to staging repositories and to Dockerhub / GCR.
 
-#
-# CWS Instrumentation image tagging & manifest publication
-#
-
-.deploy_containers-cws-instrumentation-base:
-  extends: .docker_publish_job_definition
+deploy_containers-cws-instrumentation:
   stage: deploy_cws_instrumentation
-  needs:
-    - job: "docker_build_cws_instrumentation_amd64"
-      artifacts: false
-    - job: "docker_build_cws_instrumentation_arm64"
-      artifacts: false
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
-    - if [[ "$CWS_INSTRUMENTATION_REPOSITORY" == "" ]]; then export CWS_INSTRUMENTATION_REPOSITORY="cws-instrumentation"; fi
-    - export IMG_BASE_SRC="${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
-    - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
+  rules:
+    !reference [.on_deploy]
+  variables:
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    BUCKET_BRANCH: $BUCKET_BRANCH
+  trigger:
+    include: .gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml
 
-.deploy_mutable_cws-instrumentation_tags_base:
-  extends: .docker_publish_job_definition
+deploy_containers-cws-instrumentation-on-failure:
   stage: deploy_cws_instrumentation
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
-
-# will push the `7.xx.y-rc.z` tags
-deploy_containers-cws-instrumentation-rc-versioned:
-  extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
-
-# will update the `rc` tag
-deploy_containers-cws-instrumentation-rc-mutable:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-cws-instrumentation-rc-versioned
-      artifacts: false
+  rules:
+    !reference [.on_deploy_failure]
   variables:
-    IMG_NEW_TAGS: rc
-
-# will push the `7.xx.y` tags
-deploy_containers-cws-instrumentation-final-versioned:
-  extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_manual_final]
-
-# will update the `latest` tag
-deploy_containers-cws-instrumentation-latest:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-cws-instrumentation-final-versioned
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    BUCKET_BRANCH: $BUCKET_BRANCH
+    FORCE_MANUAL: "true"
+  trigger:
+    include: .gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml
@@ -1,6 +1,7 @@
 ---
 include:
   - .gitlab/common/container_publish_job_templates.yml
+  - .gitlab/deploy_containers/conditions.yml
 
 stages:
   - deploy_cws_instrumentation
@@ -36,12 +37,12 @@ stages:
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
+  rules: !reference [.manual_on_deploy_auto_on_rc]
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:
   extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_rc]
+  rules: !reference [.on_rc]
   needs:
     - job: deploy_containers-cws-instrumentation-rc-versioned
       artifacts: false
@@ -51,12 +52,12 @@ deploy_containers-cws-instrumentation-rc-mutable:
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_manual_final]
+  rules: !reference [.on_final]
 
 # will update the `latest` tag
 deploy_containers-cws-instrumentation-latest:
   extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_manual_final]
+  rules: !reference [.on_final]
   needs:
     - job: deploy_containers-cws-instrumentation-final-versioned
       artifacts: false

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_trigger.yml
@@ -1,0 +1,64 @@
+---
+include:
+  - .gitlab/common/container_publish_job_templates.yml
+
+stages:
+  - deploy_cws_instrumentation
+  - deploy_cws_instrumentation_mutable_tags
+
+#
+# CWS Instrumentation image tagging & manifest publication
+#
+
+.deploy_containers-cws-instrumentation-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_cws_instrumentation
+  needs:
+    - job: "docker_build_cws_instrumentation_amd64"
+      artifacts: false
+    - job: "docker_build_cws_instrumentation_arm64"
+      artifacts: false
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
+    - if [[ "$CWS_INSTRUMENTATION_REPOSITORY" == "" ]]; then export CWS_INSTRUMENTATION_REPOSITORY="cws-instrumentation"; fi
+    - export IMG_BASE_SRC="${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
+    - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
+
+.deploy_mutable_cws-instrumentation_tags_base:
+  extends: .docker_publish_job_definition
+  stage: deploy_cws_instrumentation_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
+
+# will push the `7.xx.y-rc.z` tags
+deploy_containers-cws-instrumentation-rc-versioned:
+  extends: .deploy_containers-cws-instrumentation-base
+  rules: !reference [.on_deploy_manual_auto_on_rc]
+
+# will update the `rc` tag
+deploy_containers-cws-instrumentation-rc-mutable:
+  extends: .deploy_mutable_cws-instrumentation_tags_base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-cws-instrumentation-rc-versioned
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+# will push the `7.xx.y` tags
+deploy_containers-cws-instrumentation-final-versioned:
+  extends: .deploy_containers-cws-instrumentation-base
+  rules: !reference [.on_deploy_manual_final]
+
+# will update the `latest` tag
+deploy_containers-cws-instrumentation-latest:
+  extends: .deploy_mutable_cws-instrumentation_tags_base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-cws-instrumentation-final-versioned
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -1,143 +1,24 @@
 ---
-include:
-  - .gitlab/common/container_publish_job_templates.yml
+# deploy dca stage
+# Contains jobs which create child pipelines to deploy DCA to staging repositories and to Dockerhub / GCR.
 
-#
-# DCA image tagging & manifest publication
-#
-
-# Basic flavor
-.deploy_containers-dca-base:
-  extends: .docker_publish_job_definition
+deploy_dca:
   stage: deploy_dca
-  needs:
-    - job: "docker_build_cluster_agent_amd64"
-      artifacts: false
-    - job: "docker_build_cluster_agent_arm64"
-      artifacts: false
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
-    - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
-    - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
-    - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
+  rules:
+    !reference [.on_deploy]
+  variables:
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    BUCKET_BRANCH: $BUCKET_BRANCH
+  trigger:
+    include: .gitlab/deploy_dca/deploy_dca_trigger.yml
 
-.deploy_mutable_dca_tags-base:
-  extends: .docker_publish_job_definition
+deploy_dca-on-failure:
   stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
-
-deploy_containers-dca:
-  extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
-
-deploy_containers-dca-rc:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
+  rules:
+    !reference [.on_deploy_failure]
   variables:
-    IMG_NEW_TAGS: rc
-
-deploy_containers-dca-latest:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest
-
-deploy_containers-dca_internal:
-  extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_internal_manual_final]
-
-deploy_containers-dca_internal-rc:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc
-
-deploy_containers-dca_internal-latest:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest
-
-# Fips flavor
-.deploy_containers-dca-fips-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  needs:
-    - job: "docker_build_cluster_agent_fips_amd64"
-      artifacts: false
-    - job: "docker_build_cluster_agent_fips_arm64"
-      artifacts: false
-  before_script:
-    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
-    - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
-    - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
-    - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
-    - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips"
-
-.deploy_mutable_dca_tags-fips-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
-
-deploy_containers-dca-fips:
-  extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
-
-deploy_containers-dca-fips-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest-fips
-
-deploy_containers-dca-fips-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc-fips
-
-deploy_containers-dca-fips_internal:
-  extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
-
-deploy_containers-dca-fips_internal-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc-fips
-
-deploy_containers-dca-fips_internal-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest-fips
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    BUCKET_BRANCH: $BUCKET_BRANCH
+    FORCE_MANUAL: "true"
+  trigger:
+    include: .gitlab/deploy_dca/deploy_dca_trigger.yml

--- a/.gitlab/deploy_dca/deploy_dca_trigger.yml
+++ b/.gitlab/deploy_dca/deploy_dca_trigger.yml
@@ -1,6 +1,7 @@
 ---
 include:
   - .gitlab/common/container_publish_job_templates.yml
+  - .gitlab/deploy_containers/conditions.yml
 
 stages:
   - deploy_dca
@@ -36,11 +37,11 @@ stages:
 
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
+  rules: !reference [.manual_on_deploy_auto_on_rc]
 
 deploy_containers-dca-rc:
   extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_rc]
+  rules: !reference [.on_rc]
   needs:
     - job: deploy_containers-dca
       artifacts: false
@@ -49,7 +50,7 @@ deploy_containers-dca-rc:
 
 deploy_containers-dca-latest:
   extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_manual_final]
+  rules: !reference [.on_final]
   needs:
     - job: deploy_containers-dca
       artifacts: false
@@ -58,11 +59,11 @@ deploy_containers-dca-latest:
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_internal_final]
 
 deploy_containers-dca_internal-rc:
   extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_rc]
+  rules: !reference [.on_internal_rc]
   needs:
     - job: deploy_containers-dca_internal
       artifacts: false
@@ -71,7 +72,7 @@ deploy_containers-dca_internal-rc:
 
 deploy_containers-dca_internal-latest:
   extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_internal_final]
   needs:
     - job: deploy_containers-dca_internal
       artifacts: false
@@ -104,11 +105,11 @@ deploy_containers-dca_internal-latest:
 
 deploy_containers-dca-fips:
   extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_manual_auto_on_rc]
+  rules: !reference [.manual_on_deploy_auto_on_rc]
 
 deploy_containers-dca-fips-latest:
   extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_manual_final]
+  rules: !reference [.on_final]
   needs:
     - job: deploy_containers-dca-fips
       artifacts: false
@@ -117,7 +118,7 @@ deploy_containers-dca-fips-latest:
 
 deploy_containers-dca-fips-rc:
   extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_rc]
+  rules: !reference [.on_rc]
   needs:
     - job: deploy_containers-dca-fips
       artifacts: false
@@ -126,11 +127,11 @@ deploy_containers-dca-fips-rc:
 
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_internal_final]
 
 deploy_containers-dca-fips_internal-rc:
   extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_rc]
+  rules: !reference [.on_internal_rc]
   needs:
     - job: deploy_containers-dca-fips_internal
       artifacts: false
@@ -139,7 +140,7 @@ deploy_containers-dca-fips_internal-rc:
 
 deploy_containers-dca-fips_internal-latest:
   extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_internal_final]
   needs:
     - job: deploy_containers-dca-fips_internal
       artifacts: false

--- a/.gitlab/deploy_dca/deploy_dca_trigger.yml
+++ b/.gitlab/deploy_dca/deploy_dca_trigger.yml
@@ -1,0 +1,147 @@
+---
+include:
+  - .gitlab/common/container_publish_job_templates.yml
+
+stages:
+  - deploy_dca
+  - deploy_dca_mutable_tags
+
+#
+# DCA image tagging & manifest publication
+#
+
+# Basic flavor
+.deploy_containers-dca-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca
+  needs:
+    - job: "docker_build_cluster_agent_amd64"
+      artifacts: false
+    - job: "docker_build_cluster_agent_arm64"
+      artifacts: false
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
+    - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
+    - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
+    - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
+
+.deploy_mutable_dca_tags-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
+
+deploy_containers-dca:
+  extends: .deploy_containers-dca-base
+  rules: !reference [.on_deploy_manual_auto_on_rc]
+
+deploy_containers-dca-rc:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-dca-latest:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+
+deploy_containers-dca_internal:
+  extends: .deploy_containers-dca-base
+  rules: !reference [.on_deploy_internal_manual_final]
+
+deploy_containers-dca_internal-rc:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-dca_internal-latest:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+
+# Fips flavor
+.deploy_containers-dca-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca
+  needs:
+    - job: "docker_build_cluster_agent_fips_amd64"
+      artifacts: false
+    - job: "docker_build_cluster_agent_fips_arm64"
+      artifacts: false
+  before_script:
+    - if [[ "$VERSION" == "" ]]; then VERSION="$(dda inv agent.version --url-safe)" || exit $?; fi
+    - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
+    - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
+    - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips"
+
+.deploy_mutable_dca_tags-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
+
+deploy_containers-dca-fips:
+  extends: .deploy_containers-dca-fips-base
+  rules: !reference [.on_deploy_manual_auto_on_rc]
+
+deploy_containers-dca-fips-latest:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips
+
+deploy_containers-dca-fips-rc:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
+
+deploy_containers-dca-fips_internal:
+  extends: .deploy_containers-dca-fips-base
+  rules: !reference [.on_deploy_internal_manual_final]
+
+deploy_containers-dca-fips_internal-rc:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
+
+deploy_containers-dca-fips_internal-latest:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips


### PR DESCRIPTION
### What does this PR do?

This PR fixes the problem with image publish jobs for `cws-instrumentation` and `dca`, where pipeline was broken due to the incorrect `needs` set.

This PR introduces a trigger of the child pipeline and split of the jobs to two stages - one for uploading the images and/or indexes and the second one for the mutable tags. The jobs in the second stage rely on the images uploaded in the first stage, so to be able to utilize the `needs` keyword we need them to be in the different gitlab stages.

The option to just remove the `needs` is not great, as we have a real dependency between the jobs and keeping them in the same stage is confusing and can actually cause issues - if someone triggers the jobs at the same time (as we usually do during the release) then the mutable tag ones will most likely fail. Therefore - introducing two stages is pereferable.

Also - to avoid adding another two stages on the already very wide gitlab pipeline this PR uses the `trigger` mechanism to create the child pipeline that is visible as a single stage on the full pipeline. We use the same approach for regular agent container publish jobs.

### Motivation

Unify and simplify the image publish jobs.

### Describe how you validated your changes
