### PR TITLE
Support for AWS SecretsManager in Secrets Helper

### DIFF
--- a/cmd/secrethelper/providers/aws_secretsmanager_secret.go
+++ b/cmd/secrethelper/providers/aws_secretsmanager_secret.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package providers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+
+	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/fips"
+	datadogHttp "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// secretsManagerClient is an interface that defines the methods we use from the ssm client
+// As the AWS SDK doesn't provide a real mock, we'll have to make our own that
+// matches this interface
+type secretsManagerClient interface {
+	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// getSecretsManagerClient is a variable that holds the function to create a new secretsManagerClient
+// it will be overwritten in tests
+var getSecretsManagerClient = func(cfg aws.Config) secretsManagerClient {
+	return secretsmanager.NewFromConfig(cfg)
+}
+
+// ReadAwsSecretsManagerSecret reads a secret stored in AWS Secrets Manager
+func ReadAwsSecretsManagerSecret(id string) secrets.SecretVal {
+	parsedArn, err := arn.Parse(id)
+	if err != nil {
+		return secrets.SecretVal{ErrorMsg: "Invalid format. Use: \"arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:<SECRET_NAME>\""}
+	}
+
+	shouldUseFips, err := fips.Enabled()
+	if err != nil {
+		log.Debugf("Could not determine if FIPS is enabled, assuming it is not: %v", err)
+		shouldUseFips = false
+	}
+
+	fipsEndpointState := aws.FIPSEndpointStateUnset
+	if shouldUseFips {
+		fipsEndpointState = aws.FIPSEndpointStateEnabled
+		log.Debug("Using FIPS endpoints for secrets management.")
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.TODO(),
+		awsconfig.WithHTTPClient(&http.Client{
+			Transport: datadogHttp.CreateHTTPTransport(pkgconfigsetup.Datadog()),
+		}),
+		awsconfig.WithRegion(parsedArn.Region),
+		awsconfig.WithUseFIPSEndpoint(fipsEndpointState),
+	)
+	if err != nil {
+		return secrets.SecretVal{ErrorMsg: fmt.Sprintf("Unable to load aws configuration: %v", err)}
+	}
+
+	secretsManagerClient := getSecretsManagerClient(cfg)
+
+	secret := &secretsmanager.GetSecretValueInput{
+		SecretId: &id,
+	}
+
+	output, err := secretsManagerClient.GetSecretValue(context.TODO(), secret)
+	if err != nil {
+		return secrets.SecretVal{ErrorMsg: fmt.Sprintf("Secrets Manager read error: %v", err)}
+	}
+
+	if output.SecretString != nil {
+		secretString := *output.SecretString // create a copy to not return an object within the AWS response
+		return secrets.SecretVal{Value: secretString}
+	} else if output.SecretBinary != nil {
+		decodedBinarySecretBytes := make([]byte, base64.StdEncoding.DecodedLen(len(output.SecretBinary)))
+		secretLen, err := base64.StdEncoding.Decode(decodedBinarySecretBytes, output.SecretBinary)
+		if err != nil {
+			return secrets.SecretVal{ErrorMsg: fmt.Sprintf("Can't base64 decode Secrets Manager secret: %v", err)}
+		}
+		return secrets.SecretVal{Value: string(decodedBinarySecretBytes[:secretLen])}
+	}
+
+	// should not happen but let's handle this gracefully
+	return secrets.SecretVal{Value: "", ErrorMsg: "Secrets Manager returned something but there seems to be no data available"}
+}

--- a/cmd/secrethelper/providers/aws_secretsmanager_secret_test.go
+++ b/cmd/secrethelper/providers/aws_secretsmanager_secret_test.go
@@ -1,0 +1,102 @@
+package providers
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+)
+
+// secretsManagerMockClient is the struct we'll use to mock the Secrets Manager client
+// for unit tests. E2E tests should be written with the real client.
+type secretsManagerMockClient struct {
+	secrets map[string]secretsmanager.GetSecretValueOutput
+}
+
+func (c *secretsManagerMockClient) GetSecretValue(_ context.Context, params *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	if params == nil || params.SecretId == nil {
+		return nil, nil
+	}
+
+	for key, value := range c.secrets {
+		if key == *params.SecretId {
+			return &value, nil
+		}
+	}
+	return nil, errors.New("secret not found")
+}
+
+func TestReadAwsSecretsManagerSecret(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingSecrets map[string]secretsmanager.GetSecretValueOutput
+		secretPath      string
+		expectedValue   string
+		expectedError   string
+	}{
+		{
+			name:            "invalid arn",
+			existingSecrets: map[string]secretsmanager.GetSecretValueOutput{},
+			secretPath:      "key 1",
+			expectedError:   "Invalid format. Use: \"arn:aws:secretsmanager:<REGION>:<ACCOUNT_ID>:secret:<SECRET_NAME>\"",
+		},
+		{
+			name:            "secret does not exist",
+			existingSecrets: map[string]secretsmanager.GetSecretValueOutput{},
+			secretPath:      "arn:aws:secretsmanager:us-east-1:000000000000:secret:my/prod/secret",
+			expectedError:   "Secrets Manager read error: secret not found",
+		},
+		{
+			name: "secret exists",
+			existingSecrets: map[string]secretsmanager.GetSecretValueOutput{
+				"arn:aws:secretsmanager:us-east-1:000000000000:secret:key1": {
+					Name:         aws.String("key1"),
+					SecretString: aws.String("foo bar"),
+				},
+				"arn:aws:secretsmanager:ca-central-1:000000000000:secret:key2": {
+					Name:         aws.String("key2"),
+					SecretString: aws.String("bar baz"),
+				},
+			},
+			secretPath:    "arn:aws:secretsmanager:ca-central-1:000000000000:secret:key2",
+			expectedValue: "bar baz",
+			expectedError: "",
+		},
+		{
+			name: "encoded string",
+			existingSecrets: map[string]secretsmanager.GetSecretValueOutput{
+				"arn:aws:secretsmanager:us-east-1:000000000000:secret:my/encoded/secret": {
+					Name:         aws.String("my/encoded/secret"),
+					SecretBinary: []byte(base64.StdEncoding.EncodeToString([]byte("my encoded secret"))),
+				},
+			},
+			secretPath:    "arn:aws:secretsmanager:us-east-1:000000000000:secret:my/encoded/secret",
+			expectedValue: "my encoded secret",
+			expectedError: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockClient := &secretsManagerMockClient{
+				secrets: test.existingSecrets,
+			}
+			getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
+				return mockClient
+			}
+
+			resolvedSecret := ReadAwsSecretsManagerSecret(test.secretPath)
+
+			if test.expectedError != "" {
+				assert.Equal(t, test.expectedError, resolvedSecret.ErrorMsg)
+			} else {
+				assert.Equal(t, test.expectedValue, resolvedSecret.Value)
+				assert.Empty(t, test.expectedError, resolvedSecret.ErrorMsg)
+			}
+		})
+	}
+}

