### PR TITLE
UnmarshalKey handles complex map types and errors better

### DIFF
--- a/pkg/config/nodetreemodel/inner_node.go
+++ b/pkg/config/nodetreemodel/inner_node.go
@@ -70,7 +70,10 @@ func (n *innerNode) Merge(src InnerNode) error {
 			dstLeaf, dstIsLeaf := dstChild.(LeafNode)
 			srcLeaf, srcIsLeaf := srcChild.(LeafNode)
 			if srcIsLeaf != dstIsLeaf {
-				return fmt.Errorf("tree conflict, can't merge inner and leaf nodes for '%s'", name)
+				// Ignore the source (incoming) node and keep the destination (current) node
+				// TODO: Improve error handling in a follow-up PR. We should collect errors
+				// and log.Error them, but not break functionality in doing so
+				continue
 			}
 
 			if srcIsLeaf {

--- a/pkg/config/nodetreemodel/inner_node_test.go
+++ b/pkg/config/nodetreemodel/inner_node_test.go
@@ -133,11 +133,9 @@ func TestMergeErrorLeafToNode(t *testing.T) {
 
 	// checking leaf to node
 	err = base.Merge(overwrite)
-	require.Error(t, err)
-	assert.Equal(t, "tree conflict, can't merge inner and leaf nodes for 'a'", err.Error())
+	require.NoError(t, err)
 
 	// checking node to leaf
 	err = overwrite.Merge(base)
-	require.Error(t, err)
-	assert.Equal(t, "tree conflict, can't merge inner and leaf nodes for 'a'", err.Error())
+	require.NoError(t, err)
 }

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -117,7 +117,7 @@ func toMapStringInterface(data any, path string) (map[string]interface{}, error)
 		}
 		return convert, nil
 	}
-	return nil, fmt.Errorf("invalid type from configuration for key '%s'", path)
+	return nil, fmt.Errorf("invalid type from configuration for key '%s': %v", path, v)
 }
 
 // loadYamlInto traverses input data parsed from YAML, checking if each node is defined by the schema.
