### PR TITLE
Enable driver verifier for Windows Agent E2E start-stop tests.

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/cenkalti/backoff"
 
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
@@ -61,6 +62,15 @@ var securityAgentConfig string
 
 //go:embed fixtures/security-agent-disabled.yaml
 var securityAgentConfigDisabled string
+
+// Folder for WER dumps.
+const werCrashDumpFolder = `C:\dumps`
+
+// Path to the system crash dump (BSOD).
+const systemCrashDumpFile = `C:\Windows\MEMORY.DMP`
+
+// The name of the downloaded system crash dump file.
+const systemCrashDumpOutFileName = `SystemCrash.DMP`
 
 // TestServiceBehaviorAgentCommandNoFIM tests the service behavior when controlled by Agent commands
 func TestNoFIMServiceBehaviorAgentCommand(t *testing.T) {
@@ -213,10 +223,18 @@ func (s *powerShellServiceCommandSuite) TestHardExitEventLogEntry() {
 		// kill the process
 		_, err = host.Execute(fmt.Sprintf("Stop-Process -Force -Id %d", pid))
 		s.Require().NoError(err, "should kill the process with PID %d", pid)
+
 		// service should stop
-		status, err := windowsCommon.GetServiceStatus(host, serviceName)
-		s.Require().NoError(err, "should get the status for %s", serviceName)
-		s.Require().Equal("Stopped", status, "%s should be stopped", serviceName)
+		s.Require().EventuallyWithT(func(c *assert.CollectT) {
+			status, err := windowsCommon.GetServiceStatus(host, serviceName)
+			if !assert.NoError(c, err) {
+				s.T().Logf("should get the status for %s", serviceName)
+				return
+			}
+			if !assert.Equal(c, "Stopped", status) {
+				s.T().Logf("waiting for %s to stop", serviceName)
+			}
+		}, 1*time.Minute, 10*time.Second, "%s should be stopped", serviceName)
 	}
 
 	// collect display names for services
@@ -240,7 +258,7 @@ func (s *powerShellServiceCommandSuite) TestHardExitEventLogEntry() {
 			})
 			assert.Len(c, matching, 1, "should have hard exit message for %s in the event log", displayName)
 		}
