### PR TITLE
map cleaner: Add on demand cleanup ability

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -139,7 +139,6 @@ func (mc *MapCleaner[K, V]) Start(interval time.Duration, preClean func() bool, 
 }
 
 // Clean eBPF map on demand.
-// `interval` determines how often the eBPF map is scanned;
 // `shouldClean` is a predicate method that determines whether a certain
 // map entry should be deleted. the callback argument `nowTS` can be directly
 // compared to timestamps generated using the `bpf_ktime_get_ns()` helper;

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -138,7 +138,7 @@ func (mc *MapCleaner[K, V]) Start(interval time.Duration, preClean func() bool, 
 	})
 }
 
-// CleanOnDemand eBPF map on demand.
+// Clean eBPF map on demand.
 // `interval` determines how often the eBPF map is scanned;
 // `shouldClean` is a predicate method that determines whether a certain
 // map entry should be deleted. the callback argument `nowTS` can be directly
@@ -146,7 +146,7 @@ func (mc *MapCleaner[K, V]) Start(interval time.Duration, preClean func() bool, 
 // `preClean` callback (optional, can pass nil) is invoked before the map is scanned; if it returns false,
 // the map is not scanned; this can be used to synchronize with other maps, or preform preliminary checks.
 // `postClean` callback (optional, can pass nil) is invoked after the map is scanned, to allow resource cleanup.
-func (mc *MapCleaner[K, V]) CleanOnDemand(preClean func() bool, postClean func(), shouldClean func(nowTS int64, k K, v V) bool) {
+func (mc *MapCleaner[K, V]) Clean(preClean func() bool, postClean func(), shouldClean func(nowTS int64, k K, v V) bool) {
 	now, err := NowNanoseconds()
 	if err != nil {
 		return

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -108,7 +108,7 @@ func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, 
 	return cleaner, nil
 }
 
-// Clean eBPF map periodically.
+// Start eBPF map periodically.
 // `interval` determines how often the eBPF map is scanned;
 // `shouldClean` is a predicate method that determines whether a certain
 // map entry should be deleted. the callback argument `nowTS` can be directly
@@ -116,7 +116,7 @@ func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, 
 // `preClean` callback (optional, can pass nil) is invoked before the map is scanned; if it returns false,
 // the map is not scanned; this can be used to synchronize with other maps, or preform preliminary checks.
 // `postClean` callback (optional, can pass nil) is invoked after the map is scanned, to allow resource cleanup.
-func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, postClean func(), shouldClean func(nowTS int64, k K, v V) bool) {
+func (mc *MapCleaner[K, V]) Start(interval time.Duration, preClean func() bool, postClean func(), shouldClean func(nowTS int64, k K, v V) bool) {
 	if mc == nil {
 		return
 	}

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -54,6 +54,8 @@ type MapCleaner[K any, V any] struct {
 	batchDeleted  telemetry.SimpleCounter
 	aborts        telemetry.SimpleCounter
 	elapsed       telemetry.SimpleHistogram
+
+	cb func(nowTS int64, shouldClean func(nowTS int64, k K, v V) bool)
 }
 
 // NewMapCleaner instantiates a new MapCleaner. defaultBatchSize controls the
@@ -81,7 +83,8 @@ func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, 
 	if useBatchAPI {
 		tags = batchTags
 	}
-	return &MapCleaner[K, V]{
+
+	cleaner := &MapCleaner[K, V]{
 		emap:          m,
 		batchSize:     batchSize,
 		done:          make(chan struct{}),
@@ -91,10 +94,21 @@ func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, 
 		aborts:        mapCleanerTelemetry.aborts.WithTags(tags),
 		elapsed:       mapCleanerTelemetry.elapsed.WithTags(tags),
 		useBatchAPI:   useBatchAPI,
-	}, nil
+	}
+
+	// Since kernel 5.6, the eBPF library supports batch operations on maps, which reduces the number of syscalls
+	// required to clean the map. We use the new batch operations if they are supported (we check with a feature test instead
+	// of a version comparison because some distros have backported this API), and fallback to
+	// the old method otherwise. The new API is also more efficient because it minimizes the number of allocations.
+	cleaner.cb = cleaner.cleanWithoutBatches
+	if useBatchAPI {
+		cleaner.cb = cleaner.cleanWithBatches
+	}
+
+	return cleaner, nil
 }
 
-// Clean eBPF map
+// Clean eBPF map periodically.
 // `interval` determines how often the eBPF map is scanned;
 // `shouldClean` is a predicate method that determines whether a certain
 // map entry should be deleted. the callback argument `nowTS` can be directly
@@ -108,14 +122,6 @@ func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, 
 	}
 
 	mc.once.Do(func() {
-		// Since kernel 5.6, the eBPF library supports batch operations on maps, which reduces the number of syscalls
-		// required to clean the map. We use the new batch operations if they are supported (we check with a feature test instead
-		// of a version comparison because some distros have backported this API), and fallback to
-		// the old method otherwise. The new API is also more efficient because it minimizes the number of allocations.
-		cleaner := mc.cleanWithoutBatches
-		if mc.useBatchAPI {
-			cleaner = mc.cleanWithBatches
-		}
 		ticker := time.NewTicker(interval)
 		go func() {
 			defer ticker.Stop()
@@ -123,25 +129,37 @@ func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, 
 			for {
 				select {
 				case <-ticker.C:
-					now, err := NowNanoseconds()
-					if err != nil {
-						break
-					}
-					// Allowing to prepare for the cleanup.
-					if preClean != nil && !preClean() {
-						continue
-					}
-					cleaner(now, shouldClean)
-					// Allowing cleanup after the cleanup.
-					if postClean != nil {
-						postClean()
-					}
+					mc.CleanOnDemand(preClean, postClean, shouldClean)
 				case <-mc.done:
 					return
 				}
 			}
 		}()
 	})
+}
+
+// CleanOnDemand eBPF map on demand.
+// `interval` determines how often the eBPF map is scanned;
+// `shouldClean` is a predicate method that determines whether a certain
+// map entry should be deleted. the callback argument `nowTS` can be directly
+// compared to timestamps generated using the `bpf_ktime_get_ns()` helper;
+// `preClean` callback (optional, can pass nil) is invoked before the map is scanned; if it returns false,
+// the map is not scanned; this can be used to synchronize with other maps, or preform preliminary checks.
+// `postClean` callback (optional, can pass nil) is invoked after the map is scanned, to allow resource cleanup.
+func (mc *MapCleaner[K, V]) CleanOnDemand(preClean func() bool, postClean func(), shouldClean func(nowTS int64, k K, v V) bool) {
+	now, err := NowNanoseconds()
+	if err != nil {
+		return
+	}
+	// Allowing to prepare for the cleanup.
+	if preClean != nil && !preClean() {
+		return
+	}
+	mc.cb(now, shouldClean)
+	// Allowing cleanup after the cleanup.
+	if postClean != nil {
+		postClean()
+	}
 }
 
 // Stop stops the map cleaner

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -129,7 +129,7 @@ func (mc *MapCleaner[K, V]) Start(interval time.Duration, preClean func() bool, 
 			for {
 				select {
 				case <-ticker.C:
-					mc.CleanOnDemand(preClean, postClean, shouldClean)
+					mc.Clean(preClean, postClean, shouldClean)
 				case <-mc.done:
 					return
 				}

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -88,7 +88,7 @@ func TestMapCleaner(t *testing.T) {
 			}
 
 			// Clean all the even entries
-			cleaner.Clean(cleanerInterval, nil, nil, func(_ int64, k int64, _ int64) bool {
+			cleaner.Start(cleanerInterval, nil, nil, func(_ int64, k int64, _ int64) bool {
 				return k%2 == 0
 			})
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -405,7 +405,7 @@ func (p *Probe) setupMapCleaner() error {
 		return fmt.Errorf("error creating map cleaner: %w", err)
 	}
 
-	p.mapCleanerEvents.Clean(defaultMapCleanerInterval, nil, nil, func(now int64, _ gpuebpf.CudaEventKey, val gpuebpf.CudaEventValue) bool {
+	p.mapCleanerEvents.Start(defaultMapCleanerInterval, nil, nil, func(now int64, _ gpuebpf.CudaEventKey, val gpuebpf.CudaEventValue) bool {
 		return (now - int64(val.Access_ktime_ns)) > defaultEventTTL.Nanoseconds()
 	})
 

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -229,7 +229,7 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 	}
 
 	ttl := p.cfg.HTTPIdleConnectionTTL.Nanoseconds()
-	mapCleaner.Clean(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val EbpfTx) bool {
+	mapCleaner.Start(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val EbpfTx) bool {
 		if updated := int64(val.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}

--- a/pkg/network/protocols/http2/dynamic_table.go
+++ b/pkg/network/protocols/http2/dynamic_table.go
@@ -91,7 +91,7 @@ func (dt *DynamicTable) setupDynamicTableMapCleaner(mgr *manager.Manager, cfg *c
 	}
 
 	terminatedConnectionsMap := make(map[netebpf.ConnTuple]struct{})
-	mapCleaner.Clean(cfg.HTTP2DynamicTableMapCleanerInterval,
+	mapCleaner.Start(cfg.HTTP2DynamicTableMapCleanerInterval,
 		func() bool {
 			dt.terminatedConnectionsEventsConsumer.Sync()
 			dt.terminatedConnectionMux.Lock()

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -423,7 +423,7 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner() {
 	}
 
 	ttl := p.cfg.HTTPIdleConnectionTTL.Nanoseconds()
-	mapCleaner.Clean(p.cfg.HTTP2DynamicTableMapCleanerInterval, nil, nil, func(now int64, _ HTTP2StreamKey, val HTTP2Stream) bool {
+	mapCleaner.Start(p.cfg.HTTP2DynamicTableMapCleanerInterval, nil, nil, func(now int64, _ HTTP2StreamKey, val HTTP2Stream) bool {
 		if updated := int64(val.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -370,7 +370,7 @@ func (p *protocol) setupInFlightMapCleaner() error {
 	}
 
 	ttl := p.cfg.HTTPIdleConnectionTTL.Nanoseconds()
-	mapCleaner.Clean(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ KafkaTransactionKey, val KafkaTransaction) bool {
+	mapCleaner.Start(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ KafkaTransactionKey, val KafkaTransaction) bool {
 		started := int64(val.Request_started)
 		return started > 0 && (now-started) > ttl
 	})

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -300,7 +300,7 @@ func (p *protocol) setupMapCleaner() {
 
 	// Clean up idle connections. We currently use the same TTL as HTTP, but we plan to rename this variable to be more generic.
 	ttl := p.cfg.HTTPIdleConnectionTTL.Nanoseconds()
-	mapCleaner.Clean(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val postgresebpf.EbpfTx) bool {
+	mapCleaner.Start(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val postgresebpf.EbpfTx) bool {
 		if updated := int64(val.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -217,7 +217,7 @@ func (p *protocol) setupMapCleaner() {
 
 	// Clean up idle connections. We currently use the same TTL as HTTP, but we plan to rename this variable to be more generic.
 	ttl := p.cfg.HTTPIdleConnectionTTL.Nanoseconds()
-	mapCleaner.Clean(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val EbpfTx) bool {
+	mapCleaner.Start(p.cfg.HTTPMapCleanerInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val EbpfTx) bool {
 		if updated := int64(val.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -784,7 +784,7 @@ func (t *ebpfTracer) setupOngoingConnectMapCleaner(m *manager.Manager) {
 		log.Errorf("error creating map cleaner: %s", err)
 		return
 	}
-	tcpOngoingConnectPidCleaner.Clean(time.Minute*5, nil, nil, func(now int64, _ netebpf.SkpConn, val netebpf.PidTs) bool {
+	tcpOngoingConnectPidCleaner.Start(time.Minute*5, nil, nil, func(now int64, _ netebpf.SkpConn, val netebpf.PidTs) bool {
 		ts := int64(val.Timestamp)
 		expired := ts > 0 && now-ts > tcpOngoingConnectMapTTL
 		if expired {
@@ -810,7 +810,7 @@ func (t *ebpfTracer) setupTLSTagsMapCleaner(m *manager.Manager) {
 		return
 	}
 	// slight jitter to avoid all maps being cleaned at the same time
-	TLSTagsMapCleaner.Clean(time.Second*70, nil, nil, func(now int64, _ netebpf.ConnTuple, val netebpf.TLSTagsWrapper) bool {
+	TLSTagsMapCleaner.Start(time.Second*70, nil, nil, func(now int64, _ netebpf.ConnTuple, val netebpf.TLSTagsWrapper) bool {
 		ts := int64(val.Updated)
 		return ts > 0 && now-ts > tlsTagsMapTTL
 	})

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -911,7 +911,7 @@ func setupConnectionProtocolMapCleaner(connectionProtocolMap *ebpf.Map, name str
 	}
 
 	ttl := connProtoTTL.Nanoseconds()
-	mapCleaner.Clean(connProtoCleaningInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val netebpf.ProtocolStackWrapper) bool {
+	mapCleaner.Start(connProtoCleaningInterval, nil, nil, func(now int64, _ netebpf.ConnTuple, val netebpf.ProtocolStackWrapper) bool {
 		return (now - int64(val.Updated)) > ttl
 	})
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introduces the ability to call for an on-demand cleanup using the map cleaner.

### Motivation

Allow using the map cleaner in `OnSyncCallback` of the uprobe attacher

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->