### PR TITLE
[EBPF] complexity: fix notify job

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -168,6 +168,7 @@ kmt_*                             @DataDog/ebpf-platform
 upload_secagent_tests*            @DataDog/ebpf-platform
 upload_sysprobe_tests*            @DataDog/ebpf-platform
 notify_ebpf_complexity_changes    @DataDog/ebpf-platform
+test_ebpf_complexity_changes      @DataDog/ebpf-platform
 pull_test_dockers*                @DataDog/universal-service-monitoring
 
 # Single machine performance

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -363,7 +363,7 @@ test_ebpf_complexity_changes:
         - "tasks/kmt.py"
         - "tasks/ebpf.py"
         - "tasks/kernel_matrix_testing/ci.py"
-      compare_to: $COMPARE_TO_BRANCH
+        compare_to: $COMPARE_TO_BRANCH
     - if: $CI_COMMIT_BRANCH == "main"
       when: never
   allow_failure: false

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -356,6 +356,7 @@ notify_ebpf_complexity_changes:
 
 test_ebpf_complexity_changes:
   extends: .notify_ebpf_complexity_changes
+  stage: source_test
   rules:
     # Execute this job whenever there are changes to the KMT python files that are used to generate the complexity data
     - changes:
@@ -366,7 +367,6 @@ test_ebpf_complexity_changes:
         compare_to: $COMPARE_TO_BRANCH
       when: always
     - !reference [.except_main_release_or_mq]
-    - when: never
   allow_failure: false
   variables:
     EXTRA_ARGS: "--skip-github-comment"

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -364,8 +364,9 @@ test_ebpf_complexity_changes:
         - "tasks/ebpf.py"
         - "tasks/kernel_matrix_testing/ci.py"
         compare_to: $COMPARE_TO_BRANCH
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: never
+      when: always
+    - !reference [.except_main_release_or_mq]
+    - when: never
   allow_failure: false
   variables:
     EXTRA_ARGS: "--skip-github-comment"

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -363,6 +363,7 @@ test_ebpf_complexity_changes:
         - "tasks/kmt.py"
         - "tasks/ebpf.py"
         - "tasks/kernel_matrix_testing/ci.py"
+      compare_to: $COMPARE_TO_BRANCH
     - if: $CI_COMMIT_BRANCH == "main"
       when: never
   allow_failure: false

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -304,17 +304,11 @@
       echo "dda inv kmt.retry-failed-pipeline --pipeline-id $CI_PIPELINE_ID"
     fi
 
-notify_ebpf_complexity_changes:
+.notify_ebpf_complexity_changes:
   extends: .notify-job
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$CI_IMAGE_LINUX_GLIBC_2_17_X64_SUFFIX:$CI_IMAGE_LINUX_GLIBC_2_17_X64
   tags: ["arch:amd64"]
   timeout: 15m
-  rules:
-    - !reference [.except_main_release_or_mq]
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_deploy]
-    - !reference [.on_system_probe_or_e2e_changes_or_manual]
-    - !reference [.on_security_agent_changes_or_manual]
   needs:
     # We need to specify the jobs that generate complexity explicitly, else we hit the limit of "needs"
     # Important: the list of platforms should match the one in .define_if_collect_complexity
@@ -349,4 +343,28 @@ notify_ebpf_complexity_changes:
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
   script:
-    - dda inv -- -e ebpf.generate-complexity-summary-for-pr --gitlab-config-file artifacts/after.gitlab-ci.yml
+    - dda inv -- -e ebpf.generate-complexity-summary-for-pr --gitlab-config-file artifacts/after.gitlab-ci.yml $EXTRA_ARGS
+
+notify_ebpf_complexity_changes:
+  extends: .notify_ebpf_complexity_changes
+  rules:
+    - !reference [.except_main_release_or_mq]
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_deploy]
+    - !reference [.on_system_probe_or_e2e_changes_or_manual]
+    - !reference [.on_security_agent_changes_or_manual]
+
+test_ebpf_complexity_changes:
+  extends: .notify_ebpf_complexity_changes
+  rules:
+    # Execute this job whenever there are changes to the KMT python files that are used to generate the complexity data
+    - changes:
+        paths:
+        - "tasks/kmt.py"
+        - "tasks/ebpf.py"
+        - "tasks/kernel_matrix_testing/ci.py"
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: never
+  allow_failure: false
+  variables:
+    EXTRA_ARGS: "--skip-github-comment"

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -356,7 +356,6 @@ notify_ebpf_complexity_changes:
 
 test_ebpf_complexity_changes:
   extends: .notify_ebpf_complexity_changes
-  stage: source_test
   rules:
     # Execute this job whenever there are changes to the KMT python files that are used to generate the complexity data
     - changes:

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1346,9 +1346,9 @@ def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
         return stack
 
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(
-        stack
-    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    assert stacks.stack_exists(stack), (
+        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    )
     return stack
 
 
@@ -1432,9 +1432,9 @@ def build(
 @task
 def clean(ctx: Context, stack: str | None = None, container=False, image=False):
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(
-        stack
-    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    assert stacks.stack_exists(stack), (
+        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    )
 
     ctx.run("rm -rf ./test/new-e2e/tests/sysprobe-functional/artifacts/pkg")
     ctx.run(f"rm -rf kmt-deps/{stack}", warn=True)
@@ -2028,9 +2028,9 @@ def selftest(ctx: Context, allow_infra_changes=False, filter: str | None = None)
 @task
 def show_last_test_results(ctx: Context, stack: str | None = None):
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(
-        stack
-    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    assert stacks.stack_exists(stack), (
+        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
+    )
     assert tabulate is not None, "tabulate module is not installed, please install it to continue"
 
     paths = KMTPaths(stack, Arch.local())
@@ -2350,6 +2350,9 @@ def download_complexity_data(
     gitlab = get_gitlab_repo()
     dest_path = Path(dest_path)
     deps: list[JobDependency] = []
+
+    # Ensure the destination path exists
+    dest_path.mkdir(parents=True, exist_ok=True)
 
     if not download_all_jobs:
         print("Parsing .gitlab-ci.yml file to understand the dependencies for notify_ebpf_complexity_changes")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1346,9 +1346,9 @@ def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
         return stack
 
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(stack), (
-        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
-    )
+    assert stacks.stack_exists(
+        stack
+    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
     return stack
 
 
@@ -1432,9 +1432,9 @@ def build(
 @task
 def clean(ctx: Context, stack: str | None = None, container=False, image=False):
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(stack), (
-        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
-    )
+    assert stacks.stack_exists(
+        stack
+    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
 
     ctx.run("rm -rf ./test/new-e2e/tests/sysprobe-functional/artifacts/pkg")
     ctx.run(f"rm -rf kmt-deps/{stack}", warn=True)
@@ -2028,9 +2028,9 @@ def selftest(ctx: Context, allow_infra_changes=False, filter: str | None = None)
 @task
 def show_last_test_results(ctx: Context, stack: str | None = None):
     stack = check_and_get_stack(stack)
-    assert stacks.stack_exists(stack), (
-        f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
-    )
+    assert stacks.stack_exists(
+        stack
+    ), f"Stack {stack} does not exist. Please create with 'dda inv kmt.create-stack --stack=<name>'"
     assert tabulate is not None, "tabulate module is not installed, please install it to continue"
 
     paths = KMTPaths(stack, Arch.local())


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the complexity notification job by ensuring the target directory for complexity data is created. It also adds a test job to ensure that changes to KMT Python code do not break it.

### Motivation

Stability of the notify_complexity_changes job.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added a CI job to validate it.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->