### PR TITLE
Add mutable tag jobs for ot-standalone, cws-instrumentation and dca

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -13,40 +13,12 @@
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}"
 
-.deploy_mutable_cws-instrumentation_tags_base:
-  extends: .docker_publish_job_definition
-  stage: deploy_cws_instrumentation
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
-
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
-# will update the `rc` tag
-deploy_containers-cws-instrumentation-rc-mutable:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-cws-instrumentation-rc-versioned
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc
-
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_manual_final]
-
-# will update the `latest` tag
-deploy_containers-cws-instrumentation-latest:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-cws-instrumentation-final-versioned
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
@@ -1,7 +1,7 @@
 # deploy mutable cws instrumentation tags stage
 # Contains jobs which deploy CWS Instrumentation related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
 
-.deploy_mutable_cws_instrumentation_tags_base:
+.deploy_mutable_cws_instrumentation_tags-base:
   extends: .docker_publish_job_definition
   stage: deploy_cws_instrumentation_mutable_tags
   dependencies: []
@@ -10,7 +10,7 @@
     - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
 
 deploy_containers-cws-instrumentation-rc-mutable:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
+  extends: .deploy_mutable_cws_instrumentation_tags-base
   rules: !reference [.on_deploy_rc]
   needs:
     - job: deploy_containers-cws-instrumentation-rc-versioned
@@ -19,7 +19,7 @@ deploy_containers-cws-instrumentation-rc-mutable:
     IMG_NEW_TAGS: rc
 
 deploy_containers-cws-instrumentation-latest:
-  extends: .deploy_mutable_cws-instrumentation_tags_base
+  extends: .deploy_mutable_cws_instrumentation_tags-base
   rules: !reference [.on_deploy_manual_final]
   needs:
     - job: deploy_containers-cws-instrumentation-final-versioned

--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
@@ -1,0 +1,28 @@
+# deploy mutable cws instrumentation tags stage
+# Contains jobs which deploy CWS Instrumentation related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
+
+.deploy_mutable_cws_instrumentation_tags_base:
+  extends: .docker_publish_job_definition
+  stage: deploy_cws_instrumentation_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CWS_INSTRUMENTATION_REPOSITORY}:${VERSION}
+
+deploy_containers-cws-instrumentation-rc-mutable:
+  extends: .deploy_mutable_cws-instrumentation_tags_base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-cws-instrumentation-rc-versioned
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-cws-instrumentation-latest:
+  extends: .deploy_mutable_cws-instrumentation_tags_base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-cws-instrumentation-final-versioned
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -14,57 +14,13 @@
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
 
-.deploy_mutable_dca_tags-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
-
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
-deploy_containers-dca-rc:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc
-
-deploy_containers-dca-latest:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest
-
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_manual_final]
-
-deploy_containers-dca_internal-rc:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc
-
-deploy_containers-dca_internal-latest:
-  extends: .deploy_mutable_dca_tags-base
-  rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest
 
 # Fips flavor
 .deploy_containers-dca-fips-base:
@@ -77,54 +33,10 @@ deploy_containers-dca_internal-latest:
     - export IMG_SOURCES="${IMG_BASE_SRC}-fips-amd64,${IMG_BASE_SRC}-fips-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips"
 
-.deploy_mutable_dca_tags-fips-base:
-  extends: .docker_publish_job_definition
-  stage: deploy_dca
-  dependencies: []
-  before_script:
-    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
-    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
-
 deploy_containers-dca-fips:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
-deploy_containers-dca-fips-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest-fips
-
-deploy_containers-dca-fips-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_rc]
-  needs:
-    - job: deploy_containers-dca-fips
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc-fips
-
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_manual_final]
-
-deploy_containers-dca-fips_internal-rc:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_rc]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: rc-fips
-
-deploy_containers-dca-fips_internal-latest:
-  extends: .deploy_mutable_dca_tags-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
-  needs:
-    - job: deploy_containers-dca-fips_internal
-      artifacts: false
-  variables:
-    IMG_NEW_TAGS: latest-fips

--- a/.gitlab/deploy_dca/deploy_dca_mutable_tags.yml
+++ b/.gitlab/deploy_dca/deploy_dca_mutable_tags.yml
@@ -1,0 +1,92 @@
+# deploy mutable DCA tags stage
+# Contains jobs which deploy DCA related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
+
+.deploy_mutable_dca_tags-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca_mutable_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}
+
+# Base flavor
+deploy_containers-dca-rc:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-dca-latest:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+
+deploy_containers-dca_internal-rc:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-dca_internal-latest:
+  extends: .deploy_mutable_dca_tags-base
+  rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+
+# Fips flavor
+.deploy_mutable_dca_tags-fips-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_dca
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - export IMG_TAG_REFERENCE=${CLUSTER_AGENT_REPOSITORY}:${VERSION}-fips
+
+deploy_containers-dca-fips-latest:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips
+
+deploy_containers-dca-fips-rc:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-dca-fips
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
+
+deploy_containers-dca-fips_internal-rc:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc-fips
+
+deploy_containers-dca-fips_internal-latest:
+  extends: .deploy_mutable_dca_tags-fips-base
+  rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-dca-fips_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest-fips

--- a/.gitlab/deploy_dca/deploy_dca_mutable_tags.yml
+++ b/.gitlab/deploy_dca/deploy_dca_mutable_tags.yml
@@ -49,7 +49,7 @@ deploy_containers-dca_internal-latest:
 # Fips flavor
 .deploy_mutable_dca_tags-fips-base:
   extends: .docker_publish_job_definition
