### PR TITLE
[SYNTH-19906] Add support for icmp linux on IPv4 and IPv6

### DIFF
--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -22,6 +22,8 @@ const (
 	ProtocolTCP Protocol = "TCP"
 	// ProtocolUDP is the UDP protocol.
 	ProtocolUDP Protocol = "UDP"
+	// ProtocolICMP is the ICMP protocol.
+	ProtocolICMP Protocol = "ICMP"
 )
 
 // TCPMethod is the method used to run a TCP traceroute.

--- a/pkg/networkpath/traceroute/icmp/icmp_driver.go
+++ b/pkg/networkpath/traceroute/icmp/icmp_driver.go
@@ -1,0 +1,306 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package icmp
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+//nolint:unused // This is used, but not on all platforms yet
+var curEchoID atomic.Uint32
+
+//nolint:unused // This is used, but not on all platforms yet
+func nextEchoID() uint16 {
+	next := curEchoID.Add(1)
+	return uint16(next)
+}
+
+type icmpDriver struct {
+	sink packets.Sink
+
+	source packets.Source
+	buffer []byte
+	parser *packets.FrameParser
+	// mu guards against concurrent access to sentProbes
+	mu         sync.Mutex
+	sentProbes map[uint8]time.Time
+	localAddr  netip.Addr
+	params     Params
+	echoID     uint16
+	isIPV6     bool
+}
+
+//nolint:unused // This is used, but not on all platforms yet
+func newICMPDriver(params Params, localAddr netip.Addr, sink packets.Sink, source packets.Source) (*icmpDriver, error) {
+	retval := &icmpDriver{
+		sink:       sink,
+		source:     source,
+		buffer:     make([]byte, 1024),
+		parser:     packets.NewFrameParser(),
+		sentProbes: make(map[uint8]time.Time),
+		localAddr:  localAddr,
+		params:     params,
+		echoID:     nextEchoID(),
+		isIPV6:     localAddr.Is6(),
+	}
+	return retval, nil
+}
+
+func (s *icmpDriver) Close() {
+	s.source.Close()
+	s.sink.Close()
+}
+
+func (s *icmpDriver) GetDriverInfo() common.TracerouteDriverInfo {
+	return common.TracerouteDriverInfo{
+		SupportsParallel: true,
+	}
+}
+
+func (s *icmpDriver) SendProbe(ttl uint8) error {
+	if ttl < s.params.ParallelParams.MinTTL || ttl > s.params.ParallelParams.MaxTTL {
+		return fmt.Errorf("icmpDriver asked to send invalid TTL %d", ttl)
+	}
+	err := s.storeProbe(ttl)
+	if err != nil {
+		return err
+	}
+
+	gen := icmpPacketGen{
+		ipPair: packets.IPPair{
+			DstAddr: s.params.Target,
+			SrcAddr: s.localAddr,
+		},
+	}
+	packet, err := gen.generate(ttl, s.echoID, s.isIPV6)
+	if err != nil {
+		return fmt.Errorf("icmpDriver failed to generate packet: %w", err)
+	}
+	log.TraceFunc(func() string {
+		return fmt.Sprintf("sending packet: %s\n", hex.EncodeToString(packet))
+	})
+	err = s.sink.WriteTo(packet, netip.AddrPortFrom(s.params.Target, 80))
+	if err != nil {
+		return fmt.Errorf("icmpDriver failed to WriteToIP: %w", err)
+	}
+	return nil
+}
+
+func (s *icmpDriver) storeProbe(ttl uint8) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// store the send time for the RTT later when we receive the response
+	if !s.sentProbes[ttl].IsZero() {
+		return fmt.Errorf("icmpDriver asked to send probe for TTL %d but it was already sent", ttl)
+	}
+	// refuse to store it if we somehow would overwrite
+	if _, ok := s.sentProbes[ttl]; ok {
+		return fmt.Errorf("icmpDriver Sendprobe tried to sent the same probe twice for ttl=%d", ttl)
+	}
+	s.sentProbes[ttl] = time.Now()
+	return nil
+}
+
+func (s *icmpDriver) findMatchingProbe(ttl uint8) (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, ok := s.sentProbes[ttl]
+	return data, ok
+}
+
+func (s *icmpDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse, error) {
+	err := s.source.SetReadDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return nil, fmt.Errorf("icmpDriver failed to SetReadDeadline: %w", err)
+	}
+	if err := packets.ReadAndParse(s.source, s.buffer, s.parser); err != nil {
+		return nil, err
+	}
+	return s.handleProbeLayers(s.parser)
+}
+
+func (s *icmpDriver) getRTTFromRelSeq(relSeq uint8) (time.Duration, error) {
+	if relSeq < s.params.ParallelParams.MinTTL || relSeq > s.params.ParallelParams.MaxTTL {
+		return 0, fmt.Errorf("getRTTFromRelSeq: invalid relative sequence number %d", relSeq)
+	}
+	t, ok := s.findMatchingProbe(relSeq)
+	if !ok || t.IsZero() {
+		return 0, fmt.Errorf("getRTTFromRelSeq: no probe sent for relative sequence number %d", relSeq)
+	}
+	return time.Since(t), nil
+}
+
+var errPacketDidNotMatchTraceroute = &common.ReceiveProbeNoPktError{Err: fmt.Errorf("packet did not match the traceroute")}
+
+func (s *icmpDriver) handleProbeLayers(parser *packets.FrameParser) (*common.ProbeResponse, error) {
+	ipPair, err := parser.GetIPPair()
+	if err != nil {
+		return nil, fmt.Errorf("icmpDriver failed to get IP pair: %w", err)
+	}
+	switch parser.GetTransportLayer() {
+	case layers.LayerTypeICMPv4:
+		t := parser.ICMP4.TypeCode.Type()
+		switch t {
+		case layers.ICMPv4TypeTimeExceeded:
+			icmpInfo, err := parser.GetICMPInfo()
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get ICMP info: %w", err)}
+			}
+			local := s.localAddr
+			target := s.params.Target
+			if icmpInfo.ICMPPair.DstAddr.Compare(target) != 0 {
+				log.Tracef("icmpDriver ignored ICMP packet which had another destination: expected=%s, actual=%s", target, icmpInfo.ICMPPair.DstAddr)
+				return nil, common.ErrPacketDidNotMatchTraceroute
+			}
+			if icmpInfo.ICMPPair.SrcAddr.Compare(local) != 0 {
+				log.Tracef("icmpDriver ignored packet which had another source: expected=%s, actual=%s", local, icmpInfo.ICMPPair.SrcAddr)
+				return nil, common.ErrPacketDidNotMatchTraceroute
+			}
+
+			msg, err := icmp.ParseMessage(ipv4.ICMPTypeEcho.Protocol(), icmpInfo.Payload)
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get echo request: %w", err)}
+			}
+			echo, ok := msg.Body.(*icmp.Echo)
+			if !ok {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get echo request: %w", err)}
+			}
+			if uint16(echo.ID) != s.echoID {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
+			}
+			rtt, err := s.getRTTFromRelSeq(uint8(echo.Seq))
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
+			}
+			return &common.ProbeResponse{
+				TTL:    uint8(echo.Seq),
+				IP:     ipPair.SrcAddr,
+				RTT:    rtt,
+				IsDest: false,
+			}, nil
+		case layers.ICMPv4TypeEchoReply:
+			if parser.ICMP4.Id != s.echoID {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
+			}
+			rtt, err := s.getRTTFromRelSeq(uint8(parser.ICMP4.Seq))
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
+			}
+			return &common.ProbeResponse{
+				TTL:    uint8(parser.ICMP4.Seq),
+				IP:     ipPair.SrcAddr,
+				RTT:    rtt,
+				IsDest: true,
+			}, nil
+
+		default:
+			return nil, errPacketDidNotMatchTraceroute
+		}
+	case layers.LayerTypeICMPv6:
+		t := parser.ICMP6.TypeCode.Type()
+		switch t {
+		case layers.ICMPv6TypeTimeExceeded:
+			icmpInfo, err := parser.GetICMPInfo()
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get ICMP info: %w", err)}
+			}
+			local := s.localAddr
+			target := s.params.Target
+			if icmpInfo.ICMPPair.DstAddr.Compare(target) != 0 {
+				log.Tracef("icmpDriver ignored ICMP packet which had another destination: expected=%s, actual=%s", target, icmpInfo.ICMPPair.DstAddr)
+				return nil, common.ErrPacketDidNotMatchTraceroute
+			}
+
+			if icmpInfo.ICMPPair.SrcAddr.Compare(local) != 0 {
+				log.Tracef("icmpDriver ignored packet which had another source: expected=%s, actual=%s", local, icmpInfo.ICMPPair.SrcAddr)
+				return nil, common.ErrPacketDidNotMatchTraceroute
+			}
+
+			echo, err := extractEchoRequest(icmpInfo)
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get echo request: %w", err)}
+			}
+			if echo.Identifier != s.echoID {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
+			}
+			rtt, err := s.getRTTFromRelSeq(uint8(echo.SeqNumber))
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
+			}
+			return &common.ProbeResponse{
+				TTL:    uint8(echo.SeqNumber),
+				IP:     ipPair.SrcAddr,
+				RTT:    rtt,
+				IsDest: false,
+			}, nil
+		case layers.ICMPv6TypeEchoReply:
+			payload := parser.ICMP6.Payload
+			if len(payload) < 4 {
+				return nil, errPacketDidNotMatchTraceroute
+			}
+			id := binary.BigEndian.Uint16(payload[0:2])
+			seq := binary.BigEndian.Uint16(payload[2:4])
+			if id != s.echoID {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("mismatched echo ID")}
+			}
+			rtt, err := s.getRTTFromRelSeq(uint8(seq))
+			if err != nil {
+				return nil, &common.BadPacketError{Err: fmt.Errorf("icmpDriver failed to get RTT: %w", err)}
+			}
+			return &common.ProbeResponse{
+				TTL:    uint8(seq),
+				IP:     ipPair.SrcAddr,
+				RTT:    rtt,
+				IsDest: true,
+			}, nil
+		default:
+			return nil, errPacketDidNotMatchTraceroute
+		}
+	default:
+		return nil, errPacketDidNotMatchTraceroute
+	}
+}
+
+func extractEchoRequest(icmpInfo packets.ICMPInfo) (*layers.ICMPv6Echo, error) {
+	var icmp6 layers.ICMPv6
+	var echo layers.ICMPv6Echo
+	dparser := gopacket.NewDecodingLayerParser(
+		layers.LayerTypeICMPv6,
+		&icmp6, &echo,
+	)
+	decoded := []gopacket.LayerType{}
+	err := dparser.DecodeLayers(icmpInfo.Payload, &decoded)
+	if err != nil {
+		return nil, fmt.Errorf("icmpDriver failed to decode ICMPv6 info payload: %w", err)
+	}
+	var unsupportedErr gopacket.UnsupportedLayerType
+	if errors.As(err, &unsupportedErr) {
+		// there are extra layers beyond TLS, ignore those too
+		err = nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("icmpDriver failed to get echo request: %w", err)
+	}
+	return &echo, nil
+}
+
+var _ common.TracerouteDriver = &icmpDriver{}

