### PR TITLE
[pkg/dyninst/test] Stabilize integration test output

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"encoding/json"
 	"io"
 	"math"
 	"os"
@@ -20,10 +21,9 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/go-json-experiment/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/config"

--- a/pkg/dyninst/testdata/decoded/sample.yaml
+++ b/pkg/dyninst/testdata/decoded/sample.yaml
@@ -1,189 +1,189 @@
 stackC:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"stackC"}}'
-  ExpectedToFail: true
+    OutputJSON: '{"stack_frames":"","captures":{"probe_id":"stackC"}}'
+    ExpectedToFail: true
 testArrayOfArrays:
-  OutputJSON: '{"stack_frames":"","captures":{"a":[[1,2],[3,4]],"probe_id":"testArrayOfArrays"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":[[1,2],[3,4]],"probe_id":"testArrayOfArrays"},"stack_frames":""}'
+    ExpectedToFail: false
 testArrayOfArraysOfArrays:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testArrayOfArraysOfArrays","b":[[[1,2],[3,4]],[[5,6],[7,8]]]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"b":[[[1,2],[3,4]],[[5,6],[7,8]]],"probe_id":"testArrayOfArraysOfArrays"},"stack_frames":""}'
+    ExpectedToFail: false
 testArrayOfStrings:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testArrayOfStrings","a":["first","second"]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":["first","second"],"probe_id":"testArrayOfStrings"},"stack_frames":""}'
+    ExpectedToFail: false
 testArrayOfStructs:
-  OutputJSON: '{"stack_frames":""}'
-  ExpectedToFail: true
+    OutputJSON: '{"stack_frames":""}'
+    ExpectedToFail: true
 testBigStruct:
-  OutputJSON: ""
-  ExpectedToFail: true
+    OutputJSON: ""
+    ExpectedToFail: true
 testBoolArray:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testBoolArray","x":[true,true]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testBoolArray","x":[true,true]},"stack_frames":""}'
+    ExpectedToFail: false
 testByteArray:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testByteArray","x":[1,1]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testByteArray","x":[1,1]},"stack_frames":""}'
+    ExpectedToFail: false
 testChannel:
-  OutputJSON: ""
-  ExpectedToFail: true
+    OutputJSON: ""
+    ExpectedToFail: true
 testCombinedByte:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testCombinedByte","w":2,"x":3,"y":0}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testCombinedByte","w":2,"x":3,"y":0},"stack_frames":""}'
+    ExpectedToFail: false
 testEmptySlice:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testEmptySlice","u":[]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testEmptySlice","u":[]},"stack_frames":""}'
+    ExpectedToFail: false
 testEmptySliceOfStructs:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testEmptySliceOfStructs","xs":[],"a":2}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":2,"probe_id":"testEmptySliceOfStructs","xs":[]},"stack_frames":""}'
+    ExpectedToFail: false
 testEmptyStruct:
-  OutputJSON: '{"captures":{"e":{},"probe_id":"testEmptyStruct"},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"e":{},"probe_id":"testEmptyStruct"},"stack_frames":""}'
+    ExpectedToFail: false
 testError:
-  OutputJSON: ""
-  ExpectedToFail: true
+    OutputJSON: ""
+    ExpectedToFail: true
 testInt8Array:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testInt8Array","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testInt8Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testInt16Array:
-  OutputJSON: '{"captures":{"probe_id":"testInt16Array","x":[1,2]},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testInt16Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testInt32Array:
-  OutputJSON: '{"captures":{"probe_id":"testInt32Array","x":[1,2]},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testInt32Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testInt64Array:
-  OutputJSON: '{"captures":{"probe_id":"testInt64Array","x":[1,2]},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testInt64Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testIntArray:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testIntArray","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testIntArray","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testInterface:
-  OutputJSON: '{"stack_frames":""}'
-  ExpectedToFail: true
+    OutputJSON: '{"stack_frames":""}'
+    ExpectedToFail: true
 testLinkedList:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testLinkedList","a":{"val":1,"b":{"Address":"","Value":{"val":2,"b":{"Address":"","Value":{"val":3,"b":"nil"}}}}}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":{"b":{"Address":"","Value":{"b":{"Address":"","Value":{"b":"nil","val":3}},"val":2}},"val":1},"probe_id":"testLinkedList"},"stack_frames":""}'
+    ExpectedToFail: false
 testMapStringToInt:
-  OutputJSON: '{"stack_frames":""}'
-  ExpectedToFail: true
+    OutputJSON: '{"stack_frames":""}'
+    ExpectedToFail: true
 testMultipleSimpleParams:
-  OutputJSON: '{"stack_frames":"","captures":{"c":122,"d":1337,"e":"xyz","probe_id":"testMultipleSimpleParams","a":false,"b":42}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":false,"b":42,"c":122,"d":1337,"e":"xyz","probe_id":"testMultipleSimpleParams"},"stack_frames":""}'
+    ExpectedToFail: false
 testNilPointer:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testNilPointer","z":"nil","a":1}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":1,"probe_id":"testNilPointer","z":"nil"},"stack_frames":""}'
