### PR TITLE
[CWS] add checks validating that TC filters return UNSPEC

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -29,14 +29,6 @@ const (
 
 	// packetCaptureSize see kernel definition
 	packetCaptureSize = 256
-
-	// state of tc action
-	// TCActOk will terminate the packet processing pipeline and allows the packet to proceed
-	TCActOk = 0
-	// TCActShot will terminate the packet processing pipeline and drop the packet
-	TCActShot = 2
-	// TCActUnspec will continue packet processing
-	TCActUnspec = -1
 )
 
 // ProgOpts defines options
@@ -130,7 +122,7 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, senderInsts as
 
 	// prepend a return instruction in case of fail
 	footerInsts := append(asm.Instructions{
-		asm.Mov.Imm(asm.R0, TCActUnspec),
+		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
 		asm.Return(),
 	}, senderInsts...)
 
@@ -217,6 +209,7 @@ func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Fi
 		asm.LoadMapPtr(asm.R1, rawPacketEventMapFd),
 		asm.FnMapLookupElem.Call(),
 		asm.JNE.Imm(asm.R0, 0, "raw-packet-event-not-null"),
+		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
 		asm.Return(),
 		// place in result in the start register and end register
 		asm.Mov.Reg(opts.PacketStart, asm.R0).WithSymbol("raw-packet-event-not-null"),
@@ -230,7 +223,7 @@ func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Fi
 		asm.LoadMapPtr(asm.R2, clsRouterMapFd),
 		asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketParserSenderKey)),
 		asm.FnTailCall.Call(),
-		asm.Mov.Imm(asm.R0, 0),
+		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
 		asm.Return(),
 	}
 

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -56,7 +56,7 @@ func (l *testLogger) Errorf(format string, params ...interface{}) {
 
 var trace bool
 
-func newVM(t *testing.T) *baloum.VM {
+func loadColSpec(t *testing.T) *ebpf.CollectionSpec {
 	useSyscallWrapper, err := secebpf.IsSyscallWrapperRequired()
 	if err != nil {
 		t.Fatal(err)
@@ -72,6 +72,12 @@ func newVM(t *testing.T) *baloum.VM {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	return spec
+}
+
+func newVM(t *testing.T) *baloum.VM {
+	spec := loadColSpec(t)
 
 	var now time.Time
 

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -88,7 +88,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 				BPFFilter: "tcp dst port 6666 and tcp[tcpflags] == tcp-syn",
 			},
 		}
-		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", rawpacket.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
+		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", probes.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
 	})
 
 	t.Run("syn-port-std-limit-ko", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 		opts := rawpacket.DefaultProgOpts()
 		opts.NopInstLen = opts.MaxProgSize - 50
 
-		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", rawpacket.TCActUnspec, 2, opts, true)
+		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", probes.TCActUnspec, 2, opts, true)
 	})
 
 	t.Run("syn-port-multi-syntax-err", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 				BPFFilter: "tcp[((tcp[12] & 0xf0) >> 2):4] = 0x7f454c46",
 			},
 		}
-		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", rawpacket.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
+		testRawPacketFilter(t, filters, "test/raw_packet_tail_calls", probes.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
 	})
 
 	t.Run("tcp-bpfdoor-magic-number", func(t *testing.T) {

--- a/pkg/security/ebpf/tests/tc_test.go
+++ b/pkg/security/ebpf/tests/tc_test.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata && pcap && cgo
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/rawpacket"
+)
+
+func TestTCActUnspec(t *testing.T) {
+	t.Run("static", func(t *testing.T) {
+		err := probes.CheckUnspecReturnCode(loadColSpec(t).Programs)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("ko", func(t *testing.T) {
+		insts := asm.Instructions{
+			asm.Mov.Imm(asm.R0, probes.TCActOk),
+			asm.Return(),
+		}
+		progSpecs := make(map[string]*ebpf.ProgramSpec)
+		progSpecs["test"] = &ebpf.ProgramSpec{
+			Name:         "test",
+			Type:         ebpf.SchedCLS,
+			Instructions: insts,
+		}
+
+		err := probes.CheckUnspecReturnCode(progSpecs)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+
+	t.Run("rawpacket", func(t *testing.T) {
+		filters := []rawpacket.Filter{
+			{
+				RuleID:    "ok",
+				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
+			},
+		}
+		progSpecs, err := rawpacket.FiltersToProgramSpecs(1, 2, filters, rawpacket.DefaultProgOpts())
+		if err != nil {
+			t.Error(err)
+		}
+
+		progSpecsMap := make(map[string]*ebpf.ProgramSpec)
+		for _, progSpec := range progSpecs {
+			progSpecsMap[progSpec.Name] = progSpec
+		}
+		err = probes.CheckUnspecReturnCode(progSpecsMap)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -612,6 +612,12 @@ func (p *EBPFProbe) setupRawPacketProgs(rs *rules.RuleSet) error {
 		colSpec.Programs[progSpec.Name] = progSpec
 	}
 
+	// verify that the programs are using the TC_ACT_UNSPEC return code
+	err = probes.CheckUnspecReturnCode(colSpec.Programs)
+	if err != nil {
+		return fmt.Errorf("programs are not using the TC_ACT_UNSPEC return code: %w", err)
+	}
+
 	col, err := lib.NewCollection(&colSpec)
 	if err != nil {
 		return fmt.Errorf("failed to load program: %w", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR introduces checks to verify that TC filters are always returns UNSPEC.

* Validate static tc filters through unit tests
* Validate dynamic tc filters through unit tests
* Validate at runtime/when loading dynamic tc filters

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

This check may incorrectly fail in the future as this is a naive check implementation. In that case we'll have to adapt.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->