@@ -164,6 +164,10 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 		childValue, err := toMapStringInterface(value, currPath)
 		if err != nil {
 			warnings = append(warnings, err)
+			// Insert child node here as a leaf. It has the wrong type, but this maintains better
+			// compatibility with how viper works.
+			dest.InsertChildNode(key, newLeafNode(value, source))
+			continue
 		}
 
 		if !dest.HasChild(key) {

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -238,17 +238,31 @@ c: 1234
 	c := cfg.(*ntmConfig)
 
 	require.Len(t, c.warnings, 1)
-	assert.Equal(t, errors.New("invalid type from configuration for key 'c'"), c.warnings[0])
+	assert.Equal(t, errors.New("invalid type from configuration for key 'c': 1234"), c.warnings[0])
 
-	expected := &innerNode{
-		children: map[string]Node{
-			"a": &leafNodeImpl{val: "orange", source: model.SourceFile},
-			"c": &innerNode{
-				children: map[string]Node{},
-			},
-		},
-	}
-	assert.Equal(t, expected, c.file)
+	// The file node with "1234" still exists, but it was not merged because it didn't match
+	// the schema layer.
+	expected := `tree(#ptr<000000>) source=root
+> a
+    leaf(#ptr<000001>), val:"orange", source:file
+> c
+  inner(#ptr<000002>)
+  > d
+      leaf(#ptr<000003>), val:true, source:default
+tree(#ptr<000004>) source=default
+> a
+    leaf(#ptr<000005>), val:"apple", source:default
+> c
+  inner(#ptr<000006>)
+  > d
+      leaf(#ptr<000007>), val:true, source:default
+tree(#ptr<000008>) source=environment-variable
+tree(#ptr<000009>) source=file
+> a
+    leaf(#ptr<000010>), val:"orange", source:file
+> c
+    leaf(#ptr<000011>), val:1234, source:file`
+	assert.Equal(t, expected, c.Stringify("all", model.OmitPointerAddr))
 }
 
 func TestToMapStringInterface(t *testing.T) {

--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package structure
 
 import (

--- a/pkg/config/structure/compatibility_test.go
+++ b/pkg/config/structure/compatibility_test.go
@@ -1,0 +1,114 @@
+package structure
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+)
+
+func constructBothConfigs(content string, dynamicSchema bool, setupFunc func(model.Setup)) (model.Config, model.Config) {
+	viperConf := viperconfig.NewViperConfig("datadog", "DD", strings.NewReplacer(".", "_"))    // nolint: forbidigo // legit use case
+	ntmConf := nodetreemodel.NewNodeTreeConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+
+	if dynamicSchema {
+		viperConf.SetTestOnlyDynamicSchema(true)
+		ntmConf.SetTestOnlyDynamicSchema(true)
+	}
+	if setupFunc != nil {
+		setupFunc(viperConf)
+		setupFunc(ntmConf)
+	}
+
+	viperConf.BuildSchema()
+	ntmConf.BuildSchema()
+
+	if len(content) > 0 {
+		viperConf.SetConfigType("yaml")
+		viperConf.ReadConfig(bytes.NewBuffer([]byte(content)))
+
+		ntmConf.SetConfigType("yaml")
+		ntmConf.ReadConfig(bytes.NewBuffer([]byte(content)))
+	}
+
+	return viperConf, ntmConf
+}
+
+func TestCompareWrongType(t *testing.T) {
+	dataYaml := `
+network_devices:
+  autodiscovery:
+    workers:
+      - 10
+        11
+        12
+`
+	viperConf, ntmConf := constructBothConfigs(dataYaml, false, func(cfg model.Setup) {
+		cfg.SetKnown("network_devices.autodiscovery.workers")
+		cfg.SetDefault("network_devices.autodiscovery.workers", 5)
+	})
+
+	type simpleConfig struct {
+		Workers int `mapstructure:"workers"`
+	}
+	cfg := simpleConfig{}
+
+	// unable to cast []int to int
+	num := viperConf.GetInt("network_devices.autodiscovery.workers")
+	assert.Equal(t, 0, num)
+
+	// unable to cast []int to int
+	num = ntmConf.GetInt("network_devices.autodiscovery.workers")
+	assert.Equal(t, 0, num)
+
+	err := viperConf.UnmarshalKey("network_devices.autodiscovery", &cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, cfg.Workers)
+
+	// NOTE: Behavior difference! UnmarshalKey will fail here because a leaf node will fail to convert
+	err = unmarshalKeyReflection(ntmConf, "network_devices.autodiscovery", &cfg)
+	assert.Error(t, err)
+}
+
+func TestCompareParseError(t *testing.T) {
+	dataYaml := `
+network_devices:
+  autodiscovery:
+    - workers: 10
+`
+	viperConf, ntmConf := constructBothConfigs(dataYaml, false, func(cfg model.Setup) {
+		cfg.SetKnown("network_devices.autodiscovery.workers")
+	})
+
+	warnings := viperConf.Warnings()
+	assert.Nil(t, warnings)
+
+	// NOTE: An additional warning is created here because the config has an error
+	warnings = ntmConf.Warnings()
+	assert.Equal(t, 1, len(warnings.Errors))
+
+	type simpleConfig struct {
+		Workers int `mapstructure:"workers"`
+	}
+	cfg := simpleConfig{}
+
+	val := viperConf.Get("network_devices.autodiscovery")
+	assert.NotNil(t, val)
+
+	val = ntmConf.Get("network_devices.autodiscovery")
+	assert.NotNil(t, val)
+
+	err := viperConf.UnmarshalKey("network_devices.autodiscovery", &cfg)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "'' expected a map, got 'slice'")
+
+	// NOTE: Error message differs, but that is an acceptable difference
+	err = unmarshalKeyReflection(ntmConf, "network_devices.autodiscovery", &cfg)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "can't GetChild(workers) of a leaf node")
+}

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1
+	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/spf13/cast v1.9.2
 	github.com/stretchr/testify v1.10.0
@@ -16,7 +17,6 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -295,7 +295,13 @@ func copyMap(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 			} else if bval, err := cast.ToBoolE(scalar.Get()); vtype == reflect.TypeOf(true) && err == nil {
 				results.SetMapIndex(reflect.ValueOf(mkey), reflect.ValueOf(bval))
 			} else {
-				return fmt.Errorf("only map[string]string and map[string]bool supported currently")
+				elem := reflect.New(vtype).Elem()
+				nextPath := append(currPath, mkey)
+				err := copyAny(elem, child, nextPath, fs)
+				if err != nil {
+					return err
+				}
+				results.SetMapIndex(reflect.ValueOf(mkey), elem)
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Improves UnmarshalKey for nodetreemodel in two ways:
1) Allows complex map types (such as `map[string][]innerConfig`) in fields that get unmarshaled to
2) Handles parsing errors more like how viper does, to improve compatibility

When run with `DD_CONF_NODETREEMODEL=true` this fixes the unit tests in `pkg/snmp` and `pkg/snmp/snmpparse`.

### Motivation

Fixing tests for nodetreemodel

### Describe how you validated your changes

Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
