### PR TITLE
[ AGNTLOG-224 ] Split utilization and capacity logging metrics according to a more granular level

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -459,7 +459,8 @@ func newHTTPPassthroughPipeline(
 	if desc.contentType == logshttp.ProtobufContentType {
 		strategy = sender.NewStreamStrategy(inputChan, senderImpl.In(), encoder)
 	} else {
-		strategy = sender.NewBatchStrategy(inputChan,
+		strategy = sender.NewBatchStrategy(
+			inputChan,
 			senderImpl.In(),
 			make(chan struct{}),
 			serverlessMeta,
@@ -469,7 +470,9 @@ func newHTTPPassthroughPipeline(
 			endpoints.BatchMaxContentSize,
 			desc.eventType,
 			encoder,
-			pipelineMonitor)
+			pipelineMonitor,
+			"0",
+		)
 	}
 
 	log.Debugf("Initialized event platform forwarder pipeline. eventType=%s mainHosts=%s additionalHosts=%s batch_max_concurrent_send=%d batch_max_content_size=%d batch_max_size=%d, input_chan_size=%d, compression_kind=%s, compression_level=%d",

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -370,7 +370,7 @@ func TestDestinationHA(t *testing.T) {
 		}
 		isEndpointMRF := endpoint.IsMRF
 
-		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), false, client.NewNoopDestinationMetadata(), configmock.New(t), 1, 1, metrics.NewNoopPipelineMonitor(""))
+		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), false, client.NewNoopDestinationMetadata(), configmock.New(t), 1, 1, metrics.NewNoopPipelineMonitor(""), "test")
 		isDestMRF := dest.IsMRF()
 
 		assert.Equal(t, isEndpointMRF, isDestMRF)

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -38,7 +38,7 @@ func NewSyncDestination(
 	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, time.Second*10, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0")),
+		destination:    newDestination(endpoint, contentType, destinationsContext, time.Second*10, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package http
 
 import (
@@ -82,7 +84,7 @@ func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestinat
 	endpoint.BackoffMax = 10
 	endpoint.RecoveryInterval = 1
 
-	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""))
+	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""), "test")
 	return &TestServer{
 		httpServer:          ts,
 		DestCtx:             destCtx,

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -383,7 +383,7 @@ func (s *Launcher) restartTailerAfterFileRotation(oldTailer *tailer.Tailer, file
 }
 
 // createTailer returns a new initialized tailer
-func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Message, pipelineMonitor metrics.PipelineMonitor) *tailer.Tailer {
+func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Message, capacityMonitor *metrics.CapacityMonitor) *tailer.Tailer {
 	tailerInfo := status.NewInfoRegistry()
 
 	tailerOptions := &tailer.TailerOptions{
@@ -393,7 +393,7 @@ func (s *Launcher) createTailer(file *tailer.File, outputChan chan *message.Mess
 		Decoder:         decoder.NewDecoderFromSource(file.Source, tailerInfo),
 		Info:            tailerInfo,
 		TagAdder:        s.tagger,
-		PipelineMonitor: pipelineMonitor,
+		CapacityMonitor: capacityMonitor,
 		Registry:        s.registry,
 	}
 

--- a/pkg/logs/metrics/capacity_monitor.go
+++ b/pkg/logs/metrics/capacity_monitor.go
@@ -44,6 +44,9 @@ func newCapacityMonitorWithTick(name, instance string, tickChan <-chan time.Time
 
 // AddIngress records the ingress of a payload
 func (i *CapacityMonitor) AddIngress(pl MeasurablePayload) {
+	if i == nil {
+		return
+	}
 	i.Lock()
 	defer i.Unlock()
 	i.ingress += pl.Count()
@@ -53,6 +56,9 @@ func (i *CapacityMonitor) AddIngress(pl MeasurablePayload) {
 
 // AddEgress records the egress of a payload
 func (i *CapacityMonitor) AddEgress(pl MeasurablePayload) {
+	if i == nil {
+		return
+	}
 	i.Lock()
 	defer i.Unlock()
 	i.egress += pl.Count()
@@ -62,6 +68,9 @@ func (i *CapacityMonitor) AddEgress(pl MeasurablePayload) {
 }
 
 func (i *CapacityMonitor) sample() {
+	if i == nil {
+		return
+	}
 	select {
 	case <-i.tickChan:
 		i.avgItems = ewma(float64(i.ingress-i.egress), i.avgItems)
@@ -76,6 +85,9 @@ func ewma(newValue float64, oldValue float64) float64 {
 }
 
 func (i *CapacityMonitor) report() {
+	if i == nil {
+		return
+	}
 	TlmUtilizationItems.Set(i.avgItems, i.name, i.instance)
 	TlmUtilizationBytes.Set(i.avgBytes, i.name, i.instance)
 }

--- a/pkg/logs/metrics/pipeline_monitor.go
+++ b/pkg/logs/metrics/pipeline_monitor.go
@@ -9,7 +9,20 @@ import (
 	"sync"
 )
 
-const ewmaAlpha = 2 / (float64(30) + 1) // ~ 0.0645 for a 30s window
+const (
+	ewmaAlpha = 2 / (float64(30) + 1) // ~ 0.0645 for a 30s window
+
+	// ProcessorTlmName is the telemetry name for processor components
+	ProcessorTlmName = "processor"
+	// StrategyTlmName is the telemetry name for strategy components
+	StrategyTlmName = "strategy"
+	// SenderTlmName is the telemetry name for sender components
+	SenderTlmName = "sender"
+	// WorkerTlmName is the telemetry name for worker components
+	WorkerTlmName = "worker"
+	// SenderTlmInstanceID is the default instance ID for sender components
+	SenderTlmInstanceID = "0"
+)
 
 // MeasurablePayload represents a payload that can be measured in bytes and count
 type MeasurablePayload interface {
@@ -20,10 +33,10 @@ type MeasurablePayload interface {
 // PipelineMonitor is an interface for monitoring the capacity of a pipeline.
 // Pipeline monitors are used to measure both capacity and utilization of components.
 type PipelineMonitor interface {
-	ID() string
-	ReportComponentIngress(size MeasurablePayload, name string)
-	ReportComponentEgress(size MeasurablePayload, name string)
-	MakeUtilizationMonitor(name string) UtilizationMonitor
+	GetCapacityMonitor(name string, instanceID string) *CapacityMonitor
+	ReportComponentIngress(size MeasurablePayload, name string, instanceID string)
+	ReportComponentEgress(size MeasurablePayload, name string, instanceID string)
+	MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor
 }
 
 // NoopPipelineMonitor is a no-op implementation of PipelineMonitor.
@@ -34,46 +47,45 @@ type NoopPipelineMonitor struct {
 }
 
 // NewNoopPipelineMonitor creates a new no-op pipeline monitor
-func NewNoopPipelineMonitor(id string) *NoopPipelineMonitor {
+func NewNoopPipelineMonitor(instanceID string) *NoopPipelineMonitor {
 	return &NoopPipelineMonitor{
-		instanceID: id,
+		instanceID: instanceID,
 	}
 }
 
-// ID returns the instance id of the monitor
-func (n *NoopPipelineMonitor) ID() string {
-	return n.instanceID
+// GetCapacityMonitor returns the capacity monitor for the given name and instance ID.
+// Returns nil for NoopPipelineMonitor as it doesn't track capacity.
+func (n *NoopPipelineMonitor) GetCapacityMonitor(_ string, _ string) *CapacityMonitor {
+	return nil
 }
 
 // ReportComponentIngress does nothing.
-func (n *NoopPipelineMonitor) ReportComponentIngress(_ MeasurablePayload, _ string) {}
+func (n *NoopPipelineMonitor) ReportComponentIngress(_ MeasurablePayload, _ string, _ string) {}
 
 // ReportComponentEgress does nothing.
-func (n *NoopPipelineMonitor) ReportComponentEgress(_ MeasurablePayload, _ string) {}
+func (n *NoopPipelineMonitor) ReportComponentEgress(_ MeasurablePayload, _ string, _ string) {}
 
 // MakeUtilizationMonitor returns a no-op utilization monitor.
-func (n *NoopPipelineMonitor) MakeUtilizationMonitor(_ string) UtilizationMonitor {
+func (n *NoopPipelineMonitor) MakeUtilizationMonitor(_ string, _ string) UtilizationMonitor {
 	return &NoopUtilizationMonitor{}
 }
 
 // TelemetryPipelineMonitor is a PipelineMonitor that reports capacity metrics to telemetry
 type TelemetryPipelineMonitor struct {
-	monitors   map[string]*CapacityMonitor
-	instanceID string
-	lock       sync.RWMutex
+	monitors map[string]*CapacityMonitor
+	lock     sync.RWMutex
 }
 
 // NewTelemetryPipelineMonitor creates a new pipeline monitort that reports capacity and utiilization metrics as telemetry
-func NewTelemetryPipelineMonitor(instanceID string) *TelemetryPipelineMonitor {
+func NewTelemetryPipelineMonitor() *TelemetryPipelineMonitor {
 	return &TelemetryPipelineMonitor{
-		monitors:   make(map[string]*CapacityMonitor),
-		instanceID: instanceID,
-		lock:       sync.RWMutex{},
+		monitors: make(map[string]*CapacityMonitor),
+		lock:     sync.RWMutex{},
 	}
 }
 
-func (c *TelemetryPipelineMonitor) getMonitor(name string) *CapacityMonitor {
-	key := name + c.instanceID
+func (c *TelemetryPipelineMonitor) getMonitor(name string, instanceID string) *CapacityMonitor {
+	key := name + instanceID
 
 	c.lock.RLock()
 	monitor, exists := c.monitors[key]
@@ -82,7 +94,7 @@ func (c *TelemetryPipelineMonitor) getMonitor(name string) *CapacityMonitor {
 	if !exists {
 		c.lock.Lock()
 		if c.monitors[key] == nil {
-			c.monitors[key] = NewCapacityMonitor(name, c.instanceID)
+			c.monitors[key] = NewCapacityMonitor(name, instanceID)
 		}
 		monitor = c.monitors[key]
 		c.lock.Unlock()
@@ -91,22 +103,22 @@ func (c *TelemetryPipelineMonitor) getMonitor(name string) *CapacityMonitor {
 	return monitor
 }
 
-// ID returns the instance id of the monitor
-func (c *TelemetryPipelineMonitor) ID() string {
-	return c.instanceID
+// MakeUtilizationMonitor creates a new utilization monitor for a component.
+func (c *TelemetryPipelineMonitor) MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor {
+	return NewTelemetryUtilizationMonitor(name, instanceID)
 }
 
-// MakeUtilizationMonitor creates a new utilization monitor for a component.
-func (c *TelemetryPipelineMonitor) MakeUtilizationMonitor(name string) UtilizationMonitor {
-	return NewTelemetryUtilizationMonitor(name, c.instanceID)
+// GetCapacityMonitor returns the capacity monitor for the given name and instance ID.
+func (c *TelemetryPipelineMonitor) GetCapacityMonitor(name string, instanceID string) *CapacityMonitor {
+	return c.getMonitor(name, instanceID)
 }
 
 // ReportComponentIngress reports the ingress of a payload to a component.
-func (c *TelemetryPipelineMonitor) ReportComponentIngress(pl MeasurablePayload, name string) {
-	c.getMonitor(name).AddIngress(pl)
+func (c *TelemetryPipelineMonitor) ReportComponentIngress(pl MeasurablePayload, name string, instanceID string) {
+	c.getMonitor(name, instanceID).AddIngress(pl)
 }
 
 // ReportComponentEgress reports the egress of a payload from a component.
-func (c *TelemetryPipelineMonitor) ReportComponentEgress(pl MeasurablePayload, name string) {
-	c.getMonitor(name).AddEgress(pl)
+func (c *TelemetryPipelineMonitor) ReportComponentEgress(pl MeasurablePayload, name string, instanceID string) {
+	c.getMonitor(name, instanceID).AddEgress(pl)
 }

--- a/pkg/logs/metrics/pipeline_monitor_test.go
+++ b/pkg/logs/metrics/pipeline_monitor_test.go
@@ -12,35 +12,35 @@ import (
 )
 
 func TestPipelineMonitorTracksCorrectCapacity(t *testing.T) {
-	pm := NewTelemetryPipelineMonitor("test")
+	pm := NewTelemetryPipelineMonitor()
 
-	pm.ReportComponentIngress(mockPayload{count: 1, size: 1}, "1")
-	pm.ReportComponentIngress(mockPayload{count: 5, size: 5}, "5")
-	pm.ReportComponentIngress(mockPayload{count: 10, size: 10}, "10")
+	pm.ReportComponentIngress(mockPayload{count: 1, size: 1}, "1", "test")
+	pm.ReportComponentIngress(mockPayload{count: 5, size: 5}, "5", "test")
+	pm.ReportComponentIngress(mockPayload{count: 10, size: 10}, "10", "test")
 
-	assert.Equal(t, pm.getMonitor("1").ingress, int64(1))
-	assert.Equal(t, pm.getMonitor("1").ingressBytes, int64(1))
+	assert.Equal(t, pm.getMonitor("1", "test").ingress, int64(1))
+	assert.Equal(t, pm.getMonitor("1", "test").ingressBytes, int64(1))
 
-	assert.Equal(t, pm.getMonitor("5").ingress, int64(5))
-	assert.Equal(t, pm.getMonitor("5").ingressBytes, int64(5))
+	assert.Equal(t, pm.getMonitor("5", "test").ingress, int64(5))
+	assert.Equal(t, pm.getMonitor("5", "test").ingressBytes, int64(5))
 
-	assert.Equal(t, pm.getMonitor("10").ingress, int64(10))
-	assert.Equal(t, pm.getMonitor("10").ingressBytes, int64(10))
+	assert.Equal(t, pm.getMonitor("10", "test").ingress, int64(10))
+	assert.Equal(t, pm.getMonitor("10", "test").ingressBytes, int64(10))
 
-	pm.ReportComponentEgress(mockPayload{count: 1, size: 1}, "1")
-	pm.ReportComponentEgress(mockPayload{count: 5, size: 5}, "5")
-	pm.ReportComponentEgress(mockPayload{count: 10, size: 10}, "10")
+	pm.ReportComponentEgress(mockPayload{count: 1, size: 1}, "1", "test")
+	pm.ReportComponentEgress(mockPayload{count: 5, size: 5}, "5", "test")
+	pm.ReportComponentEgress(mockPayload{count: 10, size: 10}, "10", "test")
 
-	assert.Equal(t, pm.getMonitor("1").egress, int64(1))
-	assert.Equal(t, pm.getMonitor("1").egressBytes, int64(1))
+	assert.Equal(t, pm.getMonitor("1", "test").egress, int64(1))
+	assert.Equal(t, pm.getMonitor("1", "test").egressBytes, int64(1))
 
-	assert.Equal(t, pm.getMonitor("5").egress, int64(5))
-	assert.Equal(t, pm.getMonitor("5").egressBytes, int64(5))
+	assert.Equal(t, pm.getMonitor("5", "test").egress, int64(5))
+	assert.Equal(t, pm.getMonitor("5", "test").egressBytes, int64(5))
 
-	assert.Equal(t, pm.getMonitor("10").egress, int64(10))
-	assert.Equal(t, pm.getMonitor("10").egressBytes, int64(10))
+	assert.Equal(t, pm.getMonitor("10", "test").egress, int64(10))
+	assert.Equal(t, pm.getMonitor("10", "test").egressBytes, int64(10))
 
-	assert.Equal(t, pm.getMonitor("1").ingress-pm.getMonitor("1").egress, int64(0))
-	assert.Equal(t, pm.getMonitor("5").ingress-pm.getMonitor("5").egress, int64(0))
-	assert.Equal(t, pm.getMonitor("10").ingress-pm.getMonitor("10").egress, int64(0))
+	assert.Equal(t, pm.getMonitor("1", "test").ingress-pm.getMonitor("1", "test").egress, int64(0))
+	assert.Equal(t, pm.getMonitor("5", "test").ingress-pm.getMonitor("5", "test").egress, int64(0))
+	assert.Equal(t, pm.getMonitor("10", "test").ingress-pm.getMonitor("10", "test").egress, int64(0))
 }

--- a/pkg/logs/pipeline/mock/mock.go
+++ b/pkg/logs/pipeline/mock/mock.go
@@ -59,6 +59,6 @@ func (p *mockProvider) NextPipelineChan() chan *message.Message {
 }
 
 // NextPipelineChanWithInstance returns the next pipeline
-func (p *mockProvider) NextPipelineChanWithMonitor() (chan *message.Message, metrics.PipelineMonitor) {
-	return p.msgChan, metrics.NewNoopPipelineMonitor("")
+func (p *mockProvider) NextPipelineChanWithMonitor() (chan *message.Message, *metrics.CapacityMonitor) {
+	return p.msgChan, metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", "")
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -41,6 +41,7 @@ func NewPipeline(
 	hostname hostnameinterface.Component,
 	cfg pkgconfigmodel.Reader,
 	compression logscompression.Component,
+	instanceID string,
 ) *Pipeline {
 	strategyInput := make(chan *message.Message, pkgconfigsetup.Datadog().GetInt("logs_config.message_channel_size"))
 	flushChan := make(chan struct{})
@@ -55,11 +56,11 @@ func NewPipeline(
 	} else {
 		encoder = processor.RawEncoder
 	}
-	strategy := getStrategy(strategyInput, senderImpl.In(), flushChan, endpoints, serverlessMeta, senderImpl.PipelineMonitor(), compression)
+	strategy := getStrategy(strategyInput, senderImpl.In(), flushChan, endpoints, serverlessMeta, senderImpl.PipelineMonitor(), compression, instanceID)
 
 	inputChan := make(chan *message.Message, pkgconfigsetup.Datadog().GetInt("logs_config.message_channel_size"))
 	processor := processor.New(cfg, inputChan, strategyInput, processingRules,
-		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor())
+		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor(), instanceID)
 
 	return &Pipeline{
 		InputChan:       inputChan,
@@ -97,6 +98,7 @@ func getStrategy(
 	serverlessMeta sender.ServerlessMeta,
 	pipelineMonitor metrics.PipelineMonitor,
 	compressor logscompression.Component,
+	instanceID string,
 ) sender.Strategy {
 	if endpoints.UseHTTP || serverlessMeta.IsEnabled() {
 		var encoder compressioncommon.Compressor
@@ -104,8 +106,7 @@ func getStrategy(
 		if endpoints.Main.UseCompression {
 			encoder = compressor.NewCompressor(endpoints.Main.CompressionKind, endpoints.Main.CompressionLevel)
 		}
-
-		return sender.NewBatchStrategy(inputChan, outputChan, flushChan, serverlessMeta, sender.NewArraySerializer(), endpoints.BatchWait, endpoints.BatchMaxSize, endpoints.BatchMaxContentSize, "logs", encoder, pipelineMonitor)
+		return sender.NewBatchStrategy(inputChan, outputChan, flushChan, serverlessMeta, sender.NewArraySerializer(), endpoints.BatchWait, endpoints.BatchMaxSize, endpoints.BatchMaxContentSize, "logs", encoder, pipelineMonitor, instanceID)
 	}
 	return sender.NewStreamStrategy(inputChan, outputChan, compressor.NewCompressor(compressioncommon.NoneKind, 0))
 }

--- a/pkg/logs/pipeline/processor_only_provider.go
+++ b/pkg/logs/pipeline/processor_only_provider.go
@@ -23,7 +23,7 @@ type processorOnlyProvider struct {
 	processor       *processor.Processor
 	inputChan       chan *message.Message
 	outputChan      chan *message.Message
-	pipelineMonitor *metrics.TelemetryPipelineMonitor
+	pipelineMonitor metrics.PipelineMonitor
 }
 
 // NewProcessorOnlyProvider is used by the logs check subcommand as the feature does not require the functionalities of the log pipeline other then the processor.
@@ -33,7 +33,7 @@ func NewProcessorOnlyProvider(diagnosticMessageReceiver diagnostic.MessageReceiv
 	encoder := processor.JSONEncoder
 	inputChan := make(chan *message.Message, chanSize)
 	pipelineID := "0"
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor()
+	pipelineMonitor := metrics.NewNoopPipelineMonitor(pipelineID)
 	processor := processor.New(cfg, inputChan, outputChan, processingRules,
 		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor, pipelineID)
 

--- a/pkg/logs/pipeline/processor_only_provider.go
+++ b/pkg/logs/pipeline/processor_only_provider.go
@@ -7,7 +7,6 @@ package pipeline
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -33,10 +32,10 @@ func NewProcessorOnlyProvider(diagnosticMessageReceiver diagnostic.MessageReceiv
 	outputChan := make(chan *message.Message, chanSize)
 	encoder := processor.JSONEncoder
 	inputChan := make(chan *message.Message, chanSize)
-	pipelineID := 0
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor(strconv.Itoa(pipelineID))
+	pipelineID := "0"
+	pipelineMonitor := metrics.NewTelemetryPipelineMonitor()
 	processor := processor.New(cfg, inputChan, outputChan, processingRules,
-		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor)
+		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor, pipelineID)
 
 	p := &processorOnlyProvider{
 		processor:       processor,
@@ -72,8 +71,8 @@ func (p *processorOnlyProvider) NextPipelineChan() chan *message.Message {
 	return p.inputChan
 }
 
-func (p *processorOnlyProvider) NextPipelineChanWithMonitor() (chan *message.Message, metrics.PipelineMonitor) {
-	return p.inputChan, p.pipelineMonitor
+func (p *processorOnlyProvider) NextPipelineChanWithMonitor() (chan *message.Message, *metrics.CapacityMonitor) {
+	return p.inputChan, p.pipelineMonitor.GetCapacityMonitor(metrics.ProcessorTlmName, "0")
 }
 
 func (p *processorOnlyProvider) GetOutputChan() chan *message.Message {

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -386,7 +386,7 @@ func TestBuffering(t *testing.T) {
 			scanner:       sds.CreateScanner("42"),
 		},
 		pipelineMonitor: pm,
-		utilization:     pm.MakeUtilizationMonitor("processor"),
+		utilization:     pm.MakeUtilizationMonitor("processor", "0"),
 	}
 
 	var processedMessages atomic.Int32

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -78,7 +78,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)
@@ -108,7 +108,7 @@ func TestBatchStrategyOverflowsOnTooLargeMessage(t *testing.T) {
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)
@@ -142,7 +142,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 	timerInterval := 100 * time.Millisecond
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), timerInterval, 100, 100, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), timerInterval, 100, 100, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	for round := 0; round < 3; round++ {
@@ -167,7 +167,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	flushChan := make(chan struct{})
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	message := message.NewMessage([]byte("a"), nil, "", 0)
@@ -192,7 +192,7 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 	message := message.NewMessage([]byte{}, nil, "", 0)
 
@@ -216,7 +216,7 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	strategy.Start()
 
 	// all of these messages will get buffered
@@ -264,7 +264,7 @@ func TestBatchStrategyFlushChannel(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), NewArraySerializer(), time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	strategy.Start()
 
 	// all of these messages will get buffered
@@ -315,7 +315,7 @@ func TestBatchStrategyDiscardsPayloadWhenSerializerFails(t *testing.T) {
 	flushChan := make(chan struct{})
 	// Fail on the 2nd call to Serialize, never fail Finish.
 	serializer := NewMockSerializer(2, 0)
-	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), serializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), serializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)
@@ -354,7 +354,7 @@ func TestBatchStrategyDiscardsPayloadWhenSerializerFailsOnFinish(t *testing.T) {
 	flushChan := make(chan struct{})
 	// Fail on the 1st call to Finish, never fail Serialize.
 	serializer := NewMockSerializer(0, 1)
-	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), serializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), serializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""), "test")
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)

--- a/pkg/logs/sender/http/http_sender_test.go
+++ b/pkg/logs/sender/http/http_sender_test.go
@@ -104,7 +104,7 @@ func TestHttpDestinationFactory(t *testing.T) {
 			)
 
 			// Test 1: Verify first call creates destinations
-			destinations1 := factory()
+			destinations1 := factory("test")
 			assert.NotNil(t, destinations1)
 
 			// Verify destination quantities
@@ -139,7 +139,7 @@ func TestHttpDestinationFactory(t *testing.T) {
 			}
 
 			// Test 2: Verify second call creates new destination instances
-			destinations2 := factory()
+			destinations2 := factory("test")
 			assert.NotNil(t, destinations2)
 			assert.NotSame(t, destinations1, destinations2,
 				"Factory should create new destinations instance")

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -42,7 +42,7 @@ func TestNewSenderWorkerDistribution(t *testing.T) {
 			// Setup
 			config := configmock.New(t)
 			destinations := &client.Destinations{}
-			destFactory := func() *client.Destinations { return destinations }
+			destFactory := func(_ string) *client.Destinations { return destinations }
 			bufferSize := 100
 			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
 

--- a/pkg/logs/sender/tcp/tcp_sender.go
+++ b/pkg/logs/sender/tcp/tcp_sender.go
@@ -31,7 +31,7 @@ func NewTCPSender(
 	workersPerQueue int,
 ) *sender.Sender {
 	log.Debugf("Creating a new sender for component %s with %d queues, %d tcp workers", componentName, queueCount, workersPerQueue)
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor("tcp_sender")
+	pipelineMonitor := metrics.NewTelemetryPipelineMonitor()
 
 	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverlessMeta, status)
 
@@ -54,7 +54,7 @@ func tcpDestinationFactory(
 	status statusinterface.Status,
 ) sender.DestinationFactory {
 	isServerless := serverlessMeta != nil
-	return func() *client.Destinations {
+	return func(_ string) *client.Destinations {
 		reliable := []client.Destination{}
 		additionals := []client.Destination{}
 		for _, endpoint := range endpoints.GetReliableEndpoints() {

--- a/pkg/logs/sender/tcp/tcp_sender_test.go
+++ b/pkg/logs/sender/tcp/tcp_sender_test.go
@@ -96,7 +96,7 @@ func TestTCPDestinationFactory(t *testing.T) {
 			)
 
 			// Test 1: Verify first call creates destinations
-			destinations1 := factory()
+			destinations1 := factory("test")
 			assert.NotNil(t, destinations1)
 
 			// Verify destination quantities
@@ -121,7 +121,7 @@ func TestTCPDestinationFactory(t *testing.T) {
 			}
 
 			// Test 2: Verify second call creates new destination instances
-			destinations2 := factory()
+			destinations2 := factory("test")
 			assert.NotNil(t, destinations2)
 			assert.NotSame(t, destinations1, destinations2,
 				"Factory should create new destinations instance")

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -120,21 +120,21 @@ type Tailer struct {
 	info            *status.InfoRegistry
 	bytesRead       *status.CountInfo
 	movingSum       *util.MovingSum
-	PipelineMonitor metrics.PipelineMonitor
+	CapacityMonitor *metrics.CapacityMonitor
 	registry        auditor.Registry
 }
 
 // TailerOptions holds all possible parameters that NewTailer requires in addition to optional parameters that can be optionally passed into. This can be used for more optional parameters if required in future
 type TailerOptions struct {
-	OutputChan      chan *message.Message   // Required
-	File            *File                   // Required
-	SleepDuration   time.Duration           // Required
-	Decoder         *decoder.Decoder        // Required
-	Info            *status.InfoRegistry    // Required
-	Rotated         bool                    // Optional
-	TagAdder        tag.EntityTagAdder      // Required
-	PipelineMonitor metrics.PipelineMonitor // Required
-	Registry        auditor.Registry        // Required
+	OutputChan      chan *message.Message    // Required
+	File            *File                    // Required
+	SleepDuration   time.Duration            // Required
+	Decoder         *decoder.Decoder         // Required
+	Info            *status.InfoRegistry     // Required
+	Rotated         bool                     // Optional
+	TagAdder        tag.EntityTagAdder       // Required
+	CapacityMonitor *metrics.CapacityMonitor // Required
+	Registry        auditor.Registry         // Required
 }
 
 // NewTailer returns an initialized Tailer, read to be started.
@@ -187,7 +187,7 @@ func NewTailer(opts *TailerOptions) *Tailer {
 		info:                   opts.Info,
 		bytesRead:              bytesRead,
 		movingSum:              movingSum,
-		PipelineMonitor:        opts.PipelineMonitor,
+		CapacityMonitor:        opts.CapacityMonitor,
 		registry:               opts.Registry,
 	}
 
@@ -210,7 +210,7 @@ func addToTailerInfo(k, m string, tailerInfo *status.InfoRegistry) {
 func (t *Tailer) NewRotatedTailer(
 	file *File,
 	outputChan chan *message.Message,
-	pipelineMonitor metrics.PipelineMonitor,
+	capacityMonitor *metrics.CapacityMonitor,
 	decoder *decoder.Decoder,
 	info *status.InfoRegistry,
 	tagAdder tag.EntityTagAdder,
@@ -224,7 +224,7 @@ func (t *Tailer) NewRotatedTailer(
 		Info:            info,
 		Rotated:         true,
 		TagAdder:        tagAdder,
-		PipelineMonitor: pipelineMonitor,
+		CapacityMonitor: capacityMonitor,
 		Registry:        registry,
 	}
 
@@ -389,7 +389,7 @@ func (t *Tailer) forwardMessages() {
 		// normal case.
 		select {
 		case t.outputChan <- msg:
-			t.PipelineMonitor.ReportComponentIngress(msg, "processor")
+			t.CapacityMonitor.AddIngress(msg)
 		case <-t.forwardContext.Done():
 		}
 	}

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -65,7 +65,7 @@ func (suite *TailerTestSuite) SetupTest() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -122,7 +122,7 @@ func (suite *TailerTestSuite) TestTailerTimeDurationConfig() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -291,7 +291,7 @@ func (suite *TailerTestSuite) TestDirTagWhenTailingFiles() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -323,7 +323,7 @@ func (suite *TailerTestSuite) TestBuildTagsFileOnly() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -352,7 +352,7 @@ func (suite *TailerTestSuite) TestBuildTagsFileDir() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -386,7 +386,7 @@ func (suite *TailerTestSuite) TestTruncatedTag() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -420,7 +420,7 @@ func (suite *TailerTestSuite) TestMutliLineAutoDetect() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 
@@ -457,7 +457,7 @@ func (suite *TailerTestSuite) TestDidRotateNilFullpath() {
 		SleepDuration:   sleepDuration,
 		Decoder:         decoder.NewDecoderFromSource(suite.source, info),
 		Info:            info,
-		PipelineMonitor: metrics.NewNoopPipelineMonitor(""),
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
 		Registry:        auditor.NewMockRegistry(),
 	}
 

--- a/releasenotes/notes/utilization-monitor-fix-c18317b9a2294a17.yaml
+++ b/releasenotes/notes/utilization-monitor-fix-c18317b9a2294a17.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improved the granularity of the Logs Agent pipeline monitor to track the capacity of each individual component of the pipeline.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The existing monitors used to identify and track resource allocation in the logs agent pipeline have been set to monitor the system at a very high level following the separation of the log agent's sender from the processor/strategy pipeline. 
Each main component tracks utilization/capacity as a singular entity rather than accounting for divisions of resources amongst its subcomponents. For example, the strategy pipeline component combines and reports its information as a singular number, despite there being 4 distinct strategy routines running on average. Recapturing the ability to monitor the components on a more granular level has the potential to be much more helpful when debugging certain classes of issues. 

This PR will attach instanceIDs to each of the major components to meaningfully see the behavior of their subcomponents. An example prometheus output in the new format is 
```
# HELP logs_component_utilization__bytes Gauge of the number of bytes currently held in a component and its buffers
# TYPE logs_component_utilization__bytes gauge
logs_component_utilization__bytes{instance="0",name="sender"} 96.86164602172508
logs_component_utilization__bytes{instance="2",name="processor"} 19.157356049314203
logs_component_utilization__bytes{instance="2",name="strategy"} 110.30437914691598
logs_component_utilization__bytes{instance="3",name="processor"} 10.831449356384455
logs_component_utilization__bytes{instance="3",name="strategy"} 121.05683618608943
logs_component_utilization__bytes{instance="q0s0",name="destination_reliable_0"} 81.14695323216918
logs_component_utilization__bytes{instance="q0s0",name="worker"} 96.86164602172508
# HELP logs_component_utilization__items Gauge of the number of items currently held in a component and its buffers
# TYPE logs_component_utilization__items gauge
logs_component_utilization__items{instance="0",name="sender"} 4.035901917571878
logs_component_utilization__items{instance="2",name="processor"} 0.7982231687214254
logs_component_utilization__items{instance="2",name="strategy"} 4.596015797788166
logs_component_utilization__items{instance="3",name="processor"} 0.4513103898493523
logs_component_utilization__items{instance="3",name="strategy"} 5.044034841087059
logs_component_utilization__items{instance="q0s0",name="destination_reliable_0"} 3.3811230513403827
logs_component_utilization__items{instance="q0s0",name="worker"} 4.035901917571878
# HELP logs_component_utilization__ratio Gauge of the utilization ratio of a component
# TYPE logs_component_utilization__ratio gauge
logs_component_utilization__ratio{instance="2",name="processor"} 9.725632976053808e-05
logs_component_utilization__ratio{instance="2",name="strategy"} 0.00010593946922206945
logs_component_utilization__ratio{instance="3",name="processor"} 2.9504501267019528e-05
logs_component_utilization__ratio{instance="3",name="strategy"} 3.797890311443881e-05
logs_component_utilization__ratio{instance="q0s0",name="destination_reliable_0"} 1.2004623758720116e-05
logs_component_utilization__ratio{instance="q0s0",name="worker"} 1.3957554083711945e-06
```

#### Low Level Details
The discrete components of the logs agent are, in operational order:
Processor
Strategy
Sender
Worker
Destination

Each subcomponent of the Processor has a one-to-one relationship with a subcomponent of the Strategy. These pairs are always assigned the same instanceID, which corresponds to the concept of a "pipeline id". 

Sender is a unique structure in this model, as it has no subcomponents and all data in the system inevitably routes through its singleton. It also does no work, and instead acts as a decoupler to allow work generated from a given Processor/Strategy pair to be freely distributed to whichever "Worker" subcomponent is available. As such, it is always designated as instanceID "0" for utilization_bytes/utilization_items, and it has no concept of a utilization_ratio. 

Workers have a variable subcomponent setup, with the concept of worker ids and worker queue assignments. As such, the instanceID for workers allows for grouping on queue ids while also preserving individual worker id uniqueness. Destinations are always assigned to a single worker and already have uniquely identifiable names, so all they require is to have their instanceID match their equivalent worker's instance. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
In addition to automated testing, prometheus metrics were generated and examined for all three of the possible pipeline configurations (HTTP/TCP/Legacy) to confirm that ids were correctly generated across the different possible permutations of subcomponents.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->