### PR TITLE
feat(update.buildimages): Exclude windows by default

### DIFF
--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -4,7 +4,7 @@ import yaml
 from invoke import Context, Exit, task
 
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag, update_gitlab_config, update_test_infra_def
-from tasks.libs.common.color import color_message
+from tasks.libs.common.color import Color, color_message
 
 
 @task(
@@ -15,19 +15,26 @@ from tasks.libs.common.color import color_message
         "list_images": "List all available images",
     }
 )
-def update(_: Context, tag: str = "", images: str = "", test: bool = True, list_images: bool = False):
+def update(
+    _: Context, tag: str = "", images: str = "", test: bool = True, list_images: bool = False, windows: bool = False
+):
     """
     Update local files to use a new version of dedicated images from agent-buildimages
     Use --no-test to commit without the _test_only suffixes
     Use --list-images to list all available images
     """
+    generate_windows_images = 'win' in images.casefold() or windows
     if list_images:
         print("List of available images:")
         modified = update_gitlab_config(".gitlab-ci.yml", "", update=False)
     else:
         print("Updating images:")
-        modified = update_gitlab_config(".gitlab-ci.yml", tag, images, test=test)
+        modified = update_gitlab_config(".gitlab-ci.yml", tag, images, test=test, windows=generate_windows_images)
     print(f"  {', '.join(modified)}")
+    if not generate_windows_images:
+        print(
+            f"[{color_message('WARNING', Color.ORANGE)}] - Windows images are not updated by default, use --windows/-w to update them"
+        )
 
 
 @task(

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -22,6 +22,7 @@ def update(
     Update local files to use a new version of dedicated images from agent-buildimages
     Use --no-test to commit without the _test_only suffixes
     Use --list-images to list all available images
+    Use --windows to update windows images
     """
     generate_windows_images = 'win' in images.casefold() or windows
     if list_images:

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -1300,7 +1300,7 @@ def update_test_infra_def(file_path, image_tag, is_dev_image=False, prefix_comme
         yaml.dump(test_infra_def, test_infra_version_file, explicit_start=True)
 
 
-def update_gitlab_config(file_path, tag, images="", test=True, update=True):
+def update_gitlab_config(file_path, tag, images="", test=True, update=True, windows=False):
     """
     Override variables in .gitlab-ci.yml file.
     """
@@ -1310,7 +1310,7 @@ def update_gitlab_config(file_path, tag, images="", test=True, update=True):
     gitlab_ci = yaml.safe_load("".join(file_content))
     variables = gitlab_ci['variables']
     # Select the buildimages prefixed with CI_IMAGE matchins input images list
-    images_to_update = list(find_buildimages(variables, images))
+    images_to_update = list(find_buildimages(variables, images, windows=windows))
     if update:
         output = update_image_tag(file_content, tag, images_to_update, test=test)
         with open(file_path, "w") as gl:
@@ -1318,7 +1318,7 @@ def update_gitlab_config(file_path, tag, images="", test=True, update=True):
     return images_to_update
 
 
-def find_buildimages(variables, images="", prefix="CI_IMAGE_"):
+def find_buildimages(variables, images="", prefix="CI_IMAGE_", windows=False):
     """
     Select the buildimages variables to update.
     With default values, the former CI_IMAGE_ variables are updated.
@@ -1330,6 +1330,8 @@ def find_buildimages(variables, images="", prefix="CI_IMAGE_"):
             and variable.endswith(suffix)
             and any(image in variable.casefold() for image in images.casefold().split(","))
         ):
+            if 'WIN' in variable and not windows:
+                continue
             yield variable.removesuffix(suffix)
 
 

--- a/tasks/unit_tests/gitlab_api_tests.py
+++ b/tasks/unit_tests/gitlab_api_tests.py
@@ -490,10 +490,23 @@ class TestFilterVariables(unittest.TestCase):
         variables = {
             'CI_IMAGE_AGENT': 'tintin',
             'CI_IMAGE_AGENT_SUFFIX': '',
+            'CI_IMAGE_AGENT_WIN': 'milou',
+            'CI_IMAGE_AGENT_WIN_SUFFIX': '',
             'OTHER_VARIABLE_SUFFIX': '',
             'OTHER_VARIABLE': 'lampion',
         }
         self.assertEqual(list(find_buildimages(variables)), ['CI_IMAGE_AGENT'])
+
+    def test_no_windows(self):
+        variables = {
+            'CI_IMAGE_AGENT': 'tintin',
+            'CI_IMAGE_AGENT_SUFFIX': '',
+            'CI_IMAGE_AGENT_WIN': 'milou',
+            'CI_IMAGE_AGENT_WIN_SUFFIX': '',
+            'OTHER_VARIABLE_SUFFIX': '',
+            'OTHER_VARIABLE': 'lampion',
+        }
+        self.assertEqual(list(find_buildimages(variables, windows=True)), ['CI_IMAGE_AGENT', 'CI_IMAGE_AGENT_WIN'])
 
     def test_one_image(self):
         variables = {
@@ -652,7 +665,12 @@ class TestUpdateGitlabConfig(unittest.TestCase):
         self.assertEqual(
             len(
                 update_gitlab_config(
-                    "tasks/unit_tests/testdata/variables.yml", tag="gru", images="", test=False, update=False
+                    "tasks/unit_tests/testdata/variables.yml",
+                    tag="gru",
+                    images="",
+                    test=False,
+                    update=False,
+                    windows=True,
                 )
             ),
             14,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Add a new option to exclude the update of the windows image by default. As we generate the windows image only when it's modified, in the default case we don't need to update its value.
- Add a warning when the image is not generated so that we are aware

### Motivation
Since we merged https://github.com/DataDog/datadog-agent-buildimages/pull/867 and https://github.com/DataDog/datadog-agent/pull/37976 the update of the windows image is done less often, so we have to adapt this script.
A follow-up PR will be done on `buildimages` to generate the correct command in the slack message

### Describe how you validated your changes
Updated unit tests
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I did not use the test on the dockerhub API because:
- we don't publish in dockerhub for a `test_only` image
- we don't publish all images (eg deb_armhf) This is maybe a problem, and this will be solved when we will decommission these images 😄 