### PR TITLE
[CWS-4844] Report rule error for every policy a rule is part of

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -678,7 +678,7 @@ func getPoliciesVersions(rs *rules.RuleSet, includeInternalPolicies bool) []stri
 
 	cache := make(map[string]bool)
 	for _, rule := range rs.GetRules() {
-		for _, pInfo := range rule.UsedBy {
+		for pInfo := range rule.Policies() {
 			if rule.Policy.IsInternal && !includeInternalPolicies {
 				continue
 			}

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -372,7 +372,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 	var exists bool
 
 	for _, rule := range rs.GetRules() {
-		for _, pInfo := range rule.UsedBy {
+		for pInfo := range rule.Policies() {
 			if pInfo.IsInternal && !includeInternalPolicies {
 				continue
 			}
@@ -381,7 +381,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, PolicyStatusLoaded, "")
 				mp[pInfo.Name] = policyState
 			}
-			policyState.Rules = append(policyState.Rules, RuleStateFromRule(rule.PolicyRule, &pInfo, "loaded", ""))
+			policyState.Rules = append(policyState.Rules, RuleStateFromRule(rule.PolicyRule, pInfo, "loaded", ""))
 		}
 	}
 
@@ -389,7 +389,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 	if err != nil && err.Errors != nil {
 		for _, err := range err.Errors {
 			if rerr, ok := err.(*rules.ErrRuleLoad); ok {
-				for _, pInfo := range rerr.Rule.UsedBy {
+				for pInfo := range rerr.Rule.Policies() {
 					if pInfo.IsInternal && !includeInternalPolicies {
 						continue
 					}
@@ -402,7 +402,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 					} else if policyState.Status == PolicyStatusLoaded {
 						policyState.Status = PolicyStatusPartiallyLoaded
 					}
-					policyState.Rules = append(policyState.Rules, RuleStateFromRule(rerr.Rule, &pInfo, string(rerr.Type()), rerr.Err.Error()))
+					policyState.Rules = append(policyState.Rules, RuleStateFromRule(rerr.Rule, pInfo, string(rerr.Type()), rerr.Err.Error()))
 				}
 			} else if pErr, ok := err.(*rules.ErrPolicyLoad); ok {
 				policyName := pErr.Name

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -1,0 +1,434 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package monitor holds rules related files
+package monitor
+
+import (
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	gocmpopts "github.com/google/go-cmp/cmp/cmpopts"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+type testPolicy struct {
+	info rules.PolicyInfo
+	def  rules.PolicyDef
+}
+
+func TestPolicyMonitorPolicyState(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		policies             []*testPolicy
+		testPolicyStatesCb   func(t *testing.T, states []*PolicyState)
+		expectedPolicyStates []*PolicyState
+	}{
+		{
+			name:                 "no policy",
+			policies:             nil,
+			expectedPolicyStates: nil,
+		},
+		{
+			name: "single policy",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusLoaded,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.file.path == "/etc/foo/bar"`,
+							Status:     "loaded",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rule with no expression",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID: "rule_a",
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:      "rule_a",
+							Status:  "error",
+							Message: rules.ErrRuleWithoutExpression.Error(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty policy",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Empty Policy",
+						Source: "test",
+					},
+					def: rules.PolicyDef{},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Empty Policy",
+						Source: "test",
+					},
+					Status:  PolicyStatusError,
+					Message: rules.ErrPolicyIsEmpty.Error(),
+				},
+			},
+		},
+		{
+			name: "multiple policies with same erroneous rule",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							},
+							{
+								ID:         "rule_b",
+								Expression: `foo.bar.path == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							Status:     "error",
+							Message:    "rule compilation error: field `exec.foo.bar` not found",
+						},
+						{
+							ID:         "rule_b",
+							Expression: `foo.bar.path == "/etc/foo/bar"`,
+							Status:     "error",
+							Message:    "rule compilation error: field `foo.bar.path` not found",
+						},
+					},
+				},
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							Status:     "error",
+							Message:    "rule compilation error: field `exec.foo.bar` not found",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "partially loaded policy",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							},
+							{
+								ID:         "rule_b",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusPartiallyLoaded,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_b",
+							Expression: `exec.file.path == "/etc/foo/bar"`,
+							Status:     "loaded",
+						},
+						{
+							ID:         "rule_a",
+							Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							Status:     "error",
+							Message:    "rule compilation error: field `exec.foo.bar` not found",
+						},
+					},
+				},
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					Status: PolicyStatusFullyRejected,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.foo.bar == "/etc/foo/bar"`,
+							Status:     "error",
+							Message:    "rule compilation error: field `exec.foo.bar` not found",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "policy with one filtered rule",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+							},
+							{
+								ID:                     "rule_b",
+								Expression:             `exec.file.path == "/etc/foo/baz"`,
+								AgentVersionConstraint: "< 0.0.1",
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusLoaded,
+					Rules: []*RuleState{
+						{
+							ID:         "rule_a",
+							Expression: `exec.file.path == "/etc/foo/bar"`,
+							Status:     "loaded",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "policy with only filtered rules",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar"`,
+								AgentVersionConstraint: "< 0.0.1",
+							},
+							{
+								ID:                     "rule_b",
+								Expression:             `exec.file.path == "/etc/foo/baz"`,
+								AgentVersionConstraint: "< 0.0.2",
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: nil,
+		},
+	}
+
+	agentVersion, err := utils.GetAgentSemverVersion()
+	if err != nil {
+		t.Fatal("failed to get agent version:", err)
+	}
+
+	var macroFilters []rules.MacroFilter
+	var ruleFilters []rules.RuleFilter
+
+	agentVersionFilter, err := rules.NewAgentVersionFilter(agentVersion)
+	if err != nil {
+		t.Fatal("failed to create agent version filter:", err)
+	} else {
+		macroFilters = append(macroFilters, agentVersionFilter)
+		ruleFilters = append(ruleFilters, agentVersionFilter)
+	}
+
+	eventCtor := func() eval.Event {
+		return &model.Event{}
+	}
+	ruleOpts, evalOpts := rules.NewBothOpts(map[eval.EventType]bool{"*": true})
+
+	// Sort options for gocmp to ensure consistent ordering of slices
+	goCmpOpts := []gocmp.Option{
+		gocmpopts.SortSlices(func(a, b *PolicyState) bool {
+			return a.PolicyMetadata.Name < b.PolicyMetadata.Name
+		}),
+		gocmpopts.SortSlices(func(a, b *RuleState) bool {
+			return a.ID < b.ID
+		}),
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rs := rules.NewRuleSet(&model.Model{}, eventCtor, ruleOpts, evalOpts)
+			loader := rules.NewPolicyLoader(newTestPolicyProvider(tc.policies...))
+			errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})
+			policyStates := NewPoliciesState(rs, errs, false)
+
+			assert.True(t, gocmp.Equal(tc.expectedPolicyStates, policyStates, goCmpOpts...), gocmp.Diff(tc.expectedPolicyStates, policyStates, goCmpOpts...), "policy states mismatch")
+		})
+	}
+}
+
+type testPolicyProvider struct {
+	policies []*testPolicy
+}
+
+func newTestPolicyProvider(policies ...*testPolicy) *testPolicyProvider {
+	return &testPolicyProvider{
+		policies: policies,
+	}
+}
+
+func (p *testPolicyProvider) Type() string {
+	return "test"
+}
+
+func (p *testPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFilters []rules.RuleFilter) ([]*rules.Policy, *multierror.Error) {
+	var policies []*rules.Policy
+	var multiErr *multierror.Error
+
+	for _, policy := range p.policies {
+		p, err := rules.LoadPolicyFromDefinition(&policy.info, &policy.def, macroFilters, ruleFilters)
+		if p != nil {
+			policies = append(policies, p)
+		}
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	return policies, multiErr
+}
+
+func (p *testPolicyProvider) Start() {
+	// No-op for test provider
+}
+
+func (p *testPolicyProvider) Close() error {
+	// No-op for test provider
+	return nil
+}
+
+func (p *testPolicyProvider) SetOnNewPoliciesReadyCb(_ func()) {
+	// No-op for test provider
+}

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -9,6 +9,7 @@ package rules
 import (
 	"fmt"
 	"io"
+	"iter"
 	"reflect"
 	"slices"
 
@@ -53,6 +54,20 @@ type PolicyRule struct {
 	Policy     PolicyInfo
 	ModifiedBy []PolicyInfo
 	UsedBy     []PolicyInfo
+}
+
+// Policies returns an iterator over the policies that this rule is part of.
+func (r *PolicyRule) Policies() iter.Seq[*PolicyInfo] {
+	return func(yield func(*PolicyInfo) bool) {
+		if !yield(&r.Policy) {
+			return
+		}
+		for _, policy := range r.UsedBy {
+			if !yield(&policy) {
+				return
+			}
+		}
+	}
 }
 
 func (r *PolicyRule) isAccepted() bool {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1073,7 +1073,6 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 				existingRule.UsedBy = append(existingRule.UsedBy, rule.Policy)
 				existingRule.MergeWith(rule)
 			} else {
-				rule.UsedBy = append(rule.UsedBy, rule.Policy)
 				rulesIndex[rule.Def.ID] = rule
 				allRules = append(allRules, rule)
 			}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -1048,7 +1048,12 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 
 	for _, policy := range policies {
 		if len(policy.macros) == 0 && len(policy.rules) == 0 && (policy.Info.Name != DefaultPolicyName && !policy.Info.IsInternal) {
-			errs = multierror.Append(errs, &ErrPolicyLoad{Name: policy.Info.Name, Version: policy.Info.Version, Source: policy.Info.Source, Err: ErrPolicyIsEmpty})
+			errs = multierror.Append(errs, &ErrPolicyLoad{
+				Name:    policy.Info.Name,
+				Version: policy.Info.Version,
+				Source:  policy.Info.Source,
+				Err:     ErrPolicyIsEmpty,
+			})
 			continue
 		}
 

--- a/pkg/security/secl/schemas/heartbeat.schema.json
+++ b/pkg/security/secl/schemas/heartbeat.schema.json
@@ -38,6 +38,7 @@
                     "enum": [
                         "loaded",
                         "partially_loaded",
+                        "fully_rejected",
                         "error"
                     ]
                 },

--- a/pkg/security/secl/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/secl/schemas/ruleset_loaded.schema.json
@@ -48,6 +48,7 @@
                     "enum": [
                         "loaded",
                         "partially_loaded",
+                        "fully_rejected",
                         "error"
                     ]
                 },


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- fix erroneous multi-policy rules being reported as part of a single policy
- add a new `fully_rejected` policy status to indicate that all rules in a policy couldn't be loaded
- add a policy iterator on rules
- add unit tests

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->