### PR TITLE
dyninst: create norms around setting up logging

### DIFF
--- a/pkg/dyninst/actuator/main_test.go
+++ b/pkg/dyninst/actuator/main_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package actuator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+)
+
+func TestMain(m *testing.M) {
+	dyninsttest.SetupLogging()
+	os.Exit(m.Run())
+}

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 //go:embed testdata/decoded/*.yaml
@@ -89,11 +88,6 @@ func testDyninst(
 	probes []irgen.ProbeDefinition,
 	expOut map[string]string,
 ) {
-	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(
-		os.Stderr, log.DebugLvl, "[%LEVEL] %Msg\n",
-	)
-	require.NoError(t, err)
-	log.SetupLogger(logger, "debug")
 	t.Logf("Testing with actuator")
 	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-integration-test")
 	defer cleanup()

--- a/pkg/dyninst/main_test.go
+++ b/pkg/dyninst/main_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+)
+
+func TestMain(m *testing.M) {
+	dyninsttest.SetupLogging()
+	os.Exit(m.Run())
+}

--- a/pkg/dyninst/procmon/main_test.go
+++ b/pkg/dyninst/procmon/main_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/time/rate"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+)
+
+func TestMain(m *testing.M) {
+	analysisFailureLogLimiter.SetLimit(rate.Inf)
+	dyninsttest.SetupLogging()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
The primary thing here is to set up a utility function to set up logging consistently. The intention is to call this setup function in a TestMain.

Example of the default format:
```
d 16:03:28.177952641 @actuator.go:171| event: eventProgramAttached{programID: 1, processID: {PID:113694}}
d 16:03:28.179447592 @actuator.go:144| sending update: {[] [{PID:113694}]}
d 16:03:28.179522307 @actuator.go:171| event: eventProcessesUpdated{updated: 0, removed: 1}
d 16:03:28.179627972 @actuator.go:168| Received shutdown event
```
Json format:
```
{"time":1750953833754972794,"level":"Debug","msg":"event: eventProgramAttached{programID: 1, processID: {PID:113932}}","path":"actuator/actuator.go","func":"github.com/DataDog/datadog-agent/pkg/dyninst/actuator.(*Actuator).runEventProcessor","line":171}
{"time":1750953833757064633,"level":"Debug","msg":"sending update: {[] [{PID:113932}]}","path":"actuator/actuator.go","func":"github.com/DataDog/datadog-agent/pkg/dyninst/actuator.(*Actuator).HandleUpdate","line":144}
{"time":1750953833757162786,"level":"Debug","msg":"event: eventProcessesUpdated{updated: 0, removed: 1}","path":"actuator/actuator.go","func":"github.com/DataDog/datadog-agent/pkg/dyninst/actuator.(*Actuator).runEventProcessor","line":171}
{"time":1750953833757195137,"level":"Debug","msg":"Received shutdown event","path":"actuator/actuator.go","func":"github.com/DataDog/datadog-agent/pkg/dyninst/actuator.(*Actuator).runEventProcessor","line":168}
```
Relates to https://datadoghq.atlassian.net/browse/DEBUG-4107