### PR TITLE
[AGENTRUN-499] Replace ReadWrite IPC comp impl by ReadOnly for non-start command

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -146,7 +146,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			haagentfx.Module(),
 			logscompression.Module(),
 			metricscompression.Module(),
-			ipcfx.ModuleReadWrite(),
+			ipcfx.ModuleReadOnly(),
 		)
 	}
 

--- a/cmd/process-agent/subcommands/config/config.go
+++ b/cmd/process-agent/subcommands/config/config.go
@@ -87,7 +87,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					fx.Supply(globalParams, args, command.GetCoreBundleParamsForOneShot(globalParams)),
 					core.Bundle(),
 					process.Bundle(),
-					ipcfx.ModuleReadWrite(),
+					ipcfx.ModuleReadOnly(),
 				)
 			},
 		},

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -200,7 +200,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				getPlatformModules(),
 				jmxloggerimpl.Module(jmxloggerimpl.NewDisabledParams()),
 				haagentfx.Module(),
-				ipcfx.ModuleReadWrite(),
+				ipcfx.ModuleReadOnly(),
 			)
 		},
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR transition the IPC component implementation used in `check`, `jmx` and `config set` commands to use `ReadOnly` instead of `ReadWrite`. This prevent these commands to create auth artifacts if they are not already presents on the filesystem. 

### Motivation
Using `ReadWrite` implementations for non-start commands would create auth artifacts on filesystem. Even though this is not an issue per-se, we want these command to not affect the customer environment.  

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The impacted commands have been tested manually.

### Possible Drawbacks / Trade-offs
Transitioning to `ReadOnly` implementation would make these commands to fail if the Agent haven't been ran at least one time before.