--- a/pkg/networkpath/traceroute/icmp/icmp_driver_test.go
+++ b/pkg/networkpath/traceroute/icmp/icmp_driver_test.go
@@ -1,0 +1,415 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package icmp
+
+import (
+	"encoding/binary"
+	"errors"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+)
+
+func initTest(t *testing.T, ipv6 bool) (*icmpDriver, *packets.MockSink, *packets.MockSource) {
+	ctrl := gomock.NewController(t)
+	mockSource := packets.NewMockSource(ctrl)
+	mockSink := packets.NewMockSink(ctrl)
+
+	ipAddress := netip.MustParseAddr("1.2.3.4")
+	if ipv6 {
+		ipAddress = netip.MustParseAddr("2001:0db8:abcd:0012::0a00:fffe")
+	}
+	params := Params{
+		Target: ipAddress,
+		ParallelParams: common.TracerouteParallelParams{TracerouteParams: common.TracerouteParams{
+			MinTTL:            1,
+			MaxTTL:            30,
+			TracerouteTimeout: 100 * time.Second,
+			PollFrequency:     time.Millisecond,
+			SendDelay:         10 * time.Millisecond,
+		}},
+	}
+	srcIP := netip.MustParseAddr("5.6.7.8")
+	if ipv6 {
+		srcIP = netip.MustParseAddr("2001:0db8:1234:5678:0000:0000:9abc:def0")
+	}
+
+	driver, err := newICMPDriver(params, srcIP, mockSink, mockSource)
+	require.NoError(t, err)
+
+	return driver, mockSink, mockSource
+}
+
+func expectIDs(t *testing.T, buf []byte, ipv6 bool, ttl uint8, srcIP, targetIP netip.Addr) {
+	var IP4 layers.IPv4
+	var IP6 layers.IPv6
+	var ICMPV4 layers.ICMPv4
+	var ICMPV6 layers.ICMPv6
+	var Payload gopacket.Payload
+
+	parser := gopacket.NewDecodingLayerParser(
+		layers.LayerTypeIPv4,
+		&IP4, &ICMPV4, &Payload,
+	)
+	if ipv6 {
+		parser = gopacket.NewDecodingLayerParser(
+			layers.LayerTypeIPv6,
+			&IP6, &ICMPV6, &Payload,
+		)
+	}
+	decoded := []gopacket.LayerType{}
+	err := parser.DecodeLayers(buf, &decoded)
+	var unsupportedErr gopacket.UnsupportedLayerType
+	if errors.As(err, &unsupportedErr) {
+		err = nil
+	}
+	require.NoError(t, err)
+
+	if ipv6 {
+		require.Equal(t, srcIP.Compare(netip.MustParseAddr(IP6.SrcIP.String())), 0)
+		require.Equal(t, targetIP.Compare(netip.MustParseAddr(IP6.DstIP.String())), 0)
+	} else {
+		require.Equal(t, srcIP.Compare(netip.MustParseAddr(IP4.SrcIP.String())), 0)
+		require.Equal(t, targetIP.Compare(netip.MustParseAddr(IP4.DstIP.String())), 0)
+		require.Equal(t, ttl, uint8(ICMPV4.Seq))
+	}
+}
+
+func mockICMPResp(t *testing.T, hopIP net.IP, ttl uint8, echoID uint16, icmpInfo packets.ICMPInfo, timeExceeded bool) []byte {
+	ipLayer := &layers.IPv4{
+		Version:  4,
+		Length:   20,
+		TTL:      ttl,
+		Protocol: layers.IPProtocolICMPv4,
+		DstIP:    icmpInfo.ICMPPair.SrcAddr.AsSlice(),
+		SrcIP:    hopIP,
+	}
+
+	var icmpLayer *layers.ICMPv4
+	if timeExceeded {
+		icmpLayer = &layers.ICMPv4{
+			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeTimeExceeded, layers.ICMPv4CodeTTLExceeded),
+		}
+	} else {
+		icmpLayer = &layers.ICMPv4{
+			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoReply, 0),
+			Id:       echoID,
+			Seq:      uint16(ttl),
+		}
+	}
+
+	var payload gopacket.Payload
+	if timeExceeded {
+		innerIPLayer := &layers.IPv4{
+			Version:  4,
+			Length:   20,
+			TTL:      ttl,
+			Id:       echoID,
+			Protocol: layers.IPProtocolICMPv4,
+			SrcIP:    icmpInfo.ICMPPair.SrcAddr.AsSlice(),
+			DstIP:    icmpInfo.ICMPPair.DstAddr.AsSlice(),
+		}
+
+		innerICMPEcho := &layers.ICMPv4{
+			TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+			Id:       echoID,
+			Seq:      uint16(ttl),
+		}
+
+		echoPayload := gopacket.Payload("hello")
+
+		innerBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+		err := gopacket.SerializeLayers(innerBuf, opts,
+			innerIPLayer,
+			innerICMPEcho,
+			echoPayload,
+		)
+		require.NoError(t, err)
+
+		payload = innerBuf.Bytes()
+	} else {
+		payload = gopacket.Payload("hello")
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	err := gopacket.SerializeLayers(buf, opts,
+		ipLayer,
+		icmpLayer,
+		payload,
+	)
+	require.NoError(t, err)
+
+	return buf.Bytes()
+}
+
+func mockICMPv6Resp(t *testing.T, hopIP net.IP, ttl uint8, echoID uint16, icmpInfo packets.ICMPInfo, timeExceeded bool) []byte {
+	ipv6Layer := &layers.IPv6{
+		Version:    6,
+		HopLimit:   ttl,
+		NextHeader: layers.IPProtocolICMPv6,
+		SrcIP:      hopIP,
+		DstIP:      icmpInfo.ICMPPair.SrcAddr.AsSlice(),
+	}
+
+	var icmpv6Layer *layers.ICMPv6
+	var payload gopacket.Payload
+
+	if timeExceeded {
+		icmpv6Layer = &layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeTimeExceeded, 0),
+		}
+		err := icmpv6Layer.SetNetworkLayerForChecksum(ipv6Layer)
+		require.NoError(t, err)
+
+		innerIPv6 := &layers.IPv6{
+			Version:    6,
+			HopLimit:   ttl,
+			NextHeader: layers.IPProtocolICMPv6,
+			SrcIP:      icmpInfo.ICMPPair.SrcAddr.AsSlice(),
+			DstIP:      icmpInfo.ICMPPair.DstAddr.AsSlice(),
+		}
+
+		innerICMPv6 := &layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+		}
+		err = innerICMPv6.SetNetworkLayerForChecksum(innerIPv6)
+		require.NoError(t, err)
+
+		innerEcho := &layers.ICMPv6Echo{
+			Identifier: echoID,
+			SeqNumber:  uint16(ttl),
+		}
+
+		echoPayload := gopacket.Payload("hello")
+
+		innerBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+		err = gopacket.SerializeLayers(innerBuf, opts,
+			innerIPv6,
+			innerICMPv6,
+			innerEcho,
+			echoPayload,
+		)
+		require.NoError(t, err)
+
+		payload = innerBuf.Bytes()
+	} else {
+		icmpv6Layer = &layers.ICMPv6{
+			TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoReply, 0),
+		}
+		err := icmpv6Layer.SetNetworkLayerForChecksum(ipv6Layer)
+		require.NoError(t, err)
+		buf := make([]byte, 4+5)
+		binary.BigEndian.PutUint16(buf[0:2], echoID)
+		binary.BigEndian.PutUint16(buf[2:4], uint16(ttl))
+		copy(buf[4:], "hello")
+		payload = buf
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+
+	var err error
+	if timeExceeded {
+		err = gopacket.SerializeLayers(buf, opts,
+			ipv6Layer,
+			icmpv6Layer,
+			// there are 4 unused bytes in the ICMP payload before the message body
+			// https://en.wikipedia.org/wiki/ICMPv6#Format
+			gopacket.Payload([]byte{0, 0, 0, 0}),
+			payload,
+		)
+	} else {
+		err = gopacket.SerializeLayers(buf, opts,
+			ipv6Layer,
+			icmpv6Layer,
+			payload,
+		)
+	}
+	require.NoError(t, err)
+
+	return buf.Bytes()
+}
+
+func mockRead(mockSource *packets.MockSource, packet []byte) {
+	mockSource.EXPECT().Read(gomock.Any()).DoAndReturn(func(buf []byte) (int, error) {
+		n := copy(buf, packet)
+		return n, nil
+	})
+}
+
+func TestICMPDriverTwoHops(t *testing.T) {
+	driver, mockSink, mockSource := initTest(t, false)
+
+	// *** TTL=1 -- get back an ICMP TTL exceeded
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, buf, false, 1, driver.localAddr, driver.params.Target)
+		require.Equal(t, driver.params.Target.Compare(addrPort.Addr()), 0)
+		return nil
+	})
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+
+	// make the source return an ICMP TTL exceeded
+	hopIP := net.ParseIP("42.42.42.42")
+	icmpResp := mockICMPResp(t, hopIP, 1, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: driver.localAddr,
+			DstAddr: driver.params.Target,
+		},
+	}, true)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).DoAndReturn(func(deadline time.Time) error {
+		require.True(t, deadline.After(time.Now().Add(500*time.Millisecond)))
+		return nil
+	})
+	mockRead(mockSource, icmpResp)
+
+	// should get back the ICMP hop IP
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), probeResp.TTL)
+	require.True(t, hopIP.Equal(probeResp.IP.AsSlice()))
+	require.False(t, probeResp.IsDest)
+
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, buf, false, 2, driver.localAddr, driver.params.Target)
+		require.Equal(t, driver.params.Target.Compare(addrPort.Addr()), 0)
+		return nil
+	})
+
+	// send the second packet
+	err = driver.SendProbe(2)
+	require.NoError(t, err)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+	icmpResp = mockICMPResp(t, driver.params.Target.AsSlice(), 2, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: driver.localAddr,
+			DstAddr: driver.params.Target,
+		},
+	}, false)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(2), probeResp.TTL)
+	require.Equal(t, driver.params.Target.AsSlice(), probeResp.IP.AsSlice())
+	require.True(t, probeResp.IsDest)
+}
+
+func TestICMPDriverTwoHopsV6(t *testing.T) {
+	driver, mockSink, mockSource := initTest(t, true)
+
+	// *** TTL=1 -- get back an ICMP TTL exceeded
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, buf, true, 1, driver.localAddr, driver.params.Target)
+		require.Equal(t, driver.params.Target.Compare(addrPort.Addr()), 0)
+		return nil
+	})
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+
+	// make the source return an ICMP TTL exceeded
+	hopIP := net.ParseIP("2001:0db8:85a3::8a2e:0370:7334")
+	icmpResp := mockICMPv6Resp(t, hopIP, 1, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: driver.localAddr,
+			DstAddr: driver.params.Target,
+		},
+	}, true)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).DoAndReturn(func(deadline time.Time) error {
+		require.True(t, deadline.After(time.Now().Add(500*time.Millisecond)))
+		return nil
+	})
+	mockRead(mockSource, icmpResp)
+
+	// should get back the ICMP hop IP
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), probeResp.TTL)
+	require.True(t, hopIP.Equal(probeResp.IP.AsSlice()))
+	require.False(t, probeResp.IsDest)
+
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(func(buf []byte, addrPort netip.AddrPort) error {
+		expectIDs(t, buf, true, 2, driver.localAddr, driver.params.Target)
+		require.Equal(t, driver.params.Target.Compare(addrPort.Addr()), 0)
+		return nil
+	})
+
+	// send the second packet
+	err = driver.SendProbe(2)
+	require.NoError(t, err)
+
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).Return(nil)
+	icmpResp = mockICMPv6Resp(t, driver.params.Target.AsSlice(), 2, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: driver.localAddr,
+			DstAddr: driver.params.Target,
+		},
+	}, false)
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.NoError(t, err)
+	require.Equal(t, uint8(2), probeResp.TTL)
+	require.Equal(t, driver.params.Target.AsSlice(), probeResp.IP.AsSlice())
+	require.True(t, probeResp.IsDest)
+}
+
+func TestICMPDriverICMPMismatchedIP(t *testing.T) {
+	driver, mockSink, mockSource := initTest(t, false)
+	mockSource.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
+	mockSink.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil)
+
+	// trigger the mock
+	err := driver.SendProbe(1)
+	require.NoError(t, err)
+
+	hopIP := net.ParseIP("42.42.42.42")
+	badIP := netip.MustParseAddr("8.8.8.8")
+	icmpResp := mockICMPResp(t, hopIP, 1, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: driver.localAddr,
+			DstAddr: badIP,
+		},
+	}, true)
+
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err := driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+
+	icmpResp = mockICMPResp(t, hopIP, 1, driver.echoID, packets.ICMPInfo{
+		ICMPPair: packets.IPPair{
+			SrcAddr: badIP,
+			DstAddr: driver.params.Target,
+		},
+	}, true)
+
+	mockRead(mockSource, icmpResp)
+
+	probeResp, err = driver.ReceiveProbe(1 * time.Second)
+	require.Nil(t, probeResp)
+	require.ErrorIs(t, err, common.ErrPacketDidNotMatchTraceroute)
+}

