### PR TITLE
[AGENTRUN-508] Allow to provide dynamic Status Providers

### DIFF
--- a/comp/core/status/component.go
+++ b/comp/core/status/component.go
@@ -82,3 +82,33 @@ func NewHeaderInformationProvider(provider HeaderProvider) HeaderInformationProv
 		Provider: provider,
 	}
 }
+
+// DynamicInformationProvider stores dynamic Providers getter
+type DynamicInformationProvider struct {
+	fx.Out
+
+	Getter func() []Provider `group:"dyn_status"`
+}
+
+// DynamicHeaderInformationProvider stores dynamic HeaderProvider getter
+type DynamicHeaderInformationProvider struct {
+	fx.Out
+
+	Getter func() []HeaderProvider `group:"dyn_header_status"`
+}
+
+// NewDynamicInformationProvider returns a new DynamicInformationProvider to be called when generating the agent status
+// It allows to dynamically add Providers to the status component
+func NewDynamicInformationProvider(getter func() []Provider) DynamicInformationProvider {
+	return DynamicInformationProvider{
+		Getter: getter,
+	}
+}
+
+// NewDynamicHeaderInformationProvider returns a new DynamicHeaderInformationProvider to be called when generating the agent status
+// It allows to dynamically add HeaderProviders to the status component
+func NewDynamicHeaderInformationProvider(getter func() []HeaderProvider) DynamicHeaderInformationProvider {
+	return DynamicHeaderInformationProvider{
+		Getter: getter,
+	}
+}