+    ExpectedToFail: false
 testNilSlice:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testNilSlice","xs":[]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testNilSlice","xs":[]},"stack_frames":""}'
+    ExpectedToFail: false
 testNilSliceOfStructs:
-  OutputJSON: '{"captures":{"probe_id":"testNilSliceOfStructs","xs":[],"a":5},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":5,"probe_id":"testNilSliceOfStructs","xs":[]},"stack_frames":""}'
+    ExpectedToFail: false
 testNilSliceWithOtherParams:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testNilSliceWithOtherParams","a":1,"s":[],"x":5}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":1,"probe_id":"testNilSliceWithOtherParams","s":[],"x":5},"stack_frames":""}'
+    ExpectedToFail: false
 testOneStringInStructPointer:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testOneStringInStructPointer","a":{"Address":"","Value":{"a":"omg"}}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":{"Address":"","Value":{"a":"omg"}},"probe_id":"testOneStringInStructPointer"},"stack_frames":""}'
+    ExpectedToFail: false
 testPointerLoop:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testPointerLoop","a":{"Value":{"b":{"Address":""},"val":1},"Address":""}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":{"Address":"","Value":{"b":{"Address":""},"val":1}},"probe_id":"testPointerLoop"},"stack_frames":""}'
+    ExpectedToFail: false
 testRuneArray:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testRuneArray","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testRuneArray","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleBool:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleBool","x":true}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleBool","x":true},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleByte:
-  OutputJSON: '{"captures":{"probe_id":"testSingleByte","x":97},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleByte","x":97},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleFloat32:
-  OutputJSON: '{"captures":{"probe_id":"testSingleFloat32","x":0},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleFloat32","x":0},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleFloat64:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleFloat64","x":0}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleFloat64","x":0},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleInt:
-  OutputJSON: '{"captures":{"x":-1512,"probe_id":"testSingleInt"},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleInt","x":-1512},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleInt8:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleInt8","x":-8}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleInt8","x":-8},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleInt16:
-  OutputJSON: '{"stack_frames":"","captures":{"x":-16,"probe_id":"testSingleInt16"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleInt16","x":-16},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleInt32:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleInt32","x":-32}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleInt32","x":-32},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleInt64:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleInt64","x":-64}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleInt64","x":-64},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleRune:
-  OutputJSON: '{"stack_frames":"","captures":{"x":1,"probe_id":"testSingleRune"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleRune","x":1},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleString:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleString","x":"abc"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleString","x":"abc"},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleUint:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleUint","x":1512}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleUint","x":1512},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleUint8:
-  OutputJSON: '{"captures":{"probe_id":"testSingleUint8","x":8},"stack_frames":""}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleUint8","x":8},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleUint16:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleUint16","x":16}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleUint16","x":16},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleUint32:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleUint32","x":32}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleUint32","x":32},"stack_frames":""}'
+    ExpectedToFail: false
 testSingleUint64:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSingleUint64","x":64}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSingleUint64","x":64},"stack_frames":""}'
+    ExpectedToFail: false
 testSliceOfSlices:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testSliceOfSlices","u":[[4],[5,6],[7,8,9]]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testSliceOfSlices","u":[[4],[5,6],[7,8,9]]},"stack_frames":""}'
+    ExpectedToFail: false
 testStringArray:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testStringArray","x":["one","two"]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testStringArray","x":["one","two"]},"stack_frames":""}'
+    ExpectedToFail: false
 testStringPointer:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testStringPointer","z":{"Address":"","Value":"abc"}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testStringPointer","z":{"Address":"","Value":"abc"}},"stack_frames":""}'
+    ExpectedToFail: false
 testStringSlice:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testStringSlice","s":["abc","xyz","123"]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testStringSlice","s":["abc","xyz","123"]},"stack_frames":""}'
+    ExpectedToFail: false
 testStruct:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testStruct","x":{"aNumber":2,"nested":{"anotherInt":3,"anotherString":"four"},"aBool":true,"aString":"one"}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testStruct","x":{"aBool":true,"aNumber":2,"aString":"one","nested":{"anotherInt":3,"anotherString":"four"}}},"stack_frames":""}'
+    ExpectedToFail: false
 testStructSlice:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testStructSlice","xs":[{"aUint8":42,"aBool":true},{"aUint8":24,"aBool":true}],"a":3}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":3,"probe_id":"testStructSlice","xs":[{"aBool":true,"aUint8":42},{"aBool":true,"aUint8":24}]},"stack_frames":""}'
+    ExpectedToFail: false
 testThreeStrings:
-  OutputJSON: '{"stack_frames":"","captures":{"x":"abc","y":"def","z":"ghi","probe_id":"testThreeStrings"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testThreeStrings","x":"abc","y":"def","z":"ghi"},"stack_frames":""}'
+    ExpectedToFail: false
 testThreeStringsInStruct:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testThreeStringsInStruct","a":{"a":"abc","b":"def","c":"ghi"}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":{"a":"abc","b":"def","c":"ghi"},"probe_id":"testThreeStringsInStruct"},"stack_frames":""}'
