### PR TITLE
[EBPF] gpu: handle runtime changes of CUDA_VISIBLE_DEVICES

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -56,6 +56,7 @@ func processFile(rdr io.Reader, out io.Writer) error {
 		"Topic_name",
 		"Trigger_comm",
 		"Victim_comm",
+		"Devices",
 	}
 
 	// Convert []int8 to []byte in multiple generated fields from the kernel, to simplify

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -1052,6 +1052,7 @@ func (s *SharedLibrarySuite) TestMultipleLibsets() {
 	// Create test files for different libsets
 	cryptoLibPath, _ := createTempTestFile(t, "foo-libssl.so")
 	gpuLibPath, _ := createTempTestFile(t, "foo-libcudart.so")
+	libcLibPath, _ := createTempTestFile(t, "foo-libc.so")
 
 	attachCfg := AttacherConfig{
 		Rules: []*AttachRule{
@@ -1063,9 +1064,13 @@ func (s *SharedLibrarySuite) TestMultipleLibsets() {
 				LibraryNameRegex: regexp.MustCompile(`foo-libcudart\.so`),
 				Targets:          AttachToSharedLibraries,
 			},
+			{
+				LibraryNameRegex: regexp.MustCompile(`foo-libc\.so`),
+				Targets:          AttachToSharedLibraries,
+			},
 		},
 		EbpfConfig:                     ebpfCfg,
-		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetCrypto, sharedlibraries.LibsetGPU},
+		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetCrypto, sharedlibraries.LibsetGPU, sharedlibraries.LibsetLibc},
 		EnablePeriodicScanNewProcesses: false,
 	}
 
@@ -1094,6 +1099,7 @@ func (s *SharedLibrarySuite) TestMultipleLibsets() {
 	testCases := []testCase{
 		{cryptoLibPath, "foo-libssl.so", "crypto library"},
 		{gpuLibPath, "foo-libcudart.so", "GPU library"},
+		{libcLibPath, "foo-libc.so", "libc library"},
 	}
 
 	var commands []*exec.Cmd

--- a/pkg/ebpf/uprobes/testutil.go
+++ b/pkg/ebpf/uprobes/testutil.go
@@ -250,7 +250,12 @@ func waitAndRetryIfFail(t *testing.T, setupFunc func(), testFunc func() bool, re
 		}
 	}
 
