### PR TITLE
Fix Fleet Issue with persisting Third Party Integrations

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -37,6 +37,7 @@
       - E2E_MSI_TEST: TestUpgrade
       - E2E_MSI_TEST: TestUpgradeFromLatest
       - E2E_MSI_TEST: TestPersistingIntegrations
+      - E2E_MSI_TEST: TestPersistingIntegrationsDuringUninstall
       - E2E_MSI_TEST: TestDisablePersistingIntegrations
       - E2E_MSI_TEST: TestIntegrationFolderPermissions
       - E2E_MSI_TEST: TestIntegrationRollback

--- a/releasenotes/notes/fix-persisting-integrations-9662f13870de9057.yaml
+++ b/releasenotes/notes/fix-persisting-integrations-9662f13870de9057.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    Fixes python integrations not being persisted after Agent uninstall.
+    Fixes Python integrations not being persisted after Agent uninstall.
     Enables persisting integration during fleet updates.
 

--- a/releasenotes/notes/fix-persisting-integrations-9662f13870de9057.yaml
+++ b/releasenotes/notes/fix-persisting-integrations-9662f13870de9057.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes python integrations not being persisted after Agent uninstall.
+    Enables persisting integration during fleet updates.
+

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -473,7 +473,9 @@ func (s *testPersistingIntegrationsDuringUninstall) TestPersistingIntegrationsDu
 	s.Require().NoError(err, "should install pip package")
 
 	// uninstall agent
