### PR TITLE
Remove hardcoded occurences of `omnibus/pkg` in our build scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,9 +108,14 @@ variables:
   # For an unknown reason, it does not go well with
   # a ruby dependency if we build directly into $CI_PROJECT_DIR/.omnibus
   OMNIBUS_BASE_DIR: /omnibus
+  # Some scripts are ran in a different context such as a container and don't have
+  # access to OMNIBUS_PACKAGE_DIR directly. To avoid spreading out many hardcoded
+  # occurrences of "omnibus/pkg" we expose it as a single variable that can be
+  # used to construct the full path expected by the CI
+  OMNIBUS_PACKAGE_SUBDIR: omnibus/pkg
   # Directory in which we put the artifacts after the build
-  # Must be in $CI_PROJECT_DIR
-  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/omnibus/pkg/
+  # Must be in $CI_PROJECT_DIR to be usable as an artifact
+  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_SUBDIR
   # Directory in which we put the SUSE artifacts after the SUSE build
   # Must be in $CI_PROJECT_DIR
   # RPM builds and SUSE RPM builds create artifacts with the same name.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ variables:
   OMNIBUS_PACKAGE_SUBDIR: omnibus/pkg
   # Directory in which we put the artifacts after the build
   # Must be in $CI_PROJECT_DIR to be usable as an artifact
-  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_SUBDIR
+  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_SUBDIR/
   # Directory in which we put the SUSE artifacts after the SUSE build
   # Must be in $CI_PROJECT_DIR
   # RPM builds and SUSE RPM builds create artifacts with the same name.

--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -23,6 +23,8 @@ build_windows_container_entrypoint:
       -e WINDOWS_BUILDER=true
       -e AWS_NETWORKING=true
       -e TARGET_ARCH="$ARCH"
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       c:\mnt\Dockerfiles\agent\windows\entrypoint\build.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/choco_build/choco_build.yml
+++ b/.gitlab/choco_build/choco_build.yml
@@ -22,7 +22,7 @@
       -e BUCKET_BRANCH="$BUCKET_BRANCH"
       -e AWS_NETWORKING=true
       ${WINBUILDIMAGE}
-      powershell.exe -C "C:\mnt\tasks\winbuildscripts\Generate-Chocolatey-Package.ps1 -MSIDirectory c:\mnt\omnibus\pkg -Flavor $FLAVOR -InstallDeps 1"
+      powershell.exe -C "C:\mnt\tasks\winbuildscripts\Generate-Chocolatey-Package.ps1 -MSIDirectory c:\mnt\$OMNIBUS_PACKAGE_SUBDIR -Flavor $FLAVOR -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - $CopyNupkgToS3 = "$S3_CP_CMD --recursive --exclude '*' --include '*.nupkg' build-out $S3_RELEASE_ARTIFACTS_URI/choco/nupkg"
     - Invoke-Expression $CopyNupkgToS3

--- a/.gitlab/choco_build/choco_build.yml
+++ b/.gitlab/choco_build/choco_build.yml
@@ -29,7 +29,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - omnibus/pkg
+      - $OMNIBUS_PACKAGE_DIR/
   # Sometimes Chocolatey is flakey
   retry: 2
 

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -29,6 +29,8 @@
       -e GOMODCACHE="c:\modcache"
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-IntegrationTests.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/lint/windows.yml
+++ b/.gitlab/lint/windows.yml
@@ -21,6 +21,8 @@
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
       -e GOMODCACHE="c:\modcache"
       -e RUST_LOG="uv=trace"
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-Linters.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -14,7 +14,6 @@ WORKDIR="/tmp"
 export INSTALL_DIR="$WORKDIR/datadog-agent-build/bin"
 export CONFIG_DIR="$WORKDIR/datadog-agent-build/config"
 export OMNIBUS_DIR="$WORKDIR/omnibus_build"
-export OMNIBUS_PACKAGE_DIR="$PWD"/omnibus/pkg
 
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR" "$OMNIBUS_DIR"
 mkdir -p "$INSTALL_DIR" "$CONFIG_DIR" "$OMNIBUS_DIR"
@@ -102,7 +101,7 @@ if [ "$SIGN" = true ]; then
     unset LATEST_DMG
 
     # Find latest .dmg file in $GOPATH/src/github.com/Datadog/datadog-agent/omnibus/pkg
