### PR TITLE
[CWS] add the ability to retry event container tagging

### DIFF
--- a/pkg/security/events/event.go
+++ b/pkg/security/events/event.go
@@ -50,5 +50,5 @@ type Event interface {
 
 // EventSender defines an event sender
 type EventSender interface {
-	SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string, service string)
+	SendEvent(rule *rules.Rule, event Event, extTagsCb func() ([]string, bool), service string)
 }

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -315,7 +315,7 @@ func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEv
 
 // SendEvent sends an event to the backend after checking that the rate limiter allows it for the provided rule
 // Implements the EventSender interface
-func (c *CWSConsumer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
+func (c *CWSConsumer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() ([]string, bool), service string) {
 	if c.rateLimiter.Allow(rule.ID, event) {
 		c.eventSender.SendEvent(rule, event, extTagsCb, service)
 	} else {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -67,7 +67,7 @@ type pendingMsg struct {
 	actionReports   []model.ActionReport
 	service         string
 	timestamp       time.Time
-	extTagsCb       func() []string
+	extTagsCb       func() ([]string, bool)
 	sendAfter       time.Time
 	retry           int
 }
@@ -292,8 +292,13 @@ func (a *APIServer) start(ctx context.Context) {
 		case now := <-ticker.C:
 			a.dequeue(now, func(msg *pendingMsg) bool {
 				if msg.extTagsCb != nil {
+					tags, retryable := msg.extTagsCb()
+					if len(tags) == 0 && retryable && msg.retry < maxRetry {
+						return false
+					}
+
 					// dedup
-					for _, tag := range msg.extTagsCb() {
+					for _, tag := range tags {
 						if !slices.Contains(msg.tags, tag) {
 							msg.tags = append(msg.tags, tag)
 						}
@@ -351,7 +356,7 @@ func (a *APIServer) GetConfig(_ context.Context, _ *api.GetConfigParams) (*api.S
 }
 
 // SendEvent forwards events sent by the runtime security module to Datadog
-func (a *APIServer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
+func (a *APIServer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() ([]string, bool), service string) {
 	backendEvent := events.BackendEvent{
 		Title: rule.Def.Description,
 		AgentContext: events.AgentContext{

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -520,17 +520,14 @@ func (e *RuleEngine) RuleMatch(ctx *eval.Context, rule *rules.Rule, event eval.E
 	// which can be modified during queuing
 	service := e.probe.GetService(ev)
 
-	var extTagsCb func() []string
+	var extTagsCb func() ([]string, bool)
 
 	if ev.ContainerContext.ContainerID != "" {
 		// copy the container ID here to avoid later data race
 		containerID := ev.ContainerContext.ContainerID
 
-		// the container tags might not be resolved yet
-		if time.Unix(0, int64(ev.ContainerContext.CreatedAt)).Add(TagMaxResolutionDelay).After(time.Now()) {
-			extTagsCb = func() []string {
-				return e.probe.GetEventTags(containerID)
-			}
+		extTagsCb = func() ([]string, bool) {
+			return e.probe.GetEventTags(containerID), true
 		}
 	}
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -88,7 +88,7 @@ func (tm *testModule) HandleEvent(event *model.Event) {
 
 func (tm *testModule) HandleCustomEvent(_ *rules.Rule, _ *events.CustomEvent) {}
 
-func (tm *testModule) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
+func (tm *testModule) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() ([]string, bool), service string) {
 	tm.eventHandlers.RLock()
 	defer tm.eventHandlers.RUnlock()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently the tagging of events based on the container ID is broken on 2 axis:
- if the event is emitted shortly after the container creation (less than 5 seconds) we don't tag it
- if the tagger doesn't immediately return tags we don't retry/wait for more

This PR fixes those 2 issues, re-using the retry mechanism used by the resolution of action reports.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->