-	}, 1*time.Minute, 1*time.Second, "should have hard exit messages in the event log")
+	}, 3*time.Minute, 10*time.Second, "should have hard exit messages in the event log")
 }
 
 type agentServiceDisabledSuite struct {
@@ -467,23 +485,35 @@ func (s *baseStartStopSuite) SetupSuite() {
 	// SetupSuite needs to defer CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer s.CleanupOnSetupFailure()
 
+	host := s.Env().RemoteHost
+
+	// Enable driver verifier and reboot
+	out, err := windowsCommon.EnableDriverVerifier(host, s.getInstalledKernelServices())
+	if err != nil {
+		s.T().Logf("Driver verifier error output:\n%s", err)
+	}
+	if out != "" {
+		s.T().Logf("Driver verifier output:\n%s", out)
+	}
+
+	windowsCommon.RebootAndWait(host, backoff.NewConstantBackOff(10*time.Second))
+
 	// TODO(WINA-1320): mark this crash as flaky while we investigate it
 	flake.MarkOnLog(s.T(), "Exception code: 0x40000015")
 
 	// Enable crash dumps
-	s.dumpFolder = `C:\dumps`
-	err := windowsCommon.EnableWERGlobalDumps(s.Env().RemoteHost, s.dumpFolder)
+	s.dumpFolder = werCrashDumpFolder
+	err = windowsCommon.EnableWERGlobalDumps(host, s.dumpFolder)
 	s.Require().NoError(err, "should enable WER dumps")
 	env := map[string]string{
 		"GOTRACEBACK": "wer",
 	}
 	for _, svc := range s.getInstalledUserServices() {
-		err := windowsCommon.SetServiceEnvironment(s.Env().RemoteHost, svc, env)
+		err := windowsCommon.SetServiceEnvironment(host, svc, env)
 		s.Require().NoError(err, "should set environment for %s", svc)
 	}
 
 	// Disable failure actions (auto restart service) so they don't interfere with the tests
-	host := s.Env().RemoteHost
 	for _, serviceName := range s.getInstalledServices() {
 		cmd := fmt.Sprintf(`sc.exe failure "%s" reset= 0 actions= none`, serviceName)
 		_, err := host.Execute(cmd)
@@ -598,6 +628,9 @@ func (s *baseStartStopSuite) AfterTest(suiteName, testName string) {
 		// collect agent logs
 		s.collectAgentLogs()
 	}
+
+	// check if the host crashed.
+	s.Require().False(s.collectSystemCrashDump(), "should not have system crash dump")
 }
 
 func (s *baseStartStopSuite) collectAgentLogs() {
@@ -670,7 +703,7 @@ func (s *baseStartStopSuite) assertServiceState(expected string, serviceName str
 		if !assert.Equal(c, expected, status, "%s should be %s", serviceName, expected) {
 			s.T().Logf("waiting for %s to be %s, status %s", serviceName, expected, status)
 		}
-	}, 2*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
+	}, 3*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
 
 	// if a driver service failed to get to the expected state, capture a kernel dump for debugging.
 	if s.T().Failed() && slices.Contains(s.getInstalledKernelServices(), serviceName) {
@@ -713,7 +746,7 @@ func (s *baseStartStopSuite) stopAllServices() {
 				err := windowsCommon.StopService(host, serviceName)
 				assert.NoError(c, err, "should stop %s", serviceName)
 			}
-		}, 1*time.Minute, 1*time.Second, "%s should be in the expected state", serviceName)
+		}, 3*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
 	}
 }
 func (s *baseStartStopSuite) getInstalledUserServices() []string {
@@ -846,4 +879,26 @@ func (s *baseStartStopSuite) captureLiveKernelDump(host *components.RemoteHost, 
 
 	// Cleanup the "localhost" subdirectory.
 	host.RemoveAll(sourceDumpDir)
+}
+
+func (s *baseStartStopSuite) collectSystemCrashDump() bool {
+	// Look for a system crash dump. These may be triggered by Driver Verifier.
+	// Stop the test immediately if one is found.
+
+	s.T().Log("Checking for system crash dump")
+	systemCrashDumpOutPath := filepath.Join(s.SessionOutputDir(), systemCrashDumpOutFileName)
+
+	// Check if a system crash dump was already downloaded.
+	if _, err := os.Stat(systemCrashDumpOutPath); err != nil {
+		if !os.IsNotExist(err) {
+			s.T().Logf("Found existing system crash dump %s", systemCrashDumpOutPath)
+			return true
+		}
+	}
+
+	systemDump, err := windowsCommon.DownloadSystemCrashDump(
+		s.Env().RemoteHost, systemCrashDumpFile, systemCrashDumpOutPath)
+	s.Assert().NoError(err, "should download system crash dump")
+
+	return systemDump != ""
 }

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -703,7 +703,7 @@ func (s *baseStartStopSuite) assertServiceState(expected string, serviceName str
 		if !assert.Equal(c, expected, status, "%s should be %s", serviceName, expected) {
 			s.T().Logf("waiting for %s to be %s, status %s", serviceName, expected, status)
 		}
-	}, 3*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
+	}, 5*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
 
 	// if a driver service failed to get to the expected state, capture a kernel dump for debugging.
 	if s.T().Failed() && slices.Contains(s.getInstalledKernelServices(), serviceName) {
@@ -746,7 +746,7 @@ func (s *baseStartStopSuite) stopAllServices() {
 				err := windowsCommon.StopService(host, serviceName)
 				assert.NoError(c, err, "should stop %s", serviceName)
 			}
-		}, 3*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
+		}, 5*time.Minute, 10*time.Second, "%s should be in the expected state", serviceName)
 	}
 }
 func (s *baseStartStopSuite) getInstalledUserServices() []string {


### PR DESCRIPTION
### What does this PR do?
This PR enables driver verifier for the Windows Agent E2E start-stop tests. A callback after each test will check for a system crash dump on the test host (C:\Windows\MEMORY.DUMP) and download it.  The timeout for checking service status has been increased due to driver verifier potentially making the test host a little slower.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1403
This applies standardized checks on the production Datadog drivers to help catch overlooked runtime issues and help provide better diagnostics.

### Describe how you validated your changes
Created a custom ddnpm driver that is guaranteed to trigger a driver verifier bugcheck.
Created a custom Windows Agent installer that pulls this custom ddnpm driver.
Ran the start-stop tests in CI/CD, verifying for crashes and downloading of the system crash dump.

### Possible Drawbacks / Trade-offs
- The error handling of CI/CD is not consistent.  Some tests will timeout before downloading the the system crash dump.  Some tests will detect that a kernel (driver) service did not stop and will stop the test without downloading the system crash dump.  The logs will describe whether a system crash dump was found and whether timed out.
- Enabling driver verifier requires a reboot and will cause the system to be generally slower. As such, driver verifier is only enabled on a limited set of tests due to potential noise/overhead.
