### PR TITLE
Add support for env var DD_TAGS in the windows agent install script

### DIFF
--- a/releasenotes/notes/add-env-vars-to-install-datadog-ps1-82810de788e28035.yaml
+++ b/releasenotes/notes/add-env-vars-to-install-datadog-ps1-82810de788e28035.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add support for environment variables DD_LOGS_ENABLED, DD_TAGS to the Windows Agent install script 
+    that is used when Remote Agent Management is enabled (Install-Datadog.psi).

--- a/releasenotes/notes/add-env-vars-to-install-datadog-ps1-82810de788e28035.yaml
+++ b/releasenotes/notes/add-env-vars-to-install-datadog-ps1-82810de788e28035.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add support for environment variables DD_LOGS_ENABLED, DD_TAGS to the Windows Agent install script 
-    that is used when Remote Agent Management is enabled (Install-Datadog.psi).
+    Add support for the DD_LOGS_ENABLED and DD_TAGS environment variables in the Windows Agent install script 
+    used when Remote Agent Management is enabled (Install-Datadog.psi).

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -186,6 +186,13 @@ function Update-DatadogAgentConfig() {
       Write-Host "Writing DD_REMOTE_UPDATES"
       Update-DatadogConfigFile "^[ #]*remote_updates:.*" "remote_updates: $($env:DD_REMOTE_UPDATES.ToLower())"
    }
+   
+   if ($env:DD_TAGS) {
+      Write-Host "Writing DD_TAGS"
+      $tags = $env:DD_TAGS -split '[, ]' | Where-Object { $_ -ne '' } | ForEach-Object { "  - $_" }
+      $tagsYaml = "tags:`n" + ($tags -join "`n")
+      Update-DatadogConfigFile "^[ #]*tags:.*" $tagsYaml
+   }
 }
 
 if ($env:SCRIPT_IMPORT_ONLY) {

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -193,6 +193,11 @@ function Update-DatadogAgentConfig() {
       $tagsYaml = "tags:`n" + ($tags -join "`n")
       Update-DatadogConfigFile "^[ #]*tags:.*" $tagsYaml
    }
+
+   if ($env:DD_LOGS_ENABLED) {
+      Write-Host "Writing DD_LOGS_ENABLED"
+      Update-DatadogConfigFile "^[ #]*logs_enabled:.*" "logs_enabled: $($env:DD_LOGS_ENABLED.ToLower())"
+   }
 }
 
 if ($env:SCRIPT_IMPORT_ONLY) {

--- a/tools/windows/DatadogAgentInstallScript/Test-Update-DatadogAgentConfig.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Test-Update-DatadogAgentConfig.ps1
@@ -261,6 +261,36 @@ Test-ConfigUpdate -TestName "Update-DatadogConfigFile replacing content in file 
     ) `
     -AssertMessage "Config should match expected content with api_key replaced in file without EOL"
 
+# Test: Update-DatadogAgentConfig with DD_TAGS set
+Test-ConfigUpdate -TestName "Update-DatadogAgentConfig with DD_TAGS set" `
+    -InitialConfig $defaultInitialConfig `
+    -EnvironmentVariables @{ DD_TAGS = "env:prod,service:web" } `
+    -ExpectedConfig @(
+        "# Test datadog.yaml configuration file",
+        "# api_key: placeholder_key",
+        "# site: datadoghq.com",
+        "# dd_url: https://app.datadoghq.com",
+        "# remote_updates: false",
+        "tags:",
+        "  - env:prod",
+        "  - service:web"
+    ) `
+    -AssertMessage "Config should match expected content with tags added"
+
+# Test: Update-DatadogAgentConfig with DD_LOGS_ENABLED set
+Test-ConfigUpdate -TestName "Update-DatadogAgentConfig with DD_LOGS_ENABLED set" `
+    -InitialConfig $defaultInitialConfig `
+    -EnvironmentVariables @{ DD_LOGS_ENABLED = "true" } `
+    -ExpectedConfig @(
+        "# Test datadog.yaml configuration file",
+        "# api_key: placeholder_key",
+        "# site: datadoghq.com",
+        "# dd_url: https://app.datadoghq.com",
+        "# remote_updates: false",
+        "logs_enabled: true"
+    ) `
+    -AssertMessage "Config should match expected content with logs_enabled set to true"
+
 # Cleanup
 Cleanup-Tests
 


### PR DESCRIPTION
### What does this PR do?
This PR allows install script `Install-Datadog.ps1` to recognize environment variables `DD_TAGS` and `DD_LOGS_ENABLED` and write it to the `datadog.yaml`, which allows customers to add host tags and enable log collection during install. 

### Motivation
See customer escalation [AGENT-14093](https://datadoghq.atlassian.net/browse/AGENT-14093). @ArmentaRoberto modified the script with the changes in this PR to enable these settings for the customer. 

### Describe how you validated your changes
1. Before Fix (Reproduction):
    - Set `$env:DD_TAGS = 'env:production,ticket:12345'` and `$env:DD_LOGS_ENABLED = 'true'`
    - Ran original Install-Datadog.ps1
    - Result: No output for "Writing DD_TAGS" or "Writing DD_LOGS_ENABLED", settings not applied to datadog.yaml

2. After Fix (Validation):
    - Applied changes to `Update-DatadogAgentConfig()` function
    - Set same environment variables and ran modified script
    - Result: Saw "Writing DD_TAGS" and "Writing DD_LOGS_ENABLED" output during installation

3. Verification:
    - Checked datadog.yaml: Tags section uncommented with correct values, `logs_enabled: true` set
    - Ran agent.exe status: Confirmed tags visible in Host Tags section
    - Tested both space-separated and comma-separated tag formats: Both work correctly

4. Backward Compatibility:
    - Ran script without DD_TAGS/DD_LOGS_ENABLED set: Existing functionality unchanged
    - All existing DD_ environment variables continue to work as before
    - The changes enable DD_TAGS and DD_LOGS_ENABLED environment variables to work during installation, consistent with other supported DD_ variables.

### Possible Drawbacks / Trade-offs
None.

[AGENT-14093]: https://datadoghq.atlassian.net/browse/AGENT-14093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