### PR TITLE
Remove secret binary from heroku agent package

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -31,7 +31,7 @@ dependency 'libpcap' if linux_target? and !heroku_target? # system-probe depende
 # Include traps db file in snmp.d/traps_db/
 dependency 'snmp-traps'
 
-dependency 'secret-generic-connector'
+dependency 'secret-generic-connector' if !heroku_target?
 
 dependency 'datadog-agent-integrations-py3'
 

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -31,7 +31,7 @@ dependency 'libpcap' if linux_target? and !heroku_target? # system-probe depende
 # Include traps db file in snmp.d/traps_db/
 dependency 'snmp-traps'
 
-dependency 'secret-generic-connector' if !heroku_target?
+dependency 'secret-generic-connector' unless heroku_target?
 
 dependency 'datadog-agent-integrations-py3'
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove the secret binary added in https://github.com/DataDog/datadog-agent/pull/36383 from the heroku agent package.

### Motivation
The size increase is not considered worth it for Heroku, and most functionalities from the secret binary don't apply (eg. fetch secret from k8s or cloud providers). 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->