### PR TITLE
[AGENTRUN-515] Fix network Windows check to avoid emitting metrics for all struct fields

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network_windows.go
+++ b/pkg/collector/corechecks/net/networkv2/network_windows.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -176,17 +175,17 @@ type mibTCPStats struct {
 	DwRtoMin       uint32
 	DwRtoMax       uint32
 	DwMaxConn      uint32
-	DwActiveOpens  uint32
-	DwPassiveOpens uint32
-	DwAttemptFails uint32
-	DwEstabResets  uint32
-	DwCurrEstab    uint32
-	DwInSegs       uint32
-	DwOutSegs      uint32
-	DwRetransSegs  uint32
-	DwInErrs       uint32
-	DwOutRsts      uint32
-	DwNumConns     uint32
+	DwActiveOpens  uint32 `metric_name:"active_opens"`
+	DwPassiveOpens uint32 `metric_name:"passive_opens"`
+	DwAttemptFails uint32 `metric_name:"attempt_fails"`
+	DwEstabResets  uint32 `metric_name:"established_resets"`
+	DwCurrEstab    uint32 `metric_name:"current_established" metric_type:"gauge"`
+	DwInSegs       uint32 `metric_name:"in_segs"`
+	DwOutSegs      uint32 `metric_name:"out_segs"`
+	DwRetransSegs  uint32 `metric_name:"retrans_segs"`
+	DwInErrs       uint32 `metric_name:"in_errors"`
+	DwOutRsts      uint32 `metric_name:"out_resets"`
+	DwNumConns     uint32 `metric_name:"connections" metric_type:"gauge"`
 }
 
 var (
@@ -215,20 +214,6 @@ func getTCPStats(protocolName string) (*mibTCPStats, error) {
 
 // Collect metrics from Microsoft's TCPSTATS
 func (c *NetworkCheck) submitTCPStats(sender sender.Sender) {
-	tcpStatsMapping := map[string]string{
-		"DwActiveOpens":  ".active_opens",
-		"DwPassiveOpens": ".passive_opens",
-		"DwAttemptFails": ".attempt_fails",
-		"DwEstabResets":  ".established_resets",
-		"DwCurrEstab":    ".current_established", // Gauge
-		"DwInSegs":       ".in_segs",
-		"DwOutSegs":      ".out_segs",
-		"DwRetransSegs":  ".retrans_segs",
-		"DwInErrs":       ".in_errors",
-		"DwOutRsts":      ".out_resets",
-		"DwNumConns":     ".connections", // Gauge
-	}
-
 	tcp4Stats, err := c.net.TCPStats("tcp4")
 	if err != nil {
 		log.Errorf("OSError getting TCP4 stats from GetTcpStatisticsEx: %s", err)
@@ -258,13 +243,13 @@ func (c *NetworkCheck) submitTCPStats(sender sender.Sender) {
 			DwOutRsts:      tcp4Stats.DwOutRsts + tcp6Stats.DwOutRsts,
 			DwNumConns:     tcp4Stats.DwNumConns + tcp6Stats.DwNumConns,
 		}
-		c.submitMetricsFromStruct(sender, "system.net.tcp", tcpAllStats, tcpStatsMapping)
+		c.submitMetricsFromStruct(sender, "system.net.tcp.", tcpAllStats)
 	}
-	c.submitMetricsFromStruct(sender, "system.net.tcp4", tcp4Stats, tcpStatsMapping)
-	c.submitMetricsFromStruct(sender, "system.net.tcp6", tcp6Stats, tcpStatsMapping)
+	c.submitMetricsFromStruct(sender, "system.net.tcp4.", tcp4Stats)
+	c.submitMetricsFromStruct(sender, "system.net.tcp6.", tcp6Stats)
 }
 
-func (c *NetworkCheck) submitMetricsFromStruct(sender sender.Sender, metricPrefix string, tcpStats *mibTCPStats, tcpStatsMapping map[string]string) {
+func (c *NetworkCheck) submitMetricsFromStruct(sender sender.Sender, metricPrefix string, tcpStats *mibTCPStats) {
 	if tcpStats == nil {
 		return
 	}
@@ -272,10 +257,15 @@ func (c *NetworkCheck) submitMetricsFromStruct(sender sender.Sender, metricPrefi
 	s := reflect.ValueOf(tcpStats).Elem()
 	sType := s.Type()
 	for i := 0; i < s.NumField(); i++ {
-		fieldName := sType.Field(i).Name
-		metricName := metricPrefix + tcpStatsMapping[fieldName]
+		tag := sType.Field(i).Tag
+		metric_name := tag.Get("metric_name")
+		if metric_name == "" {
+			continue
+		}
+
+		metricName := metricPrefix + metric_name
 		metricValue := s.Field(i).Uint()
-		if strings.HasSuffix(metricName, ".connections") || strings.HasSuffix(metricName, ".current_established") {
+		if tag.Get("metric_type") == "gauge" {
 			sender.Gauge(metricName, float64(metricValue), "", nil)
 		} else {
 			if c.config.instance.CollectRateMetrics {

--- a/pkg/collector/corechecks/net/networkv2/network_windows.go
+++ b/pkg/collector/corechecks/net/networkv2/network_windows.go
@@ -258,12 +258,12 @@ func (c *NetworkCheck) submitMetricsFromStruct(sender sender.Sender, metricPrefi
 	sType := s.Type()
 	for i := 0; i < s.NumField(); i++ {
 		tag := sType.Field(i).Tag
-		metric_name := tag.Get("metric_name")
-		if metric_name == "" {
+		metricNameTag := tag.Get("metric_name")
+		if metricNameTag == "" {
 			continue
 		}
 
-		metricName := metricPrefix + metric_name
+		metricName := metricPrefix + metricNameTag
 		metricValue := s.Field(i).Uint()
 		if tag.Get("metric_type") == "gauge" {
 			sender.Gauge(metricName, float64(metricValue), "", nil)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the network Windows check to avoid emitting metrics for every field of the `mibTCPStats` struct, and only emit for the ones we want.

### Motivation
Fix the e2e test, have the same metrics as the Python check.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
E2e test (CI)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->