### PR TITLE
[ebpfless] Count SYN-RST as a closed connection

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -269,7 +269,7 @@ func (t *TCPProcessor) updateRstFlag(conn *network.ConnectionStats, st *connecti
 	}
 	conn.TCPFailures[uint16(reason)]++
 
-	if st.tcpState == connStatEstablished {
+	if st.tcpState != connStatClosed {
 		conn.Monotonic.TCPClosed++
 	}
 	*st = connectionState{

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -558,7 +558,7 @@ func TestConnRefusedSyn(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      0,
+		TCPClosed:      1,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }
@@ -591,7 +591,7 @@ func TestConnRefusedSynAck(t *testing.T) {
 		RecvPackets:    1,
 		Retransmits:    0,
 		TCPEstablished: 0,
-		TCPClosed:      0,
+		TCPClosed:      1,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
 }

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1836,7 +1836,7 @@ func httpSupported() bool {
 }
 
 func isPrebuilt(cfg *config.Config) bool {
-	if cfg.EnableRuntimeCompiler || cfg.EnableCORE {
+	if cfg.EnableRuntimeCompiler || cfg.EnableCORE || cfg.EnableEbpfless {
 		return false
 	}
 	return true
@@ -3105,4 +3105,5 @@ func (s *TracerSuite) TestTCPSynRst() {
 	assert.NotEqual(t, network.UNKNOWN, conn.Direction)
 
 	assert.Equal(t, uint32(1), conn.TCPFailures[uint16(unix.ECONNREFUSED)])
+	assert.Equal(t, uint16(1), conn.Monotonic.TCPClosed)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR changes ebpfless to count a closed connection when a RST happens before a handshake finishes. It also fixes a prebuilt check that was skipping some ebpfless tests.

### Motivation
This PR matches ebpfless's behavior to the ebpf tracer when a connection is closed .

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
`TestTCPSynRst` should pass on all tracer modes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->