### PR TITLE
Build images in two steps to control what gets stored in registry cache

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -11,25 +11,24 @@
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
       fi
+    - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
+    - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
+    - !reference [.login_to_docker_readonly]
     # Caching setup
-    - DOCKER_CACHE_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
-    - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_TARGET}"
+    - DOCKER_CACHE_REGISTRY_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
+    - CACHE_SOURCE="--cache-from type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET}"
     - CACHE_TO=""
-    - |
-      DOCKER_NO_CACHE=""
-      for target in ${NO_CACHE_TARGETS}; do
-        DOCKER_NO_CACHE="${DOCKER_NO_CACHE_FILTER} --no-cache-filter ${target}"
-      done
+    - CACHE_TARGET=${CACHE_TARGET:-}
     # Don't use caching on nightlies, to allow for regular cache invalidation,
     # and update the cache on both main and nightly builds
     - |
       if [[ "$BUCKET_BRANCH" == "nightly" ]]; then
         DOCKER_NO_CACHE="--no-cache"
         CACHE_SOURCE=""
-        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_TARGET},mode=max"
+        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max"
       fi
       if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
-        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_TARGET},mode=max"
+        CACHE_TO="--cache-to type=registry,ref=${DOCKER_CACHE_REGISTRY_TARGET},mode=max"
       fi
     # Don't use the cache on deploy pipelines to make sure we get the latest of everything
     - |
@@ -37,19 +36,39 @@
         DOCKER_NO_CACHE="--no-cache"
         CACHE_SOURCE=""
       fi
-    - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
-    - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
-    - !reference [.login_to_docker_readonly]
+    - |
+      if [[ -n "${CACHE_TO}" && -n "${CACHE_TARGET}" ]]; then
+        # Build cacheable target to only export certain steps to registry.
+        # Doing this first build separately lets us avoid uploading heavy artifacts (such as Agent packages),
+        # that can't be usefully cached, to the remote cache.
+        echo "Building ${CACHE_TARGET} for cache"
+        docker buildx build --pull --platform linux/$ARCH \
+          ${CACHE_SOURCE} \
+          ${CACHE_TO} \
+          ${DOCKER_NO_CACHE} \
+          --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \
+          --build-arg CIBUILD=true \
+          --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} \
+          --build-arg DD_GIT_REPOSITORY_URL=https://github.com/DataDog/datadog-agent \
+          --build-arg DD_GIT_COMMIT_SHA=${CI_COMMIT_SHA} \
+          $BUILD_ARG \
+          ${EXTRA_BUILD_CONTEXT} \
+          --file $BUILD_CONTEXT/Dockerfile \
+          --target ${CACHE_TARGET} \
+          $BUILD_CONTEXT
+        # On non-deploy pipelines we're fine with relying on the cache from this point on
+        DOCKER_NO_CACHE=""
+      fi
     # Build image, use target none label to avoid replication
     - |-
       docker buildx build --push --pull --platform linux/$ARCH \
         ${CACHE_SOURCE} \
-        ${CACHE_TO} \
         ${DOCKER_NO_CACHE} \
         --build-arg AGENT_BASE_IMAGE_TAG=${AGENT_BASE_IMAGE_TAG} \
         --build-arg CIBUILD=true \
         --build-arg GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL} \
         $BUILD_ARG \
+        $TARGET_ARG \
         --build-arg DD_GIT_REPOSITORY_URL=https://github.com/DataDog/datadog-agent \
         --build-arg DD_GIT_COMMIT_SHA=${CI_COMMIT_SHA} \
         ${EXTRA_BUILD_CONTEXT} \
@@ -116,8 +135,9 @@ docker_build_agent7:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    CACHE_TARGET: release-base
 
 # TODO: Move this job to .gitlab/deploy_containers/deploy_containers_a7.yml.
 # This cannot be done now because of the following reasons:
@@ -150,8 +170,9 @@ docker_build_agent7_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7
-    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    CACHE_TARGET: release-base
 
 # build agent7 fips image
 docker_build_fips_agent7:
@@ -165,8 +186,9 @@ docker_build_fips_agent7:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips
-    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
+    CACHE_TARGET: release-base
 
 docker_build_fips_agent7_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -179,8 +201,9 @@ docker_build_fips_agent7_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips
-    BUILD_ARG: --target test --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
+    CACHE_TARGET: release-base
 
 # build agent7 jmx image
 docker_build_agent7_jmx:
@@ -194,8 +217,9 @@ docker_build_agent7_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
+    CACHE_TARGET: release-base
 
 docker_build_agent7_jmx_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -208,8 +232,9 @@ docker_build_agent7_jmx_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-arm64.tar.xz
+    CACHE_TARGET: release-base
 
 docker_build_fips_agent7_jmx:
   extends: [.docker_build_job_definition_amd64, .docker_build_artifact]
