### PR TITLE
[ACIX-681] Move "result JSON File" parsing logic to a shared lib

### DIFF
--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -76,6 +76,7 @@ class ResultJson:
 
     @property
     def package_tests_dict(self) -> dict[str, dict[str, list[ResultJsonLine]]]:
+        """Returns a dictionary of all ResultJsonLines sorted by package and test."""
         if not self._package_tests_dict:
             self._package_tests_dict = self._sort_into_packages_and_tests()
 
@@ -98,6 +99,9 @@ class ResultJson:
 
         for package, tests in self.package_tests_dict.items():
             for test_name, actions in tests.items():
+                if test_name == "_":
+                    # Skip package-level actions, as they are not tests
+                    continue
                 if run_is_failing(actions):
                     failing_tests[package].add(test_name)
 

--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -112,7 +112,8 @@ def run_is_failing(lines: list[ResultJsonLine]) -> bool:
     """Determines the failure status of the test run based on the actions in the lines."""
     is_fail = False
     for line in lines:
-        if line.action == ActionType.FAIL:
+        # Some test lines don't set their action to fail when they panic, but we should also consider that a failure
+        if line.action == ActionType.FAIL or line.output and "panic:" in line.output:
             is_fail = True
         elif line.action == ActionType.PASS:
             # As soon as we find a PASS action, we can conclude the test run is not a failure (retry succeeded)

--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -109,7 +109,11 @@ class ResultJson:
 
 
 def run_is_failing(lines: list[ResultJsonLine]) -> bool:
-    """Determines the failure status of the test run based on the actions in the lines."""
+    """
+    Determines the failure status of the test run based on the actions in the lines.
+    A run is considered failing if it contains a FAIL action or if it has an output with "panic:" in it.
+    Make sure the lines in `lines` all refer to the same test !
+    """
     is_fail = False
     for line in lines:
         # Some test lines don't set their action to fail when they panic, but we should also consider that a failure

--- a/tasks/libs/testing/result_json.py
+++ b/tasks/libs/testing/result_json.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class ActionType(Enum):
+    START = "start"  # noqa: F841
+    RUN = "run"  # noqa: F841
+    OUTPUT = "output"  # noqa: F841
+    FAIL = "fail"
+    PASS = "pass"
+    SKIP = "skip"  # noqa: F841
+    PAUSE = "pause"  # noqa: F841
+    CONT = "cont"  # noqa: F841
+
+
+@dataclass
+class ResultJsonLine:
+    time: datetime
+    action: ActionType
+    package: str
+
+    # The test name is optional, as some lines may correspond to package-level actions
+    test: str | None = None
+    # The output is optional, as some lines may not have any output associated with them
+    output: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ResultJsonLine":
+        return cls(
+            time=datetime.fromisoformat(data["Time"]),
+            action=ActionType(data["Action"]),
+            package=data["Package"],
+            test=data.get("Test"),
+            output=data.get("Output"),
+        )
+
+
+def run_is_failing(lines: list[ResultJsonLine]) -> bool:
+    """Determines the failure status of the test run based on the actions in the lines."""
+    is_fail = False
+    for line in lines:
+        if line.action == ActionType.FAIL:
+            is_fail = True
+        elif line.action == ActionType.PASS:
+            # As soon as we find a PASS action, we can conclude the test run is not a failure (retry succeeded)
+            is_fail = False
+            break
+    return is_fail

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -33,6 +33,7 @@ from tasks.libs.common.utils import (
     gitlab_section,
     running_in_ci,
 )
+from tasks.libs.testing.result_json import ActionType, ResultJson
 from tasks.test_core import DEFAULT_E2E_TEST_OUTPUT_JSON
 from tasks.testwasher import TestWasher
 from tasks.tools.e2e_stacks import destroy_remote_stack
