### PR TITLE
[AGENTCFG-154] Adding an host metadata payload field to inform if the Agent is FIPS-enabled

### DIFF
--- a/cmd/process-agent/subcommands/status/status_test.go
+++ b/cmd/process-agent/subcommands/status/status_test.go
@@ -87,7 +87,8 @@ func TestStatus(t *testing.T) {
 			"logs": null,
 			"install-method": null,
 			"proxy-info": null,
-			"otlp": null
+			"otlp": null,
+			"fips_mode": false
 			}
 		},
 		"expvars": {

--- a/comp/metadata/host/hostimpl/utils/host.go
+++ b/comp/metadata/host/hostimpl/utils/host.go
@@ -164,9 +164,11 @@ func getProxyMeta(conf model.Reader) *ProxyMeta {
 }
 
 func getFipsMode() bool {
-	if val, err := fips.Enabled(); err == nil {
+	val, err := fips.Enabled()
+	if err == nil {
 		return val
 	}
+	log.Warn("Could not determine if FIPS mode is enabled: ", err)
 	return false
 }
 

--- a/comp/metadata/host/hostimpl/utils/host.go
+++ b/comp/metadata/host/hostimpl/utils/host.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/configcheck"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
@@ -98,6 +99,7 @@ type Payload struct {
 	InstallMethod *InstallMethod    `json:"install-method"`
 	ProxyMeta     *ProxyMeta        `json:"proxy-info"`
 	OtlpMeta      *OtlpMeta         `json:"otlp"`
+	FipsMode      bool              `json:"fips_mode"`
 }
 
 func getNetworkMeta(ctx context.Context) *NetworkMeta {
@@ -161,6 +163,14 @@ func getProxyMeta(conf model.Reader) *ProxyMeta {
 	}
 }
 
+func getFipsMode() bool {
+	if val, err := fips.Enabled(); err == nil {
+		return val
+	} else {
+		return false
+	}
+}
+
 // GetOSVersion returns the current OS version
 func GetOSVersion() string {
 	hostInfo := GetInformation()
@@ -192,6 +202,7 @@ func GetPayload(ctx context.Context, conf model.Reader, hostname hostnameinterfa
 		InstallMethod: getInstallMethod(conf),
 		ProxyMeta:     getProxyMeta(conf),
 		OtlpMeta:      &OtlpMeta{Enabled: otlpIsEnabled(conf)},
+		FipsMode:      getFipsMode(),
 	}
 
 	// Cache the metadata for use in other payloads

--- a/comp/metadata/host/hostimpl/utils/host.go
+++ b/comp/metadata/host/hostimpl/utils/host.go
@@ -166,9 +166,8 @@ func getProxyMeta(conf model.Reader) *ProxyMeta {
 func getFipsMode() bool {
 	if val, err := fips.Enabled(); err == nil {
 		return val
-	} else {
-		return false
 	}
+	return false
 }
 
 // GetOSVersion returns the current OS version

--- a/comp/metadata/host/hostimpl/utils/host_test.go
+++ b/comp/metadata/host/hostimpl/utils/host_test.go
@@ -144,6 +144,7 @@ func TestGetPayload(t *testing.T) {
 	assert.NotNil(t, p.InstallMethod)
 	assert.NotNil(t, p.ProxyMeta)
 	assert.NotNil(t, p.OtlpMeta)
+	assert.NotNil(t, p.FipsMode)
 
 	_, found = cache.Cache.Get(hostCacheKey)
 	assert.True(t, found)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
We originally sent this information via agent_metadata, but agent_metadata is no longer part of the v5 payload it sends to sobotka, so we have to manually add this fips_mode field to the v5 payload.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I ran an agent incorporating these changes and pointed it to staging, where `fips_mode:true`. I then was able to see a metric `dd.agent_stats.fips_mode` with the same tag in the metrics explorer ui.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->