--- a/cmd/secrethelper/secret_helper.go
+++ b/cmd/secrethelper/secret_helper.go
@@ -47,6 +47,7 @@ const (
 	providerPrefixSeparator = "@"
 	filePrefix              = "file"
 	k8sSecretPrefix         = "k8s_secret"
+	awsSecretsManagerPrefix = "aws_secretsmanager"
 )
 
 // cliParams are the command-line arguments for this subcommand
@@ -171,6 +172,8 @@ func readSecretsUsingPrefixes(secretsList []string, rootPath string, kubeSecretG
 			res[secretID] = providers.ReadSecretFile(id)
 		case k8sSecretPrefix:
 			res[secretID] = providers.ReadKubernetesSecret(kubeSecretGetter, id)
+		case awsSecretsManagerPrefix:
+			res[secretID] = providers.ReadAwsSecretsManagerSecret(id)
 		default:
 			res[secretID] = secrets.SecretVal{Value: "", ErrorMsg: fmt.Sprintf("provider not supported: %s", prefix)}
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This change extends the supported secrets providers to include AWS Secrets Manager. By providing an ARN to a secret as the id, the secrets helper can pull the secret from Secrets Manager provided that the agent was granted read access to the secret.

Unfortunately I'm not a go developer and haven't contributed to this repository before so I'm going to need some help to get this across the line.

### Motivation

We're trying to configure DataDog Database Monitoring for our MongoDB Atlas cluster. All of our infrastructure is containerized in AWS running on Fargate. I couldn't see a way to launch an Agent to monitor Atlas in Fargate and provide the database credentials in a secure way. All of the documentation points to using docker labels which would necessitate providing the database credentials in plaintext in the task definition.

I saw that the agent has _some_ support for pulling secrets from external services, but only from files or kubernetes secrets. There's mention of AWS Secrets Manager but we'd have to provide some sort of executable to provide the secrets. I figured it made sense to extend the existing functionality to include support for AWS Secrets Manager.

This issue was highlighted in https://github.com/DataDog/datadog-agent/issues/9676

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I've added a new unit test for the function to get secrets from AWS Secrets Manager.

Unfortunately I'm not sure how to effectively validate these changes, I'm very sorry. This PR is more of a proof of concept. I'm not a go developer and have little experience with this repository. I'm happy to hand this off to someone with more experience or work with someone to get the changes adopted though!

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->