--- a/pkg/networkpath/traceroute/icmp/icmp_packet.go
+++ b/pkg/networkpath/traceroute/icmp/icmp_packet.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package icmp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+type icmpPacketGen struct {
+	ipPair packets.IPPair
+}
+
+func (s *icmpPacketGen) generatePacketV4(ttl uint8, echoID uint16) (*layers.IPv4, *layers.ICMPv4, error) {
+	ipLayer := &layers.IPv4{
+		Version:  4,
+		TTL:      ttl,
+		SrcIP:    s.ipPair.SrcAddr.AsSlice(),
+		DstIP:    s.ipPair.DstAddr.AsSlice(),
+		Id:       echoID,
+		Protocol: layers.IPProtocolICMPv4,
+	}
+	icmpLayer := &layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+		Id:       echoID,
+		Seq:      uint16(ttl),
+	}
+	return ipLayer, icmpLayer, nil
+}
+
+func (s *icmpPacketGen) generatePacketV6(ttl uint8, echoID uint16) (*layers.IPv6, *layers.ICMPv6, []byte, error) {
+	ipLayer := &layers.IPv6{
+		Version:    6,
+		HopLimit:   ttl,
+		SrcIP:      s.ipPair.SrcAddr.AsSlice(),
+		DstIP:      s.ipPair.DstAddr.AsSlice(),
+		NextHeader: layers.IPProtocolICMPv6,
+	}
+	icmpLayer := &layers.ICMPv6{
+		TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+	}
+
+	// Construct payload: ID (2 bytes) + Seq (2 bytes) + data
+	payload := make([]byte, 5)
+	binary.BigEndian.PutUint16(payload[0:2], echoID)
+	binary.BigEndian.PutUint16(payload[2:4], uint16(ttl))
+	payload[4] = ttl // Extra data byte (same as IPv4 version)
+
+	return ipLayer, icmpLayer, payload, nil
+}
+
+func (s *icmpPacketGen) generate(ttl uint8, echoID uint16, ipv6 bool) ([]byte, error) {
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+
+	if ipv6 {
+		ip6, icmpv6, payload, err := s.generatePacketV6(ttl, echoID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate IPv6 packet: %w", err)
+		}
+		err = icmpv6.SetNetworkLayerForChecksum(ip6)
+		if err != nil {
+			return nil, fmt.Errorf("failed to SetNetworkLayerForChecksum IPv6 packet: %w", err)
+		}
+		err = gopacket.SerializeLayers(buf, opts, ip6, icmpv6, gopacket.Payload(payload))
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize IPv6 packet: %w", err)
+		}
+		return buf.Bytes(), nil
+	}
+	ip4, icmpv4, err := s.generatePacketV4(ttl, echoID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate IPv4 packet: %w", err)
+	}
+	err = gopacket.SerializeLayers(buf, opts, ip4, icmpv4, gopacket.Payload([]byte{ttl}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize IPv4 packet: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/networkpath/traceroute/icmp/portable_icmp/portable_icmp.go
+++ b/pkg/networkpath/traceroute/icmp/portable_icmp/portable_icmp.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package main contains a portable binary to easily run ICMP traceroutes
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/icmp"
+
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	pkglogsetup "github.com/DataDog/datadog-agent/pkg/util/log/setup"
+)
+
+func main() {
+
+	loglevel := "debug"
+
+	err := pkglogsetup.SetupLogger(
+		pkglogsetup.LoggerName("icmp"),
+		loglevel,
+		"",
+		"",
+		false,
+		true,
+		false,
+		pkgconfigsetup.Datadog(),
+	)
+	if err != nil {
+		fmt.Printf("SetupLogger failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	if len(os.Args) < 2 {
+		println("Usage: portable_icmp <target>")
+		os.Exit(1)
+	}
+	target := os.Args[1]
+
+	cfg := icmp.Params{
+		Target: netip.MustParseAddr(target),
+		ParallelParams: common.TracerouteParallelParams{
+			TracerouteParams: common.TracerouteParams{
+				MinTTL:            1,
+				MaxTTL:            30,
+				TracerouteTimeout: 1 * time.Second,
+				PollFrequency:     100 * time.Millisecond,
+				SendDelay:         10 * time.Millisecond,
+			},
+		},
+	}
+
+	results, err := icmp.RunICMPTraceroute(context.Background(), cfg)
+	if err != nil {
+		fmt.Printf("Traceroute failed: %s\n", err)
+		os.Exit(1)
+	}
+	json, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		fmt.Printf("Error marshalling results: %s\n", err)
+		os.Exit(1)
+	}
+	println(string(json))
+}

--- a/pkg/networkpath/traceroute/icmp/traceroute_icmp.go
+++ b/pkg/networkpath/traceroute/icmp/traceroute_icmp.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package icmp has icmp tracerouting logic
+package icmp
+
+import (
+	"fmt"
+	"net/netip"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+)
+
+// NotSupportedError means not on a supported platform.
+type NotSupportedError struct {
+	Err error
+}
+
+func (e *NotSupportedError) Error() string {
+	return fmt.Sprintf("icmp not supported by the target: %s", e.Err)
+}
+func (e *NotSupportedError) Unwrap() error {
+	return e.Err
+}
+
+// Params is the ICMP traceroute parameters
+type Params struct {
+	// Target is the IP:port to traceroute
+	Target netip.Addr
+	// ParallelParams are the standard params for parallel traceroutes
+	ParallelParams common.TracerouteParallelParams
+}
+
+// MaxTimeout returns the sum of all timeouts/delays for an ICMP traceroute
+func (p Params) MaxTimeout() time.Duration {
+	ttl := time.Duration(p.ParallelParams.MaxTTL - p.ParallelParams.MinTTL)
+	return ttl * p.ParallelParams.MaxTimeout()
+}

--- a/pkg/networkpath/traceroute/icmp/traceroute_icmp_linux.go
+++ b/pkg/networkpath/traceroute/icmp/traceroute_icmp_linux.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package icmp
+
+import (
+	"context"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
+	"net/netip"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func (p Params) validate() error {
+	addr := p.Target
+	if !addr.IsValid() {
+		return fmt.Errorf("ICMP traceroute provided invalid IP address")
+	}
+	return nil
+}
+
+type icmpResult struct {
+	LocalAddr netip.AddrPort
+	Hops      []*common.ProbeResponse
+}
+
+func runICMPTraceroute(ctx context.Context, p Params) (*icmpResult, error) {
+	err := p.validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid icmp driver params: %w", err)
+	}
+
+	local, udpConn, err := common.LocalAddrForHost(p.Target.AsSlice(), 80)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local addr: %w", err)
+	}
+	udpConn.Close()
+	deadline := time.Now().Add(p.MaxTimeout())
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	sink, err := packets.NewSinkUnix(p.Target)
+	if err != nil {
+		return nil, fmt.Errorf("runICMPTraceroute failed to make SinkUnix: %w", err)
+	}
+
+	source, err := packets.NewAFPacketSource()
+	if err != nil {
+		sink.Close()
+		return nil, fmt.Errorf("runICMPTraceroute failed to make ICMP raw conn: %w", err)
+	}
+
+	// create the raw packet connection which watches for TCP/ICMP responses
+	driver, err := newICMPDriver(p, local.AddrPort().Addr(), sink, source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init icmp driver: %w", err)
+	}
+	defer driver.Close()
+
+	log.Debugf("icmp traceroute dialing %s", p.Target)
+	// this actually runs the traceroute
+	resp, err := common.TracerouteParallel(ctx, driver, p.ParallelParams)
+	if err != nil {
+		return nil, fmt.Errorf("icmp traceroute failed: %w", err)
+	}
+
+	result := &icmpResult{
+		LocalAddr: local.AddrPort(),
+		Hops:      resp,
+	}
+	return result, nil
+}
+
+// RunICMPTraceroute fully executes a ICMP traceroute using the given parameters
+func RunICMPTraceroute(ctx context.Context, p Params) (*common.Results, error) {
+	icmpResult, err := runICMPTraceroute(ctx, p)
+	if err != nil {
+		return nil, fmt.Errorf("icmp traceroute failed: %w", err)
+	}
+
+	hops, err := common.ToHops(p.ParallelParams.TracerouteParams, icmpResult.Hops)
+	if err != nil {
+		return nil, fmt.Errorf("icmp traceroute ToHops failed: %w", err)
+	}
+
+	result := &common.Results{
+		Source:     icmpResult.LocalAddr.Addr().AsSlice(),
+		SourcePort: icmpResult.LocalAddr.Port(),
+		Target:     p.Target.AsSlice(),
+		Hops:       hops,
+		Tags:       []string{"icmp"},
+	}
+
+	return result, nil
+}

