### PR TITLE
fix terminated endpointslices collection

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -55,6 +55,7 @@ type CollectorMetadata struct {
 	LabelsAsTags                         map[string]string
 	AnnotationsAsTags                    map[string]string
 	SupportsTerminatedResourceCollection bool
+	IsGenericCollector                   bool
 }
 
 // CollectorTags returns static tags to be added to all resources collected by the collector.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/generic.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/generic.go
@@ -51,6 +51,7 @@ func (r GenericResource) NewGenericCollector() (*CRCollector, error) {
 			NodeType:                             r.NodeType,
 			Version:                              r.GroupVersion,
 			SupportsTerminatedResourceCollection: true,
+			IsGenericCollector:                   true,
 		},
 		gvr:       gv.WithResource(r.Name),
 		processor: processors.NewProcessor(&k8sProcessors.CRHandlers{IsGenericResource: true}),

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -111,7 +111,7 @@ func toTypedSlice(k8sCollector collectors.K8sCollector, list []interface{}) inte
 		return nil
 	}
 
-	if k8sCollector.Metadata().NodeType == orchestrator.K8sCR || k8sCollector.Metadata().NodeType == orchestrator.K8sCRD {
+	if k8sCollector.Metadata().NodeType == orchestrator.K8sCR || k8sCollector.Metadata().NodeType == orchestrator.K8sCRD || k8sCollector.Metadata().IsGenericCollector {
 		typedList := make([]runtime.Object, 0, len(list))
 		for i := range list {
 			if _, ok := list[i].(runtime.Object); !ok {


### PR DESCRIPTION
### What does this PR do?

When EndpointSlice collection is enabled, a panic occurs during terminated resource collection. 
```
UTC | CORE | ERROR | (pkg/collector/corechecks/cluster/orchestrator/processors/errors.go:30 in RecoverOnPanic) | unable to process resources (panic!): goroutine 565 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x64
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.RecoverOnPanic()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/errors.go:29 +0x2c
panic({0x3055e40?, 0x409a62d6e0?})
	/usr/local/go/src/runtime/panic.go:792 +0x124
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s.(*CRHandlers).ResourceList(0x150000000000028?, {0x150007f0080?, 0x409c9b15f8?}, {0x2e57ac0?, 0x40b230cbe8?})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr.go:70 +0x158

```

This happens because we use a generic collector based on CR collector to gather EndpointSlice manifests. Therefore, we need to update the terminated resource collection logic to support the generic collector.


### QA

Deploy agent on a cluster with config and `DD_ORCHESTRATOR_EXPLORER_TERMINATED_RESOURCES_ENABLED=true`

```
  confd:
    orchestrator.yaml: |-
      init_config:
      instances:
        - collectors:
          - endpointslices
```

Delete an EndpointSlice and verify that the cluster agent does not panic.

### ToDo

Add an e2e test for terminated resource collection.