### PR TITLE
dyninst: fix frameless function CFA computation

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -212,6 +212,7 @@ func (a *effects) compileProgram(
 		)
 		if err != nil {
 			err = fmt.Errorf("failed to compile eBPF program: %w", err)
+			a.reporter.ReportCompilationFailed(programID, err)
 			a.sendEvent(eventProgramCompilationFailed{
 				programID: programID,
 				err:       err,
@@ -281,6 +282,7 @@ func (a *effects) loadProgram(compiled *CompiledProgram) {
 
 		loaded, err := loadProgram(a.ringbufMap, compiled)
 		if err != nil {
+			a.reporter.ReportLoadingFailed(compiled.IR.ID, err)
 			a.sendEvent(eventProgramCompilationFailed{
 				programID: compiled.IR.ID,
 				err:       fmt.Errorf("failed to load collection spec: %w", err),
@@ -346,6 +348,7 @@ func (a *effects) attachToProcess(
 			loaded, executable, processID, a.reporter,
 		)
 		if err != nil {
+			a.reporter.ReportAttachingFailed(loaded.id, processID, err)
 			a.sendEvent(eventProgramAttachingFailed{
 				programID: loaded.id,
 				err:       fmt.Errorf("failed to attach to process: %w", err),

--- a/pkg/dyninst/actuator/configuration.go
+++ b/pkg/dyninst/actuator/configuration.go
@@ -92,14 +92,30 @@ func WithReporter(reporter Reporter) Option {
 // TODO: This is not sufficient for what we'll need for driving the
 // diagnostics output, but it's a start to drive testing.
 type Reporter interface {
-	ReportAttached(processID ProcessID, probes []config.Probe)
-	ReportDetached(processID ProcessID, probes []config.Probe)
+
+	// ReportAttached is called when a program is attached to a process.
+	ReportAttached(ProcessID, []config.Probe)
+
+	// ReportDetached is called when a program is detached from a process.
+	ReportDetached(ProcessID, []config.Probe)
+
+	// ReportCompilationFailed is called when a program fails to compile.
+	ReportCompilationFailed(ir.ProgramID, error)
+
+	// ReportLoadingFailed is called when a program fails to load.
+	ReportLoadingFailed(ir.ProgramID, error)
+
+	// ReportAttachingFailed is called when a program fails to attach to a process.
+	ReportAttachingFailed(ir.ProgramID, ProcessID, error)
 }
 
 type noopReporter struct{}
 
-func (noopReporter) ReportAttached(ProcessID, []config.Probe) {}
-func (noopReporter) ReportDetached(ProcessID, []config.Probe) {}
+func (noopReporter) ReportAttached(ProcessID, []config.Probe)             {}
+func (noopReporter) ReportDetached(ProcessID, []config.Probe)             {}
+func (noopReporter) ReportCompilationFailed(ir.ProgramID, error)          {}
+func (noopReporter) ReportLoadingFailed(ir.ProgramID, error)              {}
+func (noopReporter) ReportAttachingFailed(ir.ProgramID, ProcessID, error) {}
 
 // WithRingBufSize sets the size of the ring buffer for the Actuator.
 func WithRingBufSize(size int) Option {

--- a/pkg/dyninst/compiler/codegen/code.go
+++ b/pkg/dyninst/compiler/codegen/code.go
@@ -87,9 +87,13 @@ func GenerateCCode(program sm.Program, out io.Writer) (attachpoints []BPFAttachP
 				PC:     f.InjectionPC,
 				Cookie: uint64(len(attachpoints)),
 			})
+			frameless := "false"
+			if f.Frameless {
+				frameless = "true"
+			}
 			mustFprintf(
-				out, "\t{.throttler_idx = %d, .stack_machine_pc = 0x%x, .pointer_chasing_limit = %d, .frameless = false},\n",
-				f.ThrottlerIdx, metadata.FunctionLoc[f], f.PointerChasingLimit,
+				out, "\t{.throttler_idx = %d, .stack_machine_pc = 0x%x, .pointer_chasing_limit = %d, .frameless = %s},\n",
+				f.ThrottlerIdx, metadata.FunctionLoc[f], f.PointerChasingLimit, frameless,
 			)
 		}
 	}

--- a/pkg/dyninst/compiler/sm/functions.go
+++ b/pkg/dyninst/compiler/sm/functions.go
@@ -45,6 +45,7 @@ type ProcessEvent struct {
 	InjectionPC         uint64
 	ThrottlerIdx        int
 	PointerChasingLimit uint32
+	Frameless           bool
 	EventRootType       *ir.EventRootType
 }
 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.c
@@ -5,22 +5,22 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CHASE_POINTERS, 
 		SM_OP_RETURN, 
 
-	// 0x3: ProcessExpression[Probe[main.intArg]@0x4a804a.expr[0]]
+	// 0x3: ProcessExpression[Probe[main.intArg]@0x4a806a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x19: ProcessEvent[Probe[main.intArg]@4a804a]
+	// 0x19: ProcessEvent[Probe[main.intArg]@4a806a]
 		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0x4a804a.expr[0]]
+		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0x4a806a.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x28: ProcessType[string]
 		SM_OP_PROCESS_STRING, 0x2b, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x2e: ProcessExpression[Probe[main.stringArg]@0x4a80ca.expr[0]]
+	// 0x2e: ProcessExpression[Probe[main.stringArg]@0x4a80ea.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -28,16 +28,16 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_RETURN, 
 
-	// 0x50: ProcessEvent[Probe[main.stringArg]@4a80ca]
+	// 0x50: ProcessEvent[Probe[main.stringArg]@4a80ea]
 		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0x4a80ca.expr[0]]
+		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0x4a80ea.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x5f: ProcessType[[]int]
 		SM_OP_PROCESS_SLICE, 0x2d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0x4a814a.expr[0]]
+	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0x4a816a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -46,27 +46,27 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x5f, 0x00, 0x00, 0x00, // ProcessType[[]int]
 		SM_OP_RETURN, 
 
-	// 0x92: ProcessEvent[Probe[main.intSliceArg]@4a814a]
+	// 0x92: ProcessEvent[Probe[main.intSliceArg]@4a816a]
 		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0x4a814a.expr[0]]
+		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0x4a816a.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0x4a81ca.expr[0]]
+	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0x4a81ea.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@4a81ca]
+	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@4a81ea]
 		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0x4a81ca.expr[0]]
+		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0x4a81ea.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0xcc: ProcessType[[]string]
 		SM_OP_PROCESS_SLICE, 0x2f, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0x4a824a.expr[0]]
