### PR TITLE
[Backport 7.67.x] fix panic when there is no question in the DNS layer

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1334,15 +1334,17 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			event.Type = uint32(model.DNSEventType) // remap to regular DNS event type
 			event.DNS = model.DNSEvent{
 				ID: dnsLayer.ID,
-				Question: model.DNSQuestion{
+				Response: &model.DNSResponse{
+					ResponseCode: uint8(dnsLayer.ResponseCode),
+				},
+			}
+			if len(dnsLayer.Questions) != 0 {
+				event.DNS.Question = model.DNSQuestion{
 					Name:  string(dnsLayer.Questions[0].Name),
 					Class: uint16(dnsLayer.Questions[0].Class),
 					Type:  uint16(dnsLayer.Questions[0].Type),
 					Size:  uint16(len(data[offset:])),
-				},
-				Response: &model.DNSResponse{
-					ResponseCode: uint8(dnsLayer.ResponseCode),
-				},
+				}
 			}
 		}
 


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/17f0dd6efbcb55074942fac0d34c43b9cd9ff63f from https://github.com/DataDog/datadog-agent/pull/38107.

---

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the following panic, seen on 7.68.0rc4 and 7.67.1-rc.1:
```
panic: runtime error: index out of range [0] with length 0
goroutine 601 [running]:
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent(0xc004ea8e08, 0x0, {0xc003daa580, 0xe2, 0x561})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1353 +0x5b65
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent(0xc000b9a270, 0xc0056be4c0, 0x0?, 0xc0013c1f38?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go:60 +0x31
github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
	/go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.12/ringbuffer.go:138 +0x187
created by github.com/DataDog/ebpf-manager.(*RingBuffer).Start in goroutine 1
	/go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.12/ringbuffer.go:108 +0x125
```

by ensuring we check the size of dnslayer.questions before accessing the first element.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->