@@ -222,8 +247,9 @@ docker_build_fips_agent7_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
+    CACHE_TARGET: release-base
 
 docker_build_fips_agent7_arm64_jmx:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -236,8 +262,9 @@ docker_build_fips_agent7_arm64_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
-    NO_CACHE_TARGETS: extract release
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
+    CACHE_TARGET: release-base
 
 # agent base image: future agent images will be based on this image
 .docker_build_base_image:
@@ -248,7 +275,8 @@ docker_build_fips_agent7_arm64_jmx:
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent-base-image
     BUILD_CONTEXT: Dockerfiles/base-image
-    BUILD_ARG: --target release
+    TARGET_ARG: --target release
+    CACHE_TARGET: release
 
 docker_build_base_image_amd64:
   extends: [.docker_build_base_image, .docker_build_job_definition_amd64]
@@ -297,7 +325,9 @@ docker_build_agent7_full:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-full
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-amd64.tar.xz
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-amd64.tar.xz
+    CACHE_TARGET: release-base
 
 docker_build_agent7_full_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -311,7 +341,9 @@ docker_build_agent7_full_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-full
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-arm64.tar.xz
+    TARGET_ARG: --target test
+    BUILD_ARG: --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-*-7*-arm64.tar.xz
+    CACHE_TARGET: release-base
 
 # build the cluster-agent image
 .docker_build_cluster_agent:
@@ -322,6 +354,7 @@ docker_build_agent7_full_arm64:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cluster-agent
     BUILD_CONTEXT: Dockerfiles/cluster-agent
     ARTIFACTS_BUILD_CONTEXT: /tmp/build_artifacts
+    CACHE_TARGET: release-base
   before_script:
     - mkdir -p ${ARTIFACTS_BUILD_CONTEXT}
     - mv -vf $CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $ARTIFACTS_BUILD_CONTEXT/
@@ -357,6 +390,7 @@ docker_build_cluster_agent_arm64:
     BUILD_CONTEXT: Dockerfiles/cluster-agent
     TAG_SUFFIX: -fips
     ARTIFACTS_BUILD_CONTEXT: /tmp/build_artifacts
+    CACHE_TARGET: release-base
   before_script:
     - mkdir -p ${ARTIFACTS_BUILD_CONTEXT}
     - mv -vf $CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $ARTIFACTS_BUILD_CONTEXT/
@@ -425,6 +459,7 @@ docker_build_dogstatsd_amd64:
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
+    CACHE_TARGET: release-base
   timeout: 20m
 
 # build the dogstatsd image
@@ -439,4 +474,5 @@ docker_build_dogstatsd_arm64:
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
+    CACHE_TARGET: release-base
   timeout: 20m

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -60,48 +60,6 @@ RUN echo "$(cat /output/s6.$TARGETARCH.sha256) /output/s6.tgz" | sha256sum -c - 
 COPY bouncycastle-fips/pom.xml /opt/bouncycastle-fips/
 RUN if [ -n "$WITH_JMX_FIPS" ]; then cd /opt/bouncycastle-fips && mvn dependency:copy-dependencies; else mkdir -p /opt/bouncycastle-fips/target/dependency; fi
 
-############################################
-#  Preparation stage: extract and cleanup  #
-############################################
-
-FROM extract-base AS extract
-ARG TARGETARCH
-ARG WITH_JMX
-
-ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
-# copy everything - globbing with args wont work
-COPY ${DD_AGENT_ARTIFACT} /
-WORKDIR /output
-
-# Configuration:
-#   - copy default config files
-COPY datadog*.yaml etc/datadog-agent/
-
-# Installation information
-COPY install_info etc/datadog-agent/
-
-# Extract and cleanup:
-#   - unused systemd unit
-#   - GPL sources for embedded software  # FIXME: move upstream
-#   - docs and manpages                  # FIXME: move upstream
-#   - static libraries                   # FIXME: move upstream
-#   - jmxfetch on nojmx build
-
-RUN --mount=from=artifacts,target=/artifacts \
- find /artifacts -maxdepth 1 -type f -name "datadog-*-$TARGETARCH.tar.xz" ! -name "$DD_AGENT_ARTIFACT" -exec rm {} \; \
- && find /artifacts -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
- && rm -rf usr etc/init lib \
-    go/ \
-    opt/datadog-agent/sources \
-    opt/datadog-agent/embedded/share/doc \
-    opt/datadog-agent/embedded/share/man \
-    # self-test certificates that are detected (false positive) as private keys
-    opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
- && find opt/datadog-agent/ -iname "*.a" -delete \
- && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi \
- && mkdir conf.d checks.d
-
-
 ########################################################################
 #  Construct the base image for the release, everything but the Agent  #
 ########################################################################
@@ -168,6 +126,47 @@ ENV JAVA_TOOL_OPTIONS="${WITH_JMX_FIPS:+--module-path=/opt/bouncycastle-fips -Dj
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
 COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh secrets-helper/readsecret_multiple_providers.sh /