+	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0x4a826a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x03, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -75,9 +75,9 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0xcc, 0x00, 0x00, 0x00, // ProcessType[[]string]
 		SM_OP_RETURN, 
 
-	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@4a824a]
+	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@4a826a]
 		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0x4a824a.expr[0]]
+		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0x4a826a.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x10e: ProcessType[[3]string]
@@ -86,95 +86,107 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0x4a82ca.expr[0]]
+	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0x4a82ea.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
 		SM_OP_RETURN, 
 
-	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@4a82ca]
+	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@4a82ea]
 		SM_OP_PREPARE_EVENT_ROOT, 0x3a, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0x4a82ca.expr[0]]
+		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0x4a82ea.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x14e: ProcessExpression[Probe[main.mapArg]@0x4a840a.expr[0]]
+	// 0x14e: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8360.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_DEREFERENCE_CFA, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
+		SM_OP_RETURN, 
+
+	// 0x16f: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8360]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8360.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x17e: ProcessExpression[Probe[main.mapArg]@0x4a844a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x15d: ProcessEvent[Probe[main.mapArg]@4a840a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0x4a840a.expr[0]]
-		SM_OP_RETURN, 
-
-	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0x4a8473.expr[0]]
-		SM_OP_EXPR_PREPARE, 
-		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-		SM_OP_RETURN, 
-
-	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@4a8473]
+	// 0x18d: ProcessEvent[Probe[main.mapArg]@4a844a]
 		SM_OP_PREPARE_EVENT_ROOT, 0x3c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0x4a8473.expr[0]]
+		SM_OP_CALL, 0x7e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0x4a844a.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x18a: ProcessExpression[Probe[main.inlined]@0x4a834a.expr[0]]
+	// 0x19c: ProcessExpression[Probe[main.bigMapArg]@0x4a84b3.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x1ab: ProcessEvent[Probe[main.bigMapArg]@4a84b3]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x9c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0x4a84b3.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x1ba: ProcessExpression[Probe[main.inlined]@0x4a838a.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1a0: ProcessEvent[Probe[main.inlined]@4a834a]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a834a.expr[0]]
+	// 0x1d0: ProcessEvent[Probe[main.inlined]@4a838a]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xba, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a838a.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1af: ProcessExpression[Probe[main.inlined]@0x4a7da6.expr[0]]
+	// 0x1df: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_RETURN, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1bf: ProcessEvent[Probe[main.inlined]@4a7da6]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xaf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a7da6.expr[0]]
+	// 0x1ef: ProcessEvent[Probe[main.inlined]@4a7dce]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xdf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1ce: ProcessType[*****int]
+	// 0x1fe: ProcessType[*****int]
 		SM_OP_PROCESS_POINTER, 0x03, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1d4: ProcessExpression[Probe[main.PointerChainArg]@0x4a7fe6.expr[0]]
+	// 0x204: ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xce, 0x01, 0x00, 0x00, // ProcessType[*****int]
+		SM_OP_CALL, 0xfe, 0x01, 0x00, 0x00, // ProcessType[*****int]
 		SM_OP_RETURN, 
 
-	// 0x1ef: ProcessEvent[Probe[main.PointerChainArg]@4a7fe6]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd4, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0x4a7fe6.expr[0]]
+	// 0x21f: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3f, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x04, 0x02, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1fe: ProcessType[[]string.array]
+	// 0x22e: ProcessType[[]string.array]
 		SM_OP_PROCESS_SLICE_DATA_PREP, 
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x20a: ProcessType[****int]
+	// 0x23a: ProcessType[****int]
 		SM_OP_PROCESS_POINTER, 0x04, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x210: ProcessType[***int]
+	// 0x240: ProcessType[***int]
 		SM_OP_PROCESS_POINTER, 0x05, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x216: ProcessType[**int]
+	// 0x246: ProcessType[**int]
 		SM_OP_PROCESS_POINTER, 0x06, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x21c: ProcessType[*int]
+	// 0x24c: ProcessType[*int]
 		SM_OP_PROCESS_POINTER, 0x01, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
@@ -193,7 +205,7 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_ILLEGAL, 
 		SM_OP_ILLEGAL, 
 };
-const uint64_t stack_machine_code_len = 559;
+const uint64_t stack_machine_code_len = 607;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
@@ -206,13 +218,14 @@ const probe_params_t probe_params[] = {
 	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 4, .stack_machine_pc = 0xff, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 3, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x16f, .pointer_chasing_limit = 4294967295, .frameless = true},
+	{.throttler_idx = 7, .stack_machine_pc = 0x18d, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1ab, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1d0, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 4294967295, .frameless = true},
+	{.throttler_idx = 10, .stack_machine_pc = 0x21f, .pointer_chasing_limit = 3, .frameless = true},
 };
