### PR TITLE
Add way to run commands in the invoke env

### DIFF
--- a/.dda/extend/commands/run/i/__init__.py
+++ b/.dda/extend/commands/run/i/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+from dda.cli.base import dynamic_command, ensure_features_installed, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(
+    short_help="Run command in the legacy invoke virtual env",
+    context_settings={"help_option_names": [], "ignore_unknown_options": True},
+)
+@click.argument("args", nargs=-1, required=True)
+@pass_app
+def cmd(app: Application, *, args: tuple[str, ...]) -> None:
+    """
+    Run command in the legacy invoke virtual env.
+    """
+    venv_path = app.config.storage.join("venvs", "legacy").data
+    with app.tools.uv.virtual_env(venv_path) as venv:
+        ensure_features_installed(["legacy-tasks"], app=app, prefix=str(venv.path))
+        app.subprocess.exit_with(list(args))

--- a/.dda/extend/commands/run/i/__init__.py
+++ b/.dda/extend/commands/run/i/__init__.py
@@ -22,4 +22,4 @@ def cmd(app: Application, *, args: tuple[str, ...]) -> None:
     venv_path = app.config.storage.join("venvs", "legacy").data
     with app.tools.uv.virtual_env(venv_path) as venv:
         ensure_features_installed(["legacy-tasks"], app=app, prefix=str(venv.path))
-        app.subprocess.exit_with(list(args))
+        app.subprocess.attach(list(args))


### PR DESCRIPTION
### Motivation

Sometimes we need to directly run Python tools that are installed in the environment rather than our own code, e.g. https://datadoghq.dev/datadog-agent/guidelines/contributing/#reno

```
❯ dda run i reno -h
usage: reno.EXE [-h] [-v] [-q] [--rel-notes-dir RELNOTESDIR] {new,list,report,cache,lint,semver-next} ...

options:
  -h, --help            show this help message and exit
  -v, --verbose         produce more output
  -q, --quiet           produce less output
  --rel-notes-dir RELNOTESDIR, -d RELNOTESDIR
                        location of release notes YAML files

commands:
  valid commands

  {new,list,report,cache,lint,semver-next}
                        additional help
    new                 create a new note
    list                list notes files based on query arguments
    report              generate release notes report
    cache               generate release notes cache
    lint                check some common mistakes
    semver-next         calculate next release version based on semver rules
```