### PR TITLE
(fleet) avoid setting tags when install script parent is injected

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -35,6 +35,7 @@ func WriteConfigs(config Config, configDir string) error {
 		return fmt.Errorf("could not create config directory: %w", err)
 	}
 
+	config = sanitizeConfig(config)
 	err = writeConfig(filepath.Join(configDir, datadogConfFile), config.DatadogYAML, 0640, true)
 	if err != nil {
 		return fmt.Errorf("could not write datadog.yaml: %w", err)
@@ -64,6 +65,14 @@ func WriteConfigs(config Config, configDir string) error {
 		}
 	}
 	return nil
+}
+
+func sanitizeConfig(config Config) Config {
+	apmInjectTagPrefix := "_dd.injection.mode:"
+	if len(config.DatadogYAML.Tags) == 1 && strings.HasPrefix(config.DatadogYAML.Tags[0], apmInjectTagPrefix) {
+		config.DatadogYAML.Tags = nil
+	}
+	return config
 }
 
 func writeConfig(path string, config any, perms os.FileMode, merge bool) error {

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -183,7 +183,7 @@ func TestSanitizeInjectionModeTag(t *testing.T) {
 	config := Config{
 		DatadogYAML: DatadogConfig{
 			APIKey: "1234567890",
-			Tags: []string{"_dd.injection.mode:host"},
+			Tags:   []string{"_dd.injection.mode:host"},
 		},
 	}
 

--- a/pkg/fleet/installer/setup/config/config_test.go
+++ b/pkg/fleet/installer/setup/config/config_test.go
@@ -177,3 +177,24 @@ func TestApplicationMonitoring(t *testing.T) {
 
 	assert.Equal(t, *config.ApplicationMonitoringYAML, cfgres)
 }
+
+func TestSanitizeInjectionModeTag(t *testing.T) {
+	tempDir := t.TempDir()
+	config := Config{
+		DatadogYAML: DatadogConfig{
+			APIKey: "1234567890",
+			Tags: []string{"_dd.injection.mode:host"},
+		},
+	}
+
+	err := WriteConfigs(config, tempDir)
+	assert.NoError(t, err)
+
+	// Check datadog.yaml
+	datadogYAML, err := os.ReadFile(filepath.Join(tempDir, datadogConfFile))
+	assert.NoError(t, err)
+	var datadog map[string]interface{}
+	err = yaml.Unmarshal(datadogYAML, &datadog)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"api_key": "1234567890"}, datadog)
+}


### PR DESCRIPTION
This PR addresses a weird interaction between APM's SSI and the install script.

APM SSI adds a `DD_TAGS=_dd.injection.mode` env variable to all injected processes. This is usually fine but in a very specific scenario where:
1. A process in python/ruby/etc... is injected
2. This process starts the install script

This can lead to an unexpected `DD_TAGS` being passed to the install script, overriding the previous values.