@@ -551,32 +552,30 @@ def post_process_output(path: str, test_depth: int = 1) -> list[tuple[str, str, 
 
         return True
 
-    with open(path) as f:
-        lines = [json.loads(line) for line in f]
+    result_json = ResultJson.from_file(path)
 
-    lines = [
-        json_line for json_line in lines if "Package" in json_line and "Test" in json_line and "Output" in json_line
-    ]
+    lines = [line for line in result_json.lines if line.output and line.test]
 
-    tests = {(json_line["Package"], json_line["Test"]): [] for json_line in lines}
+    tests: dict[tuple[str, str], list] = {(json_line.package, json_line.test): [] for json_line in lines}  # type: ignore
 
     # Used to preserve order, line where a test appeared first
-    test_order = {(json_line["Package"], json_line["Test"]): i for (i, json_line) in list(enumerate(lines))[::-1]}
+    test_order = {(json_line.package, json_line.test): i for (i, json_line) in list(enumerate(lines))[::-1]}
 
     for json_line in lines:
-        if json_line["Action"] == "output":
-            output: str = json_line["Output"]
+        assert json_line.output and json_line.test  # Just making mypy happy
+        if json_line.action == ActionType.OUTPUT:
+            output: str = json_line.output
             if "===" in output:
                 continue
 
             # Append logs to all children tests + this test
-            current_test_name_splitted = json_line["Test"].split("/")
+            current_test_name_splitted = json_line.test.split("/")
             for (package, test_name), logs in tests.items():
-                if package != json_line["Package"]:
+                if package != json_line.package:
                     continue
 
                 if is_parent(current_test_name_splitted, test_name.split("/")):
-                    logs.append(json_line["Output"])
+                    logs.append(json_line.output)
 
     # Rebuild order
     return sorted(

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -71,62 +71,65 @@ class TestResult(ExecResult):
     def get_failure(self, flavor):
         failure_string = ""
 
-        if self.failed:
-            failure_string = self.failure_string(flavor)
-            failed_packages = set()
-            failed_tests = defaultdict(set)
+        if not self.failed:
+            return self.failed, failure_string
 
-            # TODO(AP-1959): this logic is now repreated, with some variations, in three places:
-            # here, in system-probe.py, and in libs/pipeline_notifications.py
-            # We should have some common result.json parsing lib.
-            if self.result_json_path is not None and os.path.exists(self.result_json_path):
-                with open(self.result_json_path, encoding="utf-8") as tf:
-                    for line in tf:
-                        json_test = json.loads(line.strip())
-                        # This logic assumes that the lines in result.json are "in order", i.e. that retries
-                        # are logged after the initial test run.
+        if self.result_json_path is None or not os.path.exists(self.result_json_path):
+            failure_string += "No result json saved, cannot determine whether tests failed or not."
+            return self.failed, failure_string
 
-                        # The line is a "Package" line, but not a "Test" line.
-                        # We take these into account, because in some cases (panics, race conditions),
-                        # individual test failures are not reported, only a package-level failure is.
-                        if 'Package' in json_test and 'Test' not in json_test:
-                            package = json_test['Package']
-                            action = json_test["Action"]
+        failure_string = self.failure_string(flavor)
+        failed_packages = set()
+        failed_tests = defaultdict(set)
 
-                            if action == "fail":
-                                failed_packages.add(package)
-                            elif action == "pass" and package in failed_tests:
-                                # The package was retried and fully succeeded, removing from the list of packages to report
-                                failed_packages.remove(package)
+        # TODO(AP-1959): this logic is now repreated, with some variations, in three places:
+        # here, in system-probe.py, and in libs/pipeline_notifications.py
+        # We should have some common result.json parsing lib.
+        with open(self.result_json_path, encoding="utf-8") as tf:
+            for line in tf:
+                json_test = json.loads(line.strip())
+                # This logic assumes that the lines in result.json are "in order", i.e. that retries
+                # are logged after the initial test run.
 
-                        # The line is a "Test" line.
-                        elif 'Package' in json_test and 'Test' in json_test:
-                            name = json_test['Test']
-                            package = json_test['Package']
-                            action = json_test["Action"]
-                            if action == "fail":
-                                failed_tests[package].add(name)
-                            elif action == "pass" and name in failed_tests.get(package, set()):
-                                # The test was retried and succeeded, removing from the list of tests to report
-                                failed_tests[package].remove(name)
+                # The line is a "Package" line, but not a "Test" line.
+                # We take these into account, because in some cases (panics, race conditions),
+                # individual test failures are not reported, only a package-level failure is.
+                if 'Package' in json_test and 'Test' not in json_test:
+                    package = json_test['Package']
+                    action = json_test["Action"]
+
+                    if action == "fail":
+                        failed_packages.add(package)
+                    elif action == "pass" and package in failed_tests:
+                        # The package was retried and fully succeeded, removing from the list of packages to report
+                        failed_packages.remove(package)
+
+                # The line is a "Test" line.
+                elif 'Package' in json_test and 'Test' in json_test:
+                    name = json_test['Test']
+                    package = json_test['Package']
+                    action = json_test["Action"]
+                    if action == "fail":
+                        failed_tests[package].add(name)
+                    elif action == "pass" and name in failed_tests.get(package, set()):
+                        # The test was retried and succeeded, removing from the list of tests to report
+                        failed_tests[package].remove(name)
+
+        if not failed_packages:
+            failure_string += "The test command failed, but no test failures detected in the result json."
+            return self.failed, failure_string
+
+        failure_string += "Test failures:\n"
+        for package in sorted(failed_packages):
+            tests = failed_tests.get(package, set())
+            if not tests:
+                failure_string += f"- {package} package failed due to panic / race condition\n"
             else:
-                failure_string += "No result json saved, cannot determine whether tests failed or not."
-                return self.failed, failure_string
+                for name in sorted(tests):
+                    failure_string += f"- {package} {name}\n"
 
-            if failed_packages:
-                failure_string += "Test failures:\n"
-                for package in sorted(failed_packages):
-                    tests = failed_tests.get(package, set())
-                    if not tests:
-                        failure_string += f"- {package} package failed due to panic / race condition\n"
-                    else:
-                        for name in sorted(tests):
-                            failure_string += f"- {package} {name}\n"
-
-                            if running_in_ci():
-                                failure_string += f"  See this test name on main in Test Visibility at {get_test_link_to_test_on_main(package, name)}\n"
-            else:
-                failure_string += "The test command failed, but no test failures detected in the result json."
+                    if running_in_ci():
+                        failure_string += f"  See this test name on main in Test Visibility at {get_test_link_to_test_on_main(package, name)}\n"
 
         return self.failed, failure_string
 

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -91,12 +91,15 @@ class TestWasher:
         - The test failed and is marked as flaky
         - Test failed and is not marked as flaky but all its failing children are marked as flaky or are flaky failures.
         """
+        # TODO[ACIX-913]: Fix the semantics of this function - it actually returns all flaky tests, not just *failing* tests.
+        # See for example the test_pretty_print_inner_depth2 test in tasks/unit_tests/e2e_testing_tests.py.
+        # When running the test, this function returns a non-empty result, even though all the tests in the dummy json output are passing.
+        # This is not super easy to fix, because it is used in many places that now rely on this behavior.
         failing_tests = self.test_output_json.failing_tests
 
         flaky_failures = defaultdict(set)
-        for package, tests in failing_tests.items():
-            for test in tests:
-                lines = self.test_output_json.package_tests_dict[package][test]
+        for package, tests in self.test_output_json.package_tests_dict.items():
+            for test, lines in tests.items():
                 if any(self.is_flaky_failure(package, test, line.output) for line in lines if line.output):
                     flaky_failures[package].add(test)
 

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import json
 import os
 import re
 from collections import defaultdict
@@ -15,6 +14,7 @@ from tasks.libs.ciproviders.gitlab_api import (
 from tasks.libs.common.utils import gitlab_section
 from tasks.libs.pipeline.generation import remove_fields, update_child_job_variables, update_needs_parent
 from tasks.libs.testing.flakes import consolidate_flaky_failures
+from tasks.libs.testing.result_json import ResultJson
 from tasks.test_core import DEFAULT_TEST_OUTPUT_JSON, TestResult
 
 FLAKY_TEST_INDICATOR = "flakytest: this is a known flaky test"
@@ -35,6 +35,7 @@ class TestWasher:
         # If FLAKY_PATTERNS_CONFIG is set in the environment, it will be used to determine which tests are flaky. Should have the same format as flakes.yaml
 
         self.test_output_json_file = test_output_json_file
+        self.test_output_json = ResultJson.from_file(test_output_json_file)  # type: ignore[attribute-defined-outside-init]
         self.flaky_test_indicator = flaky_test_indicator
         self.flakes_file_paths = flakes_file_paths or ["flakes.yaml"]
         if os.environ.get("FLAKY_PATTERNS_CONFIG"):
@@ -54,16 +55,15 @@ class TestWasher:
         """
         marked_flaky_test = defaultdict(set)  # dict[package] =  {TestName, TestName2}
 
-        with open(self.test_output_json_file, encoding='utf-8') as f:
-            for line in f:
-                test_result = json.loads(line)
-                if "Test" not in test_result:
+        for package, tests in self.test_output_json.package_tests_dict.items():
+            for test_name, actions in tests.items():
+                if test_name == "_":
+                    # This is a package-level action list, we don't care about it for flaky tests
                     continue
-                if "Output" in test_result and self.is_marked_flaky(
-                    test_result["Package"], test_result["Test"], test_result["Output"]
-                ):
-                    print("Test is marked as flaky", test_result["Package"], test_result["Test"])
-                    marked_flaky_test[test_result["Package"]].add(test_result["Test"])
+                # If the test is marked as flaky, we add it to the marked flaky tests
+                if any(self.is_marked_flaky(package, test_name, action.output) for action in actions if action.output):
+                    marked_flaky_test[package].add(test_name)
+
         return marked_flaky_test
 
     def is_marked_flaky(self, package: str, test: str, log: str) -> bool:
@@ -82,18 +82,7 @@ class TestWasher:
         """
         Read the test output json file and return the tests that are failing
         """
-        failing_tests = defaultdict(set)
-        with open(self.test_output_json_file, encoding='utf-8') as f:
-            for line in f:
-                test_result = json.loads(line)
-                if "Test" not in test_result:
-                    continue
-                if "Action" in test_result and test_result["Action"] == "fail":
-                    failing_tests[test_result["Package"]].add(test_result["Test"])
-                if "Output" in test_result and "panic:" in test_result["Output"]:
-                    failing_tests[test_result["Package"]].add(test_result["Test"])
-
-        return failing_tests
+        return self.test_output_json.failing_tests  # type: ignore[assignment]
 
     def get_flaky_failures(self) -> dict:
         """
@@ -102,32 +91,14 @@ class TestWasher:
         - The test failed and is marked as flaky
         - Test failed and is not marked as flaky but all its failing children are marked as flaky or are flaky failures.
         """
-        flaky_failures = defaultdict(set)  # dict[package] =  {TestName, TestName2}
-        failing_tests = defaultdict(set)
-        with open(self.test_output_json_file, encoding='utf-8') as f:
-            for line in f:
-                test_result = json.loads(line)
-                if "Test" not in test_result:
-                    continue
-                if "Package" not in test_result:
-                    continue
-                if "Action" in test_result and test_result["Action"] == "fail":
-                    failing_tests[test_result["Package"]].add(test_result["Test"])
+        failing_tests = self.test_output_json.failing_tests
 
-                if "Output" in test_result and "panic:" in test_result["Output"]:
-                    failing_tests[test_result["Package"]].add(test_result["Test"])
-
-                if (
-                    test_result["Package"] in flaky_failures
-                    and test_result["Test"] in flaky_failures[test_result["Package"]]
-                ):
-                    # Already added to the flaky failures, no need to try again
-                    continue
-
-                if "Output" in test_result and self.is_flaky_failure(
-                    test_result["Package"], test_result["Test"], test_result["Output"]
-                ):
-                    flaky_failures[test_result["Package"]].add(test_result["Test"])
+        flaky_failures = defaultdict(set)
+        for package, tests in failing_tests.items():
+            for test in tests:
+                lines = self.test_output_json.package_tests_dict[package][test]
+                if any(self.is_flaky_failure(package, test, line.output) for line in lines if line.output):
+                    flaky_failures[package].add(test)
 
         for pkg, test in failing_tests.items():
             if pkg not in flaky_failures:
@@ -218,7 +189,6 @@ class TestWasher:
         If only known flaky tests are failing, we should succeed.
         If failing, displays the failing tests that are not known to be flaky
         """
-
         should_succeed = True
         failed_command = False
         failed_tests = []

--- a/tasks/unit_tests/json_result_tests.py
+++ b/tasks/unit_tests/json_result_tests.py
@@ -1,0 +1,110 @@
+import json
+import random
+from datetime import datetime
+from glob import glob
+from pathlib import Path
+from unittest import TestCase
+
+from tasks.libs.testing.result_json import ActionType, ResultJsonLine, run_is_failing
+
+
+def get_dummy_result_lines(test_name: str, test_package: str, cnt: int) -> list[ResultJsonLine]:
+    possible_actions = [ActionType.SKIP, ActionType.PAUSE, ActionType.CONT]
+    output = []
+    for _ in range(cnt):
+        action = random.choice(possible_actions)
+        output.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=action,
+                package=test_package,
+                test=test_name,
+                output=f"Dummy output for {test_name} with action {action} !",
+            )
+        )
+    return output
+
+
+class TestJSONResultLine(TestCase):
+    test_name = "TestExample"
+    test_package = "github.com/DataDog/datadog-agent/test/example"
+
+    def test_parsing(self):
+        # Verify that all test json files in the testdata directory can be parsed
+        test_files = glob(str(Path(__file__).parent / "testdata" / "test_output_*.json"))
+        for file in test_files:
+            with open(file) as f:
+                for line in f:
+                    # Just make sure this does not raise an exception
+                    ResultJsonLine.from_dict(json.loads(line))
+
+    def test_run_is_failing_negative(self):
+        # Verify that run_is_failing works correctly for a non-failing run
+        lines = get_dummy_result_lines(self.test_name, self.test_package, 3)
+        lines.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=ActionType.PASS,
+                package=self.test_package,
+                test=self.test_name,
+                output="Run completed successfully.",
+            )
+        )
+        result = run_is_failing(lines)
+        self.assertFalse(result, "Expected run_is_failing to return False for a non-failing run.")
+
+    def test_run_is_failing_positive(self):
+        # Verify that run_is_failing works correctly for a failing run
+        lines = get_dummy_result_lines(self.test_name, self.test_package, 3)
+        lines.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=ActionType.FAIL,
+                package=self.test_package,
+                test=self.test_name,
+                output="Run failed !",
+            )
+        )
+        result = run_is_failing(lines)
+        self.assertTrue(result, "Expected run_is_failing to return True for a failing run.")
+
+    def test_run_is_failing_with_retry(self):
+        # Verify that run_is_failing works correctly with retries
+        lines = get_dummy_result_lines(self.test_name, self.test_package, 2)
+        lines.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=ActionType.FAIL,
+                package=self.test_package,
+                test=self.test_name,
+                output="Run failed, retrying...",
+            )
+        )
+        lines.extend(get_dummy_result_lines(self.test_name, self.test_package, 2))
+        lines.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=ActionType.PASS,
+                package=self.test_package,
+                test=self.test_name,
+                output="Retry successful.",
+            )
+        )
+        lines.extend(get_dummy_result_lines(self.test_name, self.test_package, 2))
+        result = run_is_failing(lines)
+        self.assertFalse(result, "Expected run_is_failing to return False for a run with a successful retry.")
+
+    def test_run_is_failing_with_panic(self):
+        # Verify that run_is_failing works correctly with a line not marked as fail but with a panic message
+        lines = get_dummy_result_lines(self.test_name, self.test_package, 3)
+        lines.append(
+            ResultJsonLine(
+                time=datetime.now(),
+                action=ActionType.PASS,
+                package=self.test_package,
+                test=self.test_name,
+                output="panic: something went wrong!",
+            )
+        )
+        result = run_is_failing(lines)
+        self.assertTrue(result, "Expected run_is_failing to return True for a run with a panic.")

--- a/tasks/unit_tests/json_result_tests.py
+++ b/tasks/unit_tests/json_result_tests.py
@@ -5,7 +5,7 @@ from glob import glob
 from pathlib import Path
 from unittest import TestCase
 
-from tasks.libs.testing.result_json import ActionType, ResultJsonLine, run_is_failing
+from tasks.libs.testing.result_json import ActionType, ResultJson, ResultJsonLine, merge_result_jsons, run_is_failing
 
 
 def get_dummy_result_lines(test_name: str, test_package: str, cnt: int) -> list[ResultJsonLine]:
@@ -108,3 +108,121 @@ class TestJSONResultLine(TestCase):
         )
         result = run_is_failing(lines)
         self.assertTrue(result, "Expected run_is_failing to return True for a run with a panic.")
+
+
+class TestJSONResult(TestCase):
+    def test_parsing(self):
+        # Verify that all test json files in the testdata directory can be parsed
+        test_files = glob(str(Path(__file__).parent / "testdata" / "test_output_*.json"))
+        for file in test_files:
+            # Just make sure this does not raise an exception
+            res = ResultJson.from_file(file)
+            self.assertGreater(len(res.lines), 0, f"Expected at least one line in {file}")
+
+    def test_package_tests_dict(self):
+        # Verify that package_tests_dict is correctly populated
+        # This test file was chosen as it
+        res = ResultJson.from_file(str(Path(__file__).parent / "testdata" / "test_output_varied.json"))
+        package_tests_dict_actions = {
+            package: {test: [line.action.value for line in lines] for test, lines in tests.items()}
+            for package, tests in res.package_tests_dict.items()
+        }
+
+        expected_package_tests_dict_actions = {
+            "github.com/DataDog/datadog-agent/testpackage1": {
+                "test_1": ["start", "pause", "cont", "run", "fail"],
+                "test_2": ["start", "pause", "cont", "pass"],
+                "test_3": ["start", "pause", "cont", "fail"],
+                "test_4": ["skip"],
+                "_": ["start", "run", "output", "pause", "cont", "fail"],
+            },
+            "github.com/DataDog/datadog-agent/testpackage2": {
+                "test_1": ["start", "pause", "cont", "fail"],
+                "test_2": ["start", "output", "run", "output", "pass"],
+                "_": ["start", "run", "run", "pause", "cont", "output", "fail"],
+            },
+            "github.com/DataDog/datadog-agent/testpackage3/inner_package": {
+                "test_1": ["start", "pause", "cont", "output", "pause", "cont", "pass"]
+            },
+        }
+
+        self.assertEqual(
+            package_tests_dict_actions,
+            expected_package_tests_dict_actions,
+            "The package_tests_dict does not match the expected structure.",
+        )
+
+    def test_failing_tests(self):
+        # Verify that failing tests are correctly identified for a few json test files
+        files_and_answers = {
+            "test_output_varied.json": {
+                ("github.com/DataDog/datadog-agent/testpackage1", "test_1"),
+                ("github.com/DataDog/datadog-agent/testpackage1", "test_3"),
+                ("github.com/DataDog/datadog-agent/testpackage2", "test_1"),
+            },
+            "test_output_flaky_retried.json": {
+                ("github.com/DataDog/datadog-agent/testpackage1", "test_1"),
+            },
+            "test_output_failure_panic.json": {
+                ("github.com/DataDog/datadog-agent/pkg/serverless/trace", "TestLoadConfigShouldBeFast")
+            },
+            "test_output_failure_only_parent.json": {
+                ("github.com/DataDog/datadog-agent/test/new-e2e/tests/containers", "TestEKSSuite"),
+            },
+            "test_output_no_failure.json": set(),
+            "test_output_failure_no_marker.json": {
+                ("github.com/DataDog/datadog-agent/pkg/gohai", "TestGetPayload"),
+            },
+        }
+        for file, answers in files_and_answers.items():
+            res = ResultJson.from_file(str(Path(__file__).parent / "testdata" / file))
+            failing_tests = {(package, test) for package, tests in res.failing_tests.items() for test in tests}
+            self.assertEqual(failing_tests, answers, f"The failing tests do not match the expected set for {file}.")
+
+    def test_failing_packages(self):
+        # Verify that failing packages are correctly identified for a few json test files
+        files_and_answers = {
+            "test_output_varied.json": {
+                "github.com/DataDog/datadog-agent/testpackage1",
+                "github.com/DataDog/datadog-agent/testpackage2",
+            },
+            "test_output_flaky_retried.json": {"github.com/DataDog/datadog-agent/testpackage1"},
+            "test_output_failure_panic.json": {"github.com/DataDog/datadog-agent/pkg/serverless/trace"},
+            "test_output_failure_only_parent.json": {
+                "github.com/DataDog/datadog-agent/test/new-e2e/tests/containers",
+            },
+            "test_output_no_failure.json": set(),
+            "test_output_failure_no_marker.json": {
+                "github.com/DataDog/datadog-agent/pkg/gohai",
+            },
+        }
+        for file, answers in files_and_answers.items():
+            res = ResultJson.from_file(str(Path(__file__).parent / "testdata" / file))
+            failing_packages = res.failing_packages
+            self.assertEqual(
+                failing_packages, answers, f"The failing packages do not match the expected set for {file}."
+            )
+
+    def test_merge_result_jsons(self):
+        # Verify that merging multiple ResultJson objects works correctly
+        res1 = ResultJson.from_file(str(Path(__file__).parent / "testdata" / "test_output_varied.json"))
+        res2 = ResultJson.from_file(str(Path(__file__).parent / "testdata" / "test_output_flaky_retried.json"))
+        res3 = ResultJson.from_file(str(Path(__file__).parent / "testdata" / "test_output_failure_panic.json"))
+        merged = merge_result_jsons([res1, res2, res3])
+
+        # Check the failing packages
+        expected_failing_packages = {
+            "github.com/DataDog/datadog-agent/testpackage1",
+            "github.com/DataDog/datadog-agent/testpackage2",
+            "github.com/DataDog/datadog-agent/pkg/serverless/trace",
+        }
+        self.assertEqual(merged.failing_packages, expected_failing_packages)
+
+        # Check the failing tests
+        # Note that since testpackage1/test3 has been retried in res2 it should not be considered failing
+        expected_failing_tests = {
+            "github.com/DataDog/datadog-agent/testpackage1": {"test_1"},
+            "github.com/DataDog/datadog-agent/testpackage2": {"test_1"},
+            "github.com/DataDog/datadog-agent/pkg/serverless/trace": {"TestLoadConfigShouldBeFast"},
+        }
+        self.assertEqual(merged.failing_tests, expected_failing_tests)

--- a/tasks/unit_tests/testdata/test_output_flaky_retried.json
+++ b/tasks/unit_tests/testdata/test_output_flaky_retried.json
@@ -1,0 +1,26 @@
+{"Time": "2025-06-27T11:28:21.4693584+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693754+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693774+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693814+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: run", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693834+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.5636324+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636934+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636974+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: cont", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636994+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.7477684+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478204+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478264+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478304+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: fail", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7767834+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3", "Output": "Retrying test_3"}
+{"Time": "2025-06-27T11:28:21.7768074+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7768234+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7768254+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: output", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7768294+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: output", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7768314+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: pass", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7768344+01:00", "Action": "skip", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_4"}
+{"Time": "2025-06-27T11:28:21.7768374+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768404+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: run"}
+{"Time": "2025-06-27T11:28:21.7768444+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768454+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: pause"}
+{"Time": "2025-06-27T11:28:22.7768404+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: cont"}
+{"Time": "2025-06-27T11:28:22.7768444+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: fail"}

--- a/tasks/unit_tests/testdata/test_output_varied.json
+++ b/tasks/unit_tests/testdata/test_output_varied.json
@@ -1,0 +1,43 @@
+{"Time": "2025-06-27T11:28:21.4693584+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693754+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693774+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693814+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: run", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693834+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.5636324+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636934+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636974+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: cont", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636994+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.7477684+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478204+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478264+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478304+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: fail", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7767834+01:00", "Action": "skip", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_4"}
+{"Time": "2025-06-27T11:28:21.7768074+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768234+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: run"}
+{"Time": "2025-06-27T11:28:21.7768314+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768374+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: pause"}
+{"Time": "2025-06-27T11:28:21.7768404+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: cont"}
+{"Time": "2025-06-27T11:28:21.7768444+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: fail"}
+{"Time": "2025-06-27T11:28:21.9620364+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621304+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: pause", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621434+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: cont", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621504+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: fail", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9878384+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage2, action: start", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9878984+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9879114+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9879204+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9879264+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage2, action: pass", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:22.0718944+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: start"}
+{"Time": "2025-06-27T11:28:22.0720984+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: run"}
+{"Time": "2025-06-27T11:28:22.0721314+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.0721504+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: pause"}
+{"Time": "2025-06-27T11:28:22.0721604+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: cont"}
+{"Time": "2025-06-27T11:28:22.0721774+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.0721884+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.1033644+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034464+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034584+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034744+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: output", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034924+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: pause", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1035014+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: cont", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1035104+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Unifies and moves all the logic related to parsing the "result json files" generated by `go test` into its own lib. 

### Motivation

This logic was duplicated in many places, also reading and parsing the same "result json" files multiple times. By moving this into its own lib we avoid this duplication.

This is also required for a bugfix in #37862 that impacts how these "Result JSON" files are handled in `new-e2e-tests.run`

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing and new unit tests

### Possible Drawbacks / Trade-offs

I tried to keep the behavior the same, but a lot of the functions in `TestWasher` have (imo) poorly defined semantics, ambiguous names and conventions that differ between them. For example:
- `get_flaky_failures` actually also returns tests that passed, not only failures
- Sometimes we consider a test to be failed if one of its parents failed or if there was a package-level failure, sometimes we don't
- There is some ambiguity between what is a "flaky" test and a test that is "marked as flaky"
- ...
This makes it difficult to be sure some edge case has not had its behavior changed. Hopefully the existing unit tests are enough to avoid this.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->