### PR TITLE
[CWS] Fix CWS instrumentation timeout

### DIFF
--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -52,7 +53,7 @@ func (o *Copy) prepareCommand(destFile string) []string {
 }
 
 // CopyToPod copies the provided local file to the provided container
-func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string) error {
+func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
 	o.Container = container
 	localFile = path.Clean(localFile)
 	remoteFile = path.Clean(remoteFile)
@@ -87,7 +88,7 @@ func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, c
 		Stdin: true,
 	}
 
-	if err := o.Execute(pod, o.prepareCommand(remoteFile), streamOptions); err != nil {
+	if err := o.Execute(pod, o.prepareCommand(remoteFile), streamOptions, timeout); err != nil {
 		return err
 	}
 

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/exec.go
@@ -11,6 +11,8 @@ package k8sexec
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -50,7 +52,7 @@ func NewExec(apiClient *apiserver.APIClient) Exec {
 }
 
 // Execute runs the exec command
-func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOptions) error {
+func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOptions, timeout time.Duration) error {
 	restClient, err := e.APIClient.RESTClient(
 		"/api",
 		&schema.GroupVersion{Version: "v1"},
@@ -84,9 +86,15 @@ func (e Exec) Execute(pod *corev1.Pod, command []string, streamOptions StreamOpt
 		return err
 	}
 
-	return exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  streamOptions.In,
 		Stdout: streamOptions.Out,
 		Stderr: streamOptions.ErrOut,
 	})
+	if err != nil {
+		return fmt.Errorf("SPDY stream error: %v", err)
+	}
+	return nil
 }

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
@@ -9,6 +9,7 @@ package k8sexec
 
 import (
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -42,7 +43,7 @@ func (hc *HealthCommand) prepareCommand(destFile string) []string {
 }
 
 // Run runs the cws-instrumentation health command
-func (hc *HealthCommand) Run(remoteFile string, pod *corev1.Pod, container string) error {
+func (hc *HealthCommand) Run(remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
 	hc.Container = container
 
 	streamOptions := StreamOptions{
@@ -53,7 +54,7 @@ func (hc *HealthCommand) Run(remoteFile string, pod *corev1.Pod, container strin
 		Stdin: false,
 	}
 
-	if err := hc.Execute(pod, hc.prepareCommand(remoteFile), streamOptions); err != nil {
+	if err := hc.Execute(pod, hc.prepareCommand(remoteFile), streamOptions, timeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR is a fix of https://github.com/DataDog/datadog-agent/pull/37697. The timeout from the initial PR correctly times out the pods/exec admission request if our mutating webhook is too slow to answer, but it doesn't timeout the request on the cluster-agent's end.

### Motivation

Prevent the cluster-agent from keeping open connections for minutes (if not hours) when the `api-server` / `etcd` are lagging behind. We want everything to timeout at the same time (both the `pods/exec` admission request and the request handler).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->