### PR TITLE
[AGENTRUN-502] Create non-scrubbed list to avoid hardcoded ignored list in flare intake

### DIFF
--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -160,7 +160,7 @@ func (fb *builder) Save() (string, error) {
 		fb.Lock()
 		defer fb.Unlock()
 		if len(fb.nonScrubbedFiles) == 0 {
-			return []byte(`{"files": [], "message": "No files were added without scrubbing"}`), nil
+			return []byte(`{"files": [], "message": "All files were scrubbed"}`), nil
 		}
 
 		// Convert map keys to slice for JSON output

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -8,6 +8,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -32,10 +33,11 @@ const (
 
 func newBuilder(root string, hostname string, localFlare bool, flareArgs types.FlareArgs) (*builder, error) {
 	fb := &builder{
-		tmpDir:     root,
-		permsInfos: permissionsInfos{},
-		isLocal:    localFlare,
-		flareArgs:  flareArgs,
+		tmpDir:           root,
+		permsInfos:       permissionsInfos{},
+		isLocal:          localFlare,
+		flareArgs:        flareArgs,
+		nonScrubbedFiles: make(map[string]bool),
 	}
 
 	fb.flareDir = filepath.Join(fb.tmpDir, hostname)
@@ -127,6 +129,9 @@ type builder struct {
 	scrubber *scrubber.Scrubber
 
 	logFile *os.File
+
+	// nonScrubbedFiles tracks files that were added without scrubbing
+	nonScrubbedFiles map[string]bool
 }
 
 func getArchiveName() string {
@@ -149,6 +154,33 @@ func (fb *builder) Save() (string, error) {
 		fb.Lock()
 		defer fb.Unlock()
 		return fb.permsInfos.commit()
+	})
+
+	_ = fb.AddFileFromFunc("non_scrubbed_files.json", func() ([]byte, error) {
+		fb.Lock()
+		defer fb.Unlock()
+		if len(fb.nonScrubbedFiles) == 0 {
+			return []byte(`{"files": [], "message": "No files were added without scrubbing"}`), nil
+		}
+
+		// Convert map keys to slice for JSON output
+		files := make([]string, 0, len(fb.nonScrubbedFiles))
+		for file := range fb.nonScrubbedFiles {
+			files = append(files, file)
+		}
+
+		// Create JSON structure
+		result := map[string]interface{}{
+			"files": files,
+			"count": len(files),
+		}
+
+		jsonData, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling non-scrubbed files to JSON: %v", err)
+		}
+
+		return jsonData, nil
 	})
 
 	_ = fb.logFile.Close()
@@ -232,6 +264,11 @@ func (fb *builder) addFile(shouldScrub bool, destFile string, content []byte) er
 		if err != nil {
 			return fb.logError("error scrubbing content for '%s': %s", destFile, err)
 		}
+	} else {
+		// Track non-scrubbed files
+		fb.Lock()
+		fb.nonScrubbedFiles[destFile] = true
+		fb.Unlock()
 	}
 
 	fb.Lock()
@@ -292,6 +329,11 @@ func (fb *builder) copyFileTo(shouldScrub bool, srcFile string, destFile string)
 		if err != nil {
 			return fb.logError("error scrubbing content for file '%s': %s", destFile, err)
 		}
+	} else {
+		// Track non-scrubbed files
+		fb.Lock()
+		fb.nonScrubbedFiles[destFile] = true
+		fb.Unlock()
 	}
 
 	fb.Lock()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This pull request introduces an automated approach to managing non-scrubbed files during the Flare intake process. Instead of relying on a hardcoded ignore list in the backend, this update generates and maintains a JSON file containing all non-scrubbed files. This ensures that only non-text files are excluded from scrubbing dynamically, improving maintainability and reducing the risk of errors caused by manual updates.

### Motivation

Avoid to scrub profiles

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Generated a flare manually: `agent flare --profile 30`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Log file are present in the list since logs are scrubbed at runtime, however all log files will still be scrubbed on the intake side.