### PR TITLE
Remove kmt.create-stack task

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -15,7 +15,6 @@
     *   [kmt.init](#kmtinit)
     *   [kmt.update-resources](#kmtupdate-resources)
     *   [kmt.ls](#kmtls)
-    *   [kmt.create-stack](#kmtcreate-stack)
     *   [kmt.gen-config](#kmtgen-config)
     *   [kmt.launch-stack](#kmtlaunch-stack)
     *   [kmt.status](#kmtstatus)
@@ -354,16 +353,6 @@ Lists available VM images and indicates which ones are already downloaded locall
 ```bash
 dda inv -e kmt.ls
 ```
-
-### `kmt.create-stack`
-
-Creates a new, empty stack.
-
-```bash
-dda inv -e kmt.create-stack [--stack=<name>]
-```
-
-If no `--stack` name is provided, one is automatically generated from the current git branch name. Note that `kmt.gen-config --init-stack` provides a convenient way to create and configure a stack in one step.
 
 ### `kmt.gen-config`
 

--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -365,8 +365,8 @@ dda inv -e kmt.gen-config --vms=<list> [--stack=<name>]
 **Common Flags:**
 
 -   `--vms=<list>`: A comma-separated list of VMs to add to the stack. See [Specifying VMs](#specifying-vms) below for the format.
+-   `--init-stack`: Automatically creates the stack if it doesn't exist. Stack name is generated from the current git branch name, if not explicitly provided. This is true by default.
 -   `--stack=<name>`: The target stack. Defaults to a name based on the current git branch.
--   `--init-stack`: Automatically creates the stack if it doesn't exist.
 -   `--new`: Creates a fresh configuration file, removing any existing VMs from the stack's configuration.
 -   `--from-ci-pipeline=<id>`: Configures the stack to replicate failed jobs from a CI pipeline. See [CI Integration](#ci-integration).
 

--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -75,9 +75,8 @@ dda inv -e kmt.init --all-images
 A stack is a collection of VMs. This command will create a new stack and configure it to run one local Ubuntu 22.04 VM.
 
 ```bash
-# --init-stack creates the stack if it does not exist
 # If --stack is not provided, a name is generated from your git branch
-dda inv -e kmt.gen-config --vms=ubuntu_22.04-local-distro --init-stack
+dda inv -e kmt.gen-config --vms=ubuntu_22.04-local-distro
 ```
 
 **3. Launch the Stack**
@@ -151,15 +150,14 @@ dda inv -e kmt.init --remote-setup-only
 This command will create a new stack and configure it to run one remote Ubuntu 22.04 VM on an x86_64 EC2 instance.
 
 ```bash
-# --init-stack creates the stack if it does not exist
-dda inv -e kmt.gen-config --vms=x86-jammy-distro --init-stack
+dda inv -e kmt.gen-config --vms=x86-jammy-distro
 ```
 
 You can also specify multiple VMs with different architectures. KMT will launch them on separate EC2 instances.
 
 ```bash
 # This configures a stack with multiple x86_64 and arm64 VMs
-dda inv -e kmt.gen-config --vms=x86-jammy-distro,x86-focal-distro,arm64-amazon4.14-distro,arm64-amazon5.10-distro --init-stack
+dda inv -e kmt.gen-config --vms=x86-jammy-distro,x86-focal-distro,arm64-amazon4.14-distro,arm64-amazon5.10-distro
 ```
 
 **3. Launch the Stack**
@@ -230,7 +228,7 @@ Provide a list of both local and remote VMs to the `gen-config` command.
 
 ```bash
 # This configures one local Ubuntu 22.04 VM and one remote x86_64 Ubuntu 22.04 VM
-dda inv -e kmt.gen-config --vms=ubuntu_22.04-local-distro,x86-jammy-distro --init-stack
+dda inv -e kmt.gen-config --vms=ubuntu_22.04-local-distro,x86-jammy-distro
 ```
 
 **3. Launch the Stack**

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -133,7 +133,7 @@ def gen_config(
     stack: str | None = None,
     vms: str = "",
     sets: str = "",
-    init_stack=False,
+    init_stack=True,
     vcpu: str | None = None,
     memory: str | None = None,
     new=False,

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -112,11 +112,6 @@ CLANG_PATH_CI = Path("/opt/datadog-agent/embedded/bin/clang-bpf")
 LLC_PATH_CI = Path("/opt/datadog-agent/embedded/bin/llc-bpf")
 
 
-@task
-def create_stack(ctx, stack=None):
-    stacks.create_stack(ctx, stack)
-
-
 @task(
     help={
         "vms": "Comma separated List of VMs to setup. Each definition must contain the following elemets (recipe, architecture, version).",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
`kmt.create-stack` does not fit into KMT workflow. It does not lead to the correct generation of the stacks.output file leading to failures when destroying the stack.

The recommended approach to create a stack is via the `kmt.gen-config` task. Users can refer to the KMT readme for more information.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->