--- a/pkg/networkpath/traceroute/icmp/traceroute_icmp_nolinux.go
+++ b/pkg/networkpath/traceroute/icmp/traceroute_icmp_nolinux.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package icmp
+
+import (
+	"context"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+)
+
+var errPlatformNotSupported = &NotSupportedError{
+	Err: errors.New("ICMP traceroute is not supported on this platform"),
+}
+
+// RunICMPTraceroute is not supported
+func RunICMPTraceroute(_ctx context.Context, _p Params) (*common.Results, error) {
+	return nil, errPlatformNotSupported
+}

--- a/pkg/networkpath/traceroute/packets/frame_parser.go
+++ b/pkg/networkpath/traceroute/packets/frame_parser.go
@@ -147,7 +147,6 @@ func (p *FrameParser) GetIPPair() (IPPair, error) {
 	case layers.LayerTypeIPv6:
 		return getIPv6Pair(&p.IP6), nil
 	default:
-		// TODO IPv6
 		return IPPair{}, fmt.Errorf("GetIPPair: unexpected IP layer type %s", p.Layers[0])
 	}
 }

--- a/pkg/networkpath/traceroute/sack/sack_driver_linux.go
+++ b/pkg/networkpath/traceroute/sack/sack_driver_linux.go
@@ -226,7 +226,6 @@ func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to get ICMP info: %w", err)}
 		}
