### PR TITLE
Update SMP version to 0.23.1

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -22,7 +22,7 @@ single-machine-performance-regression_detector:
       - outputs/decision_record.md # for posterity, this is appended to final PR comment
     when: always
   variables:
-    SMP_VERSION: 0.22.0
+    SMP_VERSION: 0.23.1
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   script:

--- a/test/regression/cases/docker_containers_cpu/experiment.yaml
+++ b/test/regression/cases/docker_containers_cpu/experiment.yaml
@@ -31,7 +31,7 @@ checks:
   - name: simple_check run
     description: Ensure the agent properly detected the containers
     bounds:
-      series: target.simple_check.run
+      series: target/simple_check.run
       # This is a counter metric incremented by one each time the check is run.
       # There are 200 containers with 2 instances of the check per container.
       # The metric should reach 400 as soon as the all 200 containers have been discovered

--- a/test/regression/cases/docker_containers_memory/experiment.yaml
+++ b/test/regression/cases/docker_containers_memory/experiment.yaml
@@ -37,7 +37,7 @@ checks:
   - name: simple_check run
     description: Ensure the agent properly detected the containers
     bounds:
-      series: target.simple_check.run
+      series: target/simple_check.run
       # This is a counter metric incremented by one each time the check is run.
       # There are 200 containers with 2 instances of the check per container.
       # The metric should reach 400 as soon as the all 200 containers have been discovered


### PR DESCRIPTION
### What does this PR do?

SMP has updated the server-side version of Agent's Regression Detector infrastructure, this new CLI version matches the new infra version (0.23.1)

### Motivation

SMP maintains +1 compat with clients, so we must upgrade now to match the current server-side code.

### Describe how you validated your changes
pending RD report here in-PR

### Possible Drawbacks / Trade-offs

### Additional Notes
