### PR TITLE
Print disk usage in disk check e2e test between runs to help debugging

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
@@ -14,12 +14,13 @@ import (
 	gocmpopts "github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/testcommon/check"
 	checkUtils "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-runtimes/checks/common"
-	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 )
 
 type diskCheckSuite struct {
@@ -38,6 +39,22 @@ func (v *diskCheckSuite) getSuiteOptions() []e2e.SuiteOption {
 	))
 
 	return suiteOptions
+}
+
+// printDiskUsage prints the disk usage for the current environment
+// used to debug the disk check getting different values on some runs
+func (v *diskCheckSuite) printDiskUsage() {
+	if v.descriptor.Family() != e2eos.WindowsFamily {
+		// only the windows version is flaky so no need to handle linux
+		return
+	}
+
+	diskUsage, err := v.Env().RemoteHost.Execute("Get-PSDrive -Name C")
+	if err != nil {
+		v.T().Logf("error getting disk usage: %s", err)
+		return
+	}
+	v.T().Logf("disk usage: %s", diskUsage)
 }
 
 func (v *diskCheckSuite) TestCheckDisk() {
@@ -59,9 +76,12 @@ instances:
 	for _, testCase := range testCases {
 		v.Run(testCase.name, func() {
 			v.T().Log("run the disk check using old version")
+			v.printDiskUsage()
 			pythonMetrics := v.runDiskCheck(testCase.agentConfig, testCase.checkConfig, false)
 			v.T().Log("run the disk check using new version")
+			v.printDiskUsage()
 			goMetrics := v.runDiskCheck(testCase.agentConfig, testCase.checkConfig, true)
+			v.printDiskUsage()
 
 			// assert the check output
 			diff := gocmp.Diff(pythonMetrics, goMetrics,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Log disk usage in disk check e2e test between runs of the versions of the check.

### Motivation
The check has been flaky recently, and we don't know if the issue is that the value we collect is incorrect or if the disk is really used significantly more between the two runs.
This logging should help debug this.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->