--- a/comp/core/status/statusimpl/status.go
+++ b/comp/core/status/statusimpl/status.go
@@ -73,10 +73,10 @@ func newStatus(deps dependencies) provides {
 	providers := newProviderGetter(
 		deps.Log,
 		newCommonHeaderProvider(deps.Params, deps.Config),
-		deps.HeaderProviders,
-		deps.Providers,
-		deps.DynamicHeaderProviders,
-		deps.DynamicProviders,
+		fxutil.GetAndFilterGroup(deps.HeaderProviders),
+		fxutil.GetAndFilterGroup(deps.Providers),
+		fxutil.GetAndFilterGroup(deps.DynamicHeaderProviders),
+		fxutil.GetAndFilterGroup(deps.DynamicProviders),
 	)
 
 	c := &statusImplementation{

--- a/comp/core/status/statusimpl/status_provider_manager.go
+++ b/comp/core/status/statusimpl/status_provider_manager.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package statusimpl implements the status component interface
+package statusimpl
+
+import (
+	"hash/fnv"
+	"sort"
+	"strings"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// statusProviderManager is a manager for status providers.
+// It handles both static and dynamic providers, sorting them and caching the results.
+// Change detection for dynamic providers are based on header indexes and provider names.
+type statusProviderManager struct {
+	log log.Component
+
+	// Static providers
+	commonHeaderProvider status.HeaderProvider
+	headerProviders      []status.HeaderProvider
+	statusProviders      []status.Provider
+
+	// Dynamic providers
+	headerProvidersGetters []func() []status.HeaderProvider
+	providersGetters       []func() []status.Provider
+
+	// internal cache
+	_sortedSectionNames       []string
+	_sortedHeaderProviders    []status.HeaderProvider
+	_sortedProvidersBySection map[string][]status.Provider
+
+	// last dynamic providers hash
+	_lastDynamicProvidersHash uint64
+}
+
+func newProviderGetter(
+	log log.Component,
+	commonHeaderProvider status.HeaderProvider,
+	headerProviders []status.HeaderProvider,
+	statusProviders []status.Provider,
+	headerProvidersGetters []func() []status.HeaderProvider,
+	providersGetters []func() []status.Provider,
+) statusProviderManager {
+	providerGetter := statusProviderManager{
+		log:                    log,
+		commonHeaderProvider:   commonHeaderProvider,
+		headerProviders:        headerProviders,
+		statusProviders:        statusProviders,
+		headerProvidersGetters: headerProvidersGetters,
+		providersGetters:       providersGetters,
+	}
+
+	// Initialize the internal cache
+	providerGetter.sortProviders(true)
+
+	return providerGetter
+}
+
+// sortProviders sorts and caches the status and header providers managed by the statusProviderManager.
+// It determines whether a resort is necessary based on the presence of dynamic providers or a change
+// in the set of dynamic providers, detected via a hash of their names and sections. If no changes are
+// detected and resorting is not forced, the cached sorted providers are reused. Otherwise, it performs
+// the following steps:
+//   - Computes a hash of the current dynamic providers to detect changes.
+//   - Sorts section names alphabetically, ensuring the "collector" section appears first if present.
+//   - Sorts providers within each section alphabetically by name.
+//   - Sorts header providers by their index, ensuring the common header provider appears first.
+//   - Updates the internal cache with the newly sorted providers and section names.
+//
+// The function is optimized to avoid unnecessary sorting and supports both static and dynamic providers.
+func (p *statusProviderManager) sortProviders(forceResort bool) {
+	// If we are not forcing a resort and there is no dynamic providers,
+	// we can return the cached sorted providers
+	if !forceResort && len(p.providersGetters) == 0 && len(p.headerProvidersGetters) == 0 {
+		p.log.Debug("No dynamic providers found, returning cached sorted providers")
+		return
+	}
+
+	// Checking if the dynamic providers have changed by computing a hash of the providers
+	// by iteratevely computing fnv hash of the provider names and sections
+	hasher := fnv.New64a()
+
+	for _, getter := range p.headerProvidersGetters {
+		for _, provider := range getter() {
+			hasher.Write([]byte{byte(provider.Index())})
+			hasher.Write([]byte(provider.Name()))
+		}
+	}
+	for _, getter := range p.providersGetters {
+		for _, provider := range getter() {
+			hasher.Write([]byte(provider.Name()))
+		}
+	}
+
+	// compare the hash of the current providers with the last one
+	currentDynamicProvidersHash := hasher.Sum64()
+	if p._lastDynamicProvidersHash == currentDynamicProvidersHash {
+		// If the hash is the same, we can return the cached sorted providers
+		p.log.Debugf("Dynamic providers have not changed (%v == %v), returning cached sorted providers", currentDynamicProvidersHash, p._lastDynamicProvidersHash)
+		return
+	}
+	p.log.Debugf("Dynamic providers have changed (%v != %v), resorting providers", currentDynamicProvidersHash, p._lastDynamicProvidersHash)
+	// If the hash is different, we need to re-sort the providers
+	p._lastDynamicProvidersHash = currentDynamicProvidersHash
+
+	// Sections are sorted by name
+	// The exception is the collector section. We want that to be the first section to be displayed
+	// We manually insert the collector section in the first place after sorting them alphabetically
+	sortedSectionNames := []string{}
+	collectorSectionPresent := false
+
+	// Get all providers from the static and dynamic providers
+	providers := fxutil.GetAndFilterGroup(p.statusProviders)
+	for _, getter := range p.providersGetters {
+		providers = append(providers, fxutil.GetAndFilterGroup(getter())...)
+	}
+
+	for _, provider := range providers {
+		if provider.Section() == status.CollectorSection && !collectorSectionPresent {
+			collectorSectionPresent = true
+		}
+
+		if !present(provider.Section(), sortedSectionNames) && provider.Section() != status.CollectorSection {
+			sortedSectionNames = append(sortedSectionNames, strings.ToLower(provider.Section()))
+		}
+	}
+
+	sort.Strings(sortedSectionNames)
+
+	if collectorSectionPresent {
+		sortedSectionNames = append([]string{status.CollectorSection}, sortedSectionNames...)
+	}
+
+	// Providers of each section are sort alphabetically by name
+	// Section names are stored lower case
+	sortedProvidersBySection := map[string][]status.Provider{}
+	for _, provider := range providers {
+		lowerSectionName := strings.ToLower(provider.Section())
+		providers := sortedProvidersBySection[lowerSectionName]
+		sortedProvidersBySection[lowerSectionName] = append(providers, provider)
+	}
+	for section, providers := range sortedProvidersBySection {
+		sortedProvidersBySection[section] = sortByName(providers)
+	}
+
+	// Header providers are sorted by index
+	// We manually insert the common header provider in the first place after sorting is done
+	sortedHeaderProviders := fxutil.GetAndFilterGroup(p.headerProviders)
+	for _, getter := range p.headerProvidersGetters {
+		sortedHeaderProviders = append(sortedHeaderProviders, fxutil.GetAndFilterGroup(getter())...)
+	}
+
+	sort.SliceStable(sortedHeaderProviders, func(i, j int) bool {
+		return sortedHeaderProviders[i].Index() < sortedHeaderProviders[j].Index()
+	})
+
+	sortedHeaderProviders = append([]status.HeaderProvider{p.commonHeaderProvider}, sortedHeaderProviders...)
+
+	// Update the internal cache with the sorted providers
+	p._sortedSectionNames = sortedSectionNames
+	p._sortedProvidersBySection = sortedProvidersBySection
+	p._sortedHeaderProviders = sortedHeaderProviders
+}
+
+func sortByName(providers []status.Provider) []status.Provider {
+	sort.SliceStable(providers, func(i, j int) bool {
+		return providers[i].Name() < providers[j].Name()
+	})
+
+	return providers
+}
+
+// SortedProviders returns the sorted providers by section.
+func (p *statusProviderManager) SortedHeaderProviders() []status.HeaderProvider {
+	p.sortProviders(false)
+	return p._sortedHeaderProviders
+}
+
+// SortedSectionNames returns the sorted section names.
+func (p *statusProviderManager) SortedSectionNames() []string {
+	p.sortProviders(false)
+	return p._sortedSectionNames
+}
+
+// SortedProvidersBySection returns the sorted providers by section.
+func (p *statusProviderManager) SortedProvidersBySection() map[string][]status.Provider {
+	p.sortProviders(false)
+	return p._sortedProvidersBySection
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR enables components to provide dynamic Status and Header providers, allowing the Agent to include status sections whose set of providers can change at runtime. This is achieved by introducing new types (`DynamicInformationProvider`, `DynamicHeaderInformationProvider`) and refactoring the internal status management logic to support both static and dynamic providers efficiently.

### Motivation
The motivation is to allow subAgents (such as those registered via the RemoteAgentRegistry) to provide their own status sections dynamically, without altering the existing output order of the `status` command. This flexibility is required to support forwardable and runtime-driven status sections from remote subAgents or other dynamic sources.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- Added unit tests (`TestProviderGetterCaching`) to ensure dynamic providers are handled correctly, including:
  - Dynamic addition of providers updates the status output as expected.
  - Sorting and output order are preserved.
  - The cache prevents unnecessary recomputation when providers have not changed.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- The status output order is preserved by a caching mechanism that avoids unnecessary sorting unless the set of dynamic providers changes.
- The new mechanism is backward-compatible with existing static status providers.
- This approach ensures extensibility for future remote/dynamic status sections with minimal impact on core logic and performance.