### PR TITLE
dyninst/procmon: add a package to monitor processes

### DIFF
--- a/pkg/dyninst/actuator/process.go
+++ b/pkg/dyninst/actuator/process.go
@@ -53,6 +53,8 @@ type ProcessID struct {
 	// PID is the operating system process ID.
 	PID int32
 
+	// Service is the service name for the process.
+	Service string
 	// Realistically this should include something about the start time of
 	// the process to be robust to PID wraparound. This is less of a problem
 	// these days now that pids in linux are 32 bits, but technically it's
@@ -61,7 +63,10 @@ type ProcessID struct {
 
 // String returns a string representation of the process ID.
 func (p ProcessID) String() string {
-	return fmt.Sprintf("{PID:%d}", p.PID)
+	if p.Service == "" {
+		return fmt.Sprintf("{PID:%d}", p.PID)
+	}
+	return fmt.Sprintf("{PID:%d,Svc:%s}", p.PID, p.Service)
 }
 
 // FileHandle identifies a file on a device.

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -284,7 +284,7 @@ func (r *testReporter) ReportAttachingFailed(
 ) {
 	defer close(r.attached)
 	r.t.Fatalf(
-		"attaching failed for program %d to process %d: %v",
+		"attaching failed for program %d to process %v: %v",
 		programID, processID, err,
 	)
 }

--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -1,0 +1,182 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+	"os"
+	"path"
+	"strconv"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+// TODO: At some future point we may want to find a build ID and use that to
+// cache the properties of the binary.
+//
+// [0] https://opentelemetry.io/docs/specs/otel/profiles/mappings/#algorithm-for-processexecutablebuild_idhtlhash
+
+// analyzeProcess performs light analysis of the process and its binary
+// to determine if it's interesting, and what its executable is.
+func analyzeProcess(
+	pid uint32, procfsRoot string,
+) (processAnalysis, error) {
+	ddEnv, err := analyzeEnviron(int32(pid), procfsRoot)
+	if err != nil {
+		return processAnalysis{}, fmt.Errorf(
+			"failed to check if process %d is interesting: %w", pid, err,
+		)
+	}
+	if ddEnv.serviceName == "" || !ddEnv.diEnabled {
+		log.Tracef("process %d is not interesting: service name is %q, DD_DYNINST_ENABLED is %v", pid, ddEnv.serviceName, ddEnv.diEnabled)
+		return processAnalysis{interesting: false}, nil
+	}
+
+	exePath := path.Join(procfsRoot, strconv.Itoa(int(pid)), "exe")
+	exeLink, err := os.Readlink(exePath)
+	if err != nil {
+		return processAnalysis{}, fmt.Errorf(
+			"failed to open exe link for pid %d: %w", pid, err,
+		)
+	}
+
+	isGo, err := isGoElfBinary(exeLink)
+	if err != nil {
+		return processAnalysis{}, fmt.Errorf(
+			"failed to check if exe is go binary: %w", err,
+		)
+	}
+	if !isGo {
+		return processAnalysis{interesting: false}, nil
+	}
+
+	exe := actuator.Executable{Path: exePath}
+	st, err := os.Stat(exeLink)
+	if err != nil {
+		return processAnalysis{}, fmt.Errorf(
+			"failed to stat exe link for pid %v: %w", pid, err,
+		)
+	}
+	if st, ok := st.Sys().(*syscall.Stat_t); ok {
+		exe.Key = actuator.FileKey{
+			FileHandle: actuator.FileHandle{
+				Dev: uint64(st.Dev),
+				Ino: st.Ino,
+			},
+			FileCookie: actuator.FileCookie(st.Mtim),
+		}
+	}
+
+	return processAnalysis{
+		service:     ddEnv.serviceName,
+		exe:         exe,
+		interesting: true,
+	}, nil
+}
+
+type ddEnvVars struct {
+	serviceName string
+	diEnabled   bool
+}
+
+const ddServiceEnvVar = "DD_SERVICE"
+const ddDynInstEnabledEnvVar = "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
+
+func analyzeEnviron(pid int32, procfsRoot string) (ddEnvVars, error) {
+	procEnv := path.Join(procfsRoot, strconv.Itoa(int(pid)), "environ")
+	env, err := os.ReadFile(procEnv)
+	if err != nil {
+		return ddEnvVars{}, fmt.Errorf(
+			"failed to read proc env at %s: %w", procEnv, err,
+		)
+	}
+	var ddEnv ddEnvVars
+	for envVar, val := range envVars(env) {
+		switch envVar {
+		case ddServiceEnvVar:
+			ddEnv.serviceName = val
+		case ddDynInstEnabledEnvVar:
+			ddEnv.diEnabled, _ = strconv.ParseBool(val)
+		}
+		if ddEnv.serviceName != "" && ddEnv.diEnabled {
+			break
+		}
+	}
+	return ddEnv, nil
+}
+
+// envVars returns an iterator over the environment variables in the given
+// procfs environment file.
+func envVars(procEnviron []byte) iter.Seq2[string, string] {
+	return func(yield func(string, string) bool) {
+		cur := procEnviron
+		for len(cur) > 0 {
+			curVar := cur
+			if idx := bytes.IndexByte(cur, 0); idx != -1 {
+				curVar = cur[:idx]
+				cur = cur[idx+1:]
+			} else {
+				cur = nil
+			}
+			eqIdx := bytes.IndexByte(curVar, '=')
+			if eqIdx == -1 { // shouldn't happen, just skip it
+				continue
+			}
+			if !yield(string(curVar[:eqIdx]), string(curVar[eqIdx+1:])) {
+				return
+			}
+		}
+	}
+}
+
+var goSections = map[string]struct{}{
+	".gosymtab":     {},
+	".gopclntab":    {},
+	".go.buildinfo": {},
+}
+
+// isGoElfBinary returns true if the given executable is an ELF file that
+// contains go sections and debug info.
+//
+// In the future we may want to look and see here if there's a relevant
+// version of the trace agent that we care about, but for now we leave
+// that to later analysis of dwarf.
+func isGoElfBinary(exePath string) (bool, error) {
+	f, err := os.Open(exePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open exe: %w", err)
+	}
+	defer f.Close()
+
+	elfFile, err := safeelf.NewFile(f)
+	if err != nil {
+		log.Tracef("isGoElfBinary(%s): not an ELF file: %v", exePath, err)
+		return false, nil
+	}
+	defer elfFile.Close() // no-op, but why not
+
+	var hasDebugInfo, hasGoSections bool
+	for _, section := range elfFile.Sections {
+		if _, ok := goSections[section.Name]; ok {
+			hasGoSections = true
+		}
+		if section.Name == ".debug_info" {
+			hasDebugInfo = true
+		}
+	}
+	log.Tracef(
+		"isGoElfBinary(%s): hasGoSections: %v, hasDebugInfo: %v",
+		exePath, hasGoSections, hasDebugInfo,
+	)
+	return hasGoSections && hasDebugInfo, nil
+}

--- a/pkg/dyninst/procmon/analyze_test.go
+++ b/pkg/dyninst/procmon/analyze_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+func makeEnviron(t *testing.T, keyVals ...string) []byte {
+	require.Truef(
+		t, len(keyVals)%2 == 0,
+		"keyVals must be a multiple of 2, got %d: %v", len(keyVals), keyVals,
+	)
+	var buf bytes.Buffer
+	for i := 0; i < len(keyVals); i += 2 {
+		fmt.Fprintf(&buf, "%s=%s\x00", keyVals[i], keyVals[i+1])
+	}
+	return buf.Bytes()
+}
+
+func TestAnalyzeProcess(t *testing.T) {
+	envTrue := makeEnviron(t,
+		ddDynInstEnabledEnvVar, "true",
+		ddServiceEnvVar, "foo",
+	)
+	envFalse := makeEnviron(t,
+		"FOO", "bar",
+	)
+
+	const exeTargetName = "exe_target"
+
+	// makeProcFS creates a minimal on-disk proc-like structure under a temp dir
+	// and returns the path that should be used as procfsRoot when calling
+	// buildUpdate.
+	makeProcFS := func(
+		t *testing.T, pid uint32, env []byte, withExe bool,
+	) (
+		tmpDir string, procRoot string, cleanup func(),
+	) {
+		tmpDir = t.TempDir()
+		procRoot = filepath.Join(tmpDir, "proc")
+
+		procDir := filepath.Join(procRoot, strconv.Itoa(int(pid)))
+		require.NoError(t, os.MkdirAll(procDir, 0o755))
+
+		// /proc/<pid>/environ
+		require.NoError(t, os.WriteFile(filepath.Join(procDir, "environ"), env, 0o644))
+
+		if withExe {
+			// create a fake executable file and a symlink named "exe" pointing to it
+			exeTarget := filepath.Join(tmpDir, exeTargetName)
+			require.NoError(t, os.WriteFile(exeTarget, []byte{}, 0o755))
+			require.NoError(t, os.Symlink(exeTarget, filepath.Join(procDir, "exe")))
+		}
+
+		return tmpDir, procRoot, func() {
+			os.RemoveAll(tmpDir)
+		}
+	}
+
+	t.Run("not interesting env", func(t *testing.T) {
+		_, procRoot, cleanup := makeProcFS(t, 102, envFalse, true)
+		defer cleanup()
+		res, err := analyzeProcess(102, procRoot)
+		require.NoError(t, err)
+		require.False(t, res.interesting)
+	})
+
+	t.Run("no interesting exe", func(t *testing.T) {
+		_, procRoot, cleanup := makeProcFS(t, 101, envTrue, true)
+		defer cleanup()
+		res, err := analyzeProcess(101, procRoot)
+		require.NoError(t, err)
+		require.False(t, res.interesting)
+		require.Empty(t, res.exe)
+	})
+
+	t.Run("exe missing", func(t *testing.T) {
+		_, procRoot, cleanup := makeProcFS(t, 103, envTrue, false)
+		defer cleanup()
+		res, err := analyzeProcess(103, procRoot)
+		require.Regexp(t, "failed to open exe link for pid 103.*: no such file or directory", err)
+		require.False(t, res.interesting)
+	})
+
+	t.Run("interesting", func(t *testing.T) {
+		cfgs := testprogs.MustGetCommonConfigs(t)
+		bin := testprogs.MustGetBinary(t, "simple", cfgs[0])
+
+		tmpDir, procRoot, cleanup := makeProcFS(t, 104, envTrue, true)
+		defer cleanup()
+		exeTarget := filepath.Join(tmpDir, exeTargetName)
+		require.NoError(t, os.Remove(exeTarget), "failed to remove exe target", exeTarget)
+		{
+			f, err := os.Create(exeTarget)
+			require.NoError(t, err)
+			binReader, err := os.Open(bin)
+			require.NoError(t, err)
+			_, err = io.Copy(f, binReader)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+			require.NoError(t, binReader.Close())
+		}
+		res, err := analyzeProcess(104, procRoot)
+		require.NoError(t, err)
+		require.True(t, res.interesting)
+		require.NotEmpty(t, res.exe.Path)
+		require.Equal(t, "foo", res.service)
+	})
+}

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package procmon implements a process monitor that can be used to track
+// processes and their executables and report interesting processes to the
+// actuator.
+package procmon
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Actuator is the recipient of process updates.
+type Actuator interface {
+	HandleUpdate(update actuator.ProcessesUpdate)
+}
+
+// ProcessMonitor encapsulates the logic of processing events from an event
+// monitor and translating them into actuator.ProcessesUpdate calls to the
+// actuator.
+type ProcessMonitor struct {
+	actuator   Actuator
+	procfsRoot string
+
+	eventsCh chan event
+	doneCh   chan struct{}
+
+	wg           sync.WaitGroup
+	shutdownOnce sync.Once
+}
+
+// NewProcessMonitor creates a new ProcessMonitor that will send updates to the
+// given Actuator.
+func NewProcessMonitor(act Actuator) *ProcessMonitor {
+	return newProcessMonitor(act, kernel.ProcFSRoot())
+}
+
+// NotifyExec is a callback to notify the monitor that a process has started.
+func (pm *ProcessMonitor) NotifyExec(pid uint32) {
+	pm.sendEvent(&processEvent{kind: processEventKindExec, pid: pid})
+}
+
+// NotifyExit is a callback to notify the monitor that a process has exited.
+func (pm *ProcessMonitor) NotifyExit(pid uint32) {
+	pm.sendEvent(&processEvent{kind: processEventKindExit, pid: pid})
+}
+
+// newProcessMonitor is injectable with a fake FS for tests.
+func newProcessMonitor(act Actuator, procFS string) *ProcessMonitor {
+	pm := &ProcessMonitor{
+		actuator:   act,
+		procfsRoot: procFS,
+		eventsCh:   make(chan event, 1024),
+		doneCh:     make(chan struct{}),
+	}
+
+	pm.wg.Add(1)
+	go func() {
+		defer pm.wg.Done()
+		run(pm.eventsCh, pm.doneCh, pm)
+	}()
+
+	return pm
+}
+
+// sendEvent attempts to send an event to the state machine unless we're
+// already shutting down.
+func (pm *ProcessMonitor) sendEvent(ev event) {
+	select {
+	case <-pm.doneCh:
+	default:
+		select {
+		case pm.eventsCh <- ev:
+		case <-pm.doneCh:
+		}
+	}
+}
+
+// Close requests an orderly shutdown and waits for completion.
+func (pm *ProcessMonitor) Close() {
+	pm.shutdownOnce.Do(func() {
+		close(pm.doneCh)
+		pm.wg.Wait()
+	})
+}
+
+// analysisFailureLogLimiter is used to limit the rate of logging analysis
+// failures.
+//
+// It is set to infinite in tests.
+var analysisFailureLogLimiter = rate.NewLimiter(rate.Every(1*time.Second), 10)
+
+// analyzeProcess analyzes the process with the given PID and sends the result
+// to the state machine.
+func (pm *ProcessMonitor) analyzeProcess(pid uint32) {
+	pm.wg.Add(1)
+	go func() {
+		defer pm.wg.Done()
+		pa, err := analyzeProcess(pid, pm.procfsRoot)
+		if err != nil && analysisFailureLogLimiter.Allow() {
+			log.Infof("failed to analyze process %d: %v", pid, err)
+		}
+		pm.sendEvent(&analysisResult{
+			pid:             pid,
+			err:             err,
+			processAnalysis: pa,
+		})
+	}()
+}
+
+func (pm *ProcessMonitor) reportProcessesUpdate(u actuator.ProcessesUpdate) {
+	pm.actuator.HandleUpdate(u)
+}
+
+// Ensure ProcessMonitor implements smEffects.
+var _ effects = (*ProcessMonitor)(nil)
+
+func run(eventsCh <-chan event, doneCh <-chan struct{}, eff effects) {
+	state := newState()
+	for {
+		select {
+		case ev := <-eventsCh:
+			state.handle(ev, eff)
+		case <-doneCh:
+			return
+		}
+	}
+}

--- a/pkg/dyninst/procmon/state.go
+++ b/pkg/dyninst/procmon/state.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+)
+
+// TODO: We should add rate limiting on the actual rate at which we will
+// analyze processes and the amount of time per unit time we'll spend
+// doing it.
+
+type processEventKind uint8
+
+const (
+	processEventKindExec processEventKind = iota
+	processEventKindExit
+)
+
+type processEvent struct {
+	kind processEventKind
+	pid  uint32
+}
+
+type processAnalysis struct {
+	service     string
+	exe         actuator.Executable
+	interesting bool
+}
+
+type analysisResult struct {
+	pid uint32
+	err error
+	processAnalysis
+}
+
+type event interface{ event() }
+
+func (e *processEvent) event()   {}
+func (r *analysisResult) event() {}
+
+// effects holds the side-effects the pure state machine can trigger.
+// All its methods are synchronous from the point of view of Handle, so the
+// heavy work (analyzeProcess) should start goroutines internally.
+// None of these methods return values – new information must come back as
+// events (processResult) posted through whatever channel the effects knows.
+
+type effects interface {
+	analyzeProcess(pid uint32)
+	reportProcessesUpdate(update actuator.ProcessesUpdate)
+}
+
+type state struct {
+	alive    map[uint32]struct{}
+	queued   []uint32
+	inFlight bool
+
+	// The processes that are in the current update being built but have
+	// not yet been reported.
+	pending map[uint32]struct{}
+
+	updates  []actuator.ProcessUpdate
+	removals []actuator.ProcessID
+}
+
+func newState() *state {
+	return &state{
+		alive:   make(map[uint32]struct{}),
+		pending: make(map[uint32]struct{}),
+	}
+}
+
+func (s *state) handle(ev event, eff effects) {
+	switch e := ev.(type) {
+	case *processEvent:
+		switch e.kind {
+		case processEventKindExec:
+			if _, ok := s.alive[e.pid]; !ok {
+				s.alive[e.pid] = struct{}{}
+				s.pending[e.pid] = struct{}{}
+				s.queued = append(s.queued, e.pid)
+			}
+		case processEventKindExit:
+			if _, ok := s.alive[e.pid]; ok {
+				delete(s.alive, e.pid)
+				if _, ok := s.pending[e.pid]; !ok {
+					pid := actuator.ProcessID{PID: int32(e.pid)}
+					s.removals = append(s.removals, pid)
+				}
+			}
+		}
+	case *analysisResult:
+		s.inFlight = false
+		if e.err != nil || !e.interesting {
+			delete(s.alive, uint32(e.pid))
+		} else {
+			s.updates = append(s.updates, actuator.ProcessUpdate{
+				ProcessID: actuator.ProcessID{
+					PID:     int32(e.pid),
+					Service: e.service,
+				},
+				Executable: e.exe,
+			})
+		}
+	}
+
+	// Start the next analysis if idle.
+	for !s.inFlight && len(s.queued) > 0 {
+		pid := s.queued[0]
+		s.queued = s.queued[1:]
+		if _, ok := s.alive[pid]; ok {
+			s.inFlight = true
+			eff.analyzeProcess(pid)
+		}
+	}
+
+	shouldReport := !s.inFlight && len(s.queued) == 0 &&
+		(len(s.updates) > 0 || len(s.removals) > 0)
+	if !shouldReport {
+		return
+	}
+
+	clear(s.pending)
+
+	// Drop updates for processes that exited before we finished building.
+	isDead := func(pid uint32) bool { _, ok := s.alive[pid]; return !ok }
+	s.updates = slices.DeleteFunc(s.updates, func(u actuator.ProcessUpdate) bool {
+		return isDead(uint32(u.ProcessID.PID))
+	})
+	if len(s.updates) > 0 || len(s.removals) > 0 {
+		report := actuator.ProcessesUpdate{
+			Processes: s.updates,
+			Removals:  s.removals,
+		}
+		s.updates = nil
+		s.removals = nil
+		eff.reportProcessesUpdate(report)
+	}
+}

--- a/pkg/dyninst/procmon/state_test.go
+++ b/pkg/dyninst/procmon/state_test.go
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+)
+
+func TestStateMachine(t *testing.T) {
+	type step struct {
+		ev      event
+		analyze []uint32                  // nil if no build expected after this step
+		update  *actuator.ProcessesUpdate // nil if no update expected after this step
+	}
+
+	type opt func(*step)
+
+	upd := func(procPids ...uint32) opt {
+		return func(s *step) {
+			if s.update == nil {
+				s.update = &actuator.ProcessesUpdate{}
+			}
+			for _, pid := range procPids {
+				s.update.Processes = append(s.update.Processes, actuator.ProcessUpdate{
+					ProcessID: actuator.ProcessID{PID: int32(pid)},
+				})
+			}
+		}
+	}
+
+	rem := func(procPids ...uint32) opt {
+		return func(s *step) {
+			if s.update == nil {
+				s.update = &actuator.ProcessesUpdate{}
+			}
+			for _, pid := range procPids {
+				s.update.Removals = append(s.update.Removals, actuator.ProcessID{PID: int32(pid)})
+			}
+		}
+	}
+
+	analyze := func(procPids ...uint32) opt {
+		return func(s *step) {
+			s.analyze = append(s.analyze, procPids...)
+		}
+	}
+
+	exec := func(pid uint32) event {
+		return &processEvent{kind: processEventKindExec, pid: pid}
+	}
+	exit := func(pid uint32) event {
+		return &processEvent{kind: processEventKindExit, pid: pid}
+	}
+	res := func(pid uint32, interesting bool, err error) event {
+		return &analysisResult{
+			pid:             pid,
+			err:             err,
+			processAnalysis: processAnalysis{interesting: interesting},
+		}
+	}
+	interesting := func(pid uint32) event { return res(pid, true, nil) }
+	uninteresting := func(pid uint32) event { return res(pid, false, nil) }
+	failed := func(pid uint32, err error) event { return res(pid, false, err) }
+
+	s := func(ev event, opts ...opt) step {
+		s := step{ev: ev}
+		for _, opt := range opts {
+			opt(&s)
+		}
+		return s
+	}
+
+	tests := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "simple exec interested",
+			steps: []step{
+				s(exec(1), analyze(1)),
+				s(res(1, true, nil), upd(1)),
+			},
+		},
+		{
+			name: "exec then exit before build done",
+			steps: []step{
+				s(exec(2), analyze(2)),
+				s(exit(2)),
+				s(interesting(2)),
+			},
+		},
+		{
+			name: "exec not interesting",
+			steps: []step{
+				s(exec(3), analyze(3)),
+				s(uninteresting(3)),
+			},
+		},
+		{
+			name: "reported then removed",
+			steps: []step{
+				s(exec(4), analyze(4)),
+				s(interesting(4), upd(4)),
+				s(exit(4), rem(4)),
+			},
+		},
+		{
+			name: "queueing delays reporting",
+			steps: []step{
+				s(exec(5), analyze(5)),
+				s(exec(6)),
+				s(exec(7)),
+				s(exec(8)),
+				s(interesting(5), analyze(6)),
+				s(uninteresting(6), analyze(7)),
+				s(interesting(7), analyze(8)),
+				s(failed(8, fmt.Errorf("test error")), upd(5, 7)),
+				s(exit(6)),
+				s(exit(7), rem(7)),
+				s(exit(8)),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name != "queueing delays reporting" {
+				t.Skipf("skipping %q != %q", tc.name, "queueing delays reporting")
+			}
+			st := newState()
+			for i, s := range tc.steps {
+				if !t.Run(fmt.Sprint(i), func(t *testing.T) {
+					mock := &mockEffects{}
+					st.handle(s.ev, mock)
+					if s.update != nil {
+						require.Equal(
+							t,
+							[]actuator.ProcessesUpdate{*s.update},
+							mock.updates,
+						)
+					} else {
+						require.Empty(t, mock.updates)
+					}
+					require.Equal(t, s.analyze, mock.builds)
+				}) {
+					break
+				}
+			}
+		})
+	}
+}
+
+// It can synchronously feed processResult events back into the state machine
+// and records every ProcessesUpdate sent to the actuator.
+type mockEffects struct {
+	updates []actuator.ProcessesUpdate
+	builds  []uint32
+}
+
+func (m *mockEffects) analyzeProcess(pid uint32) {
+	m.builds = append(m.builds, pid)
+}
+
+func (m *mockEffects) reportProcessesUpdate(u actuator.ProcessesUpdate) {
+	m.updates = append(m.updates, u)
+}


### PR DESCRIPTION
### What does this PR do?

This type exports two functions which align with the callbacks to be set up with the process.Subscriber [0].

[0]: https://github.com/DataDog/datadog-agent/blob/6a5104c7/pkg/ebpf/process/monitor.go#L25-L33

https://datadoghq.atlassian.net/browse/DEBUG-4107