### PR TITLE
Avoid silence failure, and reduce CPU to avoid OOMkill

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -104,7 +104,7 @@ go_e2e_test_binaries:
   needs:
     - go_e2e_deps
   variables:
-    KUBERNETES_CPU_REQUEST: 8
+    KUBERNETES_CPU_REQUEST: 4
     KUBERNETES_MEMORY_REQUEST: 64Gi
     KUBERNETES_MEMORY_LIMIT: 64Gi
   before_script:

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -150,10 +150,13 @@ def build_binaries(
                     if success:
                         success_count += 1
                         # Store the original package path and binary name
-                        binary_name = pkg.replace("/", "-").replace("\\", "-") + ".test"
-                        built_packages.append((pkg_result, binary_name))
+
                     else:
                         failure_count += 1
+
+                    # Even if it failed to build, we still want to add it to the manifest, so that we know something is missing in the test execution
+                    binary_name = pkg.replace("/", "-").replace("\\", "-") + ".test"
+                    built_packages.append((pkg_result, binary_name))
 
                     # Print progress
                     with print_lock:
@@ -198,7 +201,8 @@ def build_binaries(
     print(f"Manifest created: {manifest_file_path}")
 
     if failure_count > 0:
-        print(f"Warning: {failure_count} packages failed to build")
+        print(f"Error: {failure_count} packages failed to build")
+        raise Exit(code=1)
 
 
 @task(

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -149,7 +149,6 @@ def build_binaries(
                     pkg_result, success, message = future.result()
                     if success:
                         success_count += 1
-                        # Store the original package path and binary name
 
                     else:
                         failure_count += 1


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reduce CPU request to avoid OOMKill on job building test binaries. In the end it does not increase the duration of the build job.
And make sure that some build silently fail, which could make some test not executed.

### Motivation


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->