### PR TITLE
Add additional e2e test cases for diskv2 configurations

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
@@ -99,11 +99,11 @@ instances:
 	}
 	p := math.Pow10(v.metricCompareDecimals)
 	for _, testCase := range testCases {
-		v.Run(testCase.name, func() {
-			if testCase.onlyLinux && v.descriptor.Family() == e2eos.WindowsFamily {
-				continue
-			}
+		if testCase.onlyLinux && v.descriptor.Family() == e2eos.WindowsFamily {
+			continue
+		}
 
+		v.Run(testCase.name, func() {
 			v.T().Log("run the disk check using old version")
 			pythonMetrics := v.runDiskCheck(testCase.agentConfig, testCase.checkConfig, false)
 			v.T().Log("run the disk check using new version")

--- a/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
@@ -45,6 +45,7 @@ func (v *diskCheckSuite) TestCheckDisk() {
 		name        string
 		checkConfig string
 		agentConfig string
+		onlyLinux   bool
 	}{
 		{
 			"default",
@@ -53,11 +54,56 @@ instances:
   - use_mount: false
 `,
 			``,
+			false,
+		},
+		{
+			"all partitions",
+			`init_config:
+instances:
+  - use_mount: true
+    all_partitions: true
+`,
+			``,
+			false,
+		},
+		{
+			"tag by filesystem",
+			`init_config:
+instances:
+  - use_mount: false
+    tag_by_filesystem: true
+`,
+			``,
+			false,
+		},
+		{
+			"do not tag by label",
+			`init_config:
+instances:
+  - use_mount: false
+    tag_by_label: false
+`,
+			``,
+			true,
+		},
+		{
+			"use lsblk",
+			`init_config:
+instances:
+  - use_mount: false
+    use_lsblk: true
+`,
+			``,
+			true,
 		},
 	}
 	p := math.Pow10(v.metricCompareDecimals)
 	for _, testCase := range testCases {
 		v.Run(testCase.name, func() {
+			if testCase.onlyLinux && v.descriptor.Family() == e2eos.WindowsFamily {
+				continue
+			}
+
 			v.T().Log("run the disk check using old version")
 			pythonMetrics := v.runDiskCheck(testCase.agentConfig, testCase.checkConfig, false)
 			v.T().Log("run the disk check using new version")

--- a/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
@@ -99,7 +99,7 @@ instances:
 	}
 	p := math.Pow10(v.metricCompareDecimals)
 	for _, testCase := range testCases {
-		if testCase.onlyLinux && v.descriptor.Family() == e2eos.WindowsFamily {
+		if testCase.onlyLinux && v.descriptor.Family() != e2eos.LinuxFamily {
 			continue
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds additional test cases for different configuration settings for the diskv2 check to confirm behavior with the python check as we work through the migration.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->