### PR TITLE
[QG] Make sure cws instrumentation warns based on the configured timeout

### DIFF
--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -426,7 +426,9 @@ func (ci *CWSInstrumentation) resolveNodeArch(nodeName string, apiClient kuberne
 
 	if out == nil {
 		// try by querying the api directly
-		node, err := apiClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		ctx, cancel := context.WithTimeout(context.Background(), ci.timeout)
+		defer cancel()
+		node, err := apiClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return "", fmt.Errorf("couldn't describe node %s from the API server: %v", nodeName, err)
 		}
@@ -468,7 +470,9 @@ func (ci *CWSInstrumentation) hasReadonlyRootfs(pod *corev1.Pod, container strin
 
 func (ci *CWSInstrumentation) getPod(apiClient kubernetes.Interface, name string, ns string) (*corev1.Pod, error) {
 	start := time.Now()
-	pod, err := apiClient.CoreV1().Pods(ns).Get(context.Background(), name, metav1.GetOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), ci.timeout)
+	defer cancel()
+	pod, err := apiClient.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
 	// measure execution time
 	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), ci.mode.String(), webhookForCommandsName, "query_pod", strconv.FormatBool(err == nil), "")
 	return pod, err
@@ -661,9 +665,11 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 }
 
 func (ci *CWSInstrumentation) injectCWSCommandInstrumentationRemoteCopy(pod *corev1.Pod, container string, cwsInstrumentationLocalPath, cwsInstrumentationRemotePath string) error {
-	apiclient, err := apiserverUtils.WaitForAPIClient(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), ci.timeout)
+	defer cancel()
+	apiclient, err := apiserverUtils.WaitForAPIClient(ctx)
 	if err != nil {
-		return fmt.Errorf("couldn't initialize API client")
+		return fmt.Errorf("couldn't initialize API client: %v", err)
 	}
 
 	cp := k8scp.NewCopy(apiclient)

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -478,7 +478,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentationMeasured(exec *core
 	start := time.Now()
 	injected, err := ci.injectCWSCommandInstrumentation(exec, name, ns, userInfo, apiClient)
 	totalTime := time.Since(start).Seconds()
-	if totalTime > 10 {
+	if totalTime > ci.timeout.Seconds() {
 		log.Warnf("Pod exec request to %s/%s (container %s) by %s timed out after %f seconds", ns, name, exec.Container, userInfo.Username, totalTime)
 	}
 	metrics.CWSResponseDuration.Observe(totalTime, ci.mode.String(), webhookForCommandsName, "total", strconv.FormatBool(err == nil), strconv.FormatBool(injected))

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp/cp.go
@@ -57,13 +57,13 @@ func (o *Copy) prepareCommand(destFile string) []string {
 // CopyToPod copies the provided local file to the provided container while observing the execution time
 func (o *Copy) CopyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, mode string, webhookName string, timeout time.Duration) error {
 	start := time.Now()
-	err := o.copyToPod(localFile, remoteFile, pod, container, timeout)
+	err := o.copyToPod(localFile, remoteFile, pod, container, mode, webhookName, timeout)
 	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), mode, webhookName, "copy_to_pod", strconv.FormatBool(err == nil), "")
 	return err
 }
 
 // copyToPod copies the provided local file to the provided container
-func (o *Copy) copyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
+func (o *Copy) copyToPod(localFile string, remoteFile string, pod *corev1.Pod, container string, mode string, webhookName string, timeout time.Duration) error {
 	o.Container = container
 	localFile = path.Clean(localFile)
 	remoteFile = path.Clean(remoteFile)
@@ -74,9 +74,16 @@ func (o *Copy) copyToPod(localFile string, remoteFile string, pod *corev1.Pod, c
 	}
 
 	reader, writer := io.Pipe()
-	defer reader.Close()
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
 	tarErrChan := make(chan error, 1)
 	go func(src, dest string, writer io.WriteCloser) {
+		tarStart := time.Now()
+		defer func() {
+			metrics.CWSResponseDuration.Observe(time.Since(tarStart).Seconds(), mode, webhookName, "copy_to_pod_tar", "true", "")
+		}()
 		if err := makeTar(src, dest, writer); err != nil {
 			_ = writer.Close()
 			tarErrChan <- fmt.Errorf("failed to tar local file: %v", err)
@@ -98,9 +105,12 @@ func (o *Copy) copyToPod(localFile string, remoteFile string, pod *corev1.Pod, c
 		Stdin: true,
 	}
 
-	if err := o.Execute(pod, o.prepareCommand(remoteFile), streamOptions, timeout); err != nil {
-		return err
+	start := time.Now()
+	if err := o.Execute(pod, o.prepareCommand(remoteFile), streamOptions, mode, webhookName, timeout); err != nil {
+		metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), mode, webhookName, "copy_to_pod_cmd_execute", "false", "")
+		return fmt.Errorf("command execute error (in %s): %v", time.Since(start), err)
 	}
+	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), mode, webhookName, "copy_to_pod_cmd_execute", "true", "")
 
 	// close pipe, wait for tar chan to finish and check tar error
 	tarErr := <-tarErrChan

--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec/health_command.go
@@ -47,12 +47,12 @@ func (hc *HealthCommand) prepareCommand(destFile string) []string {
 // Run runs the cws-instrumentation health command
 func (hc *HealthCommand) Run(remoteFile string, pod *corev1.Pod, container string, mode string, webhookName string, timeout time.Duration) error {
 	start := time.Now()
-	err := hc.run(remoteFile, pod, container, timeout)
+	err := hc.run(remoteFile, pod, container, mode, webhookName, timeout)
 	metrics.CWSResponseDuration.Observe(time.Since(start).Seconds(), mode, webhookName, "health_command", strconv.FormatBool(err == nil), "")
 	return err
 }
 
-func (hc *HealthCommand) run(remoteFile string, pod *corev1.Pod, container string, timeout time.Duration) error {
+func (hc *HealthCommand) run(remoteFile string, pod *corev1.Pod, container string, mode string, webhookName string, timeout time.Duration) error {
 	hc.Container = container
 
 	streamOptions := StreamOptions{
@@ -63,7 +63,7 @@ func (hc *HealthCommand) run(remoteFile string, pod *corev1.Pod, container strin
 		Stdin: false,
 	}
 
-	if err := hc.Execute(pod, hc.prepareCommand(remoteFile), streamOptions, timeout); err != nil {
+	if err := hc.Execute(pod, hc.prepareCommand(remoteFile), streamOptions, mode, webhookName, timeout); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes sure we use the configured timeout to decide when to produce a warning on timed out requests.

### Motivation

Better monitoring and visibility into what's happening.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->