### PR TITLE
[DJM] Use job id as a resource key for job clusters

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -168,11 +168,16 @@ func setupCommonHostTags(s *common.Setup) {
 		setHostTag(s, "jobid", jobID)
 		setHostTag(s, "runid", runID)
 		setHostTag(s, "dd.internal.resource:databricks_job", jobID)
-
 	}
 	setHostTag(s, "data_workload_monitoring_trial", "true")
 
-	setIfExists(s, "DB_CLUSTER_ID", "dd.internal.resource:databricks_cluster", nil)
+	// Set databricks_cluster resource tag based on whether we're on a job cluster
+	isJobCluster, _ := os.LookupEnv("DB_IS_JOB_CLUSTER")
+	if isJobCluster == "TRUE" && ok {
+		setHostTag(s, "dd.internal.resource:databricks_cluster", jobID)
+	} else {
+		setIfExists(s, "DB_CLUSTER_ID", "dd.internal.resource:databricks_cluster", nil)
+	}
 
 	addCustomHostTags(s)
 }

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -53,7 +53,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 			},
 		},
 		{
-			name: "with job, run ids",
+			name: "with job, run ids but not job cluster",
 			env: map[string]string{
 				"DB_CLUSTER_NAME": "job-123-run-456",
 			},
@@ -64,6 +64,23 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"jobid:123",
 				"runid:456",
 				"dd.internal.resource:databricks_job:123",
+			},
+		},
+		{
+			name: "with job, run ids and is job cluster",
+			env: map[string]string{
+				"DB_CLUSTER_NAME":   "job-123-run-456",
+				"DB_IS_JOB_CLUSTER": "TRUE",
+			},
+			wantTags: []string{
+				"data_workload_monitoring_trial:true",
+				"databricks_cluster_name:job-123-run-456",
+				"databricks_is_job_cluster:TRUE",
+				"cluster_name:job-123-run-456",
+				"jobid:123",
+				"runid:456",
+				"dd.internal.resource:databricks_job:123",
+				"dd.internal.resource:databricks_cluster:123",
 			},
 		},
 		{
@@ -126,7 +143,27 @@ func TestSetupCommonHostTags(t *testing.T) {
 			},
 		},
 		{
-			name: "internal resource tags with cluster ID from env",
+			name: "job cluster with cluster ID and DB_IS_JOB_CLUSTER=TRUE",
+			env: map[string]string{
+				"DB_CLUSTER_ID":     "cluster-67890",
+				"DB_CLUSTER_NAME":   "job-999-run-888",
+				"DB_IS_JOB_CLUSTER": "TRUE",
+			},
+			wantTags: []string{
+				"data_workload_monitoring_trial:true",
+				"databricks_cluster_name:job-999-run-888",
+				"databricks_cluster_id:cluster-67890",
+				"databricks_is_job_cluster:TRUE",
+				"cluster_id:cluster-67890",
+				"cluster_name:job-999-run-888",
+				"jobid:999",
+				"runid:888",
+				"dd.internal.resource:databricks_job:999",
+				"dd.internal.resource:databricks_cluster:999",
+			},
+		},
+		{
+			name: "job pattern but not a job cluster (DB_IS_JOB_CLUSTER not TRUE)",
 			env: map[string]string{
 				"DB_CLUSTER_ID":   "cluster-67890",
 				"DB_CLUSTER_NAME": "job-999-run-888",
@@ -153,6 +190,23 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"databricks_cluster_id:cluster-only-12345",
 				"cluster_id:cluster-only-12345",
 				"dd.internal.resource:databricks_cluster:cluster-only-12345",
+			},
+		},
+		{
+			name: "DB_IS_JOB_CLUSTER=TRUE but no job pattern in cluster name",
+			env: map[string]string{
+				"DB_CLUSTER_ID":     "regular-cluster",
+				"DB_CLUSTER_NAME":   "my-regular-cluster",
+				"DB_IS_JOB_CLUSTER": "TRUE",
+			},
+			wantTags: []string{
+				"data_workload_monitoring_trial:true",
+				"databricks_cluster_name:my-regular-cluster",
+				"databricks_cluster_id:regular-cluster",
+				"databricks_is_job_cluster:TRUE",
+				"cluster_id:regular-cluster",
+				"cluster_name:my-regular-cluster",
+				"dd.internal.resource:databricks_cluster:regular-cluster",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the main key for resource tag for Databricks job cluster to be the job id instead of the cluster id.

### Motivation

This PR is a follow up on https://github.com/DataDog/datadog-agent/pull/37684
In that previous PR we've added resource tags setup in the install script for Databricks clusters.

We've made a mistake for job clusters though: we need the main key for a job cluster resource to be consistent between job runs, however we picked "cluster_id", which are not consistent between job runs.

The one key we can rely on is the actual job id, so let's use that.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Take the install script generated by this pipeline, use it in Databricks.
- For job clusters, since it's not possible to use a web terminal, created a notebook step that prints the datadog config, ran it as task in job cluster and confirmed it worked correctly
- Also ran an all purpose cluster and checked that the resource tag was still using the cluster id

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[Databricks docs on env. vars](https://docs.databricks.com/aws/en/init-scripts/environment-variables)