### PR TITLE
system probe: use a higher compression level for BTFS

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1705,7 +1705,7 @@ def generate_minimized_btfs(ctx, source_dir, output_dir, bpf_programs):
         nw.rule(name="minimize_btf", command="bpftool gen min_core_btf $in $out $input_bpf_programs")
         nw.rule(
             name="compress_minimized_btf",
-            command="tar --mtime=@0 -cJf $out -C $tar_working_directory $rel_in && rm $in",
+            command=f"tar cf $out --mtime=@0 -I 'xz -8 -T{os.environ.get('KUBERNETES_CPU_REQUEST', 1)}' -C $tar_working_directory $rel_in && rm $in",
         )
 
         for root, dirs, files in os.walk(source_dir):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use a higher compression level (8) instead of the default one (6)
Also, use multiple threads on the CI to compensate for the increased duration incurred by the higher compression level.

### Motivation

Reduce the size of the minimized-btfs.tar.xz file we ship into most our final artifacts

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

Increasing the compression level has no effect on the decompression, so this is not expected to impact customers besides the size reduction

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->