### PR TITLE
Add CRL monitoring for Windows Certificate Store integration

### DIFF
--- a/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
@@ -59,6 +59,23 @@ instances:
     #
     # days_critical: 7
 
+    ## @param enable_crl_monitoring - boolean - optional - default: false
+    ## Enables monitoring of expiration of all Certificate Revocation Lists (CRLs) in `certificate_store`.
+    #
+    # enable_crl_monitoring: false
+
+    ## @param crl_days_warning - integer - optional - default: 14
+    ## Number of days before CRL expiration from which the service check
+    ## `windows_certificate.crl_expiration` begins emitting WARNING.
+    #
+    # crl_days_warning: 14
+
+    ## @param crl_days_critical - integer - optional - default: 7
+    ## Number of days before crl expiration from which the service check
+    ## `windows_certificate.crl_expiration` begins emitting CRITICAL.
+    #
+    # crl_days_critical: 7
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
@@ -67,6 +67,8 @@ instances:
     ## @param crl_days_warning - integer - optional - default: 0
     ## Number of days before CRL expiration from which the service check
     ## `windows_certificate.crl_expiration` begins emitting WARNING.
+    ## If the CRLs in the store are updated automatically, set to 0 to avoid getting WARNING alerts.
+    ## If the CRLs are updated manually, set to the number days beforehand that you would like to recieve a WARNING.
     #
     # crl_days_warning: 0
 

--- a/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/windows_certificate.d/conf.yaml.example
@@ -64,17 +64,11 @@ instances:
     #
     # enable_crl_monitoring: false
 
-    ## @param crl_days_warning - integer - optional - default: 14
+    ## @param crl_days_warning - integer - optional - default: 0
     ## Number of days before CRL expiration from which the service check
     ## `windows_certificate.crl_expiration` begins emitting WARNING.
     #
