### PR TITLE
service discovery: Add E2E test for operator

### DIFF
--- a/test/new-e2e/tests/discovery/operator_test.go
+++ b/test/new-e2e/tests/discovery/operator_test.go
@@ -45,12 +45,12 @@ spec:
       containers:
         agent:
           env:
-            - name: DD_DISCOVERY_ENABLED
-              value: "true"
+            - name: DD_LOG_LEVEL
+              value: "debug"
         system-probe:
           env:
-            - name: DD_DISCOVERY_ENABLED
-              value: "true"
+            - name: DD_LOG_LEVEL
+              value: "debug"
 `}
 
 	e2e.Run(t, &operatorDiscoveryTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(

--- a/test/new-e2e/tests/discovery/operator_test.go
+++ b/test/new-e2e/tests/discovery/operator_test.go
@@ -1,0 +1,158 @@
+package discovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentwithoperatorparams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
+)
+
+type operatorDiscoveryTestSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func TestDiscoveryOperator(t *testing.T) {
+	customDDA := agentwithoperatorparams.DDAConfig{
+		Name: "discovery-enabled",
+		YamlConfig: `
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+spec:
+  global:
+    kubelet:
+      tlsVerify: false
+  features:
+    serviceDiscovery:
+      enabled: true
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          env:
+            - name: DD_DISCOVERY_ENABLED
+              value: "true"
+        system-probe:
+          env:
+            - name: DD_DISCOVERY_ENABLED
+              value: "true"
+`}
+	
+
+	e2e.Run(t, &operatorDiscoveryTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(
+		awskubernetes.WithOperator(),
+		awskubernetes.WithOperatorDDAOptions([]agentwithoperatorparams.Option{
+			agentwithoperatorparams.WithDDAConfig(customDDA),
+		}...),
+	)))
+}
+
+func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
+	t := s.T()
+
+	// Get agent pod for diagnostics
+	client := s.Env().KubernetesCluster.Client()
+	agentPods, err := client.CoreV1().Pods("datadog").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/component=agent",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, agentPods.Items, "No agent pods found")
+	agentPod := agentPods.Items[0]
+	
+	// Create Python server pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "python-http-server",
+			Labels: map[string]string{
+				"app": "python-server",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "server",
+					Image: "python:3",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 8000,
+							Name:          "http",
+						},
+					},
+					Command: []string{"python", "-m", "http.server", "8000"},
+				},
+			},
+		},
+	}
+
+	// Deploy Python server pod
+	_, err = client.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Wait for pod to be ready
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		podStatus, err := client.CoreV1().Pods("default").Get(context.Background(), "python-http-server", metav1.GetOptions{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		
+		if podStatus.Status.Phase == corev1.PodRunning {
+			for _, condition := range podStatus.Status.Conditions {
+				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+					t.Log("Python HTTP server pod is ready")
+					return
+				}
+			}
+		}
+		
+		assert.Fail(c, "Python HTTP server pod is not ready yet")
+	}, 2*time.Minute, 10*time.Second)
+
+	// Check services via unix socket
+	servicesOutput, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
+		"datadog", 
+		agentPod.Name, 
+		"system-probe", 
+		[]string{"curl", "-s", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/discovery/debug"},
+	)
+	if err != nil {
+		t.Logf("Failed to get services info: %v", err)
+	} else {
+		t.Logf("Services discovery info: %s", servicesOutput)
+		if strings.Contains(servicesOutput, "python") || strings.Contains(servicesOutput, "http.server") {
+			t.Log("Python server found in discovery services output")
+		}
+	}
+
+	// Check service discovery payloads
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, err := s.Env().FakeIntake.Client().GetServiceDiscoveries()
+		if !assert.NoError(c, err) {
+			return
+		}
+		
+		t.Logf("Found %d service discovery payloads", len(payloads))
+		for _, p := range payloads {
+			t.Logf("Service discovery: RequestType=%s, ServiceName=%s", p.RequestType, p.Payload.ServiceName)
+		}
+		
+		found := false
+		for _, p := range payloads {
+			if p.RequestType == "start-service" && p.Payload.ServiceName == "http.server" {
+				t.Logf("Found service discovery for http.server: %v", p.Payload)
+				found = true
+				break
+			}
+		}
+		
+		assert.True(c, found, "Did not find service discovery for Python HTTP server")
+	}, 3*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/tests/discovery/operator_test.go
+++ b/test/new-e2e/tests/discovery/operator_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
 package discovery
 
 import (
@@ -46,7 +51,6 @@ spec:
             - name: DD_DISCOVERY_ENABLED
               value: "true"
 `}
-	
 
 	e2e.Run(t, &operatorDiscoveryTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(
 		awskubernetes.WithOperator(),
@@ -67,7 +71,7 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 	require.NoError(t, err)
 	require.NotEmpty(t, agentPods.Items, "No agent pods found")
 	agentPod := agentPods.Items[0]
-	
+
 	// Create Python server pod
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,7 +107,7 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 		if !assert.NoError(c, err) {
 			return
 		}
-		
+
 		if podStatus.Status.Phase == corev1.PodRunning {
 			for _, condition := range podStatus.Status.Conditions {
 				if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
@@ -112,15 +116,15 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 				}
 			}
 		}
-		
+
 		assert.Fail(c, "Python HTTP server pod is not ready yet")
 	}, 2*time.Minute, 10*time.Second)
 
 	// Check services via unix socket
 	servicesOutput, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(
-		"datadog", 
-		agentPod.Name, 
-		"system-probe", 
+		"datadog",
+		agentPod.Name,
+		"system-probe",
 		[]string{"curl", "-s", "--unix-socket", "/var/run/sysprobe/sysprobe.sock", "http://unix/discovery/debug"},
 	)
 	if err != nil {
@@ -138,12 +142,12 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 		if !assert.NoError(c, err) {
 			return
 		}
-		
+
 		t.Logf("Found %d service discovery payloads", len(payloads))
 		for _, p := range payloads {
 			t.Logf("Service discovery: RequestType=%s, ServiceName=%s", p.RequestType, p.Payload.ServiceName)
 		}
-		
+
 		found := false
 		for _, p := range payloads {
 			if p.RequestType == "start-service" && p.Payload.ServiceName == "http.server" {
@@ -152,7 +156,7 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 				break
 			}
 		}
-		
+
 		assert.True(c, found, "Did not find service discovery for Python HTTP server")
 	}, 3*time.Minute, 10*time.Second)
 }

--- a/test/new-e2e/tests/discovery/operator_test.go
+++ b/test/new-e2e/tests/discovery/operator_test.go
@@ -145,12 +145,12 @@ func (s *operatorDiscoveryTestSuite) TestDiscoveryOperator() {
 
 		t.Logf("Found %d service discovery payloads", len(payloads))
 		for _, p := range payloads {
-			t.Logf("Service discovery: RequestType=%s, ServiceName=%s", p.RequestType, p.Payload.ServiceName)
+			t.Logf("Service discovery: RequestType=%s, GeneratedServiceName=%s", p.RequestType, p.Payload.GeneratedServiceName)
 		}
 
 		found := false
 		for _, p := range payloads {
-			if p.RequestType == "start-service" && p.Payload.ServiceName == "http.server" {
+			if p.RequestType == "start-service" && p.Payload.GeneratedServiceName == "http.server" {
 				t.Logf("Found service discovery for http.server: %v", p.Payload)
 				found = true
 				break


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add an E2E test that Service Discovery can be enabled and works correctly via
operator.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-28

### Describe how you validated your changes

CI.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