-const uint32_t num_probe_params = 11;
+const uint32_t num_probe_params = 12;
 typedef enum type {
 	TYPE_NONE = 0,
 	TYPE_1 = 1, // int
@@ -273,19 +286,20 @@ typedef enum type {
 	TYPE_56 = 56, // Probe[main.intArrayArg]
 	TYPE_57 = 57, // Probe[main.stringSliceArg]
 	TYPE_58 = 58, // Probe[main.stringArrayArg]
-	TYPE_59 = 59, // Probe[main.mapArg]
-	TYPE_60 = 60, // Probe[main.bigMapArg]
-	TYPE_61 = 61, // Probe[main.inlined]
-	TYPE_62 = 62, // Probe[main.PointerChainArg]
+	TYPE_59 = 59, // Probe[main.stringArrayArgFrameless]
+	TYPE_60 = 60, // Probe[main.mapArg]
+	TYPE_61 = 61, // Probe[main.bigMapArg]
+	TYPE_62 = 62, // Probe[main.inlined]
+	TYPE_63 = 63, // Probe[main.PointerChainArg]
 } type_t;
 
 const type_info_t type_info[] = {
 	/* 1: int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1ce},
-	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x20a},
-	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x210},
-	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x216},
-	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x21c},
+	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1fe},
+	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x23a},
+	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x240},
+	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x246},
+	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x24c},
 	/* 7: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
 	/* 8: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 9: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
@@ -326,7 +340,7 @@ const type_info_t type_info[] = {
 	/* 44: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 45: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
 	/* 46: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1fe},
+	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x22e},
 	/* 48: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 49: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
 	/* 50: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
@@ -338,15 +352,16 @@ const type_info_t type_info[] = {
 	/* 56: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
 	/* 57: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
 	/* 58: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
-	/* 59: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 60: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 61: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
-	/* 62: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 59: Probe[main.stringArrayArgFrameless]	*/{.byte_len = 49, .enqueue_pc = 0x0},
+	/* 60: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 61: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 62: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 63: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
 };
 
-const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, };
+const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, };
 
-const uint32_t num_types = 62;
+const uint32_t num_types = 63;
 
 const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
@@ -359,5 +374,6 @@ const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
 };
-#define NUM_THROTTLERS 10
+#define NUM_THROTTLERS 11

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.c
@@ -5,22 +5,22 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CHASE_POINTERS, 
 		SM_OP_RETURN, 
 
-	// 0x3: ProcessExpression[Probe[main.intArg]@0xb51ec.expr[0]]
+	// 0x3: ProcessExpression[Probe[main.intArg]@0xb522c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x19: ProcessEvent[Probe[main.intArg]@b51ec]
+	// 0x19: ProcessEvent[Probe[main.intArg]@b522c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x35, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0xb51ec.expr[0]]
+		SM_OP_CALL, 0x03, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArg]@0xb522c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x28: ProcessType[string]
 		SM_OP_PROCESS_STRING, 0x2b, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x2e: ProcessExpression[Probe[main.stringArg]@0xb525c.expr[0]]
+	// 0x2e: ProcessExpression[Probe[main.stringArg]@0xb529c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -28,16 +28,16 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_RETURN, 
 
-	// 0x50: ProcessEvent[Probe[main.stringArg]@b525c]
+	// 0x50: ProcessEvent[Probe[main.stringArg]@b529c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x36, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0xb525c.expr[0]]
+		SM_OP_CALL, 0x2e, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringArg]@0xb529c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x5f: ProcessType[[]int]
 		SM_OP_PROCESS_SLICE, 0x2d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0xb52dc.expr[0]]
+	// 0x69: ProcessExpression[Probe[main.intSliceArg]@0xb531c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -46,27 +46,27 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0x5f, 0x00, 0x00, 0x00, // ProcessType[[]int]
 		SM_OP_RETURN, 
 
-	// 0x92: ProcessEvent[Probe[main.intSliceArg]@b52dc]
+	// 0x92: ProcessEvent[Probe[main.intSliceArg]@b531c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x37, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0xb52dc.expr[0]]
+		SM_OP_CALL, 0x69, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intSliceArg]@0xb531c.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0xb535c.expr[0]]
+	// 0xa1: ProcessExpression[Probe[main.intArrayArg]@0xb539c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x08, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@b535c]
+	// 0xbd: ProcessEvent[Probe[main.intArrayArg]@b539c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x38, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0xb535c.expr[0]]
+		SM_OP_CALL, 0xa1, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.intArrayArg]@0xb539c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0xcc: ProcessType[[]string]
 		SM_OP_PROCESS_SLICE, 0x2f, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0xb53dc.expr[0]]
+	// 0xd6: ProcessExpression[Probe[main.stringSliceArg]@0xb541c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_READ_REGISTER, 0x01, 0x08, 0x08, 0x00, 0x00, 0x00, 
@@ -75,9 +75,9 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_CALL, 0xcc, 0x00, 0x00, 0x00, // ProcessType[[]string]
 		SM_OP_RETURN, 
 
-	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@b53dc]
+	// 0xff: ProcessEvent[Probe[main.stringSliceArg]@b541c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x39, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0xb53dc.expr[0]]
+		SM_OP_CALL, 0xd6, 0x00, 0x00, 0x00, // ProcessExpression[Probe[main.stringSliceArg]@0xb541c.expr[0]]
 		SM_OP_RETURN, 
 
 	// 0x10e: ProcessType[[3]string]
@@ -86,95 +86,107 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0xb545c.expr[0]]
+	// 0x11e: ProcessExpression[Probe[main.stringArrayArg]@0xb549c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_DEREFERENCE_CFA, 0x08, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
 		SM_OP_RETURN, 
 
-	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@b545c]
+	// 0x13f: ProcessEvent[Probe[main.stringArrayArg]@b549c]
 		SM_OP_PREPARE_EVENT_ROOT, 0x3a, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0xb545c.expr[0]]
+		SM_OP_CALL, 0x1e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArg]@0xb549c.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x14e: ProcessExpression[Probe[main.mapArg]@0xb559c.expr[0]]
+	// 0x14e: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5510.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_DEREFERENCE_CFA, 0x08, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x0e, 0x01, 0x00, 0x00, // ProcessType[[3]string]
+		SM_OP_RETURN, 
+
+	// 0x16f: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5510]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5510.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x17e: ProcessExpression[Probe[main.mapArg]@0xb55ec.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x15d: ProcessEvent[Probe[main.mapArg]@b559c]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x4e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0xb559c.expr[0]]
-		SM_OP_RETURN, 
-
-	// 0x16c: ProcessExpression[Probe[main.bigMapArg]@0xb5610.expr[0]]
-		SM_OP_EXPR_PREPARE, 
-		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-		SM_OP_RETURN, 
-
-	// 0x17b: ProcessEvent[Probe[main.bigMapArg]@b5610]
+	// 0x18d: ProcessEvent[Probe[main.mapArg]@b55ec]
 		SM_OP_PREPARE_EVENT_ROOT, 0x3c, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x6c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0xb5610.expr[0]]
+		SM_OP_CALL, 0x7e, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.mapArg]@0xb55ec.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x18a: ProcessExpression[Probe[main.inlined]@0xb54dc.expr[0]]
+	// 0x19c: ProcessExpression[Probe[main.bigMapArg]@0xb5660.expr[0]]
+		SM_OP_EXPR_PREPARE, 
+		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		SM_OP_RETURN, 
+
+	// 0x1ab: ProcessEvent[Probe[main.bigMapArg]@b5660]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x9c, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.bigMapArg]@0xb5660.expr[0]]
+		SM_OP_RETURN, 
+
+	// 0x1ba: ProcessExpression[Probe[main.inlined]@0xb552c.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1a0: ProcessEvent[Probe[main.inlined]@b54dc]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0x8a, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb54dc.expr[0]]
+	// 0x1d0: ProcessEvent[Probe[main.inlined]@b552c]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xba, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb552c.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1af: ProcessExpression[Probe[main.inlined]@0xb4fb8.expr[0]]
+	// 0x1df: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_RETURN, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1bf: ProcessEvent[Probe[main.inlined]@b4fb8]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3d, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xaf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb4fb8.expr[0]]
+	// 0x1ef: ProcessEvent[Probe[main.inlined]@b4fec]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0xdf, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1ce: ProcessType[*****int]
+	// 0x1fe: ProcessType[*****int]
 		SM_OP_PROCESS_POINTER, 0x03, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x1d4: ProcessExpression[Probe[main.PointerChainArg]@0xb5198.expr[0]]
+	// 0x204: ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 		SM_OP_EXPR_PREPARE, 
 		SM_OP_EXPR_READ_REGISTER, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 
 		SM_OP_EXPR_SAVE, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xce, 0x01, 0x00, 0x00, // ProcessType[*****int]
+		SM_OP_CALL, 0xfe, 0x01, 0x00, 0x00, // ProcessType[*****int]
 		SM_OP_RETURN, 
 
-	// 0x1ef: ProcessEvent[Probe[main.PointerChainArg]@b5198]
-		SM_OP_PREPARE_EVENT_ROOT, 0x3e, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
-		SM_OP_CALL, 0xd4, 0x01, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0xb5198.expr[0]]
+	// 0x21f: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
+		SM_OP_PREPARE_EVENT_ROOT, 0x3f, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 
+		SM_OP_CALL, 0x04, 0x02, 0x00, 0x00, // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 		SM_OP_RETURN, 
 
-	// 0x1fe: ProcessType[[]string.array]
+	// 0x22e: ProcessType[[]string.array]
 		SM_OP_PROCESS_SLICE_DATA_PREP, 
 		SM_OP_CALL, 0x28, 0x00, 0x00, 0x00, // ProcessType[string]
 		SM_OP_PROCESS_SLICE_DATA_REPEAT, 0x10, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x20a: ProcessType[****int]
+	// 0x23a: ProcessType[****int]
 		SM_OP_PROCESS_POINTER, 0x04, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x210: ProcessType[***int]
+	// 0x240: ProcessType[***int]
 		SM_OP_PROCESS_POINTER, 0x05, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x216: ProcessType[**int]
+	// 0x246: ProcessType[**int]
 		SM_OP_PROCESS_POINTER, 0x06, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
-	// 0x21c: ProcessType[*int]
+	// 0x24c: ProcessType[*int]
 		SM_OP_PROCESS_POINTER, 0x01, 0x00, 0x00, 0x00, 
 		SM_OP_RETURN, 
 
@@ -193,7 +205,7 @@ const uint8_t stack_machine_code[] = {
 		SM_OP_ILLEGAL, 
 		SM_OP_ILLEGAL, 
 };
-const uint64_t stack_machine_code_len = 559;
+const uint64_t stack_machine_code_len = 607;
 const uint32_t stack_machine_code_max_op = 13;
 const uint32_t chase_pointers_entrypoint = 0x1;
 
@@ -206,13 +218,14 @@ const probe_params_t probe_params[] = {
 	{.throttler_idx = 3, .stack_machine_pc = 0xbd, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 4, .stack_machine_pc = 0xff, .pointer_chasing_limit = 4294967295, .frameless = false},
 	{.throttler_idx = 5, .stack_machine_pc = 0x13f, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 6, .stack_machine_pc = 0x15d, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 7, .stack_machine_pc = 0x17b, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1a0, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 8, .stack_machine_pc = 0x1bf, .pointer_chasing_limit = 4294967295, .frameless = false},
-	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 3, .frameless = false},
+	{.throttler_idx = 6, .stack_machine_pc = 0x16f, .pointer_chasing_limit = 4294967295, .frameless = true},
+	{.throttler_idx = 7, .stack_machine_pc = 0x18d, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 8, .stack_machine_pc = 0x1ab, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1d0, .pointer_chasing_limit = 4294967295, .frameless = false},
+	{.throttler_idx = 9, .stack_machine_pc = 0x1ef, .pointer_chasing_limit = 4294967295, .frameless = true},
+	{.throttler_idx = 10, .stack_machine_pc = 0x21f, .pointer_chasing_limit = 3, .frameless = true},
 };
-const uint32_t num_probe_params = 11;
+const uint32_t num_probe_params = 12;
 typedef enum type {
 	TYPE_NONE = 0,
 	TYPE_1 = 1, // int
@@ -273,19 +286,20 @@ typedef enum type {
 	TYPE_56 = 56, // Probe[main.intArrayArg]
 	TYPE_57 = 57, // Probe[main.stringSliceArg]
 	TYPE_58 = 58, // Probe[main.stringArrayArg]
-	TYPE_59 = 59, // Probe[main.mapArg]
-	TYPE_60 = 60, // Probe[main.bigMapArg]
-	TYPE_61 = 61, // Probe[main.inlined]
-	TYPE_62 = 62, // Probe[main.PointerChainArg]
+	TYPE_59 = 59, // Probe[main.stringArrayArgFrameless]
+	TYPE_60 = 60, // Probe[main.mapArg]
+	TYPE_61 = 61, // Probe[main.bigMapArg]
+	TYPE_62 = 62, // Probe[main.inlined]
+	TYPE_63 = 63, // Probe[main.PointerChainArg]
 } type_t;
 
 const type_info_t type_info[] = {
 	/* 1: int	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1ce},
-	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x20a},
-	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x210},
-	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x216},
-	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x21c},
+	/* 2: *****int	*/{.byte_len = 8, .enqueue_pc = 0x1fe},
+	/* 3: ****int	*/{.byte_len = 8, .enqueue_pc = 0x23a},
+	/* 4: ***int	*/{.byte_len = 8, .enqueue_pc = 0x240},
+	/* 5: **int	*/{.byte_len = 8, .enqueue_pc = 0x246},
+	/* 6: *int	*/{.byte_len = 8, .enqueue_pc = 0x24c},
 	/* 7: string	*/{.byte_len = 16, .enqueue_pc = 0x28},
 	/* 8: *uint8	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 9: uint8	*/{.byte_len = 1, .enqueue_pc = 0x0},
@@ -326,7 +340,7 @@ const type_info_t type_info[] = {
 	/* 44: *string.str	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 45: []int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
 	/* 46: *[]int.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
-	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x1fe},
+	/* 47: []string.array	*/{.byte_len = 512, .enqueue_pc = 0x22e},
 	/* 48: *[]string.array	*/{.byte_len = 8, .enqueue_pc = 0x0},
 	/* 49: []*table<string,int>.array	*/{.byte_len = 2048, .enqueue_pc = 0x0},
 	/* 50: []noalg.map.group[string]int.array	*/{.byte_len = 512, .enqueue_pc = 0x0},
@@ -338,15 +352,16 @@ const type_info_t type_info[] = {
 	/* 56: Probe[main.intArrayArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
 	/* 57: Probe[main.stringSliceArg]	*/{.byte_len = 25, .enqueue_pc = 0x0},
 	/* 58: Probe[main.stringArrayArg]	*/{.byte_len = 49, .enqueue_pc = 0x0},
-	/* 59: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 60: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
-	/* 61: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
-	/* 62: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 59: Probe[main.stringArrayArgFrameless]	*/{.byte_len = 49, .enqueue_pc = 0x0},
+	/* 60: Probe[main.mapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 61: Probe[main.bigMapArg]	*/{.byte_len = 1, .enqueue_pc = 0x0},
+	/* 62: Probe[main.inlined]	*/{.byte_len = 9, .enqueue_pc = 0x0},
+	/* 63: Probe[main.PointerChainArg]	*/{.byte_len = 9, .enqueue_pc = 0x0},
 };
 
-const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, };
+const uint32_t type_ids[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, };
 
-const uint32_t num_types = 62;
+const uint32_t num_types = 63;
 
 const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
@@ -359,5 +374,6 @@ const throttler_params_t throttler_params[] = {
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
 	{.period_ns = 100000000, .budget = 500},
+	{.period_ns = 100000000, .budget = 500},
 };
-#define NUM_THROTTLERS 10
+#define NUM_THROTTLERS 11

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -78,6 +78,8 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   global_ctx.stack_walk->regs = *regs;
   global_ctx.stack_walk->stack.pcs.pcs[0] = regs->DWARF_PC_REG;
   global_ctx.stack_walk->stack.fps[0] = regs->DWARF_BP_REG;
+  // TODO: For arm64 we need to use the link register to properly set up the
+  // stack trace.
   if (params->frameless) {
     if (bpf_probe_read_user(&global_ctx.stack_walk->stack.pcs.pcs[1],
                             sizeof(global_ctx.stack_walk->stack.pcs.pcs[1]),
@@ -109,18 +111,45 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   }
   global_ctx.regs = &global_ctx.stack_walk->regs;
   frame_data_t frame_data = {
+    .stack_idx = 0,
+  };
 // Stack layout is slightly different in Go between arm64 and x86_64.
 // Established based on following documentation and machine code reads:
 // https://tip.golang.org/src/cmd/compile/abi-internal#architecture-specifics
+//
+// There's some trickery to get our hands on the CFA in Go based on whether or
+// not the leaf function is frameless. If it is frameless, then we need to
+// assume that the frame pointer is actually set up for the caller's frame.
 #if defined(bpf_target_arm64)
-    .cfa = global_ctx.regs->DWARF_BP_REG + 8,
+// On arm, if the function is framless, the base pointer will be pointing to at
+// the lowest entry of our caller's frame which is almost our CFA. If it's not
+// frameless, then the base pointer will be pointing to the lowest entry of our
+// frame and it needs to be dereferenced to get to the CFA. Fortunately, we
+// already did that dereferencing in the stack walk.
+//
+// Or at least you might think that'd be the situation. Unfortunately, or
+// perhaps fortunately, Go is marking the beginning of the prologue stack
+// adjustment as the end of the prologue. So, when we use the prologue_end
+// marker set by Go in DWARF to find the prologue end, we're actually getting
+// the beginning of the prologue adjustment and can assume the registers are
+// still set up for the caller's frame.
+//
+// See https://github.com/golang/go/issues/74357.
+    *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_BP_REG + 8;
 #elif defined(bpf_target_x86)
-    .cfa = global_ctx.regs->DWARF_BP_REG + 16,
+// On x86, if the function is frameless, the stack pointer is pointing to the
+// return pc, so one word above that is our CFA. If it's not frameless, then the
+// base pointer is pointing to our frame pointer which is 16 bytes less than our
+// CFA.
+    if (params->frameless) {
+      *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_SP_REG + 8;
+    } else {
+      *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_BP_REG + 16;
+    }
 #else
     #error "Unsupported architecture"
 #endif
-    .stack_idx = 0,
-  };
+
   if (params->stack_machine_pc != 0) {
     process_steps = stack_machine_process_frame(&global_ctx, &frame_data,
                                                 params->stack_machine_pc);

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -180,6 +180,11 @@ func testDyninst(t *testing.T, sampleServicePath string) {
 		require.NoError(t, err)
 		require.Equal(t, uint32(len(event)), header.Data_byte_len)
 		t.Logf("message header: %#v", *header)
+		if header.Stack_byte_len > 0 {
+			stackPCs, err := event.StackPCs()
+			require.NoError(t, err)
+			t.Logf("stack: %x", stackPCs)
+		}
 
 		var i int
 		for di, err := range event.DataItems() {

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -130,7 +130,15 @@ type Event struct {
 	// The datatype of the event.
 	Type *EventRootType
 	// The PC values at which the event should be injected.
-	InjectionPCs []uint64
+	InjectionPoints []InjectionPoint
 	// The condition that must be met for the event to be injected.
 	Condition *Expression
+}
+
+// InjectionPoint is a point at which an event should be injected.
+type InjectionPoint struct {
+	// The PC value at which the event should be injected.
+	PC uint64
+	// Whether the function at that PC is frameless.
+	Frameless bool
 }

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -739,7 +739,7 @@ func (v *rootVisitor) newProbe(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get line reader: %w", err)
 	}
-	var injectionPCs []uint64
+	var injectionPoints []ir.InjectionPoint
 	if subprogram.OutOfLinePCRanges == nil && len(subprogram.InlinePCRanges) == 0 {
 		return nil, fmt.Errorf("subprogram %q has no pc ranges", subprogram.Name)
 	}
@@ -750,22 +750,32 @@ func (v *rootVisitor) newProbe(
 		}
 		if !ok {
 			// Frameless subprogram, first PC should be suitable for injection.
-			injectionPCs = append(injectionPCs, subprogram.OutOfLinePCRanges[0][0])
+			injectionPoints = append(injectionPoints, ir.InjectionPoint{
+				PC:        subprogram.OutOfLinePCRanges[0][0],
+				Frameless: true,
+			})
 		} else {
-			injectionPCs = append(injectionPCs, prologueEnd)
+			injectionPoints = append(injectionPoints, ir.InjectionPoint{
+				PC:        prologueEnd,
+				Frameless: false,
+			})
 		}
 	}
 	for _, inlinedInstanceRanges := range subprogram.InlinePCRanges {
-		// Inlined instances are always frameless.
-		injectionPCs = append(injectionPCs, inlinedInstanceRanges[0][0])
+		injectionPoints = append(injectionPoints, ir.InjectionPoint{
+			PC: inlinedInstanceRanges[0][0],
+			// TODO: We need to determine from the inlined parent whether the
+			// inlined instance is frameless.
+			Frameless: true,
+		})
 	}
 
 	// TODO: Find the return locations and add a return event.
 	events := []*ir.Event{
 		{
-			ID:           v.eventIDAlloc.next(),
-			InjectionPCs: injectionPCs,
-			Condition:    nil,
+			ID:              v.eventIDAlloc.next(),
+			InjectionPoints: injectionPoints,
+			Condition:       nil,
 			// Will be populated after all the types have been resolved
 			// and placeholders have been filled in.
 			Type: nil,

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,6 +1,6 @@
 ID: 1
 Probes:
-    - ID: a
+    - ID: intArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -8,13 +8,13 @@ Probes:
       Events:
         - ID: 1
           Type: 53 EventRootType Probe[main.intArg]
-          InjectionPCs: ["0x4a804a"]
+          InjectionPoints: [{PC: "0x4a806a", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: b
+    - ID: stringArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -22,13 +22,13 @@ Probes:
       Events:
         - ID: 2
           Type: 54 EventRootType Probe[main.stringArg]
-          InjectionPCs: ["0x4a80ca"]
+          InjectionPoints: [{PC: "0x4a80ea", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: c
+    - ID: intSliceArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -36,13 +36,13 @@ Probes:
       Events:
         - ID: 3
           Type: 55 EventRootType Probe[main.intSliceArg]
-          InjectionPCs: ["0x4a814a"]
+          InjectionPoints: [{PC: "0x4a816a", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: d
+    - ID: intArrayArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -50,13 +50,13 @@ Probes:
       Events:
         - ID: 4
           Type: 56 EventRootType Probe[main.intArrayArg]
-          InjectionPCs: ["0x4a81ca"]
+          InjectionPoints: [{PC: "0x4a81ea", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: e
+    - ID: stringSliceArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -64,13 +64,13 @@ Probes:
       Events:
         - ID: 5
           Type: 57 EventRootType Probe[main.stringSliceArg]
-          InjectionPCs: ["0x4a824a"]
+          InjectionPoints: [{PC: "0x4a826a", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: f
+    - ID: stringArrayArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -78,63 +78,81 @@ Probes:
       Events:
         - ID: 6
           Type: 58 EventRootType Probe[main.stringArrayArg]
-          InjectionPCs: ["0x4a82ca"]
+          InjectionPoints: [{PC: "0x4a82ea", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: h
+    - ID: intArrayArgFrameless
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 9}
       Events:
         - ID: 7
-          Type: 59 EventRootType Probe[main.mapArg]
-          InjectionPCs: ["0x4a840a"]
+          Type: 59 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a8360", Frameless: true}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: i
+    - ID: mapArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 10}
       Events:
         - ID: 8
-          Type: 60 EventRootType Probe[main.bigMapArg]
-          InjectionPCs: ["0x4a8473"]
+          Type: 60 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a844a", Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: g
+    - ID: bigMapArg
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 11}
+      Events:
+        - ID: 9
+          Type: 61 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a84b3", Frameless: false}]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: inlined
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 1}
       Events:
-        - ID: 9
-          Type: 61 EventRootType Probe[main.inlined]
-          InjectionPCs: ["0x4a834a", "0x4a7da6"]
+        - ID: 10
+          Type: 62 EventRootType Probe[main.inlined]
+          InjectionPoints:
+            - PC: "0x4a838a"
+              Frameless: false
+            - PC: "0x4a7dce"
+              Frameless: true
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: j
+    - ID: PointerChainArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 2}
       Events:
-        - ID: 10
-          Type: 62 EventRootType Probe[main.PointerChainArg]
-          InjectionPCs: ["0x4a7fe6"]
+        - ID: 11
+          Type: 63 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a8006", Frameless: true}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
@@ -143,25 +161,25 @@ Probes:
 Subprograms:
     - ID: 3
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a8040..0x4a80a2]
+      OutOfLinePCRanges: [0x4a8060..0x4a80c2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x4a8040..0x4a8059
+            - Range: 0x4a8060..0x4a8079
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a80c0..0x4a8131]
+      OutOfLinePCRanges: [0x4a80e0..0x4a8151]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 GoStringHeaderType string
           Locations:
-            - Range: 0x4a80c0..0x4a80de
+            - Range: 0x4a80e0..0x4a80fe
               Pieces:
                 - Size: 8
                   InReg: true
@@ -175,13 +193,13 @@ Subprograms:
           IsReturn: false
     - ID: 5
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a8140..0x4a81ba]
+      OutOfLinePCRanges: [0x4a8160..0x4a81da]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a8140..0x4a815e
+            - Range: 0x4a8160..0x4a817e
               Pieces:
                 - Size: 8
                   InReg: true
@@ -199,25 +217,25 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a81c0..0x4a8227]
+      OutOfLinePCRanges: [0x4a81e0..0x4a8247]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 ArrayType [3]int
           Locations:
-            - Range: 0x4a81c0..0x4a8227
+            - Range: 0x4a81e0..0x4a8247
               Pieces: [{Size: 24, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a8240..0x4a82ba]
+      OutOfLinePCRanges: [0x4a8260..0x4a82da]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 12 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a8240..0x4a825e
+            - Range: 0x4a8260..0x4a827e
               Pieces:
                 - Size: 8
                   InReg: true
@@ -235,65 +253,77 @@ Subprograms:
           IsReturn: false
     - ID: 8
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a82c0..0x4a8327]
+      OutOfLinePCRanges: [0x4a82e0..0x4a8347]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 14 ArrayType [3]string
           Locations:
-            - Range: 0x4a82c0..0x4a8327
+            - Range: 0x4a82e0..0x4a8347
               Pieces: [{Size: 48, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 9
+      Name: main.stringArrayArgFrameless
+      OutOfLinePCRanges: [0x4a8360..0x4a8361]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0x4a8360..0x4a8361
+              Pieces: [{Size: 48, InReg: false, StackOffset: 0, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a8400..0x4a8456]
+      OutOfLinePCRanges: [0x4a8440..0x4a8496]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 15 GoMapType map[string]int
           Locations:
-            - Range: 0x4a8400..0x4a842d
+            - Range: 0x4a8440..0x4a846d
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 11
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a8460..0x4a851b]
+      OutOfLinePCRanges: [0x4a84a0..0x4a855b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 29 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a8460..0x4a8493
+            - Range: 0x4a84a0..0x4a84d3
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0x4a8493..0x4a851b
+            - Range: 0x4a84d3..0x4a855b
               Pieces: [{Size: 0, InReg: false, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a8340..0x4a83a2]
-      InlinePCRanges: [[0x4a7da6..0x4a7df3]]
+      OutOfLinePCRanges: [0x4a8380..0x4a83e2]
+      InlinePCRanges: [[0x4a7dce..0x4a7e1f]]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x4a7da6..0x4a7df3
+            - Range: 0x4a7dce..0x4a7e1f
               Pieces: []
-            - Range: 0x4a8340..0x4a8359
+            - Range: 0x4a8380..0x4a8399
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x4a7fe6..0x4a8025]]
+      InlinePCRanges: [[0x4a8006..0x4a8045]]
       Variables:
         - Name: ptr
           Type: 2 PointerType *****int
           Locations:
-            - Range: 0x4a7fbf..0x4a800b
+            - Range: 0x4a7fdf..0x4a802b
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
@@ -893,6 +923,21 @@ Types:
                   ByteSize: 48
     - __kind: EventRootType
       ID: 59
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 60
       Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -903,11 +948,11 @@ Types:
             Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: m}
+                  Variable: {subprogram: 10, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 60
+      ID: 61
       Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -918,11 +963,11 @@ Types:
             Type: 29 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: m}
+                  Variable: {subprogram: 11, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 61
+      ID: 62
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -937,7 +982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 63
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -951,4 +996,4 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 62
+MaxTypeID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,6 +1,6 @@
 ID: 1
 Probes:
-    - ID: a
+    - ID: intArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -8,13 +8,13 @@ Probes:
       Events:
         - ID: 1
           Type: 53 EventRootType Probe[main.intArg]
-          InjectionPCs: [741868]
+          InjectionPoints: [{PC: 741932, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: b
+    - ID: stringArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -22,13 +22,13 @@ Probes:
       Events:
         - ID: 2
           Type: 54 EventRootType Probe[main.stringArg]
-          InjectionPCs: [741980]
+          InjectionPoints: [{PC: 742044, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: c
+    - ID: intSliceArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -36,13 +36,13 @@ Probes:
       Events:
         - ID: 3
           Type: 55 EventRootType Probe[main.intSliceArg]
-          InjectionPCs: [742108]
+          InjectionPoints: [{PC: 742172, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: d
+    - ID: intArrayArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -50,13 +50,13 @@ Probes:
       Events:
         - ID: 4
           Type: 56 EventRootType Probe[main.intArrayArg]
-          InjectionPCs: [742236]
+          InjectionPoints: [{PC: 742300, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: e
+    - ID: stringSliceArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -64,13 +64,13 @@ Probes:
       Events:
         - ID: 5
           Type: 57 EventRootType Probe[main.stringSliceArg]
-          InjectionPCs: [742364]
+          InjectionPoints: [{PC: 742428, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: f
+    - ID: stringArrayArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
@@ -78,63 +78,81 @@ Probes:
       Events:
         - ID: 6
           Type: 58 EventRootType Probe[main.stringArrayArg]
-          InjectionPCs: [742492]
+          InjectionPoints: [{PC: 742556, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: h
+    - ID: intArrayArgFrameless
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 9}
       Events:
         - ID: 7
-          Type: 59 EventRootType Probe[main.mapArg]
-          InjectionPCs: [742812]
+          Type: 59 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: 742672, Frameless: true}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: i
+    - ID: mapArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 10}
       Events:
         - ID: 8
-          Type: 60 EventRootType Probe[main.bigMapArg]
-          InjectionPCs: [742928]
+          Type: 60 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: 742892, Frameless: false}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: g
+    - ID: bigMapArg
+      Kind: ProbeKindLog
+      Version: 0
+      Tags: []
+      Subprogram: {subprogram: 11}
+      Events:
+        - ID: 9
+          Type: 61 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: 743008, Frameless: false}]
+          Condition: null
+      Snapshot: false
+      ThrottlePeriodMs: 100
+      ThrottleBudget: 500
+      PointerChasingLimit: 4.294967295e+09
+    - ID: inlined
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 1}
       Events:
-        - ID: 9
-          Type: 61 EventRootType Probe[main.inlined]
-          InjectionPCs: [742620, 741304]
+        - ID: 10
+          Type: 62 EventRootType Probe[main.inlined]
+          InjectionPoints:
+            - PC: 742700
+              Frameless: false
+            - PC: 741356
+              Frameless: true
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
       ThrottleBudget: 500
       PointerChasingLimit: 4.294967295e+09
-    - ID: j
+    - ID: PointerChainArg
       Kind: ProbeKindLog
       Version: 0
       Tags: []
       Subprogram: {subprogram: 2}
       Events:
-        - ID: 10
-          Type: 62 EventRootType Probe[main.PointerChainArg]
-          InjectionPCs: [741784]
+        - ID: 11
+          Type: 63 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: 741836, Frameless: true}]
           Condition: null
       Snapshot: false
       ThrottlePeriodMs: 100
@@ -143,25 +161,25 @@ Probes:
 Subprograms:
     - ID: 3
       Name: main.intArg
-      OutOfLinePCRanges: [0xb51e0..0xb5250]
+      OutOfLinePCRanges: [0xb5220..0xb5290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xb51e0..0xb5200
+            - Range: 0xb5220..0xb5240
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 4
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb5250..0xb52d0]
+      OutOfLinePCRanges: [0xb5290..0xb5310]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 GoStringHeaderType string
           Locations:
-            - Range: 0xb5250..0xb5274
+            - Range: 0xb5290..0xb52b4
               Pieces:
                 - Size: 8
                   InReg: true
@@ -175,13 +193,13 @@ Subprograms:
           IsReturn: false
     - ID: 5
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb52d0..0xb5350]
+      OutOfLinePCRanges: [0xb5310..0xb5390]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb52d0..0xb52f4
+            - Range: 0xb5310..0xb5334
               Pieces:
                 - Size: 8
                   InReg: true
@@ -199,25 +217,25 @@ Subprograms:
           IsReturn: false
     - ID: 6
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb5350..0xb53d0]
+      OutOfLinePCRanges: [0xb5390..0xb5410]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 11 ArrayType [3]int
           Locations:
-            - Range: 0xb5350..0xb53d0
+            - Range: 0xb5390..0xb5410
               Pieces: [{Size: 24, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 7
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb53d0..0xb5450]
+      OutOfLinePCRanges: [0xb5410..0xb5490]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 12 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb53d0..0xb53f4
+            - Range: 0xb5410..0xb5434
               Pieces:
                 - Size: 8
                   InReg: true
@@ -235,65 +253,77 @@ Subprograms:
           IsReturn: false
     - ID: 8
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5450..0xb54d0]
+      OutOfLinePCRanges: [0xb5490..0xb5510]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 14 ArrayType [3]string
           Locations:
-            - Range: 0xb5450..0xb54d0
+            - Range: 0xb5490..0xb5510
               Pieces: [{Size: 48, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 9
+      Name: main.stringArrayArgFrameless
+      OutOfLinePCRanges: [0xb5510..0xb5520]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0xb5510..0xb5520
+              Pieces: [{Size: 48, InReg: false, StackOffset: 8, Register: 0}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5590..0xb5600]
+      OutOfLinePCRanges: [0xb55e0..0xb5650]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 15 GoMapType map[string]int
           Locations:
-            - Range: 0xb5590..0xb55c8
+            - Range: 0xb55e0..0xb5618
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 11
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5600..0xb56c0]
+      OutOfLinePCRanges: [0xb5650..0xb5710]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 29 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5600..0xb5638
+            - Range: 0xb5650..0xb5688
               Pieces: [{Size: 0, InReg: true, StackOffset: 0, Register: 0}]
-            - Range: 0xb5638..0xb56c0
+            - Range: 0xb5688..0xb5710
               Pieces: [{Size: 0, InReg: false, StackOffset: 8, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.inlined
-      OutOfLinePCRanges: [0xb54d0..0xb5540]
-      InlinePCRanges: [[0xb4fb8..0xb4ff4]]
+      OutOfLinePCRanges: [0xb5520..0xb5590]
+      InlinePCRanges: [[0xb4fec..0xb5028]]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xb4fb8..0xb4ff4
+            - Range: 0xb4fec..0xb5028
               Pieces: []
-            - Range: 0xb54d0..0xb54f0
+            - Range: 0xb5520..0xb5540
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xb5198..0xb51c8]]
+      InlinePCRanges: [[0xb51cc..0xb51fc]]
       Variables:
         - Name: ptr
           Type: 2 PointerType *****int
           Locations:
-            - Range: 0xb5170..0xb51b8
+            - Range: 0xb51a4..0xb51ec
               Pieces: [{Size: 8, InReg: true, StackOffset: 0, Register: 0}]
           IsParameter: true
           IsReturn: false
@@ -893,6 +923,21 @@ Types:
                   ByteSize: 48
     - __kind: EventRootType
       ID: 59
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenseBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 60
       Name: Probe[main.mapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -903,11 +948,11 @@ Types:
             Type: 15 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: m}
+                  Variable: {subprogram: 10, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 60
+      ID: 61
       Name: Probe[main.bigMapArg]
       ByteSize: 1
       PresenseBitsetSize: 1
@@ -918,11 +963,11 @@ Types:
             Type: 29 GoMapType map[string]main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: m}
+                  Variable: {subprogram: 11, index: 0, name: m}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 61
+      ID: 62
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -937,7 +982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 63
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenseBitsetSize: 1
@@ -951,4 +996,4 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 62
+MaxTypeID: 63

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -22,6 +22,7 @@ func main() {
 	intArrayArg([3]int{1, 2, 3})
 	stringSliceArg([]string{"a", "b", "c"})
 	stringArrayArg([3]string{"a", "b", "c"})
+	stringArrayArgFrameless([3]string{"foo", "bar", "baz"})
 	inlined(1)
 	// Passing inlined function as an argument forces out-of-line instantation.
 	funcArg(inlined)
@@ -64,6 +65,10 @@ func stringSliceArg(s []string) {
 //go:noinline
 func stringArrayArg(s [3]string) {
 	fmt.Println(s)
+}
+
+//go:noinline
+func stringArrayArgFrameless(s [3]string) {
 }
 
 func inlined(x int) {

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -1,42 +1,46 @@
 binary: simple
 probes:
-- id: a
+- id: intArg
   type: LOG_PROBE
   where:
     method_name: main.intArg
-- id: b
+- id: stringArg
   type: LOG_PROBE
   where:
     method_name: main.stringArg
-- id: c
+- id: intSliceArg
   type: LOG_PROBE
   where:
     method_name: main.intSliceArg
-- id: d
+- id: intArrayArg
   type: LOG_PROBE
   where:
     method_name: main.intArrayArg
-- id: e
+- id: stringSliceArg
   type: LOG_PROBE
   where:
     method_name: main.stringSliceArg
-- id: f
+- id: stringArrayArg
   type: LOG_PROBE
   where:
     method_name: main.stringArrayArg
-- id: g
+- id: intArrayArgFrameless
+  type: LOG_PROBE
+  where:
+    method_name: main.stringArrayArgFrameless
+- id: inlined
   type: LOG_PROBE
   where:
     method_name: main.inlined
-- id: h
+- id: mapArg
   type: LOG_PROBE
   where:
     method_name: main.mapArg
-- id: i
+- id: bigMapArg
   type: LOG_PROBE
   where:
     method_name: main.bigMapArg
-- id: j
+- id: PointerChainArg
   type: LOG_PROBE
   where:
     method_name: main.PointerChainArg


### PR DESCRIPTION
This patch does two things:
1) It propagates the frameless nature of functions.
2) It appropriately initializes the CFA based on that frameless nature.

Go leaf functions that don't use stack space do not have a prologue. We
handled this computation for deciding where to put the probe, but we
didn't translate the CFA offset calculation. Note that this fix remains
incomplete in that it's possible for inlined functions to appear underneath
a frameless parent. Plumbing for that calculation is left for later.

Resolves [DEBUG-4096](https://datadoghq.atlassian.net/browse/DEBUG-4096)

[DEBUG-4096]: https://datadoghq.atlassian.net/browse/DEBUG-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