-	require.Fail(t, "condition not met after %d retries", maxRetries, msgAndArgs)
+	extraFmt := ""
+	if len(msgAndArgs) > 0 {
+		extraFmt = fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...) + ": "
+	}
+
+	require.Fail(t, "condition not met", "%scondition not met after %d retries", extraFmt, maxRetries)
 }
 
 // processMonitorProxy is a wrapper around a ProcessMonitor that stores the

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unsafe"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
@@ -225,7 +227,7 @@ func (c *cudaEventConsumer) handleSetDevice(csde *gpuebpf.CudaSetDeviceEvent) {
 func (c *cudaEventConsumer) handleVisibleDevicesSet(vds *gpuebpf.CudaVisibleDevicesSetEvent) {
 	pid, _ := getPidTidFromHeader(&vds.Header)
 
-	c.sysCtx.setUpdatedVisibleDevicesEnvVar(int(pid), string(vds.Devices[:]))
+	c.sysCtx.setUpdatedVisibleDevicesEnvVar(int(pid), unix.ByteSliceToString(vds.Devices[:]))
 }
 
 func (c *cudaEventConsumer) handleGlobalEvent(header *gpuebpf.CudaEventHeader, data unsafe.Pointer, dataLen int) error {

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -163,7 +163,7 @@ func (c *cudaEventConsumer) Start() {
 }
 
 func isStreamSpecificEvent(eventType gpuebpf.CudaEventType) bool {
-	return eventType != gpuebpf.CudaEventTypeSetDevice
+	return eventType != gpuebpf.CudaEventTypeSetDevice && eventType != gpuebpf.CudaEventTypeVisibleDevicesSet
 }
 
 func (c *cudaEventConsumer) handleEvent(header *gpuebpf.CudaEventHeader, dataPtr unsafe.Pointer, dataLen int) error {
@@ -222,11 +222,19 @@ func (c *cudaEventConsumer) handleSetDevice(csde *gpuebpf.CudaSetDeviceEvent) {
 	c.sysCtx.setDeviceSelection(int(pid), int(tid), csde.Device)
 }
 
+func (c *cudaEventConsumer) handleVisibleDevicesSet(vds *gpuebpf.CudaVisibleDevicesSetEvent) {
+	pid, _ := getPidTidFromHeader(&vds.Header)
+
+	c.sysCtx.setUpdatedVisibleDevicesEnvVar(int(pid), string(vds.Devices[:]))
+}
+
 func (c *cudaEventConsumer) handleGlobalEvent(header *gpuebpf.CudaEventHeader, data unsafe.Pointer, dataLen int) error {
 	eventType := gpuebpf.CudaEventType(header.Type)
 	switch eventType {
 	case gpuebpf.CudaEventTypeSetDevice:
 		return handleTypedEvent(c, c.handleSetDevice, eventType, data, dataLen, gpuebpf.SizeofCudaSetDeviceEvent)
+	case gpuebpf.CudaEventTypeVisibleDevicesSet:
+		return handleTypedEvent(c, c.handleVisibleDevicesSet, eventType, data, dataLen, gpuebpf.SizeofCudaVisibleDevicesSetEvent)
 	default:
 		c.telemetry.eventErrors.Inc(telemetryEventTypeUnknown, telemetryEventErrorUnknownType)
 		return fmt.Errorf("unknown event type: %d", header.Type)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 )
 
@@ -34,6 +35,12 @@ type systemContext struct {
 	// Note that this is the device index as seen by the process itself, which might
 	// be modified by the CUDA_VISIBLE_DEVICES environment variable later
 	selectedDeviceByPIDAndTID map[int]map[int]int32
+
+	// updatedVisibleDevicesEnvVars maps each process ID to the latest visible
+	// devices environment variable that was set by the process. This is used to
+	// keep track of updates during process runtime, whic aren't visible in
+	// /proc/pid/environ.
+	updatedVisibleDevicesEnvVars map[int]string
 
 	// deviceCache is a cache of GPU devices on the system
 	deviceCache ddnvml.DeviceCache
@@ -104,10 +111,11 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 	opts := newSystemContextOptions(optList...)
 
 	ctx := &systemContext{
-		procRoot:                  opts.procRoot,
-		selectedDeviceByPIDAndTID: make(map[int]map[int]int32),
-		visibleDevicesCache:       make(map[int][]ddnvml.Device),
-		workloadmeta:              opts.wmeta,
+		procRoot:                     opts.procRoot,
+		selectedDeviceByPIDAndTID:    make(map[int]map[int]int32),
+		visibleDevicesCache:          make(map[int][]ddnvml.Device),
+		updatedVisibleDevicesEnvVars: make(map[int]string),
+		workloadmeta:                 opts.wmeta,
 	}
 
 	var err error
@@ -135,6 +143,7 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 func (ctx *systemContext) removeProcess(pid int) {
 	delete(ctx.selectedDeviceByPIDAndTID, pid)
 	delete(ctx.visibleDevicesCache, pid)
+	delete(ctx.updatedVisibleDevicesEnvVars, pid)
 
 	if ctx.cudaKernelCache != nil {
 		ctx.cudaKernelCache.CleanProcessData(pid)
@@ -251,7 +260,15 @@ func (ctx *systemContext) getCurrentActiveGpuDevice(pid int, tid int, containerI
 			return nil, fmt.Errorf("error filtering devices for container %s: %w", containerID, err)
 		}
 
-		visibleDevices, err = cuda.GetVisibleDevicesForProcess(visibleDevices, pid, ctx.procRoot)
+		envVar, ok := ctx.updatedVisibleDevicesEnvVars[pid]
+		if !ok {
+			envVar, err = kernel.GetProcessEnvVariable(pid, ctx.procRoot, cuda.CudaVisibleDevicesEnvVar)
+			if err != nil {
+				return nil, fmt.Errorf("error getting env var %s for process %d: %w", cuda.CudaVisibleDevicesEnvVar, pid, err)
+			}
+		}
+
+		visibleDevices, err = cuda.ParseVisibleDevices(visibleDevices, envVar)
 		if err != nil {
 			return nil, fmt.Errorf("error getting visible devices for process %d: %w", pid, err)
 		}
@@ -283,4 +300,11 @@ func (ctx *systemContext) setDeviceSelection(pid int, tid int, deviceIndex int32
 	}
 
 	ctx.selectedDeviceByPIDAndTID[pid][tid] = deviceIndex
+}
+
+func (ctx *systemContext) setUpdatedVisibleDevicesEnvVar(pid int, envVar string) {
+	ctx.updatedVisibleDevicesEnvVars[pid] = envVar
+
+	// Invalidate the visible devices cache to force a re-scan of the devices
+	delete(ctx.visibleDevicesCache, pid)
 }

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -38,7 +38,7 @@ type systemContext struct {
 
 	// updatedVisibleDevicesEnvVars maps each process ID to the latest visible
 	// devices environment variable that was set by the process. This is used to
-	// keep track of updates during process runtime, whic aren't visible in
+	// keep track of updates during process runtime, which aren't visible in
 	// /proc/pid/environ.
 	updatedVisibleDevicesEnvVars map[int]string
 

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -15,6 +15,7 @@ import (
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 )
 
+// CudaVisibleDevicesEnvVar is the name of the environment variable that controls the visible GPUs for CUDA applications
 const CudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 
 // ParseVisibleDevices modifies the list of GPU devices according to the

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -12,16 +12,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 )
 
-const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
+const CudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 
-// GetVisibleDevicesForProcess modifies the list of GPU devices according to the
-// value of the CUDA_VISIBLE_DEVICES environment variable for the specified
-// process. Reference:
+// ParseVisibleDevices modifies the list of GPU devices according to the
+// value of the CUDA_VISIBLE_DEVICES environment variable. Reference:
 // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#env-vars.
 //
 // As a summary, the CUDA_VISIBLE_DEVICES environment variable should be a comma
@@ -36,18 +33,7 @@ const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 // devices whose index precedes the invalid index are visible to CUDA
 // applications." If an invalid index is found, an error is returned together
 // with the list of valid devices found up until that point.
-func GetVisibleDevicesForProcess(devices []ddnvml.Device, pid int, procfs string) ([]ddnvml.Device, error) {
-	cudaVisibleDevicesForProcess, err := kernel.GetProcessEnvVariable(pid, procfs, cudaVisibleDevicesEnvVar)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get env var %s for process %d: %w", cudaVisibleDevicesEnvVar, pid, err)
-	}
-
-	return getVisibleDevices(devices, cudaVisibleDevicesForProcess)
-}
-
-// getVisibleDevices processes the list of GPU devices according to the value of
-// the CUDA_VISIBLE_DEVICES environment variable
-func getVisibleDevices(devices []ddnvml.Device, cudaVisibleDevicesForProcess string) ([]ddnvml.Device, error) {
+func ParseVisibleDevices(devices []ddnvml.Device, cudaVisibleDevicesForProcess string) ([]ddnvml.Device, error) {
 	// First, we adjust the list of devices to take into account how CUDA presents MIG devices in order. This
 	// list will not be used when searching by prefix because prefix matching is done against *all* devices,
 	// but index filtering is done against the adjusted list where devices with MIG children are replaced by

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -97,7 +97,7 @@ func TestGetVisibleDevices(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			devices, err := getVisibleDevices(devList, tc.visibleDevices)
+			devices, err := ParseVisibleDevices(devList, tc.visibleDevices)
 			if tc.expectsError {
 				require.Error(t, err)
 			} else {
@@ -319,7 +319,7 @@ func TestGetVisibleDevicesWithMIG(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			devices, err := getVisibleDevices(tc.systemDevices, tc.visibleDevices)
+			devices, err := ParseVisibleDevices(tc.systemDevices, tc.visibleDevices)
 			if tc.expectsError {
 				require.Error(t, err)
 			} else {

--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
+	"github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
@@ -71,7 +72,7 @@ func TestPytorchBatchedKernels(t *testing.T) {
 
 	telemetryMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
 	require.NoError(t, err)
-	require.Equal(t, 4, len(telemetryMetrics)) // one for each event type
+	require.Equal(t, int(ebpf.CudaEventTypeCount), len(telemetryMetrics)) // one for each event type
 	expectedEventsByType := testutil.DataSampleInfos[testutil.DataSamplePytorchBatchedKernels].EventByType
 	for _, metric := range telemetryMetrics {
 		eventTypeTag := metric.Tags()["event_type"]

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -366,4 +366,44 @@ int BPF_URETPROBE(uretprobe__cudaMemcpy) {
     return 0;
 }
 
+SEC("uprobe/setenv")
+int BPF_UPROBE(uprobe__setenv, const char *name, const char *value, int overwrite) {
+    // Check if the env var is CUDA_VISIBLE_DEVICES. This is BPF_UPROBE, so we can't use a string
+    // comparison.
+    const char cuda_visible_devices[] = "CUDA_VISIBLE_DEVICES";
+    char name_buf[sizeof(cuda_visible_devices)];
+
+    // bpf_probe_read_user_str is available from kernel 5.5, our minimum kernel version is 5.8.0
+    int res = bpf_probe_read_user_str_with_telemetry(name_buf, sizeof(name_buf), name);
+    if (res < 0) {
+        return 0;
+    }
+
+    // return value of bpf_probe_read_user_str_with_telemetry is the length of the string read,
+    // including the NULL byte. If the string is not the same length, it's not CUDA_VISIBLE_DEVICES.
+    if (res != sizeof(cuda_visible_devices)) {
+        return 0;
+    }
+
+    // bpf_strncmp is available in kernel 5.17, our minimum kernel version is 5.8.0
+    // so we need to do a manual comparison
+#pragma unroll
+    for (int i = 0; i < sizeof(cuda_visible_devices); i++) {
+        if (name[i] != cuda_visible_devices[i]) {
+            return 0;
+        }
+    }
+
+    cuda_visible_devices_set_t event = { 0 };
+
+    if (bpf_probe_read_user_str_with_telemetry(event.visible_devices, sizeof(event.visible_devices), value) < 0) {
+        return 0;
+    }
+
+    fill_header(&event.header, 0, cuda_visible_devices_set);
+
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    return 0;
+}
+
 char __license[] SEC("license") = "GPL";

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -387,7 +387,6 @@ int BPF_UPROBE(uprobe__setenv, const char *name, const char *value, int overwrit
 
     // bpf_strncmp is available in kernel 5.17, our minimum kernel version is 5.8.0
     // so we need to do a manual comparison
-#pragma unroll
     for (int i = 0; i < sizeof(cuda_visible_devices); i++) {
         if (name_buf[i] != cuda_visible_devices[i]) {
             return 0;

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -389,7 +389,7 @@ int BPF_UPROBE(uprobe__setenv, const char *name, const char *value, int overwrit
     // so we need to do a manual comparison
 #pragma unroll
     for (int i = 0; i < sizeof(cuda_visible_devices); i++) {
-        if (name[i] != cuda_visible_devices[i]) {
+        if (name_buf[i] != cuda_visible_devices[i]) {
             return 0;
         }
     }

--- a/pkg/gpu/ebpf/c/types.h
+++ b/pkg/gpu/ebpf/c/types.h
@@ -12,10 +12,12 @@ typedef enum {
     cuda_memory_event,
     cuda_sync,
     cuda_set_device,
+    cuda_visible_devices_set,
     cuda_event_type_count,
 } cuda_event_type_t;
 
 #define MAX_CONTAINER_ID_LEN 129
+#define MAX_ENV_VAR_LEN 256 // Not the actual max (which seems to be 32KB) but enough for the CUDA_VISIBLE_DEVICES env var use case
 
 typedef struct {
     __u64 pid_tgid;
@@ -69,5 +71,10 @@ typedef struct {
     __u64 stream;
     __u64 last_access_ktime_ns;
 } cuda_event_value_t;
+
+typedef struct {
+    cuda_event_header_t header;
+    char visible_devices[MAX_ENV_VAR_LEN];
+} cuda_visible_devices_set_t;
 
 #endif

--- a/pkg/gpu/ebpf/kprobe_types.go
+++ b/pkg/gpu/ebpf/kprobe_types.go
@@ -27,6 +27,8 @@ type CudaMemEventType C.cuda_memory_event_type_t
 
 type CudaSetDeviceEvent C.cuda_set_device_event_t
 
+type CudaVisibleDevicesSetEvent C.cuda_visible_devices_set_t
+
 type CudaEventKey C.cuda_event_key_t
 type CudaEventValue C.cuda_event_value_t
 
@@ -34,6 +36,7 @@ const CudaEventTypeKernelLaunch CudaEventType = C.cuda_kernel_launch
 const CudaEventTypeMemory CudaEventType = C.cuda_memory_event
 const CudaEventTypeSync CudaEventType = C.cuda_sync
 const CudaEventTypeSetDevice CudaEventType = C.cuda_set_device
+const CudaEventTypeVisibleDevicesSet CudaEventType = C.cuda_visible_devices_set
 const CudaEventTypeCount CudaEventType = C.cuda_event_type_count
 
 const CudaMemAlloc = C.cudaMalloc
@@ -44,3 +47,4 @@ const SizeofCudaMemEvent = C.sizeof_cuda_memory_event_t
 const SizeofCudaEventHeader = C.sizeof_cuda_event_header_t
 const SizeofCudaSync = C.sizeof_cuda_sync_t
 const SizeofCudaSetDeviceEvent = C.sizeof_cuda_set_device_event_t
+const SizeofCudaVisibleDevicesSetEvent = C.sizeof_cuda_visible_devices_set_t

--- a/pkg/gpu/ebpf/kprobe_types_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux.go
@@ -46,6 +46,11 @@ type CudaSetDeviceEvent struct {
 	Pad_cgo_0 [4]byte
 }
 
+type CudaVisibleDevicesSetEvent struct {
+	Header  CudaEventHeader
+	Devices [256]byte
+}
+
 type CudaEventKey struct {
 	Event     uint64
 	Pid       uint32
@@ -60,7 +65,8 @@ const CudaEventTypeKernelLaunch CudaEventType = 0x0
 const CudaEventTypeMemory CudaEventType = 0x1
 const CudaEventTypeSync CudaEventType = 0x2
 const CudaEventTypeSetDevice CudaEventType = 0x3
-const CudaEventTypeCount CudaEventType = 0x4
+const CudaEventTypeVisibleDevicesSet CudaEventType = 0x4
+const CudaEventTypeCount CudaEventType = 0x5
 
 const CudaMemAlloc = 0x0
 const CudaMemFree = 0x1
@@ -70,3 +76,4 @@ const SizeofCudaMemEvent = 0xc0
 const SizeofCudaEventHeader = 0xa8
 const SizeofCudaSync = 0xa8
 const SizeofCudaSetDeviceEvent = 0xb0
+const SizeofCudaVisibleDevicesSetEvent = 0x1a8

--- a/pkg/gpu/ebpf/kprobe_types_linux_test.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux_test.go
@@ -32,6 +32,10 @@ func TestCgoAlignment_CudaSetDeviceEvent(t *testing.T) {
 	ebpftest.TestCgoAlignment[CudaSetDeviceEvent](t)
 }
 
+func TestCgoAlignment_CudaVisibleDevicesSetEvent(t *testing.T) {
+	ebpftest.TestCgoAlignment[CudaVisibleDevicesSetEvent](t)
+}
+
 func TestCgoAlignment_CudaEventKey(t *testing.T) {
 	ebpftest.TestCgoAlignment[CudaEventKey](t)
 }

--- a/pkg/gpu/ebpf/kprobe_types_string_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_string_linux.go
@@ -12,11 +12,13 @@ func _() {
 	_ = x[CudaEventTypeMemory-1]
 	_ = x[CudaEventTypeSync-2]
 	_ = x[CudaEventTypeSetDevice-3]
+	_ = x[CudaEventTypeVisibleDevicesSet-4]
+	_ = x[CudaEventTypeCount-5]
 }
 
-const _CudaEventType_name = "CudaEventTypeKernelLaunchCudaEventTypeMemoryCudaEventTypeSyncCudaEventTypeSetDevice"
+const _CudaEventType_name = "CudaEventTypeKernelLaunchCudaEventTypeMemoryCudaEventTypeSyncCudaEventTypeSetDeviceCudaEventTypeVisibleDevicesSetCudaEventTypeCount"
 
-var _CudaEventType_index = [...]uint8{0, 25, 44, 61, 83}
+var _CudaEventType_index = [...]uint8{0, 25, 44, 61, 83, 113, 131}
 
 func (i CudaEventType) String() string {
 	if i >= CudaEventType(len(_CudaEventType_index)-1) {

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -88,6 +88,7 @@ const (
 	cudaEventDestroyProbe        probeFuncName = "uprobe__cudaEventDestroy"
 	cudaMemcpyProbe              probeFuncName = "uprobe__cudaMemcpy"
 	cudaMemcpyRetProbe           probeFuncName = "uretprobe__cudaMemcpy"
+	setenvProbe                  probeFuncName = "uprobe__setenv"
 )
 
 // ProbeDependencies holds the dependencies for the probe
@@ -391,10 +392,21 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 					},
 				},
 			},
+			{
+				LibraryNameRegex: regexp.MustCompile(`libc\.so`),
+				Targets:          uprobes.AttachToSharedLibraries,
+				ProbesSelector: []manager.ProbesSelector{
+					&manager.AllOf{
+						Selectors: []manager.ProbesSelector{
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: setenvProbe}},
+						},
+					},
+				},
+			},
 		},
 		EbpfConfig:                     &cfg.Config,
 		PerformInitialScan:             cfg.InitialProcessSync,
-		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetGPU},
+		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetGPU, sharedlibraries.LibsetLibc},
 		ScanProcessesInterval:          cfg.ScanProcessesInterval,
 		EnablePeriodicScanNewProcesses: true,
 		EnableDetailedLogging:          false,

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -394,7 +394,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 			},
 			{
 				LibraryNameRegex: regexp.MustCompile(`libc\.so`),
-				Targets:          uprobes.AttachToSharedLibraries,
+				Targets:          uprobes.AttachToSharedLibraries | uprobes.AttachToExecutable,
 				ProbesSelector: []manager.ProbesSelector{
 					&manager.AllOf{
 						Selectors: []manager.ProbesSelector{

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -160,10 +160,7 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	require.NotNil(t, stats)
 	require.NotEmpty(t, stats.Metrics)
 
-	metricKey := model.StatsKey{PID: uint32(cmd.Process.Pid), DeviceUUID: testutil.DefaultGpuUUID}
-	metrics := getMetricsEntry(metricKey, stats)
-	require.NotNil(t, metrics)
-
+	// Check expected events are received, using the telemetry counts
 	telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)
 	require.True(t, ok)
 
@@ -171,10 +168,11 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	require.NoError(t, err)
 
 	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String(): 1,
-		ebpf.CudaEventTypeSetDevice.String():    1,
-		ebpf.CudaEventTypeMemory.String():       2,
-		ebpf.CudaEventTypeSync.String():         4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
+		ebpf.CudaEventTypeKernelLaunch.String():      1,
+		ebpf.CudaEventTypeSetDevice.String():         1,
+		ebpf.CudaEventTypeMemory.String():            2,
+		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
+		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
 	}
 
 	actualEvents := make(map[string]int)
@@ -189,8 +187,15 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 		require.Equal(t, value, actualEvents[evName], "event %s count mismatch", evName)
 	}
 
+	// Ensure the metrics we get are correct
+	metricKey := model.StatsKey{PID: uint32(cmd.Process.Pid), DeviceUUID: testutil.DefaultGpuUUID}
+	metrics := getMetricsEntry(metricKey, stats)
+	require.NotNil(t, metrics)
 	require.Greater(t, metrics.UsedCores, 0.0) // core usage depends on the time this took to run, so it's not deterministic
 	require.Equal(t, metrics.Memory.MaxBytes, uint64(110))
+
+	// Check that the context was updated with the events
+	require.Equal(t, probe.sysCtx.updatedVisibleDevicesEnvVars[cmd.Process.Pid], "42")
 }
 
 func (s *probeTestSuite) TestMultiGPUSupport() {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -196,7 +196,7 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	require.Equal(t, metrics.Memory.MaxBytes, uint64(110))
 
 	// Check that the context was updated with the events
-	require.Equal(t, probe.sysCtx.updatedVisibleDevicesEnvVars[cmd.Process.Pid], "42")
+	require.Equal(t, probe.sysCtx.cudaVisibleDevicesPerProcess[cmd.Process.Pid], "42")
 }
 
 func (s *probeTestSuite) TestMultiGPUSupport() {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -111,10 +111,11 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	}
 
 	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String(): 1,
-		ebpf.CudaEventTypeSetDevice.String():    1,
-		ebpf.CudaEventTypeMemory.String():       2,
-		ebpf.CudaEventTypeSync.String():         4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
+		ebpf.CudaEventTypeKernelLaunch.String():      1,
+		ebpf.CudaEventTypeSetDevice.String():         1,
+		ebpf.CudaEventTypeMemory.String():            2,
+		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
+		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
 	}
 
 	for evName, value := range expectedEvents {

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -93,6 +93,8 @@ int main(int argc, char **argv) {
 
     cudaEventDestroy(event);
 
+    setenv("CUDA_VISIBLE_DEVICES", "42", 1);
+
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
 

--- a/pkg/network/ebpf/c/shared-libraries/maps.h
+++ b/pkg/network/ebpf/c/shared-libraries/maps.h
@@ -15,5 +15,6 @@ BPF_HASH_MAP(open_at_args, __u64, lib_path_t, 10240)
  */
 BPF_PERF_EVENT_ARRAY_MAP(crypto_shared_libraries, __u32)
 BPF_PERF_EVENT_ARRAY_MAP(gpu_shared_libraries, __u32)
+BPF_PERF_EVENT_ARRAY_MAP(libc_shared_libraries, __u32)
 
 #endif

--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -96,7 +96,7 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     u64 libc_libset_enabled = 0;
     LOAD_CONSTANT("libc_libset_enabled", libc_libset_enabled);
 
-    if (libc_libset_enabled && (match4chars(0, 'l', 'i', 'b', 'c'))) {
+    if (libc_libset_enabled && (match4chars(2, 'l', 'i', 'b', 'c'))) {
         bpf_perf_event_output(ctx, &libc_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
     }
 }

--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -63,6 +63,7 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     bool is_shared_library = false;
 #define match3chars(_base, _a, _b, _c) (path->buf[_base + i] == _a && path->buf[_base + i + 1] == _b && path->buf[_base + i + 2] == _c)
 #define match6chars(_base, _a, _b, _c, _d, _e, _f) (match3chars(_base, _a, _b, _c) && match3chars(_base + 3, _d, _e, _f))
+#define match4chars(_base, _a, _b, _c, _d) (match3chars(_base, _a, _b, _c) && path->buf[_base + i + 3] == _d)
     int i = 0;
 #pragma unroll
     for (i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
@@ -91,6 +92,13 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     if (gpu_libset_enabled && (match6chars(0, 'c', 'u', 'd', 'a', 'r', 't'))) {
         bpf_perf_event_output(ctx, &gpu_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
     }
+
+    u64 libc_libset_enabled = 0;
+    LOAD_CONSTANT("libc_libset_enabled", libc_libset_enabled);
+
+    if (libc_libset_enabled && (match4chars(0, 'l', 'i', 'b', 'c'))) {
+        bpf_perf_event_output(ctx, &libc_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
+    }
 }
 
 static __always_inline void do_sys_open_helper_exit(exit_sys_ctx *args) {
@@ -107,11 +115,10 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_ctx *args) {
 
 // This definition is the same for all architectures.
 #ifndef O_WRONLY
-#define O_WRONLY        00000001
+#define O_WRONLY 00000001
 #endif
 
-static __always_inline int should_ignore_flags(int flags)
-{
+static __always_inline int should_ignore_flags(int flags) {
     return flags & O_WRONLY;
 }
 

--- a/pkg/network/usm/sharedlibraries/libset.go
+++ b/pkg/network/usm/sharedlibraries/libset.go
@@ -13,7 +13,7 @@ const (
 	// LibsetCrypto is the libset that contains the crypto libraries (libssl, libcrypto, libgnutls)
 	LibsetCrypto Libset = "crypto"
 
-	// LibsetGPU contains the libraryes for GPU monitoring (libcudart)
+	// LibsetGPU contains the libraries for GPU monitoring (libcudart)
 	LibsetGPU Libset = "gpu"
 
 	// LibsetLibc is the libset that contains the libc library (libc.so)

--- a/pkg/network/usm/sharedlibraries/libset.go
+++ b/pkg/network/usm/sharedlibraries/libset.go
@@ -15,6 +15,9 @@ const (
 
 	// LibsetGPU contains the libraryes for GPU monitoring (libcudart)
 	LibsetGPU Libset = "gpu"
+
+	// LibsetLibc is the libset that contains the libc library (libc.so)
+	LibsetLibc Libset = "libc"
 )
 
 // LibsetToLibSuffixes maps a libset to a list of regexes that match the shared libraries that belong to that libset. Should be
@@ -22,6 +25,7 @@ const (
 var LibsetToLibSuffixes = map[Libset][]string{
 	LibsetCrypto: {"libssl", "crypto", "gnutls"},
 	LibsetGPU:    {"libcudart"},
+	LibsetLibc:   {"libc"},
 }
 
 // IsLibsetValid checks if the given libset is valid (i.e., it's in the LibsetToLibSuffixes map)

--- a/releasenotes/notes/gpu-cuda-visible-devices-fe4de39c7ce14b97.yaml
+++ b/releasenotes/notes/gpu-cuda-visible-devices-fe4de39c7ce14b97.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    GPU: fix a bug where the device assigned to a process could be wrong if it updates the CUDA_VISIBLE_DEVICES environment variable during runtime


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support for handling runtime updates for the `CUDA_VISIBLE_DEVICES` environment variable. This consists of the following changes:

* Add an uprobe to the `setenv` function in `libc`, that watches for the calls with the `CUDA_VISIBLE_DEVICES` variable name exclusively. The value will be sent to the GPU event ringbuffer.
* Add a new library set to the shared libraries watcher so that we can watch for processes opening `libc`. 
* Add a rule to the GPU monitoring attacher, to attach to all processes that have `setenv`. It's necessary to do for all processes, as a process might change its environment variable before calling any CUDA functions. If we probed only processes that have the CUDA library loaded we would miss those events.
* The GPU consumer now detects the events corresponding to changes in this variable, and will update them in the `systemContext`.
* `systemContext` will prioritize this value now over the one from `/proc/pid/environ` when finding the devices visible to a process.
* In order to select the origin of the `CUDA_VISIBLE_DEVICES`, the code retrieving the environment variable for the process has been moved  from the `pkg/gpu/cuda` package to `systemContext`.

### Motivation

https://datadoghq.atlassian.net/browse/NWL-1275

We have detected an issue in a `ray` cluster. When deployed in a node with multiple GPUs, `ray` will spawn one process per GPU. Each process will then [update](https://github.com/ray-project/ray/blob/c5e45ed42c4d23a1da0cb8ae1ade891d37866e39/python/ray/_private/accelerators/nvidia_gpu.py#L92) its own `CUDA_VISIBLE_DEVICES` environment variable. Our current approach will not detect this change, and will consider that all processes are using the same GPU.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests provided, tested also in the [GPU load test environment](https://dddev.datadoghq.com/dashboard/ws9-twf-2ry?fromUser=false&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=gjsetdev-base&tpl_var_compare_agent-env%5B0%5D=gjsetdev-new&tpl_var_kube_cluster_name%5B0%5D=sp-test-env-gpu-1&from_ts=1751892422424&to_ts=1751894222424&live=true) with no significant changes in resource usage.

Finally, manually tested this in an AWS instance with Ray running on multiple GPUs, replicating the environment with the original error.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->