-	s.uninstallAgent()
+	s.Require().True(
+		s.uninstallAgent(),
+	)
 
 	// upgrade to test agent
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.upgradeAgentPackge.AgentVersion()), func() {

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -22,6 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	thirdPartyIntegration = "datadog-ping==1.0.2"
+	pipPackage            = "grpcio"
+)
+
 // TestPersistingIntegrations tests upgrading the agent from WINDOWS_AGENT_VERSION to UPGRADE_TEST_VERSION
 func TestPersistingIntegrations(t *testing.T) {
 	s := &testPersistingIntegrationsSuite{}
@@ -55,11 +60,11 @@ func (s *testPersistingIntegrationsSuite) TestPersistingIntegrations() {
 	s.Require().NoError(err, "should get product version")
 
 	// install third party integration
-	err = s.installThirdPartyIntegration(vm, "datadog-ping==1.0.2")
+	err = s.installThirdPartyIntegration(vm, thirdPartyIntegration)
 	s.Require().NoError(err, "should install third party integration")
 
 	// install pip package
-	err = s.installPipPackage(vm, "grpcio")
+	err = s.installPipPackage(vm, pipPackage)
 	s.Require().NoError(err, "should install pip package")
 
 	// upgrade to test agent
@@ -92,10 +97,10 @@ func (s *testPersistingIntegrationsSuite) TestPersistingIntegrations() {
 	assert.NotEqual(s.T(), productVersionPre, productVersionPost, "product version should be different after upgrade")
 
 	// check that the third party integration is still installed
-	s.checkIntegrationInstall(vm, "datadog-ping==1.0.2")
+	s.checkIntegrationInstall(vm, thirdPartyIntegration)
 
 	// check that the pip package is still installed
-	s.checkPipPackageInstalled(vm, "grpcio")
+	s.checkPipPackageInstalled(vm, pipPackage)
 
 	s.uninstallAgentAndRunUninstallTests(t)
 
@@ -137,11 +142,11 @@ func (s *testDisablePersistingIntegrationsSuite) TestDisablePersistingIntegratio
 	s.Require().NoError(err, "should get product version")
 
 	// install third party integration
-	err = s.installThirdPartyIntegration(vm, "datadog-ping==1.0.2")
+	err = s.installThirdPartyIntegration(vm, thirdPartyIntegration)
 	s.Require().NoError(err, "should install third party integration")
 
 	// install pip package
-	err = s.installPipPackage(vm, "grpcio")
+	err = s.installPipPackage(vm, pipPackage)
 	s.Require().NoError(err, "should install pip package")
 
 	// upgrade to test agent
@@ -176,10 +181,10 @@ func (s *testDisablePersistingIntegrationsSuite) TestDisablePersistingIntegratio
 	assert.NotEqual(s.T(), productVersionPre, productVersionPost, "product version should be different after upgrade")
 
 	// check that the third party integration is not installed
-	s.checkIntegrationNotInstalled(vm, "datadog-ping==1.0.2")
+	s.checkIntegrationNotInstalled(vm, thirdPartyIntegration)
 
 	// check that the pip package is not installed
-	s.checkPipPackageNotInstalled(vm, "grpcio")
+	s.checkPipPackageNotInstalled(vm, pipPackage)
 
 	s.uninstallAgentAndRunUninstallTests(t)
 
@@ -358,7 +363,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 	}
 
 	// install third party integration
-	err := s.installThirdPartyIntegration(vm, "datadog-ping==1.0.2")
+	err := s.installThirdPartyIntegration(vm, thirdPartyIntegration)
 	s.Require().NoError(err, "should install third party integration")
 
 	// add package to .post_python_installed_packages.txt to check for(this will be still there on rollback)
@@ -409,7 +414,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 	s.Require().NoError(err, "should write file")
 
 	// check to see if datadog-ping==1.0.2 is still installed
-	s.checkIntegrationInstall(vm, "datadog-ping==1.0.2")
+	s.checkIntegrationInstall(vm, thirdPartyIntegration)
 
 	// upgrade again without failure
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.upgradeAgentPackge.AgentVersion()), func() {
@@ -424,7 +429,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 		s.T().FailNow()
 	}
 
-	s.checkIntegrationInstall(vm, "datadog-ping==1.0.2")
+	s.checkIntegrationInstall(vm, thirdPartyIntegration)
 
 	s.uninstallAgent()
 
@@ -465,11 +470,11 @@ func (s *testPersistingIntegrationsDuringUninstall) TestPersistingIntegrationsDu
 	s.Require().NoError(err, "should get product version")
 
 	// install third party integration
-	err = s.installThirdPartyIntegration(vm, "datadog-ping==1.0.2")
+	err = s.installThirdPartyIntegration(vm, thirdPartyIntegration)
 	s.Require().NoError(err, "should install third party integration")
 
 	// install pip package
-	err = s.installPipPackage(vm, "grpcio")
+	err = s.installPipPackage(vm, pipPackage)
 	s.Require().NoError(err, "should install pip package")
 
 	// uninstall agent
@@ -507,10 +512,10 @@ func (s *testPersistingIntegrationsDuringUninstall) TestPersistingIntegrationsDu
 	assert.NotEqual(s.T(), productVersionPre, productVersionPost, "product version should be different after upgrade")
 
 	// check that the third party integration is still installed
-	s.checkIntegrationInstall(vm, "datadog-ping==1.0.2")
+	s.checkIntegrationInstall(vm, thirdPartyIntegration)
 
 	// check that the pip package is still installed
-	s.checkPipPackageInstalled(vm, "grpcio")
+	s.checkPipPackageInstalled(vm, pipPackage)
 
 	s.uninstallAgentAndRunUninstallTests(t)
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -341,7 +341,7 @@ namespace WixSetup.Datadog_Agent
                     CustomActions.RunPreRemovePythonScript,
                     Return.ignore,
                     When.Before,
-                    Step.RemoveFiles,
+                    new Step(CleanupOnUninstall.Id),
                     Conditions.RemovingForUpgrade | Conditions.Maintenance | Conditions.Uninstalling
                 )
             {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes an issue with persisting third party integrations on the following workflow:
- install agent
- install integration
- uninstall agent
- install new agent version

This workflow is needed to persist integrations for fleet automation updates. 

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1589

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated through added e2e test that does that workflow.

Manually tested with following steps:
- install agent
- install integration:
```
& 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' integration install -t datadog-ping==1.0.2
```
- uninstall agent
- install new agent version
- Verify still installed:
```
PS C:\Users\Administrator> & 'C:\Program Files\Datadog\Datadog Agent\bin\agent.exe' integration install -t datadog-ping==1.0.2
datadog-ping 1.0.2 is already installed. Nothing to do.
PS C:\Users\Administrator>
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->