### PR TITLE
linters: enable 'perfsprint'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -450,6 +450,7 @@ linters:
     - gocheckcompilerdirectives # Checks Go compiler directives syntax
     - pkgconfigusage            # Linter for checking usage of pkgconfig inside components folder
     - forbidigo                 # prevent usage of unwanted/deprecated symbol in the code base
+    - perfsprint                # Checks when fmt.Sprintf can be replaced with a faster alternative
 
 linters-settings:
   depguard:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enable golangci-lint linter that detects usage of fmt.Sprintf that could be replaced by more efficient alternatives.

### Motivation

Remove bad uses of `fmt.Sprintf` like `fmt.Sprintf("%s%s", s1, s2)`.

```console
$ ag 'fmt\.Sprintf\("(%s)+"'
cmd/serverless-init/cloudservice/cloudrun.go
162:            containerIDURL: fmt.Sprintf("%s%s", defaultBaseURL, defaultContainerIDURL),
163:            regionURL:      fmt.Sprintf("%s%s", defaultBaseURL, defaultRegionURL),
164:            projectIDURL:   fmt.Sprintf("%s%s", defaultBaseURL, defaultProjectID),

cmd/agent/subcommands/integrations/integrations_nix_helpers.go
27:     return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, pythonMajorVersion))

test/fakeintake/client/client_integration_test.go
41:             resp, err := http.Post(fmt.Sprintf("%s%s", fi.URL(), testEndpoint), "text/plain", strings.NewReader("totoro|5|tag:valid,owner:pducolin"))
61:             resp, err := http.Post(fmt.Sprintf("%s%s", fi.URL(), "/foo/bar"), "text/plain", strings.NewReader("totoro|5|tag:before,owner:pducolin"))
80:             resp, err = http.Post(fmt.Sprintf("%s%s", fi.URL(), "/bar/foo"), "text/plain", strings.NewReader("ponyo|7|tag:after,owner:pducolin"))

test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_test.go
138:                            assert.Equal(c, longLineLog, fmt.Sprintf("%s%s", filteredLogs[0].Message, "\n"), "Test log doesn't match")

test/new-e2e/tests/windows/common/agent/package.go
155:    productName = fmt.Sprintf("%s%s", productName, nameSuffix)

internal/tools/modformatter/modformatter.go
53:                     dep := fmt.Sprintf("%s%s", prefixStr, element)

comp/dogstatsd/server/enrich_test.go
1176:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},
1198:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "none")},
1220:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42")},
1242:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.HighCardinalityString},
1265:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.OrchestratorCardinalityString},
1288:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.LowCardinalityString},
1311:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.UnknownCardinalityString},
1334:                           tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix},

comp/core/secrets/secretsimpl/secrets_test.go
608:            oldValues = append(oldValues, fmt.Sprintf("%s", oldValue))
609:            newValues = append(newValues, fmt.Sprintf("%s", newValue))
693:            changes = append(changes, fmt.Sprintf("%s", newValue))

comp/core/status/render_helpers.go
231:    return fmt.Sprintf("%s", res)

pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
520:                                    expectedCommand := fmt.Sprintf("%s%s", filepath.Join(cwsMountPath, "cws-instrumentation"), " inject --session-type k8s --data")

pkg/jmxfetch/jmxfetch.go
202:            classpath = fmt.Sprintf("%s%s%s", j.JavaToolsJarPath, string(os.PathListSeparator), classpath)
207:            classpath = fmt.Sprintf("%s%s%s", strings.Join(globalCustomJars, string(os.PathListSeparator)), string(os.PathListSeparator), classpath)
211:            classpath = fmt.Sprintf("%s%s%s", strings.Join(j.JavaCustomJarPaths, string(os.PathListSeparator)), string(os.PathListSeparator), classpath)

pkg/util/kubernetes/kubelet/kubelet_client.go
146:            fmt.Sprintf("%s%s", baseURL, path), nil)

pkg/util/kubernetes/apiserver/services_kubelet.go
143:    log.Tracef("The services matched %q", fmt.Sprintf("%s", metaBundle.Services))

pkg/config/setup/config.go
2463:                           modifyValue[index] = fmt.Sprintf("%s", newValue)

pkg/config/nodetreemodel/reflection_node.go
48:                             kstr = fmt.Sprintf("%s", mk.Interface())

pkg/config/nodetreemodel/node.go
34:                     mk = fmt.Sprintf("%s", k.Interface())

pkg/config/structure/unmarshal.go
260:                                    create[fmt.Sprintf("%s", item)] = true

pkg/security/security_profile/rules.go
184:            groupID = fmt.Sprintf("%s%s", groupID, opts.ImageName)
186:            groupID = fmt.Sprintf("%s%s", groupID, strings.ReplaceAll(uuid.New().String(), "-", "_")) // It should be unique so that we can target it at least, but ImageName should be always set

pkg/serverless/trace/inferredspan/span_enrichment.go
77:     httpurl := fmt.Sprintf("%s%s", domain, eventPayload.Path)
111:    httpurl := fmt.Sprintf("%s%s", domainName, path)
146:    httpurl := fmt.Sprintf("%s%s", domainName, path)
177:    httpurl := fmt.Sprintf("%s%s", requestContext.DomainName, routeKey)

pkg/collector/scheduler.go
234:    titleCheck := fmt.Sprintf("%s%s", titled, "Check")

pkg/ebpf/verifier/calculator/main.go
38:     return fmt.Sprintf("%s", *f)

pkg/fleet/installer/telemetry/client.go
231:                    url := fmt.Sprintf("%s%s", e.Host, telemetryEndpoint)
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->