+    ExpectedToFail: false
 testThreeStringsInStructPointer:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testThreeStringsInStructPointer","a":{"Address":"","Value":{"a":"abc","b":"def","c":"ghi"}}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"a":{"Address":"","Value":{"a":"abc","b":"def","c":"ghi"}},"probe_id":"testThreeStringsInStructPointer"},"stack_frames":""}'
+    ExpectedToFail: false
 testTypeAlias:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testTypeAlias","x":3}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testTypeAlias","x":3},"stack_frames":""}'
+    ExpectedToFail: false
 testUint8Array:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testUint8Array","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUint8Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testUint16Array:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testUint16Array","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUint16Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testUint32Array:
-  OutputJSON: '{"stack_frames":"","captures":{"x":[1,2],"probe_id":"testUint32Array"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUint32Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testUint64Array:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testUint64Array","x":[1,2]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUint64Array","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testUintArray:
-  OutputJSON: '{"stack_frames":"","captures":{"x":[1,2],"probe_id":"testUintArray"}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUintArray","x":[1,2]},"stack_frames":""}'
+    ExpectedToFail: false
 testUintPointer:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testUintPointer","x":{"Address":"","Value":1}}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUintPointer","x":{"Address":"","Value":1}},"stack_frames":""}'
+    ExpectedToFail: false
 testUintSlice:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"testUintSlice","u":[1,2,3]}}'
-  ExpectedToFail: false
+    OutputJSON: '{"captures":{"probe_id":"testUintSlice","u":[1,2,3]},"stack_frames":""}'
+    ExpectedToFail: false

--- a/pkg/dyninst/testdata/decoded/simple.yaml
+++ b/pkg/dyninst/testdata/decoded/simple.yaml
@@ -1,34 +1,33 @@
-inlined:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"inlined","x":0}}'
-  ExpectedToFail: false
-intArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"intArg","x":81985529216486900}}'
-  ExpectedToFail: false
-intArrayArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"intArrayArg","s":[1,2,3]}}'
-  ExpectedToFail: false
-intArrayArgFrameless:
-  OutputJSON: '{"captures":{"probe_id":"intArrayArgFrameless","s":["foo","bar","baz"]},"stack_frames":""}'
-  ExpectedToFail: false
-intSliceArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"intSliceArg","s":[1,2,3]}}'
-  ExpectedToFail: false
-stringArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"stringArg","s":"d"}}'
-  ExpectedToFail: false
-stringArrayArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"stringArrayArg","s":["a","b","c"]}}'
-  ExpectedToFail: false
-stringSliceArg:
-  OutputJSON: '{"stack_frames":"","captures":{"probe_id":"stringSliceArg","s":["a","b","c"]}}'
-  ExpectedToFail: false
-mapArg:
-  OutputJSON: ''
-  ExpectedToFail: true
-bigMapArg:
-  OutputJSON: ''
-  ExpectedToFail: true
 PointerChainArg:
-  OutputJSON: ''
-  ExpectedToFail: true
-
+    OutputJSON: ""
+    ExpectedToFail: true
+bigMapArg:
+    OutputJSON: ""
+    ExpectedToFail: true
+inlined:
+    OutputJSON: '{"captures":{"probe_id":"inlined","x":0},"stack_frames":""}'
+    ExpectedToFail: false
+intArg:
+    OutputJSON: '{"captures":{"probe_id":"intArg","x":81985529216486900},"stack_frames":""}'
+    ExpectedToFail: false
+intArrayArg:
+    OutputJSON: '{"captures":{"probe_id":"intArrayArg","s":[1,2,3]},"stack_frames":""}'
+    ExpectedToFail: false
+intArrayArgFrameless:
+    OutputJSON: '{"captures":{"probe_id":"intArrayArgFrameless","s":["foo","bar","baz"]},"stack_frames":""}'
+    ExpectedToFail: false
+intSliceArg:
+    OutputJSON: '{"captures":{"probe_id":"intSliceArg","s":[1,2,3]},"stack_frames":""}'
+    ExpectedToFail: false
+mapArg:
+    OutputJSON: ""
+    ExpectedToFail: true
+stringArg:
+    OutputJSON: '{"captures":{"probe_id":"stringArg","s":"d"},"stack_frames":""}'
+    ExpectedToFail: false
+stringArrayArg:
+    OutputJSON: '{"captures":{"probe_id":"stringArrayArg","s":["a","b","c"]},"stack_frames":""}'
+    ExpectedToFail: false
+stringSliceArg:
+    OutputJSON: '{"captures":{"probe_id":"stringSliceArg","s":["a","b","c"]},"stack_frames":""}'
+    ExpectedToFail: false


### PR DESCRIPTION
Surprisingly go-experiment-json by default doesn't sort maps by keys. Even though test logic is not sensitive to these orders, we want to avoid changing snapshot files when relevant code behavior stays the same.