-
 		tcpInfo, err := packets.ParseTCPFirstBytes(icmpInfo.Payload)
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to parse TCP info: %w", err)}

--- a/pkg/networkpath/traceroute/sack/sack_driver_linux.go
+++ b/pkg/networkpath/traceroute/sack/sack_driver_linux.go
@@ -226,6 +226,7 @@ func (s *sackDriver) handleProbeLayers(parser *packets.FrameParser) (*common.Pro
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to get ICMP info: %w", err)}
 		}
+
 		tcpInfo, err := packets.ParseTCPFirstBytes(icmpInfo.Payload)
 		if err != nil {
 			return nil, &common.BadPacketError{Err: fmt.Errorf("sackDriver failed to parse TCP info: %w", err)}

--- a/pkg/networkpath/traceroute/udp/udp_driver_test.go
+++ b/pkg/networkpath/traceroute/udp/udp_driver_test.go
@@ -6,7 +6,6 @@
 package udp
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
 	"net"
 	"net/netip"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/packets"
 )
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a ICMP traceroute driver for IPv4 and IPv6
### Motivation
This PR adds IPv6/IPv4 support on icmp for the existing traceroute methods

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Build for an ec2 box with IPv6 enabled:
```
GOARCH=amd64 go build github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/icmp/portable_icmp
```
2. `scp` it to the ec2 box
3. Traceroute to Google's public DNS servers: `sudo -E ./portable_icmp 2001:4860:4860::8888`


### Possible Drawbacks / Trade-offs
Also this isn't tested like the TCP driver yet

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->