### PR TITLE
evictImageTag fix

### DIFF
--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -41,7 +41,7 @@ func (netdevice *NetworkDeviceNode) appendImageTag(imageTag string) {
 
 func (netdevice *NetworkDeviceNode) evictImageTag(imageTag string) bool {
 	for key, flow := range netdevice.FlowNodes {
-		if shouldRemove := flow.evictImageTag(imageTag); !shouldRemove {
+		if flow.evictImageTag(imageTag){
 			delete(netdevice.FlowNodes, key)
 		}
 	}

--- a/pkg/security/security_profile/activity_tree/network_device_node.go
+++ b/pkg/security/security_profile/activity_tree/network_device_node.go
@@ -41,7 +41,7 @@ func (netdevice *NetworkDeviceNode) appendImageTag(imageTag string) {
 
 func (netdevice *NetworkDeviceNode) evictImageTag(imageTag string) bool {
 	for key, flow := range netdevice.FlowNodes {
-		if flow.evictImageTag(imageTag){
+		if flow.evictImageTag(imageTag) {
 			delete(netdevice.FlowNodes, key)
 		}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes an inverted conditional in `evictImageTag` that was causing flows to be removed when they shouldn’t, and vice versa. The corrected implementation now only deletes a flow when its own `evictImageTag` returns true, and returns true if all flows have been evicted

### Motivation


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->