### PR TITLE
CI: include the pipeline ID to the omnibus package dir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ variables:
   # access to OMNIBUS_PACKAGE_DIR directly. To avoid spreading out many hardcoded
   # occurrences of "omnibus/pkg" we expose it as a single variable that can be
   # used to construct the full path expected by the CI
-  OMNIBUS_PACKAGE_SUBDIR: omnibus/pkg
+  OMNIBUS_PACKAGE_SUBDIR: omnibus/pkg/$CI_PIPELINE_ID
   # Directory in which we put the artifacts after the build
   # Must be in $CI_PROJECT_DIR to be usable as an artifact
   OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_SUBDIR/

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -14,7 +14,7 @@ else
   name "agent-#{flavor}"
   package_name "datadog-#{flavor}-agent"
 end
-package_dir ENV['OMNIBUS_PACKAGE_DIR']
+Omnibus::Config.package_dir = ENV['OMNIBUS_PACKAGE_DIR']
 license "Apache-2.0"
 license_file "../LICENSE"
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -14,6 +14,7 @@ else
   name "agent-#{flavor}"
   package_name "datadog-#{flavor}-agent"
 end
+package_dir ENV['OMNIBUS_PACKAGE_DIR']
 license "Apache-2.0"
 license_file "../LICENSE"
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -14,7 +14,7 @@ else
   name "agent-#{flavor}"
   package_name "datadog-#{flavor}-agent"
 end
-Omnibus::Config.package_dir = ENV['OMNIBUS_PACKAGE_DIR']
+Omnibus::Config.package_dir ENV['OMNIBUS_PACKAGE_DIR']
 license "Apache-2.0"
 license_file "../LICENSE"
 

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.69.0",
     "dependencies": {
-        "OMNIBUS_RUBY_VERSION": "49bffd5cbf5f4fc8a357afca145482111c8880ee",
+        "OMNIBUS_RUBY_VERSION": "chouquette/build-summary",
         "JMXFETCH_VERSION": "0.49.7",
         "JMXFETCH_HASH": "470b1a19933efca4a48157b54ce48ab08a6ec6fb51f0b10337003dc428f50676",
         "MACOS_BUILD_VERSION": "master",

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -267,10 +267,8 @@ def send_build_metrics(ctx, overall_duration):
     job_name = os.environ.get('CI_JOB_NAME_SLUG')
     branch = os.environ.get('CI_COMMIT_REF_NAME')
     pipeline_id = os.environ.get('CI_PIPELINE_ID')
-    # The build summary output folder is relative to the CWD so we use
-    # PACKAGE_SUBDIR instead of PACKAGE_DIR
-    package_subdir = os.environ.get('OMNIBUS_PACKAGE_SUBDIR')
-    if not job_name or not branch or not pipeline_id or not package_subdir:
+    package_dir = os.environ.get('OMNIBUS_PACKAGE_DIR')
+    if not job_name or not branch or not pipeline_id or not package_dir:
         print(
             '''Missing required environment variables, this is probably not a CI job.
                   skipping sending build metrics'''
@@ -279,7 +277,7 @@ def send_build_metrics(ctx, overall_duration):
 
     series = []
     timestamp = int(datetime.now().timestamp())
-    with open(f'{package_subdir}/build-summary.json') as summary_json:
+    with open(f'{package_dir}/build-summary.json') as summary_json:
         j = json.load(summary_json)
         # Various software build durations are all sent as the `datadog.agent.build.duration` metric
         # with a specific tag for each software.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Include the pipeline ID in the omnibus package dir
### Motivation

This will provide a good enough isolation on windows, where we can have artifacts from multiple pipelines mixed together
See #incident-39868

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->