-    for file in "$PWD/omnibus/pkg"/*.dmg; do
+    for file in "$OMNIBUS_PACKAGE_DIR/"*.dmg; do
     if [[ -z "$LATEST_DMG" || "$file" -nt "$LATEST_DMG" ]]; then LATEST_DMG="$file"; fi
     done
 

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -36,8 +36,8 @@ agent_dmg-x64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - omnibus/pkg/*.dmg
-      - omnibus/pkg/version-manifest.json
+      - $OMNIBUS_PACKAGE_DIR/*.dmg
+      - $OMNIBUS_PACKAGE_DIR/version-manifest.json
   variables:
     SIGN: true
     KEYCHAIN_NAME: "build.keychain"

--- a/.gitlab/package_build/include.yml
+++ b/.gitlab/package_build/include.yml
@@ -3,10 +3,10 @@
 
 ---
 .upload_sbom_artifacts:
-  - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json
+  - $S3_CP_CMD $OMNIBUS_PACKAGE_SUBDIR/version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json
 
 .upload_sbom_artifacts_windows:
-  - Invoke-Expression "$S3_CP_CMD $OMNIBUS_PACKAGE_DIR\version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json"
+  - Invoke-Expression "$S3_CP_CMD $OMNIBUS_PACKAGE_SUBDIR\version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json"
   - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 
 include:

--- a/.gitlab/package_build/include.yml
+++ b/.gitlab/package_build/include.yml
@@ -6,7 +6,7 @@
   - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json
 
 .upload_sbom_artifacts_windows:
-  - Invoke-Expression "$S3_CP_CMD omnibus\pkg\version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json"
+  - Invoke-Expression "$S3_CP_CMD $OMNIBUS_PACKAGE_DIR\version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json"
   - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 
 include:

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -237,6 +237,8 @@ windows-installer-amd64:
       -e SIGN_WINDOWS_DD_WCS=true
       -e S3_OMNIBUS_CACHE_BUCKET="$S3_OMNIBUS_CACHE_BUCKET"
       -e API_KEY_ORG2=${API_KEY_ORG2}
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-InstallerPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
   after_script:

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -244,6 +244,6 @@ windows-installer-amd64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - omnibus/pkg
+      - $OMNIBUS_PACKAGE_DIR/
   variables:
     ARCH: "x64"

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -219,8 +219,8 @@ windows-installer-amd64:
   script:
     - $ErrorActionPreference = 'Stop'
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
-    - mkdir omnibus\pkg
+    - if (Test-Path $OMNIBUS_PACKAGE_DIR) { remove-item -recurse -force $OMNIBUS_PACKAGE_DIR }
+    - mkdir $OMNIBUS_PACKAGE_DIR
     - >
       docker run --rm
       -m 8192M

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -48,7 +48,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - omnibus/pkg
+      - $OMNIBUS_PACKAGE_DIR/
 
 .windows_main_agent_base:
   extends: .windows_msi_base
@@ -122,4 +122,4 @@ windows_zip_agent_binaries_x64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - omnibus/pkg
+      - $OMNIBUS_PACKAGE_DIR/

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -38,6 +38,8 @@
       -e AGENT_FLAVOR=${AGENT_FLAVOR}
       -e OMNIBUS_RUBY_VERSION="${OMNIBUS_RUBY_VERSION}"
       -e PYTHONUTF8=1
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1 -BuildUpgrade 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -114,6 +114,8 @@ windows_zip_agent_binaries_x64-a7:
       -e BUNDLE_MIRROR__RUBYGEMS__ORG=${BUNDLE_MIRROR__RUBYGEMS__ORG}
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
       -e API_KEY_ORG2=${API_KEY_ORG2}
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-OmnibusTarget.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -6,8 +6,8 @@
   script:
     - $ErrorActionPreference = 'Stop'
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
-    - mkdir omnibus\pkg
+    - if (Test-Path $OMNIBUS_PACKAGE_DIR) { remove-item -recurse -force $OMNIBUS_PACKAGE_DIR }
+    - mkdir $OMNIBUS_PACKAGE_DIR
     - >
       docker run --rm
       -m 24576M
@@ -41,7 +41,7 @@
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1 -BuildUpgrade 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - get-childitem omnibus\pkg
+    - get-childitem $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts_windows]
   after_script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -89,8 +89,8 @@ windows_zip_agent_binaries_x64-a7:
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
-    - if (Test-Path omnibus\pkg) { remove-item -recurse -force omnibus\pkg }
-    - mkdir omnibus\pkg
+    - if (Test-Path $OMNIBUS_PACKAGE_DIR) { remove-item -recurse -force $OMNIBUS_PACKAGE_DIR }
+    - mkdir $OMNIBUS_PACKAGE_DIR
     - >
       docker run --rm
       -m 8192M
@@ -117,7 +117,7 @@ windows_zip_agent_binaries_x64-a7:
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-OmnibusTarget.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
-    - get-childitem omnibus\pkg
+    - get-childitem $OMNIBUS_PACKAGE_DIR
     - !reference [.upload_sbom_artifacts_windows]
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -6,7 +6,7 @@
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
   needs: ["go_deps", "go_tools_deps"]
-  extends: 
+  extends:
     - .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
@@ -45,6 +45,8 @@
       -e S3_PERMANENT_ARTIFACTS_URI="${S3_PERMANENT_ARTIFACTS_URI}"
       -e COVERAGE_CACHE_FLAG="${COVERAGE_CACHE_FLAG}"
       -e FLAKY_PATTERNS_CONFIG="\mnt\flaky-patterns-runtime.yaml"
+      -e OMNIBUS_PACKAGE_DIR="${OMNIBUS_PACKAGE_DIR}"
+      -e OMNIBUS_PACKAGE_SUBDIR="${OMNIBUS_PACKAGE_SUBDIR}"
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-UnitTests.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1 -UploadCoverage 1 -UploadTestResults 1"
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.69.0",
     "dependencies": {
-        "OMNIBUS_RUBY_VERSION": "chouquette/build-summary",
+        "OMNIBUS_RUBY_VERSION": "49bffd5cbf5f4fc8a357afca145482111c8880ee",
         "JMXFETCH_VERSION": "0.49.7",
         "JMXFETCH_HASH": "470b1a19933efca4a48157b54ce48ab08a6ec6fb51f0b10337003dc428f50676",
         "MACOS_BUILD_VERSION": "master",

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.69.0",
     "dependencies": {
-        "OMNIBUS_RUBY_VERSION": "49bffd5cbf5f4fc8a357afca145482111c8880ee",
+        "OMNIBUS_RUBY_VERSION": "chouquette/build-summary",
         "JMXFETCH_VERSION": "0.49.7",
         "JMXFETCH_HASH": "470b1a19933efca4a48157b54ce48ab08a6ec6fb51f0b10337003dc428f50676",
         "MACOS_BUILD_VERSION": "master",

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -264,15 +264,11 @@ def should_retry_bundle_install(res):
 
 def send_build_metrics(ctx, overall_duration):
     # We only want to generate those metrics from the CI
-    src_dir = os.environ.get('CI_PROJECT_DIR')
-    if sys.platform == 'win32':
-        if src_dir is None:
-            src_dir = os.environ.get("REPO_ROOT", os.getcwd())
-
     job_name = os.environ.get('CI_JOB_NAME_SLUG')
     branch = os.environ.get('CI_COMMIT_REF_NAME')
     pipeline_id = os.environ.get('CI_PIPELINE_ID')
-    if not job_name or not branch or not src_dir or not pipeline_id:
+    package_dir = os.environ.get('OMNIBUS_PACKAGE_DIR')
+    if not job_name or not branch or not pipeline_id or not package_dir:
         print(
             '''Missing required environment variables, this is probably not a CI job.
                   skipping sending build metrics'''
@@ -281,7 +277,7 @@ def send_build_metrics(ctx, overall_duration):
 
     series = []
     timestamp = int(datetime.now().timestamp())
-    with open(f'{src_dir}/omnibus/pkg/build-summary.json') as summary_json:
+    with open(f'{package_dir}/build-summary.json') as summary_json:
         j = json.load(summary_json)
         # Various software build durations are all sent as the `datadog.agent.build.duration` metric
         # with a specific tag for each software.

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -267,8 +267,10 @@ def send_build_metrics(ctx, overall_duration):
     job_name = os.environ.get('CI_JOB_NAME_SLUG')
     branch = os.environ.get('CI_COMMIT_REF_NAME')
     pipeline_id = os.environ.get('CI_PIPELINE_ID')
-    package_dir = os.environ.get('OMNIBUS_PACKAGE_DIR')
-    if not job_name or not branch or not pipeline_id or not package_dir:
+    # The build summary output folder is relative to the CWD so we use
+    # PACKAGE_SUBDIR instead of PACKAGE_DIR
+    package_subdir = os.environ.get('OMNIBUS_PACKAGE_SUBDIR')
+    if not job_name or not branch or not pipeline_id or not package_subdir:
         print(
             '''Missing required environment variables, this is probably not a CI job.
                   skipping sending build metrics'''
@@ -277,7 +279,7 @@ def send_build_metrics(ctx, overall_duration):
 
     series = []
     timestamp = int(datetime.now().timestamp())
-    with open(f'{package_dir}/build-summary.json') as summary_json:
+    with open(f'{package_subdir}/build-summary.json') as summary_json:
         j = json.load(summary_json)
         # Various software build durations are all sent as the `datadog.agent.build.duration` metric
         # with a specific tag for each software.

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -74,11 +74,11 @@ Invoke-BuildScript `
     # Show the contents of the output package directories for debugging purposes
     Get-ChildItem -Path C:\omnibus-ruby\pkg\
     Get-ChildItem -Path "C:\opt\datadog-agent\bin\agent\"
-    Get-ChildItem -Path ".\omnibus\pkg\"
+    Get-ChildItem -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR"
 
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
-        mkdir C:\mnt\omnibus\pkg -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\omnibus\pkg\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
     }
 }

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -79,6 +79,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+
     }
 }

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -79,7 +79,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
 
     }
 }

--- a/tasks/winbuildscripts/Build-InstallerPackages.ps1
+++ b/tasks/winbuildscripts/Build-InstallerPackages.ps1
@@ -59,6 +59,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+
     }
 }

--- a/tasks/winbuildscripts/Build-InstallerPackages.ps1
+++ b/tasks/winbuildscripts/Build-InstallerPackages.ps1
@@ -59,7 +59,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
 
     }
 }

--- a/tasks/winbuildscripts/Build-InstallerPackages.ps1
+++ b/tasks/winbuildscripts/Build-InstallerPackages.ps1
@@ -54,11 +54,11 @@ Invoke-BuildScript `
     # Show the contents of the output package directories for debugging purposes
     Get-ChildItem -Path C:\omnibus-ruby\pkg\
     Get-ChildItem -Path C:\opt\datadog-installer
-    Get-ChildItem -Path ".\omnibus\pkg\"
+    Get-ChildItem -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR"
 
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
-        mkdir C:\mnt\omnibus\pkg -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\omnibus\pkg\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        mkdir C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR -Force -ErrorAction Stop | Out-Null
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
     }
 }

--- a/tasks/winbuildscripts/Build-OmnibusTarget.ps1
+++ b/tasks/winbuildscripts/Build-OmnibusTarget.ps1
@@ -76,6 +76,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\"$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+
     }
 }

--- a/tasks/winbuildscripts/Build-OmnibusTarget.ps1
+++ b/tasks/winbuildscripts/Build-OmnibusTarget.ps1
@@ -76,7 +76,7 @@ Invoke-BuildScript `
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
         mkdir C:\mnt\"$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR\*" -Destination "C:\mnt\$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop
 
     }
 }

--- a/tasks/winbuildscripts/Build-OmnibusTarget.ps1
+++ b/tasks/winbuildscripts/Build-OmnibusTarget.ps1
@@ -71,11 +71,11 @@ Invoke-BuildScript `
     # Show the contents of the output package directories for debugging purposes
     Get-ChildItem -Path C:\omnibus-ruby\pkg\
     Get-ChildItem -Path "C:\opt\datadog-agent\bin\agent\"
-    Get-ChildItem -Path ".\omnibus\pkg\"
+    Get-ChildItem -Path ".\$env:OMNIBUS_PACKAGE_SUBDIR"
 
     if ($BuildOutOfSource) {
         # Copy the resulting package to the mnt directory
-        mkdir C:\mnt\omnibus\pkg -Force -ErrorAction Stop | Out-Null
-        Copy-Item -Path ".\omnibus\pkg\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
+        mkdir C:\mnt\"$env:OMNIBUS_PACKAGE_SUBDIR" -Force -ErrorAction Stop | Out-Null
+        Copy-Item -Path ".\$env:OMNIBUS_PACKAGE_SURDIR\*" -Destination "C:\mnt\omnibus\pkg" -Force -ErrorAction Stop
     }
 }

--- a/tasks/winbuildscripts/Generate-OCIPackage.ps1
+++ b/tasks/winbuildscripts/Generate-OCIPackage.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [string] $package,
     [string] $version,
-    [string] $omnibusOutput = "$(Get-Location)\omnibus\pkg\"
+    [string] $omnibusOutput = "$(Get-Location)\$env:OMNIBUS_PACKAGE_SUBDIR\"
 )
 
 if (-not (Test-Path C:\tools\datadog-package.exe)) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove hardcoded occurrences of `omnibus/pkg` in our build scripts & CI jobs

### Motivation

We want to easily be able to change the omnibus output location from a single place if needed.
This serves as preparatory work to work around the lack of isolation for windows runners

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->