-    # crl_days_warning: 14
-
-    ## @param crl_days_critical - integer - optional - default: 7
-    ## Number of days before crl expiration from which the service check
-    ## `windows_certificate.crl_expiration` begins emitting CRITICAL.
-    #
-    # crl_days_critical: 7
+    # crl_days_warning: 0
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -529,6 +529,7 @@ func getCrlInfo(storeHandle windows.Handle) ([]crlInfoCopy, error) {
 	var crlInfo []crlInfoCopy
 	defer func() {
 		err = winutil.CertFreeCRLContext(crlContext)
+		log.Debugf("Freeing CRL context")
 		if err != nil {
 			log.Errorf("Error freeing CRL context: %v", err)
 		}
@@ -618,6 +619,7 @@ func getCrlIssuerTags(issuer string) []string {
 			issuerTags = append(issuerTags, component)
 		}
 	}
+	log.Debugf("CRL issuer tags: %v", issuerTags)
 
 	return issuerTags
 }

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -202,7 +202,7 @@ func (w *WinCertChk) Run() error {
 
 	for _, cert := range certificates {
 		log.Debugf("Found certificate: %s", cert.Subject.String())
-		daysRemaining := getCertExpiration(cert)
+		daysRemaining := getExpiration(cert.NotAfter)
 		expirationDate := cert.NotAfter.Format(time.RFC3339)
 
 		// Adding Subject and Certificate Store as tags
@@ -244,7 +244,7 @@ func (w *WinCertChk) Run() error {
 		crlIssuer := crl.Issuer
 		log.Debugf("Found CRL Issued by: %s", crlIssuer)
 
-		crlDaysRemaining := getCrlExpiration(crl.NextUpdate)
+		crlDaysRemaining := getExpiration(crl.NextUpdate)
 		crlExpirationDate := crl.NextUpdate.Format(time.RFC3339)
 
 		// Adding CRL Issuer and Certificate Store as tags
@@ -571,13 +571,8 @@ func freeContext(certContext *windows.CertContext) {
 	}
 }
 
-func getCertExpiration(cert *x509.Certificate) float64 {
-	daysRemaining := time.Until(cert.NotAfter).Hours() / 24
-	return float64(daysRemaining)
-}
-
-func getCrlExpiration(nextUpdate time.Time) float64 {
-	daysRemaining := time.Until(nextUpdate).Hours() / 24
+func getExpiration(expirationDate time.Time) float64 {
+	daysRemaining := time.Until(expirationDate).Hours() / 24
 	return float64(daysRemaining)
 }
 

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -47,8 +47,14 @@ const (
 	certEncoding       = windows.X509_ASN_ENCODING | windows.PKCS_7_ASN_ENCODING
 	cryptENotFound     = windows.Errno(windows.CRYPT_E_NOT_FOUND)
 	eInvalidArg        = windows.Errno(windows.E_INVALIDARG)
-	certX500NameStr    = 3
-	certNameStrCRLF    = 0x08000000
+
+	// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certnametostrw
+	//
+	// CERT_X500_NAME_STR converts OIDs to their X.500 key names
+	certX500NameStr = 3
+
+	// CERT_NAME_STR_CRLF_FLAG replaces commas with a \r\n separator
+	certNameStrCRLF = 0x08000000
 )
 
 // Config is the configuration options for this check

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
@@ -212,7 +212,6 @@ certificate_store: CA
 certificate_subjects:
   - INVALID
 enable_crl_monitoring: true
-crl_days_critical: -1
 crl_days_warning: -1`)
 
 	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
@@ -176,3 +176,30 @@ days_critical: -1`)
 	m.AssertNumberOfCalls(t, "ServiceCheck", 0)
 	m.AssertNumberOfCalls(t, "Commit", 0)
 }
+
+func TestWindowsCertificateWithCrl(t *testing.T) {
+	certCheck := new(WinCertChk)
+
+	instanceConfig := []byte(`
+certificate_store: CA
+certificate_subjects:
+  - Microsoft
+enable_crl_monitoring: true`)
+
+	certCheck.BuildID(integration.FakeConfigHash, instanceConfig, nil)
+	m := mocksender.NewMockSender(certCheck.ID())
+	certCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, instanceConfig, nil, "test")
+
+	m.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	m.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	m.On("Commit").Return()
+
+	certCheck.Run()
+
+	m.AssertExpectations(t)
+	m.AssertCalled(t, "Gauge", "windows_certificate.days_remaining", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.AssertCalled(t, "ServiceCheck", "windows_certificate.cert_expiration", mock.AnythingOfType("servicecheck.ServiceCheckStatus"), "", mock.AnythingOfType("[]string"), mock.AnythingOfType("string"))
+	m.AssertCalled(t, "Gauge", "windows_certificate.crl_days_remaining", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.AssertCalled(t, "ServiceCheck", "windows_certificate.crl_expiration", mock.AnythingOfType("servicecheck.ServiceCheckStatus"), "", mock.AnythingOfType("[]string"), mock.AnythingOfType("string"))
+	m.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/pkg/util/winutil/wincrypt.go
+++ b/pkg/util/winutil/wincrypt.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+// Package winutil contains Windows OS utilities
+package winutil
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	crypt32                 = windows.NewLazySystemDLL("crypt32.dll")
+	procCertEnumCRLsInStore = crypt32.NewProc("CertEnumCRLsInStore")
+	procCertFreeCRLContext  = crypt32.NewProc("CertFreeCRLContext")
+	procCertNameToStr       = crypt32.NewProc("CertNameToStrW")
+)
+
+// CRLContext contains both the encoded and decoded representations of a certificate revocation list (CRL).
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crl_context
+type CRLContext struct {
+	DwCertEncodingType uint32
+	PbCrlEncoded       *byte
+	CbCrlEncoded       uint32
+	PCrlInfo           *CRLInfo
+	HCertStore         windows.Handle
+}
+
+// CRLInfo contains the information of a certificate revocation list (CRL).
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crl_info
+type CRLInfo struct {
+	dwVersion          uint32 // nolint:unused
+	SignatureAlgorithm windows.CryptAlgorithmIdentifier
+	Issuer             windows.CertNameBlob
+	ThisUpdate         windows.Filetime
+	NextUpdate         windows.Filetime
+	cCRLEntry          uint32                   // nolint:unused
+	rgCRLEntry         []*CRLEntry              // nolint:unused
+	cExtension         uint32                   // nolint:unused
+	rgExtension        []*windows.CertExtension // nolint:unused
+}
+
+// CRLEntry contains information about a single revoked certificate. It is a member of the CRLInfo struct.
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crl_entry
+type CRLEntry struct {
+	SerialNumber   windows.CryptIntegerBlob
+	RevocationDate windows.Filetime
+	cExtension     uint32                   // nolint:unused
+	rgExtension    []*windows.CertExtension // nolint:unused
+}
+
+// CertEnumCRLsInStore retrieves the first or next certificate revocation list (CRL) context in a certificate store.
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certenumcrlsinstore
+func CertEnumCRLsInStore(hCertStore windows.Handle, pPrevCrlContext *CRLContext) (*CRLContext, error) {
+	r0, _, err := procCertEnumCRLsInStore.Call(uintptr(hCertStore), uintptr(unsafe.Pointer(pPrevCrlContext)))
+	crlcontext := (*CRLContext)(unsafe.Pointer(r0)) //nolint:govet
+	if crlcontext == nil {
+		return nil, err
+	}
+	return crlcontext, nil
+}
+
+// CertFreeCRLContext frees a certificate revocation list (CRL) context by decrementing its reference count.
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certfreecrlcontext
+func CertFreeCRLContext(pCrlContext *CRLContext) error {
+	r1, _, err := procCertFreeCRLContext.Call(uintptr(unsafe.Pointer(pCrlContext)))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+// CertNameToStrW converts an encoded name in a windows.CertNameBlob structure to a null-terminated character string.
+//
+// https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certnametostrw
+func CertNameToStrW(dwCertEncodingType uint32, pName *windows.CertNameBlob, dwStrType uint32, psz []uint16, csz uint32) (string, uint32, error) {
+	var bufferPointer uintptr
+
+	if psz == nil {
+		bufferPointer = 0
+	} else {
+		bufferPointer = uintptr(unsafe.Pointer(&psz[0]))
+	}
+
+	r0, _, err := procCertNameToStr.Call(
+		uintptr(dwCertEncodingType),
+		uintptr(unsafe.Pointer(pName)),
+		uintptr(dwStrType),
+		bufferPointer,
+		uintptr(csz),
+	)
+
+	if psz == nil || csz == 0 {
+		bufferSize := uint32(r0)
+		if bufferSize == 0 {
+			return "", 0, err
+		}
+		return "", bufferSize, nil
+	}
+
+	if r0 == 0 {
+		return "", 0, err
+	}
+
+	return windows.UTF16ToString(psz), 0, nil
+}

--- a/releasenotes/notes/windows-certificate-store-add-crl-monitoring-627d464fdcf8dcf0.yaml
+++ b/releasenotes/notes/windows-certificate-store-add-crl-monitoring-627d464fdcf8dcf0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Windows: Add CRL monitoring to the Windows Certificate Store integration.
+

--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -187,6 +187,55 @@ instances:
 
 }
 
+func (v *multiVMSuite) TestGetRemoteCertificateWithCrl() {
+	agentHost := v.Env().AgentHost
+	certificateHost := v.Env().CertificateHost
+	checkConfig := fmt.Sprintf(`
+init_config:
+instances:
+  - certificate_store: CA
+    server: %s
+    username: %s
+    password: %s
+    enable_crl_monitoring: true`, certificateHost.HostOutput.Address, TestUser, TestPassword)
+	v.T().Logf("Check config: %s", checkConfig)
+
+	_, err := agentHost.WriteFile("C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml", []byte(checkConfig))
+	v.Require().NoError(err)
+
+	err = windowsCommon.RestartService(agentHost, "datadogagent")
+	v.Require().NoError(err)
+
+	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
+	cmd := fmt.Sprintf(`&'%s' status`, agent)
+
+	// Wait for the agent to be running and check that the windows_certificate check is running
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		output, err := agentHost.Execute(cmd)
+		assert.NoError(c, err)
+		assert.Contains(c, output, "windows_certificate")
+		v.T().Logf("Agent status: %s", output)
+	}, 5*time.Minute, 10*time.Second)
+
+	cmdCheck := fmt.Sprintf(`&'%s' check windows_certificate`, agent)
+	certStoreTag := `"certificate_store:CA"`
+	serverTag := fmt.Sprintf(`"server:%s"`, certificateHost.HostOutput.Address)
+	issuerOUTag := `"crl_issuer_OU:VeriSign Commercial Software Publishers CA"`
+	output, err := agentHost.Execute(cmdCheck)
+	v.Require().NoError(err)
+	v.T().Logf("Check output: %s", output)
+
+	// Assert that the check output returns the metric and service check
+	v.Require().Contains(output, "windows_certificate.crl_days_remaining")
+	v.Require().Contains(output, "windows_certificate.crl_expiration")
+
+	// Assert that the check output returns the correct metric tags
+	v.Require().Contains(output, certStoreTag)
+	v.Require().Contains(output, serverTag)
+	v.Require().Contains(output, issuerOUTag)
+
+}
+
 func RebootHost(host *components.RemoteHost) error {
 	_, err := powershell.PsHost().Reboot().Execute(host)
 	if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds Certificate Revocation List (CRL) expiration monitoring for the Windows Certificate Store. It checks the NextUpdate field of the CRLs of a specified store.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1565

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Add the following configuration in `%PROGRAMDATA%\conf.d\windows_certificate.d\conf.yaml` and restart the Agent. It should return a metric, `windows_certificate.crl_days_remaining` and service check. `windows_certificate.crl_expiration`:
```
init_config:

instances:
  - certificate_store: CA
    enable_crl_monitoring: true
```
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->