### PR TITLE
[AGENTRUN-517] create a autodiscovery providers types package

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	autodiscoveryStatus "github.com/DataDog/datadog-agent/comp/core/autodiscovery/status"
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
@@ -80,7 +81,7 @@ type AutoConfig struct {
 	store                    *store
 	cfgMgr                   configManager
 	serviceListenerFactories map[string]listeners.ServiceListenerFactory
-	providerCatalog          map[string]providers.ConfigProviderFactory
+	providerCatalog          map[string]providerTypes.ConfigProviderFactory
 	wmeta                    option.Option[workloadmeta.Component]
 	taggerComp               tagger.Component
 	logs                     logComp.Component
@@ -199,7 +200,7 @@ func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolv
 		cfgMgr:                   cfgMgr,
 		schedulerController:      schedulerController,
 		serviceListenerFactories: make(map[string]listeners.ServiceListenerFactory),
-		providerCatalog:          make(map[string]providers.ConfigProviderFactory),
+		providerCatalog:          make(map[string]providerTypes.ConfigProviderFactory),
 		wmeta:                    wmeta,
 		taggerComp:               taggerComp,
 		logs:                     logs,
@@ -408,7 +409,7 @@ func (ac *AutoConfig) stop() {
 // expects to be polled and at which interval or it's fine for it to be invoked only once in the
 // Agent lifetime.
 // If the config provider is polled, the routine is scheduled right away
-func (ac *AutoConfig) AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration) {
+func (ac *AutoConfig) AddConfigProvider(provider providerTypes.ConfigProvider, shouldPoll bool, pollInterval time.Duration) {
 	if shouldPoll && pollInterval <= 0 {
 		log.Warnf("Polling interval <= 0 for AD provider: %s, deactivating polling", provider.String())
 		shouldPoll = false
@@ -609,7 +610,7 @@ func (ac *AutoConfig) GetIDOfCheckWithEncryptedSecrets(checkID checkid.ID) check
 }
 
 // GetProviderCatalog returns all registered ConfigProviderFactory.
-func (ac *AutoConfig) GetProviderCatalog() map[string]providers.ConfigProviderFactory {
+func (ac *AutoConfig) GetProviderCatalog() map[string]providerTypes.ConfigProviderFactory {
 	return ac.providerCatalog
 }
 
@@ -630,8 +631,8 @@ func (ac *AutoConfig) processDelService(svc listeners.Service) {
 // resulting data structure maps provider name to resource name to a set of
 // unique error messages.  The resource names do not match other identifiers
 // and are only intended for display in diagnostic tools like `agent status`.
-func (ac *AutoConfig) GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet {
-	errors := map[string]map[string]providers.ErrorMsgSet{}
+func (ac *AutoConfig) GetAutodiscoveryErrors() map[string]map[string]providerTypes.ErrorMsgSet {
+	errors := map[string]map[string]providerTypes.ErrorMsgSet{}
 	for _, cp := range ac.getConfigPollers() {
 		configErrors := cp.provider.GetConfigErrors()
 		if len(configErrors) > 0 {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
@@ -59,8 +59,8 @@ func (p *MockProvider) IsUpToDate(_ context.Context) (bool, error) {
 	return true, nil
 }
 
-func (p *MockProvider) GetConfigErrors() map[string]providers.ErrorMsgSet {
-	return make(map[string]providers.ErrorMsgSet)
+func (p *MockProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }
 
 type MockProvider2 struct {

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -21,15 +21,15 @@ import (
 // Component is the component type.
 // team: container-platform
 type Component interface {
-	AddConfigProvider(provider providers.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
+	AddConfigProvider(provider types.ConfigProvider, shouldPoll bool, pollInterval time.Duration)
 	LoadAndRun(ctx context.Context)
 	GetAllConfigs() []integration.Config
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)
 	RemoveScheduler(name string)
 	GetIDOfCheckWithEncryptedSecrets(checkID checkid.ID) checkid.ID
-	GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet
-	GetProviderCatalog() map[string]providers.ConfigProviderFactory
+	GetAutodiscoveryErrors() map[string]map[string]types.ErrorMsgSet
+	GetProviderCatalog() map[string]types.ConfigProviderFactory
 	GetTelemetryStore() *telemetry.Store
 	// TODO (component): once cluster agent uses the API component remove this function
 	GetConfigCheck() integration.ConfigCheckResponse

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
@@ -33,7 +33,7 @@ func Module() fxutil.Module {
 
 type noopAutoConfig struct{}
 
-func (n *noopAutoConfig) AddConfigProvider(providers.ConfigProvider, bool, time.Duration) {}
+func (n *noopAutoConfig) AddConfigProvider(types.ConfigProvider, bool, time.Duration) {}
 
 func (n *noopAutoConfig) LoadAndRun(context.Context) {}
 
@@ -51,12 +51,12 @@ func (n *noopAutoConfig) GetIDOfCheckWithEncryptedSecrets(checkid.ID) checkid.ID
 	return ""
 }
 
-func (n *noopAutoConfig) GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet {
-	return map[string]map[string]providers.ErrorMsgSet{}
+func (n *noopAutoConfig) GetAutodiscoveryErrors() map[string]map[string]types.ErrorMsgSet {
+	return map[string]map[string]types.ErrorMsgSet{}
 }
 
-func (n *noopAutoConfig) GetProviderCatalog() map[string]providers.ConfigProviderFactory {
-	return map[string]providers.ConfigProviderFactory{}
+func (n *noopAutoConfig) GetProviderCatalog() map[string]types.ConfigProviderFactory {
+	return map[string]types.ConfigProviderFactory{}
 }
 
 func (n *noopAutoConfig) GetTelemetryStore() *telemetry.Store {

--- a/comp/core/autodiscovery/providers/cloudfoundry.go
+++ b/comp/core/autodiscovery/providers/cloudfoundry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
@@ -33,7 +34,7 @@ type CloudFoundryConfigProvider struct {
 }
 
 // NewCloudFoundryConfigProvider instantiates a new CloudFoundryConfigProvider from given config
-func NewCloudFoundryConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewCloudFoundryConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (types.ConfigProvider, error) {
 	cfp := CloudFoundryConfigProvider{
 		lastCollected: time.Now(),
 	}
@@ -215,6 +216,6 @@ func (cf CloudFoundryConfigProvider) renderExtractedConfigs(configs []integratio
 }
 
 // GetConfigErrors is not implemented for the CloudFoundryConfigProvider
-func (cf CloudFoundryConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (cf CloudFoundryConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/cloudfoundry_nop.go
+++ b/comp/core/autodiscovery/providers/cloudfoundry_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewCloudFoundryConfigProvider instantiates a new CloudFoundryConfigProvider from given config
-var NewCloudFoundryConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewCloudFoundryConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -43,7 +44,7 @@ type ClusterChecksConfigProvider struct {
 // NewClusterChecksConfigProvider returns a new ConfigProvider collecting
 // cluster check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (providerTypes.ConfigProvider, error) {
 	if providerConfig == nil {
 		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
@@ -222,6 +223,6 @@ func (c *ClusterChecksConfigProvider) postHeartbeat(ctx context.Context) error {
 }
 
 // GetConfigErrors is not implemented for the ClusterChecksConfigProvider
-func (c *ClusterChecksConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (c *ClusterChecksConfigProvider) GetConfigErrors() map[string]providerTypes.ErrorMsgSet {
+	return make(map[string]providerTypes.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/consul.go
+++ b/comp/core/autodiscovery/providers/consul.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -54,7 +55,7 @@ type ConsulConfigProvider struct {
 }
 
 // NewConsulConfigProvider creates a client connection to consul and create a new ConsulConfigProvider
-func NewConsulConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewConsulConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (types.ConfigProvider, error) {
 	if providerConfig == nil {
 		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
@@ -292,6 +293,6 @@ func isTemplateField(key string) bool {
 }
 
 // GetConfigErrors is not implemented for the ConsulConfigProvider
-func (p *ConsulConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (p *ConsulConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/consul_nop.go
+++ b/comp/core/autodiscovery/providers/consul_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewConsulConfigProvider creates a client connection to consul and create a new ConsulConfigProvider
-var NewConsulConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewConsulConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/container.go
+++ b/comp/core/autodiscovery/providers/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -27,7 +28,7 @@ import (
 // ContainerConfigProvider implements the ConfigProvider interface for both pods and containers
 type ContainerConfigProvider struct {
 	workloadmetaStore workloadmeta.Component
-	configErrors      map[string]ErrorMsgSet                   // map[entity name]ErrorMsgSet
+	configErrors      map[string]types.ErrorMsgSet             // map[entity name]types.ErrorMsgSet
 	configCache       map[string]map[string]integration.Config // map[entity name]map[config digest]integration.Config
 	mu                sync.RWMutex
 	telemetryStore    *telemetry.Store
@@ -35,11 +36,11 @@ type ContainerConfigProvider struct {
 
 // NewContainerConfigProvider returns a new ConfigProvider subscribed to both container
 // and pods
-func NewContainerConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+func NewContainerConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (types.ConfigProvider, error) {
 	return &ContainerConfigProvider{
 		workloadmetaStore: wmeta,
 		configCache:       make(map[string]map[string]integration.Config),
-		configErrors:      make(map[string]ErrorMsgSet),
+		configErrors:      make(map[string]types.ErrorMsgSet),
 		telemetryStore:    telemetryStore,
 	}, nil
 }
@@ -157,9 +158,9 @@ func (k *ContainerConfigProvider) processEvents(evBundle workloadmeta.EventBundl
 	return changes
 }
 
-func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integration.Config, ErrorMsgSet) {
+func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integration.Config, types.ErrorMsgSet) {
 	var (
-		errMsgSet ErrorMsgSet
+		errMsgSet types.ErrorMsgSet
 		errs      []error
 		configs   []integration.Config
 	)
@@ -252,7 +253,7 @@ func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integ
 	}
 
 	if len(errs) > 0 {
-		errMsgSet = make(ErrorMsgSet)
+		errMsgSet = make(types.ErrorMsgSet)
 		for _, err := range errs {
 			errMsgSet[err.Error()] = struct{}{}
 		}
@@ -275,11 +276,11 @@ func (k *ContainerConfigProvider) generateContainerConfig(container *workloadmet
 }
 
 // GetConfigErrors returns a map of configuration errors for each namespace/pod
-func (k *ContainerConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
+func (k *ContainerConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	errors := make(map[string]ErrorMsgSet, len(k.configErrors))
+	errors := make(map[string]types.ErrorMsgSet, len(k.configErrors))
 
 	maps.Copy(errors, k.configErrors)
 

--- a/comp/core/autodiscovery/providers/container_nop.go
+++ b/comp/core/autodiscovery/providers/container_nop.go
@@ -11,4 +11,4 @@ import "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types
 
 // NewContainerConfigProvider returns a new ConfigProvider subscribed to both container
 // and pods
-var NewContainerConfigProvider types.ConfigProvider
+var NewContainerConfigProvider types.ConfigProviderFactory

--- a/comp/core/autodiscovery/providers/container_nop.go
+++ b/comp/core/autodiscovery/providers/container_nop.go
@@ -7,6 +7,8 @@
 
 package providers
 
+import "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
+
 // NewContainerConfigProvider returns a new ConfigProvider subscribed to both container
 // and pods
-var NewContainerConfigProvider ConfigProviderFactory
+var NewContainerConfigProvider types.ConfigProvider

--- a/comp/core/autodiscovery/providers/container_test.go
+++ b/comp/core/autodiscovery/providers/container_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -39,7 +40,7 @@ func TestProcessEvents(t *testing.T) {
 	cp := &ContainerConfigProvider{
 		workloadmetaStore: store,
 		configCache:       make(map[string]map[string]integration.Config),
-		configErrors:      make(map[string]ErrorMsgSet),
+		configErrors:      make(map[string]types.ErrorMsgSet),
 		telemetryStore:    telemetryStore,
 	}
 
@@ -107,7 +108,7 @@ func TestGenerateConfig(t *testing.T) {
 		name                string
 		entity              workloadmeta.Entity
 		expectedConfigs     []integration.Config
-		expectedErr         ErrorMsgSet
+		expectedErr         types.ErrorMsgSet
 		containerCollectAll bool
 	}{
 		{
@@ -354,7 +355,7 @@ func TestGenerateConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: ErrorMsgSet{
+			expectedErr: types.ErrorMsgSet{
 				"annotation ad.datadoghq.com/nonmatching.check_names is invalid: nonmatching doesn't match a container identifier [apache nginx]":  {},
 				"annotation ad.datadoghq.com/nonmatching.init_configs is invalid: nonmatching doesn't match a container identifier [apache nginx]": {},
 				"annotation ad.datadoghq.com/nonmatching.instances is invalid: nonmatching doesn't match a container identifier [apache nginx]":    {},
@@ -387,7 +388,7 @@ func TestGenerateConfig(t *testing.T) {
 					Source:        "container:docker://4ac8352d70bf1",
 				},
 			},
-			expectedErr: ErrorMsgSet{
+			expectedErr: types.ErrorMsgSet{
 				"could not extract logs config: in logs: invalid character '\"' after object key:value pair": {},
 			},
 		},
@@ -440,7 +441,7 @@ func TestGenerateConfig(t *testing.T) {
 			cp := &ContainerConfigProvider{
 				workloadmetaStore: store,
 				configCache:       make(map[string]map[string]integration.Config),
-				configErrors:      make(map[string]ErrorMsgSet),
+				configErrors:      make(map[string]types.ErrorMsgSet),
 			}
 
 			configs, err := cp.generateConfig(tt.entity)

--- a/comp/core/autodiscovery/providers/endpointschecks.go
+++ b/comp/core/autodiscovery/providers/endpointschecks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -35,7 +36,7 @@ type EndpointsChecksConfigProvider struct {
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewEndpointsChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewEndpointsChecksConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (types.ConfigProvider, error) {
 	c := &EndpointsChecksConfigProvider{
 		degradedDuration: defaultDegradedDeadline,
 	}
@@ -133,6 +134,6 @@ func (c *EndpointsChecksConfigProvider) initClient() error {
 }
 
 // GetConfigErrors is not implemented for the EndpointsChecksConfigProvider
-func (c *EndpointsChecksConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (c *EndpointsChecksConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/endpointschecks_nop.go
+++ b/comp/core/autodiscovery/providers/endpointschecks_nop.go
@@ -8,6 +8,7 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -15,4 +16,4 @@ import (
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewEndpointsChecksConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewEndpointsChecksConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/etcd.go
+++ b/comp/core/autodiscovery/providers/etcd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,7 +38,7 @@ type EtcdConfigProvider struct {
 }
 
 // NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
-func NewEtcdConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewEtcdConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (types.ConfigProvider, error) {
 	if providerConfig == nil {
 		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
@@ -226,6 +227,6 @@ func hasTemplateFields(nodes client.Nodes) bool {
 }
 
 // GetConfigErrors is not implemented for the EtcdConfigProvider
-func (p *EtcdConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (p *EtcdConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/etcd_nop.go
+++ b/comp/core/autodiscovery/providers/etcd_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
-var NewEtcdConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewEtcdConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/file.go
+++ b/comp/core/autodiscovery/providers/file.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 )
 
@@ -54,6 +55,6 @@ func (c *FileConfigProvider) String() string {
 }
 
 // GetConfigErrors is not implemented for the FileConfigProvider
-func (c *FileConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (c *FileConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/gpu.go
+++ b/comp/core/autodiscovery/providers/gpu.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -39,11 +40,11 @@ type GPUConfigProvider struct {
 	mu             sync.RWMutex
 }
 
-var _ ConfigProvider = &GPUConfigProvider{}
-var _ StreamingConfigProvider = &GPUConfigProvider{}
+var _ types.ConfigProvider = &GPUConfigProvider{}
+var _ types.StreamingConfigProvider = &GPUConfigProvider{}
 
 // NewGPUConfigProvider returns a new ConfigProvider subscribed to GPU events
-func NewGPUConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, _ *telemetry.Store) (ConfigProvider, error) {
+func NewGPUConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, _ *telemetry.Store) (types.ConfigProvider, error) {
 	return &GPUConfigProvider{
 		workloadmetaStore: wmeta,
 		gpuDeviceCache:    make(map[string]struct{}),
@@ -137,6 +138,6 @@ func (k *GPUConfigProvider) processEvents(evBundle workloadmeta.EventBundle) int
 }
 
 // GetConfigErrors returns a map of configuration errors, which is always empty for the GPUConfigProvider
-func (k *GPUConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (k *GPUConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/gpu_nop.go
+++ b/comp/core/autodiscovery/providers/gpu_nop.go
@@ -8,10 +8,11 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewGPUConfigProvider is a no-op for the serverless build, as we don't have GPU support there
-var NewGPUConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetry *telemetry.Store) (ConfigProvider, error)
+var NewGPUConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetry *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_endpoints.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -46,7 +47,7 @@ type kubeEndpointsConfigProvider struct {
 	endpointsLister    listersv1.EndpointsLister
 	upToDate           bool
 	monitoredEndpoints map[string]bool
-	configErrors       map[string]ErrorMsgSet
+	configErrors       map[string]types.ErrorMsgSet
 	telemetryStore     *telemetry.Store
 }
 
@@ -60,7 +61,7 @@ type configInfo struct {
 
 // NewKubeEndpointsConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewKubeEndpointsConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+func NewKubeEndpointsConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -75,7 +76,7 @@ func NewKubeEndpointsConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, te
 	p := &kubeEndpointsConfigProvider{
 		serviceLister:      servicesInformer.Lister(),
 		monitoredEndpoints: make(map[string]bool),
-		configErrors:       make(map[string]ErrorMsgSet),
+		configErrors:       make(map[string]types.ErrorMsgSet),
 		telemetryStore:     telemetryStore,
 	}
 
@@ -251,7 +252,7 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 		}
 
 		if len(errors) > 0 {
-			errMsgSet := make(ErrorMsgSet)
+			errMsgSet := make(types.ErrorMsgSet)
 			for _, err := range errors {
 				log.Errorf("Cannot parse endpoint template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 				errMsgSet[err.Error()] = struct{}{}
@@ -358,6 +359,6 @@ func (k *kubeEndpointsConfigProvider) cleanErrorsOfDeletedEndpoints(setCurrentEn
 }
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes endpoint
-func (k *kubeEndpointsConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
+func (k *kubeEndpointsConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
 	return k.configErrors
 }

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -57,7 +58,7 @@ type KubeEndpointsFileConfigProvider struct {
 }
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
-func NewKubeEndpointsFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewKubeEndpointsFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (types.ConfigProvider, error) {
 	templates, _, err := ReadConfigFiles(WithAdvancedADOnly)
 	if err != nil {
 		return nil, err
@@ -114,8 +115,8 @@ func (p *KubeEndpointsFileConfigProvider) String() string {
 }
 
 // GetConfigErrors is not implemented for the KubeEndpointsFileConfigProvider.
-func (p *KubeEndpointsFileConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (p *KubeEndpointsFileConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }
 
 func (p *KubeEndpointsFileConfigProvider) setUpToDate(v bool) {

--- a/comp/core/autodiscovery/providers/kube_endpoints_file_nop.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
-var NewKubeEndpointsFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeEndpointsFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_endpoints_nop.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_nop.go
@@ -8,10 +8,11 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeEndpointsConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewKubeEndpointsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeEndpointsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
@@ -957,24 +958,24 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 
 	tests := []struct {
 		name                          string
-		currentErrors                 map[string]ErrorMsgSet
+		currentErrors                 map[string]providerTypes.ErrorMsgSet
 		collectedServicesAndEndpoints []runtime.Object
 		expectedNumCollectedConfigs   int
-		expectedErrorsAfterCollect    map[string]ErrorMsgSet
+		expectedErrorsAfterCollect    map[string]providerTypes.ErrorMsgSet
 	}{
 		{
 			name:          "case without errors",
-			currentErrors: map[string]ErrorMsgSet{},
+			currentErrors: map[string]providerTypes.ErrorMsgSet{},
 			collectedServicesAndEndpoints: []runtime.Object{
 				&serviceWithoutErrors,
 				&endpointsOfServiceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name: "endpoint that has been deleted and had errors",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_endpoint_uid://default/deletedService/": {"error1": struct{}{}},
 			},
 			collectedServicesAndEndpoints: []runtime.Object{
@@ -982,11 +983,11 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 				&endpointsOfServiceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name: "endpoint with error that has been fixed",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_endpoint_uid://default/withoutErrors/": {"error1": struct{}{}},
 			},
 			collectedServicesAndEndpoints: []runtime.Object{
@@ -994,17 +995,17 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 				&endpointsOfServiceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name:          "endpoint that did not have an error but now does",
-			currentErrors: map[string]ErrorMsgSet{},
+			currentErrors: map[string]providerTypes.ErrorMsgSet{},
 			collectedServicesAndEndpoints: []runtime.Object{
 				&serviceWithErrors,
 				&endpointsOfServiceWithErrors,
 			},
 			expectedNumCollectedConfigs: 0,
-			expectedErrorsAfterCollect: map[string]ErrorMsgSet{
+			expectedErrorsAfterCollect: map[string]providerTypes.ErrorMsgSet{
 				"kube_endpoint_uid://default/withErrors/": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -1012,7 +1013,7 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 		},
 		{
 			name: "endpoint that had an error and still does",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_endpoint_uid://default/withErrors/": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -1022,7 +1023,7 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 				&endpointsOfServiceWithErrors,
 			},
 			expectedNumCollectedConfigs: 0,
-			expectedErrorsAfterCollect: map[string]ErrorMsgSet{
+			expectedErrorsAfterCollect: map[string]providerTypes.ErrorMsgSet{
 				"kube_endpoint_uid://default/withErrors/": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -1030,10 +1031,10 @@ func TestGetConfigErrors_KubeEndpoints(t *testing.T) {
 		},
 		{
 			name:                          "nothing collected",
-			currentErrors:                 map[string]ErrorMsgSet{},
+			currentErrors:                 map[string]providerTypes.ErrorMsgSet{},
 			collectedServicesAndEndpoints: []runtime.Object{},
 			expectedNumCollectedConfigs:   0,
-			expectedErrorsAfterCollect:    map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:    map[string]providerTypes.ErrorMsgSet{},
 		},
 	}
 

--- a/comp/core/autodiscovery/providers/kube_services_file.go
+++ b/comp/core/autodiscovery/providers/kube_services_file.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -22,7 +23,7 @@ type KubeServiceFileConfigProvider struct {
 }
 
 // NewKubeServiceFileConfigProvider returns a new KubeServiceFileConfigProvider
-func NewKubeServiceFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewKubeServiceFileConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (types.ConfigProvider, error) {
 	return &KubeServiceFileConfigProvider{}, nil
 }
 
@@ -48,8 +49,8 @@ func (c *KubeServiceFileConfigProvider) String() string {
 }
 
 // GetConfigErrors is not implemented for the KubeServiceFileConfigProvider.
-func (c *KubeServiceFileConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (c *KubeServiceFileConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }
 
 // toKubernetesServiceChecks generates integration configs to target

--- a/comp/core/autodiscovery/providers/kube_services_file_nop.go
+++ b/comp/core/autodiscovery/providers/kube_services_file_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeServiceFileConfigProvider returns a new KubeServiceFileConfigProvider
-var NewKubeServiceFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeServiceFileConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_services_nop.go
+++ b/comp/core/autodiscovery/providers/kube_services_nop.go
@@ -8,10 +8,11 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewKubeServiceConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewKubeServiceConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewKubeServiceConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/kube_services_test.go
+++ b/comp/core/autodiscovery/providers/kube_services_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	acTelemetry "github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
@@ -387,50 +388,50 @@ func TestGetConfigErrors_KubeServices(t *testing.T) {
 
 	tests := []struct {
 		name                        string
-		currentErrors               map[string]ErrorMsgSet
+		currentErrors               map[string]providerTypes.ErrorMsgSet
 		collectedServices           []runtime.Object
 		expectedNumCollectedConfigs int
-		expectedErrorsAfterCollect  map[string]ErrorMsgSet
+		expectedErrorsAfterCollect  map[string]providerTypes.ErrorMsgSet
 	}{
 		{
 			name:          "case without errors",
-			currentErrors: map[string]ErrorMsgSet{},
+			currentErrors: map[string]providerTypes.ErrorMsgSet{},
 			collectedServices: []runtime.Object{
 				&serviceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name: "service that has been deleted and had errors",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_service://default/deletedService": {"error1": struct{}{}},
 			},
 			collectedServices: []runtime.Object{
 				&serviceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name: "service with error that has been fixed",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_service://default/withoutErrors": {"error1": struct{}{}},
 			},
 			collectedServices: []runtime.Object{
 				&serviceWithoutErrors,
 			},
 			expectedNumCollectedConfigs: 1,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 		{
 			name:          "service that did not have an error but now does",
-			currentErrors: map[string]ErrorMsgSet{},
+			currentErrors: map[string]providerTypes.ErrorMsgSet{},
 			collectedServices: []runtime.Object{
 				&serviceWithErrors,
 			},
 			expectedNumCollectedConfigs: 0,
-			expectedErrorsAfterCollect: map[string]ErrorMsgSet{
+			expectedErrorsAfterCollect: map[string]providerTypes.ErrorMsgSet{
 				"kube_service://default/withErrors": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -438,7 +439,7 @@ func TestGetConfigErrors_KubeServices(t *testing.T) {
 		},
 		{
 			name: "service that had an error and still does",
-			currentErrors: map[string]ErrorMsgSet{
+			currentErrors: map[string]providerTypes.ErrorMsgSet{
 				"kube_service://default/withErrors": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -447,7 +448,7 @@ func TestGetConfigErrors_KubeServices(t *testing.T) {
 				&serviceWithErrors,
 			},
 			expectedNumCollectedConfigs: 0,
-			expectedErrorsAfterCollect: map[string]ErrorMsgSet{
+			expectedErrorsAfterCollect: map[string]providerTypes.ErrorMsgSet{
 				"kube_service://default/withErrors": {
 					"could not extract checks config: in instances: failed to unmarshal JSON: invalid character '\"' after object key": struct{}{},
 				},
@@ -455,10 +456,10 @@ func TestGetConfigErrors_KubeServices(t *testing.T) {
 		},
 		{
 			name:                        "nothing collected",
-			currentErrors:               map[string]ErrorMsgSet{},
+			currentErrors:               map[string]providerTypes.ErrorMsgSet{},
 			collectedServices:           []runtime.Object{},
 			expectedNumCollectedConfigs: 0,
-			expectedErrorsAfterCollect:  map[string]ErrorMsgSet{},
+			expectedErrorsAfterCollect:  map[string]providerTypes.ErrorMsgSet{},
 		},
 	}
 

--- a/comp/core/autodiscovery/providers/prometheus_pods.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
@@ -28,7 +29,7 @@ type PrometheusPodsConfigProvider struct {
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewPrometheusPodsConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewPrometheusPodsConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (providerTypes.ConfigProvider, error) {
 	checks, err := getPrometheusConfigs()
 	if err != nil {
 		return nil, err
@@ -80,6 +81,6 @@ func (p *PrometheusPodsConfigProvider) parsePodlist(podlist []*kubelet.Pod) []in
 }
 
 // GetConfigErrors is not implemented for the PrometheusPodsConfigProvider
-func (p *PrometheusPodsConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (p *PrometheusPodsConfigProvider) GetConfigErrors() map[string]providerTypes.ErrorMsgSet {
+	return make(map[string]providerTypes.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/prometheus_pods_nop.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods_nop.go
@@ -8,10 +8,11 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-var NewPrometheusPodsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewPrometheusPodsConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/prometheus_services.go
+++ b/comp/core/autodiscovery/providers/prometheus_services.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	providerTypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -66,7 +67,7 @@ type PrometheusServicesConfigProvider struct {
 }
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-func NewPrometheusServicesConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (ConfigProvider, error) {
+func NewPrometheusServicesConfigProvider(*pkgconfigsetup.ConfigurationProviders, *telemetry.Store) (providerTypes.ConfigProvider, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -318,6 +319,6 @@ func (p *PrometheusServicesConfigProvider) promAnnotationsDiffer(first, second m
 }
 
 // GetConfigErrors is not implemented for the PrometheusServicesConfigProvider
-func (p *PrometheusServicesConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (p *PrometheusServicesConfigProvider) GetConfigErrors() map[string]providerTypes.ErrorMsgSet {
+	return make(map[string]providerTypes.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/prometheus_services_nop.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-var NewPrometheusServicesConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewPrometheusServicesConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)

--- a/comp/core/autodiscovery/providers/providers.go
+++ b/comp/core/autodiscovery/providers/providers.go
@@ -9,10 +9,8 @@
 package providers
 
 import (
-	"context"
-
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -21,11 +19,11 @@ import (
 
 // RegisterProvider adds a loader to the providers catalog
 func RegisterProvider(name string,
-	factory func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error),
-	providerCatalog map[string]ConfigProviderFactory) {
+	factory func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error),
+	providerCatalog map[string]types.ConfigProviderFactory) {
 	RegisterProviderWithComponents(
 		name,
-		func(providerConfig *pkgconfigsetup.ConfigurationProviders, _ workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error) {
+		func(providerConfig *pkgconfigsetup.ConfigurationProviders, _ workloadmeta.Component, telemetryStore *telemetry.Store) (types.ConfigProvider, error) {
 			return factory(providerConfig, telemetryStore)
 		},
 		providerCatalog,
@@ -33,7 +31,7 @@ func RegisterProvider(name string,
 }
 
 // RegisterProviderWithComponents adds a loader to the providers catalog
-func RegisterProviderWithComponents(name string, factory ConfigProviderFactory, providerCatalog map[string]ConfigProviderFactory) {
+func RegisterProviderWithComponents(name string, factory types.ConfigProviderFactory, providerCatalog map[string]types.ConfigProviderFactory) {
 	if factory == nil {
 		log.Infof("ConfigProvider factory %s does not exist.", name)
 		return
@@ -47,7 +45,7 @@ func RegisterProviderWithComponents(name string, factory ConfigProviderFactory, 
 }
 
 // RegisterProviders adds all the default providers to the catalog
-func RegisterProviders(providerCatalog map[string]ConfigProviderFactory) {
+func RegisterProviders(providerCatalog map[string]types.ConfigProviderFactory) {
 	RegisterProvider(names.CloudFoundryBBS, NewCloudFoundryConfigProvider, providerCatalog)
 	RegisterProvider(names.ClusterChecksRegisterName, NewClusterChecksConfigProvider, providerCatalog)
 	RegisterProvider(names.ConsulRegisterName, NewConsulConfigProvider, providerCatalog)
@@ -62,48 +60,4 @@ func RegisterProviders(providerCatalog map[string]ConfigProviderFactory) {
 	RegisterProvider(names.PrometheusServicesRegisterName, NewPrometheusServicesConfigProvider, providerCatalog)
 	RegisterProvider(names.ZookeeperRegisterName, NewZookeeperConfigProvider, providerCatalog)
 	RegisterProviderWithComponents(names.GPU, NewGPUConfigProvider, providerCatalog)
-}
-
-// ConfigProviderFactory is any function capable to create a ConfigProvider instance
-type ConfigProviderFactory func(providerConfig *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error)
-
-// ConfigProvider represents a source of `integration.Config` values
-// that can either be applied immediately or resolved for a service and
-// applied.
-//
-// These Config values may come from files on disk, databases, environment variables,
-// container labels, etc.
-//
-// Any type implementing the interface will take care of any dependency
-// or data needed to access the resource providing the configuration.
-type ConfigProvider interface {
-	// String returns the name of the provider.  All Config instances produced
-	// by this provider will have this value in their Provider field.
-	String() string
-
-	// GetConfigErrors returns a map of errors that occurred on the last Collect
-	// call, indexed by a description of the resource that generated the error.
-	// The result is displayed in diagnostic tools such as `agent status`.
-	GetConfigErrors() map[string]ErrorMsgSet
-}
-
-// CollectingConfigProvider is an interface used together with ConfigProvider.
-// ConfigProviders that are NOT able to use streaming, and therefore need external reconciliation, should implement it.
-type CollectingConfigProvider interface {
-	// Collect is responsible of populating a list of Config instances by
-	// retrieving configuration patterns from external resources.
-	Collect(context.Context) ([]integration.Config, error)
-
-	// IsUpToDate determines whether the information returned from the last
-	// call to Collect is still correct.  If not, Collect will be called again.
-	IsUpToDate(context.Context) (bool, error)
-}
-
-// StreamingConfigProvider is an interface used together with ConfigProvider.
-// ConfigProviders that are able to use streaming should implement it, and the
-// config poller will use Stream instead of Collect to collect config changes.
-type StreamingConfigProvider interface {
-	// Stream starts the streaming config provider until the provided
-	// context is cancelled. Config changes are sent on the return channel.
-	Stream(context.Context) <-chan integration.ConfigChanges
 }

--- a/comp/core/autodiscovery/providers/types/types.go
+++ b/comp/core/autodiscovery/providers/types/types.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package types defines the types used by the autodiscovery providers
+package types
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+// ErrorMsgSet contains a list of unique configuration errors for a provider
+type ErrorMsgSet map[string]struct{}
+
+// ConfigProviderFactory is any function capable to create a ConfigProvider instance
+type ConfigProviderFactory func(providerConfig *pkgconfigsetup.ConfigurationProviders, wmeta workloadmeta.Component, telemetryStore *telemetry.Store) (ConfigProvider, error)
+
+// ConfigProvider represents a source of `integration.Config` values
+// that can either be applied immediately or resolved for a service and
+// applied.
+//
+// These Config values may come from files on disk, databases, environment variables,
+// container labels, etc.
+//
+// Any type implementing the interface will take care of any dependency
+// or data needed to access the resource providing the configuration.
+type ConfigProvider interface {
+	// String returns the name of the provider.  All Config instances produced
+	// by this provider will have this value in their Provider field.
+	String() string
+
+	// GetConfigErrors returns a map of errors that occurred on the last Collect
+	// call, indexed by a description of the resource that generated the error.
+	// The result is displayed in diagnostic tools such as `agent status`.
+	GetConfigErrors() map[string]ErrorMsgSet
+}
+
+// CollectingConfigProvider is an interface used together with ConfigProvider.
+// ConfigProviders that are NOT able to use streaming, and therefore need external reconciliation, should implement it.
+type CollectingConfigProvider interface {
+	// Collect is responsible of populating a list of Config instances by
+	// retrieving configuration patterns from external resources.
+	Collect(context.Context) ([]integration.Config, error)
+
+	// IsUpToDate determines whether the information returned from the last
+	// call to Collect is still correct.  If not, Collect will be called again.
+	IsUpToDate(context.Context) (bool, error)
+}
+
+// StreamingConfigProvider is an interface used together with ConfigProvider.
+// ConfigProviders that are able to use streaming should implement it, and the
+// config poller will use Stream instead of Collect to collect config changes.
+type StreamingConfigProvider interface {
+	// Stream starts the streaming config provider until the provided
+	// context is cancelled. Config changes are sent on the return channel.
+	Stream(context.Context) <-chan integration.ConfigChanges
+}

--- a/comp/core/autodiscovery/providers/utils.go
+++ b/comp/core/autodiscovery/providers/utils.go
@@ -60,9 +60,6 @@ type providerCache struct {
 	count int
 }
 
-// ErrorMsgSet contains a list of unique configuration errors for a provider
-type ErrorMsgSet map[string]struct{}
-
 // newProviderCache instantiate a ProviderCache.
 // nolint needed as this function is defined in a file without a build tag,
 // but only used in multiple files with different build tags, none of which

--- a/comp/core/autodiscovery/providers/zookeeper.go
+++ b/comp/core/autodiscovery/providers/zookeeper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -41,7 +42,7 @@ type ZookeeperConfigProvider struct {
 }
 
 // NewZookeeperConfigProvider returns a new Client connected to a Zookeeper backend.
-func NewZookeeperConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (ConfigProvider, error) {
+func NewZookeeperConfigProvider(providerConfig *pkgconfigsetup.ConfigurationProviders, _ *telemetry.Store) (types.ConfigProvider, error) {
 	if providerConfig == nil {
 		providerConfig = &pkgconfigsetup.ConfigurationProviders{}
 	}
@@ -207,6 +208,6 @@ func (z *ZookeeperConfigProvider) getJSONValue(key string) ([][]integration.Data
 }
 
 // GetConfigErrors is not implemented for the ZookeeperConfigProvider
-func (z *ZookeeperConfigProvider) GetConfigErrors() map[string]ErrorMsgSet {
-	return make(map[string]ErrorMsgSet)
+func (z *ZookeeperConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	return make(map[string]types.ErrorMsgSet)
 }

--- a/comp/core/autodiscovery/providers/zookeeper_nop.go
+++ b/comp/core/autodiscovery/providers/zookeeper_nop.go
@@ -8,9 +8,10 @@
 package providers
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 // NewZookeeperConfigProvider returns a new Client connected to a Zookeeper backend.
-var NewZookeeperConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (ConfigProvider, error)
+var NewZookeeperConfigProvider func(providerConfig *pkgconfigsetup.ConfigurationProviders, telemetryStore *telemetry.Store) (types.ConfigProvider, error)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR creates a `providers/types` package to define the provider types. It's mostly to keep things separate, as the providers' folders include many third-party libraries. If we want to import the provider types in the future, we would not pull all the providers' dependencies. 


### Motivation

Ensure we keep interface separate from implementations 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->