-  stage: deploy_dca
+  stage: deploy_dca_mutable_tags
   dependencies: []
   before_script:
     - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?

--- a/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
+++ b/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
@@ -17,31 +17,7 @@ deploy_containers-ot-standalone:
   extends: .deploy_containers-ot-standalone-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
 
-deploy_containers-ot-standalone-rc:
-  extends: .deploy_containers-ot-standalone-base
-  rules: !reference [.on_deploy_rc]
-  variables:
-    VERSION: rc
-
-deploy_containers-ot-standalone-latest:
-  extends: .deploy_containers-ot-standalone-base
-  rules: !reference [.on_deploy_manual_final]
-  variables:
-    VERSION: latest
-
 # Jobs to publish images to our internal registries.
 deploy_containers-ot-standalone_internal:
   extends: .deploy_containers-ot-standalone-base
   rules: !reference [.on_deploy_internal_manual_final]
-
-deploy_containers-ot-standalone_internal-rc:
-  extends: .deploy_containers-ot-standalone-base
-  rules: !reference [.on_deploy_internal_rc]
-  variables:
-    VERSION: rc
-
-deploy_containers-ot-standalone_internal-latest:
-  extends: .deploy_containers-ot-standalone-base
-  rules: !reference [.on_deploy_internal_manual_final]
-  variables:
-    VERSION: latest

--- a/.gitlab/deploy_ot_standalone/deploy_ot_standalone_mutable_tags.yml
+++ b/.gitlab/deploy_ot_standalone/deploy_ot_standalone_mutable_tags.yml
@@ -44,4 +44,3 @@ deploy_containers-ot-standalone_internal-latest:
       artifacts: false
   variables:
     IMG_NEW_TAGS: latest
-    

--- a/.gitlab/deploy_ot_standalone/deploy_ot_standalone_mutable_tags.yml
+++ b/.gitlab/deploy_ot_standalone/deploy_ot_standalone_mutable_tags.yml
@@ -1,0 +1,47 @@
+# Contains jobs which deploy OT standalone related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
+
+.deploy_mutable_ot_standalone_tags-base:
+  extends: .docker_publish_job_definition
+  stage: deploy_mutable_image_tags
+  dependencies: []
+  before_script:
+    - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
+    - if [[ "$OTEL_AGENT_REPOSITORY" == "" ]]; then export OTEL_AGENT_REPOSITORY="otel-agent"; fi
+    - export IMG_TAG_REFERENCE=${OTEL_AGENT_REPOSITORY}:${VERSION}
+
+deploy_containers-ot-standalone-rc:
+  extends: .deploy_mutable_ot_standalone_tags-base
+  rules: !reference [.on_deploy_rc]
+  needs:
+    - job: deploy_containers-ot-standalone
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-ot-standalone-latest:
+  extends: .deploy_mutable_ot_standalone_tags-base
+  rules: !reference [.on_deploy_manual_final]
+  needs:
+    - job: deploy_containers-ot-standalone
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+
+deploy_containers-ot-standalone_internal-rc:
+  extends: .deploy_mutable_ot_standalone_tags-base
+  rules: !reference [.on_deploy_internal_rc]
+  needs:
+    - job: deploy_containers-ot-standalone_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: rc
+
+deploy_containers-ot-standalone_internal-latest:
+  extends: .deploy_mutable_ot_standalone_tags-base
+  rules: !reference [.on_deploy_internal_manual_final]
+  needs:
+    - job: deploy_containers-ot-standalone_internal
+      artifacts: false
+  variables:
+    IMG_NEW_TAGS: latest
+    

--- a/.gitlab/trigger_distribution/include.yml
+++ b/.gitlab/trigger_distribution/include.yml
@@ -3,7 +3,9 @@ stages:
   - deploy_mutable_image_tags
   - deploy_packages
   - deploy_cws_instrumentation
+  - deploy_cws_instrumentation_mutable_tags
   - deploy_dca
+  - deploy_dca_mutable_tags
   - trigger_release
 
 include:
@@ -11,9 +13,12 @@ include:
   - .gitlab/common/container_publish_job_templates.yml
   - .gitlab/deploy_containers/deploy_containers_a7.yml
   - .gitlab/deploy_containers/deploy_mutable_image_tags.yml
-  - .gitlab/deploy_containers/deploy_ot_standalone.yml
+  - .gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
+  - .gitlab/deploy_ot_standalone/deploy_ot_standalone_mutable_tags.yml
   - .gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+  - .gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation_mutable_tags.yml
   - .gitlab/deploy_dca/deploy_dca.yml
+  - .gitlab/deploy_dca/deploy_dca_mutable_tags.yml
   - .gitlab/deploy_packages/winget.yml
   - .gitlab/trigger_release/agent.yml
   - .gitlab/trigger_release/installer.yml


### PR DESCRIPTION
### What does this PR do?

This PR changes the jobs for `ot-standalone`, `cws-instrumentation` and `DCA` to move from using `IMG_SOURCES` and `IMG_DESTINATIONS` to `IMG_NEW_TAGS` and `IMG_TAG_REFERENCE`. This way instead of pushing the entire image index for tags like `latest` we simply create a new tag referencing the existing artifact (created in the earlier stage).

This PR introduces new stages which are necessary for:
1. Using `needs` in the gitlab jobs so they can depend on each other and run sooner,
2. Avoid confusion when jobs which depend on themselves are in the same stage/same column - especially important for manual execution.

### Motivation

Simplify and unify image publish jobs.

### Describe how you validated your changes
This was validated internally. We should do the final test on the next RC build.