### PR TITLE
[CWS] Split Kind e2e tests into Helm and Operator tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -589,7 +589,8 @@ new-e2e-cws:
       - EXTRA_PARAMS: --run TestAgentSuiteEC2
       - EXTRA_PARAMS: --run TestAgentSuiteGCP
       - EXTRA_PARAMS: --run TestECSFargate
-      - EXTRA_PARAMS: --run TestKindSuite
+      - EXTRA_PARAMS: --run TestKindHelmSuite
+      - EXTRA_PARAMS: --run TestKindOperatorSuite
       - EXTRA_PARAMS: --run TestAgentWindowsSuite
   # Temporary, remove once we made sure the recent changes have no impact on the stability of these tests
   # NOTE: Do not remove this from e2e fips pipeline before remote config is available with fips, you can re-enable on fips pipeline when this test does not rely on remote-configuration

--- a/test/new-e2e/tests/cws/kind_helm_test.go
+++ b/test/new-e2e/tests/cws/kind_helm_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	scenkind "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	awskubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/google/uuid"
+)
+
+// Depending on the pulumi version used to run these tests, the following values may not be properly merged with the default values defined in the test-infra-definitions repository.
+// This PR https://github.com/pulumi/pulumi-kubernetes/pull/2963 should fix this issue upstream.
+const valuesFmt = `
+datadog:
+  envDict:
+    DD_HOSTNAME: "%s"
+  securityAgent:
+    runtime:
+      enabled: true
+      useSecruntimeTrack: false
+agents:
+  volumes:
+    - name: host-root-proc
+      hostPath:
+        path: /host/proc
+  volumeMounts:
+    - name: host-root-proc
+      mountPath: /host/root/proc
+  containers:
+    systemProbe:
+      env:
+        - name: HOST_PROC
+          value: "/host/root/proc"
+`
+
+func TestKindHelmSuite(t *testing.T) {
+	osDesc, err := platforms.BuildOSDescriptor(fmt.Sprintf("%s/%s/%s", osPlatform, osArch, osVersion))
+	if err != nil {
+		t.Fatalf("failed to build os descriptor: %v", err)
+	}
+
+	ddHostname := fmt.Sprintf("%s-%s", k8sHostnamePrefix, uuid.NewString()[:4])
+	values := fmt.Sprintf(valuesFmt, ddHostname)
+	t.Logf("Running testsuite with DD_HOSTNAME=%s", ddHostname)
+	e2e.Run(t, &kindSuite{ddHostname: ddHostname},
+		e2e.WithProvisioner(
+			awskubernetes.Provisioner(
+				awskubernetes.WithRunOptions(
+					scenkind.WithVMOptions(
+						ec2.WithOS(osDesc),
+					),
+					scenkind.WithoutFakeIntake(),
+					scenkind.WithAgentOptions(
+						kubernetesagentparams.WithHelmValues(values),
+					),
+				),
+			),
+		),
+	)
+}

--- a/test/new-e2e/tests/cws/kind_operator_test.go
+++ b/test/new-e2e/tests/cws/kind_operator_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentwithoperatorparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	scenkind "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	awskubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
+	"github.com/google/uuid"
+)
+
+func TestKindOperatorSuite(t *testing.T) {
+	osDesc, err := platforms.BuildOSDescriptor(fmt.Sprintf("%s/%s/%s", osPlatform, osArch, osVersion))
+	if err != nil {
+		t.Fatalf("failed to build os descriptor: %v", err)
+	}
+
+	ddHostname := fmt.Sprintf("%s-%s", k8sHostnamePrefix, uuid.NewString()[:4])
+	customDDA := agentwithoperatorparams.DDAConfig{
+		Name: "cws-enabled",
+		YamlConfig: fmt.Sprintf(`
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+spec:
+  global:
+    kubelet:
+      tlsVerify: false
+  override:
+    nodeAgent:
+      env:
+      - name: DD_HOSTNAME
+        value: %s
+  features:
+    cws:
+      enabled: true
+`, ddHostname),
+	}
+
+	e2e.Run(t, &kindSuite{}, e2e.WithProvisioner(
+		awskubernetes.Provisioner(
+			awskubernetes.WithRunOptions(
+				scenkind.WithVMOptions(
+					ec2.WithOS(osDesc),
+				),
+				scenkind.WithoutFakeIntake(),
+				scenkind.WithDeployOperator(),
+				scenkind.WithOperatorDDAOptions([]agentwithoperatorparams.Option{
+					agentwithoperatorparams.WithDDAConfig(customDDA),
+				}...),
+			),
+		),
+	))
+}

--- a/test/new-e2e/tests/cws/kind_test.go
+++ b/test/new-e2e/tests/cws/kind_test.go
@@ -6,19 +6,10 @@
 package cws
 
 import (
-	"fmt"
-	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
-
-	scenkind "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
-	awskubernetes "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/platforms"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/cws/api"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -32,61 +23,10 @@ const (
 	osVersion         = "22-04"
 )
 
-// Depending on the pulumi version used to run these tests, the following values may not be properly merged with the default values defined in the test-infra-definitions repository.
-// This PR https://github.com/pulumi/pulumi-kubernetes/pull/2963 should fix this issue upstream.
-const valuesFmt = `
-datadog:
-  envDict:
-    DD_HOSTNAME: "%s"
-  securityAgent:
-    runtime:
-      enabled: true
-      useSecruntimeTrack: false
-agents:
-  volumes:
-    - name: host-root-proc
-      hostPath:
-        path: /host/proc
-  volumeMounts:
-    - name: host-root-proc
-      mountPath: /host/root/proc
-  containers:
-    systemProbe:
-      env:
-        - name: HOST_PROC
-          value: "/host/root/proc"
-`
-
 type kindSuite struct {
 	e2e.BaseSuite[environments.Kubernetes]
 	apiClient  *api.Client
 	ddHostname string
-}
-
-func TestKindSuite(t *testing.T) {
-	osDesc, err := platforms.BuildOSDescriptor(fmt.Sprintf("%s/%s/%s", osPlatform, osArch, osVersion))
-	if err != nil {
-		t.Fatalf("failed to build os descriptor: %v", err)
-	}
-
-	ddHostname := fmt.Sprintf("%s-%s", k8sHostnamePrefix, uuid.NewString()[:4])
-	values := fmt.Sprintf(valuesFmt, ddHostname)
-	t.Logf("Running testsuite with DD_HOSTNAME=%s", ddHostname)
-	e2e.Run(t, &kindSuite{ddHostname: ddHostname},
-		e2e.WithProvisioner(
-			awskubernetes.Provisioner(
-				awskubernetes.WithRunOptions(
-					scenkind.WithVMOptions(
-						ec2.WithOS(osDesc),
-					),
-					scenkind.WithoutFakeIntake(),
-					scenkind.WithAgentOptions(
-						kubernetesagentparams.WithHelmValues(values),
-					),
-				),
-			),
-		),
-	)
 }
 
 func (s *kindSuite) SetupSuite() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Split TestKindSuite into TestKindOperatorSuite and TestKindHelmSuite

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->