+
+##########################################################
+#  Preparation stage: extract Agent package and cleanup  #
+##########################################################
+
+FROM extract-base AS extract
+ARG TARGETARCH
+ARG WITH_JMX
+
+ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
+# copy everything - globbing with args wont work
+COPY ${DD_AGENT_ARTIFACT} /
+WORKDIR /output
+
+# Configuration:
+#   - copy default config files
+COPY datadog*.yaml etc/datadog-agent/
+
+# Installation information
+COPY install_info etc/datadog-agent/
+
+# Extract and cleanup:
+#   - unused systemd unit
+#   - GPL sources for embedded software  # FIXME: move upstream
+#   - docs and manpages                  # FIXME: move upstream
+#   - static libraries                   # FIXME: move upstream
+#   - jmxfetch on nojmx build
+
+RUN --mount=from=artifacts,target=/artifacts \
+ find /artifacts -maxdepth 1 -type f -name "datadog-*-$TARGETARCH.tar.xz" ! -name "$DD_AGENT_ARTIFACT" -exec rm {} \; \
+ && find /artifacts -maxdepth 1 -name "${DD_AGENT_ARTIFACT}" -exec tar xvf {} -C . \; \
+ && rm -rf usr etc/init lib \
+    go/ \
+    opt/datadog-agent/sources \
+    opt/datadog-agent/embedded/share/doc \
+    opt/datadog-agent/embedded/share/man \
+    # self-test certificates that are detected (false positive) as private keys
+    opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
+ && find opt/datadog-agent/ -iname "*.a" -delete \
+ && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi \
+ && mkdir conf.d checks.d
 
 ###########################################################
 #  Release docker image construction including the Agent  #

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -8,12 +8,9 @@ COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
 
-####################################
-# Actual docker image construction #
-####################################
-
-FROM ubuntu:$BASE_IMAGE_UBUNTU_VERSION
-
+FROM ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS release-base
+ARG BASE_IMAGE_UBUNTU_VERSION=24.04
+ARG BASE_IMAGE_UBUNTU_NAME=noble
 LABEL maintainer "Datadog <package@datadoghq.com>"
 LABEL baseimage.os "ubuntu ${BASE_IMAGE_UBUNTU_NAME}"
 LABEL baseimage.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
@@ -50,6 +47,12 @@ COPY ./security-agent-policies/compliance/containers/*.rego /etc/datadog-agent/c
 COPY ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
 COPY readsecret.sh readsecret_multiple_providers.sh ./
+
+####################################
+# Actual docker image construction #
+####################################
+
+FROM release-base
 
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_ALPINE_VERSION=3.21
-FROM public.ecr.aws/docker/library/alpine:$BASE_IMAGE_ALPINE_VERSION
+FROM public.ecr.aws/docker/library/alpine:$BASE_IMAGE_ALPINE_VERSION AS release-base
 ARG TARGETARCH
 ARG BASE_IMAGE_ALPINE_VERSION
 
@@ -21,6 +21,9 @@ COPY entrypoint.sh probe.sh /
 RUN chmod 755 /entrypoint.sh /probe.sh
 COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
 COPY install_info /etc/datadog-agent/install_info
+
+FROM release-base
+
 COPY --from=artifacts static/dogstatsd.$TARGETARCH /dogstatsd
 
 ARG DD_GIT_REPOSITORY_URL


### PR DESCRIPTION
### What does this PR do?

This change makes it so that builds where we write to the registry-based remote cache do so on a separate build step before building the full final target; this is the only way we have of controlling what gets stored in the remote cache.

With these changes, jobs can specify a target to build to populate the cache, allowing us to not store unnecessary artifacts in it (mainly the artifacts that are built on the same pipeline and which are uncacheable in practice).

### Motivation

This is what #37483 meant to achieve, but that solution didn't work as intended, and it turned out we were still uploading everything. The motivation from that PR still applies to this one.

[ABLD-55](https://datadoghq.atlassian.net/browse/ABLD-55)

### Describe how you validated your changes

I run pipelines for all the possible conditions that we may have, by setting the relevant variables in the same job:
- commit to main: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/68586905 (both read from and write to remote cache)
- nightly: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/68579212 (start without cache and write results to cache, used to refresh the cache daily)
- deploy: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/68618729 (neither read from nor write to remote cache, ensure that deploy pipelines always get the latest available).

### Possible Drawbacks / Trade-offs

### Additional Notes

- The order of stages in the dockerfiles now becomes relevant, the `--target` argument for multi-stage builds results in building all the stages up to and including the target (regardless of the actual dependency graph). That's the reason for the reordering on the Agent dockerfile.
- I've had to split the original `--target` arguments into a separate variable (from being part of `BUILD_ARG`) to be able to pass the same build args under `BUILD_ARG` to both the cache-populating build as well as the final build. This is probably a good thing regardless.
- I had to add intermediate stages for cluster agent and dogstatsd images to be able to apply caching to those under this new implementation.

[ABLD-55]: https://datadoghq.atlassian.net/browse/ABLD-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