### PR TITLE
Trim package path in Go binaries

### DIFF
--- a/tasks/libs/common/go.py
+++ b/tasks/libs/common/go.py
@@ -35,6 +35,7 @@ def go_build(
     bin_path: str | Path | None = None,
     verbose: bool = False,
     echo: bool = False,
+    trimpath: bool = True,
 ) -> Result:
     cmd = "go build"
     if mod:
@@ -55,6 +56,8 @@ def go_build(
         cmd += f" -gcflags=\"{gcflags}\""
     if ldflags:
         cmd += f" -ldflags=\"{ldflags}\""
+    if trimpath:
+        cmd += " -trimpath"
 
     cmd += f" {entrypoint}"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add the `-trimpath` flag to Go binaries we build by default.

This doesn't impact logs, but changes stack traces for example. See below.

### Motivation
I think it's best not to show the full path on the builder if we can.
Also slight binary size reduction.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
From the help of `go build`:
```
	-trimpath
		remove all file system paths from the resulting executable.
		Instead of absolute file system paths, the recorded file names
		will begin either a module path@version (when using modules),
		or a plain import path (when using the standard library, or GOPATH).
```

Before:
```
goroutine 560 gp=0xc001e00a80 m=nil [select]:
runtime.gopark(0xc0015bced0?, 0x3?, 0x68?, 0xcd?, 0xc0015bce6a?)
	/root/sdk/go1.25rc1/src/runtime/proc.go:460 +0xce fp=0xc0015bccf0 sp=0xc0015bccd0 pc=0x4b67ee
runtime.selectgo(0xc0015bced0, 0xc0015bce64, 0xf?, 0x0, 0xc001105340?, 0x1)
	/root/sdk/go1.25rc1/src/runtime/select.go:351 +0x845 fp=0xc0015bce30 sp=0xc0015bccf0 pc=0x4925c5
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerimage.(*Check).Run(0xc001b82d80)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerimage/check.go:154 +0x325 fp=0xc0015bcf88 sp=0xc0015bce30 pc=0x2596cc5
github.com/DataDog/datadog-agent/pkg/collector/corechecks.(*LongRunningCheckWrapper).Run.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/longrunning.go:66 +0x22 fp=0xc0015bcfe0 sp=0xc0015bcf88 pc=0x1dee4c2
runtime.goexit({})
	/root/sdk/go1.25rc1/src/runtime/asm_amd64.s:1693 +0x1 fp=0xc0015bcfe8 sp=0xc0015bcfe0 pc=0x4bf181
created by github.com/DataDog/datadog-agent/pkg/collector/corechecks.(*LongRunningCheckWrapper).Run in goroutine 488
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/longrunning.go:65 +0x176
```

After:
```
goroutine 462 gp=0xc001831180 m=nil [select]:
runtime.gopark(0xc0018daf60?, 0x2?, 0x0?, 0x0?, 0xc0018daf54?)
	runtime/proc.go:435 +0xce fp=0xc0018dade0 sp=0xc0018dadc0 pc=0x4ad96e
runtime.selectgo(0xc0018daf60, 0xc0018daf50, 0xc001d4e2a0?, 0x0, 0xc000d90f00?, 0x1)
	runtime/select.go:351 +0x837 fp=0xc0018daf18 sp=0xc0018dade0 pc=0x48a337
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*processor).processQueues(0xc0019006c0, {0x438bd98, 0xc001f162d0}, 0xc0018dafb8?)
	github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle/processor.go:175 +0xe5 fp=0xc0018dafb0 sp=0xc0018daf18 pc=0x2555505
github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*processor).start.gowrap1()
	github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle/processor.go:44 +0x2c fp=0xc0018dafe0 sp=0xc0018dafb0 pc=0x255428c
runtime.goexit({})
	runtime/asm_amd64.s:1700 +0x1 fp=0xc0018dafe8 sp=0xc0018dafe0 pc=0x4b6041
created by github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle.(*processor).start in goroutine 461
	github.com/DataDog/datadog-agent/pkg/collector/corechecks/containerlifecycle/processor.go:44 +0x86
```
