### PR TITLE
Adding JMXFetch config option to allow setting env var JAVA_TOOL_OPTIONS

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2561,6 +2561,13 @@ api_key:
 #
 # jmx_telemetry_enabled: false
 
+## @param jmx_java_tool_options - string - optional
+## @env DD_JMX_JAVA_TOOL_OPTIONS - string - optional
+## If you only run Autodiscovery tests, jmxfetch might fail to pick up custom_jar_paths
+## set in the check templates. If that is the case, force custom jars here.
+#
+# jmx_java_tool_options: -javaagent:/path/to/agent.jar -XX:+UseG1GC
+
 {{ end -}}
 {{- if .Logging }}
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -647,6 +647,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
+	config.BindEnvAndSetDefault("jmx_java_tool_options", "")
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 	config.BindEnvAndSetDefault("jmx_use_container_support", false)
 	config.BindEnvAndSetDefault("jmx_max_ram_percentage", float64(25.0))

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -365,6 +365,12 @@ func (j *JMXFetch) Start(manage bool) error {
 		fmt.Sprintf("SESSION_TOKEN=%s", api.GetAuthToken()),
 	)
 
+	// append JAVA_TOOL_OPTIONS to cmd Env
+	javaToolOptions := pkgconfigsetup.Datadog().GetString("jmx_java_tool_options")
+	if len(javaToolOptions) > 0 {
+		j.cmd.Env = append(j.cmd.Env, fmt.Sprintf("JAVA_TOOL_OPTIONS=%s", javaToolOptions))
+	}
+
 	// forward the standard output to the Agent logger
 	stdout, err := j.cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Adding JMXFetch config option to allow setting env var JAVA_TOOL_OPTIONS for JMXFetch process.

### Motivation

I want to pass `JAVA_TOOL_OPTIONS` env var to JMXFetch via adding it to `datadog.yaml` rather than having to change/update the systemd service or init scripts that start the Agent.  

### Describe how you validated your changes

Update `datadog.yaml` and set `jmx_java_tool_options` or set env var `DD_JMX_JAVA_TOOL_OPTIONS` to `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005`. This causes JMXFetch start with the JVM debugger running on port `5005`.

Then using `netcat` connect to `localhost` on port `5005`:

```shell
nc 127.0.0.1 5005 -v
Connection to 127.0.0.1 5005 port [tcp/*] succeeded!
```

Or attach vscode to the Java process.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->