### PR TITLE
[EBPF] gpu: add priority selection mechanism to NVML metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -58,9 +58,10 @@ type Check struct {
 }
 
 type checkTelemetry struct {
-	metricsSent     telemetry.Counter
-	collectorErrors telemetry.Counter
-	activeMetrics   telemetry.Gauge
+	metricsSent      telemetry.Counter
+	duplicateMetrics telemetry.Counter
+	collectorErrors  telemetry.Counter
+	activeMetrics    telemetry.Gauge
 }
 
 // Factory creates a new check factory
@@ -84,9 +85,10 @@ func newCheck(tagger tagger.Component, telemetry telemetry.Component, wmeta work
 
 func newCheckTelemetry(tm telemetry.Component) *checkTelemetry {
 	return &checkTelemetry{
-		metricsSent:     tm.NewCounter(CheckName, "metrics_sent", []string{"collector"}, "Number of GPU metrics sent"),
-		collectorErrors: tm.NewCounter(CheckName, "collector_errors", []string{"collector"}, "Number of errors from NVML collectors"),
-		activeMetrics:   tm.NewGauge(CheckName, "active_metrics", nil, "Number of active metrics"),
+		metricsSent:      tm.NewCounter(CheckName, "metrics_sent", []string{"collector"}, "Number of GPU metrics sent"),
+		collectorErrors:  tm.NewCounter(CheckName, "collector_errors", []string{"collector"}, "Number of errors from NVML collectors"),
+		activeMetrics:    tm.NewGauge(CheckName, "active_metrics", nil, "Number of active metrics"),
+		duplicateMetrics: tm.NewCounter(CheckName, "duplicate_metrics", []string{"device"}, "Number of duplicate metrics removed from NVML collectors due to priority de-duplication"),
 	}
 }
 
@@ -348,6 +350,8 @@ func (c *Check) emitNvmlMetrics(snd sender.Sender, gpuToContainersMap map[string
 		return fmt.Errorf("failed to initialize NVML collectors: %w", err)
 	}
 
+	perDeviceMetrics := make(map[string][]nvidia.Metric)
+
 	var multiErr error
 	for _, collector := range c.collectors {
 		log.Debugf("Collecting metrics from NVML collector: %s", collector.Name())
@@ -357,32 +361,41 @@ func (c *Check) emitNvmlMetrics(snd sender.Sender, gpuToContainersMap map[string
 			multiErr = multierror.Append(multiErr, fmt.Errorf("collector %s failed. %w", collector.Name(), collectErr))
 		}
 
+		if len(metrics) > 0 {
+			perDeviceMetrics[collector.DeviceUUID()] = append(perDeviceMetrics[collector.DeviceUUID()], metrics...)
+		}
+
+		c.telemetry.metricsSent.Add(float64(len(metrics)), string(collector.Name()))
+	}
+
+	for deviceUUID, metrics := range perDeviceMetrics {
+		deduplicatedMetrics := nvidia.RemoveDuplicateMetrics(metrics)
+		c.telemetry.duplicateMetrics.Add(float64(len(metrics)-len(deduplicatedMetrics)), deviceUUID)
+
 		var extraTags []string
-		for _, container := range gpuToContainersMap[collector.DeviceUUID()] {
+		for _, container := range gpuToContainersMap[deviceUUID] {
 			entityID := taggertypes.NewEntityID(taggertypes.ContainerID, container.EntityID.ID)
 			tags, err := c.tagger.Tag(entityID, taggertypes.ChecksConfigCardinality)
 			if err != nil {
-				multiErr = multierror.Append(multiErr, fmt.Errorf("error collecting container tags for GPU %s: %w", collector.DeviceUUID(), err))
+				multiErr = multierror.Append(multiErr, fmt.Errorf("error collecting container tags for GPU %s: %w", deviceUUID, err))
 				continue
 			}
 
 			extraTags = append(extraTags, tags...)
 		}
 
-		for _, metric := range metrics {
+		for _, metric := range deduplicatedMetrics {
 			metricName := gpuMetricsNs + metric.Name
 			switch metric.Type {
 			case ddmetrics.CountType:
-				snd.Count(metricName, metric.Value, "", append(c.deviceTags[collector.DeviceUUID()], extraTags...))
+				snd.Count(metricName, metric.Value, "", append(c.deviceTags[deviceUUID], extraTags...))
 			case ddmetrics.GaugeType:
-				snd.Gauge(metricName, metric.Value, "", append(c.deviceTags[collector.DeviceUUID()], extraTags...))
+				snd.Gauge(metricName, metric.Value, "", append(c.deviceTags[deviceUUID], extraTags...))
 			default:
 				multiErr = multierror.Append(multiErr, fmt.Errorf("unsupported metric type %s for metric %s", metric.Type, metricName))
 				continue
 			}
 		}
-
-		c.telemetry.metricsSent.Add(float64(len(metrics)), string(collector.Name()))
 	}
 
 	return multiErr

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -22,8 +22,10 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/nvidia"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func TestProcessSysprobeStats(t *testing.T) {
@@ -126,4 +128,122 @@ func TestProcessSysprobeStats(t *testing.T) {
 	mockSender.AssertCalled(t, "Gauge", "gpu.memory.usage", float64(0), "", mock.MatchedBy(matchTagsFunc))
 	mockSender.AssertCalled(t, "Gauge", "gpu.core.limit", float64(testutil.DefaultGpuCores), "", mock.MatchedBy(matchTagsFunc))
 	mockSender.AssertCalled(t, "Gauge", "gpu.memory.limit", float64(testutil.DefaultTotalMemory), "", mock.MatchedBy(matchTagsFunc))
+}
+
+func TestEmitNvmlMetrics(t *testing.T) {
+	// Create a mock sender
+	mockSender := mocksender.NewMockSender("gpu")
+	mockSender.SetupAcceptAll()
+
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	// Create check instance using mocks
+	checkGeneric := newCheck(
+		fakeTagger,
+		testutil.GetTelemetryMock(t),
+		testutil.GetWorkloadMetaMock(t),
+	)
+	check, ok := checkGeneric.(*Check)
+	require.True(t, ok)
+
+	device1UUID := "gpu-uuid-1"
+	device2UUID := "gpu-uuid-2"
+
+	// Create mock collectors
+	for i, deviceUUID := range []string{device1UUID, device2UUID} {
+		metricValueBase := 10 * i
+
+		check.collectors = append(check.collectors, &mockCollector{
+			name:       "device",
+			deviceUUID: deviceUUID,
+			metrics: []nvidia.Metric{
+				{Name: "metric1", Value: float64(metricValueBase + 1), Type: ddmetrics.GaugeType, Priority: 0},
+				{Name: "metric2", Value: float64(metricValueBase + 2), Type: ddmetrics.GaugeType, Priority: 0},
+			},
+		})
+
+		check.collectors = append(check.collectors, &mockCollector{
+			name:       "fields",
+			deviceUUID: deviceUUID,
+			metrics: []nvidia.Metric{
+				{Name: "metric2", Value: float64(metricValueBase + 2), Type: ddmetrics.GaugeType, Priority: 1},
+				{Name: "metric3", Value: float64(metricValueBase + 3), Type: ddmetrics.GaugeType, Priority: 1},
+			},
+		})
+	}
+
+	// Set device tags
+	check.deviceTags = map[string][]string{
+		device1UUID: {"gpu_uuid:" + device1UUID, "gpu_vendor:nvidia"},
+		device2UUID: {"gpu_uuid:" + device2UUID, "gpu_vendor:nvidia"},
+	}
+
+	// Set up GPU and container tags
+	containerID := "container1"
+	containerTags := []string{"container_id:" + containerID}
+	fakeTagger.SetTags(taggertypes.NewEntityID(taggertypes.ContainerID, containerID), "foo", containerTags, nil, nil, nil)
+
+	gpuToContainersMap := map[string][]*workloadmeta.Container{
+		device1UUID: {
+			{
+				EntityID: workloadmeta.EntityID{
+					ID: containerID,
+				},
+			},
+		},
+	}
+
+	// Process the metrics
+	err := check.emitNvmlMetrics(mockSender, gpuToContainersMap)
+	assert.NoError(t, err)
+
+	// Verify metrics for each device
+	for i, deviceUUID := range []string{device1UUID, device2UUID} {
+		metricValueBase := 10 * i
+
+		// Build expected tags
+		var expectedTags []string
+		if deviceUUID == device1UUID {
+			// Device 1 has container tags
+			expectedTags = append([]string{"gpu_uuid:" + deviceUUID, "gpu_vendor:nvidia"}, containerTags...)
+		} else {
+			// Device 2 has no container tags
+			expectedTags = []string{"gpu_uuid:" + deviceUUID, "gpu_vendor:nvidia"}
+		}
+		slices.Sort(expectedTags)
+
+		matchTagsFunc := func(tags []string) bool {
+			slices.Sort(tags)
+			return slices.Equal(tags, expectedTags)
+		}
+
+		// Verify metrics for this device
+		// metric1: only from device collector (priority 0)
+		mockSender.AssertCalled(t, "Gauge", "gpu.metric1", float64(metricValueBase+1), "", mock.MatchedBy(matchTagsFunc))
+
+		// metric2: priority 1 wins (from fields collector)
+		mockSender.AssertCalled(t, "Gauge", "gpu.metric2", float64(metricValueBase+2), "", mock.MatchedBy(matchTagsFunc))
+
+		// metric3: only from fields collector (priority 1)
+		mockSender.AssertCalled(t, "Gauge", "gpu.metric3", float64(metricValueBase+3), "", mock.MatchedBy(matchTagsFunc))
+	}
+}
+
+// mockCollector implements the nvidia.Collector interface for testing
+type mockCollector struct {
+	name       nvidia.CollectorName
+	deviceUUID string
+	metrics    []nvidia.Metric
+}
+
+func (m *mockCollector) Collect() ([]nvidia.Metric, error) {
+	return m.metrics, nil
+}
+
+func (m *mockCollector) Name() nvidia.CollectorName {
+	return m.name
+}
+
+func (m *mockCollector) DeviceUUID() string {
+	return m.deviceUUID
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -15,6 +15,8 @@ package nvidia
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -40,9 +42,10 @@ const (
 
 // Metric represents a single metric collected from the NVML library.
 type Metric struct {
-	Name  string  // Name holds the name of the metric.
-	Value float64 // Value holds the value of the metric.
-	Type  metrics.MetricType
+	Name     string  // Name holds the name of the metric.
+	Value    float64 // Value holds the value of the metric.
+	Type     metrics.MetricType
+	Priority int // Priority is the priority of the metric, indicating which metric to keep in case of duplicates. 0 (default) is the lowest priority.
 }
 
 // Collector defines a collector that gets metric from a specific NVML subsystem and device
@@ -74,7 +77,6 @@ var factory = map[CollectorName]subsystemBuilder{
 
 // CollectorDependencies holds the dependencies needed to create a set of collectors.
 type CollectorDependencies struct {
-
 	// DeviceCache is a cache of GPU devices.
 	DeviceCache ddnvml.DeviceCache
 }
@@ -132,4 +134,16 @@ func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Componen
 	}
 
 	return tagsMapping
+}
+
+func RemoveDuplicateMetrics(metrics []Metric) []Metric {
+	metricsByName := make(map[string]Metric)
+
+	for _, metric := range metrics {
+		if existing, ok := metricsByName[metric.Name]; !ok || existing.Priority < metric.Priority {
+			metricsByName[metric.Name] = metric
+		}
+	}
+
+	return slices.Collect(maps.Values(metricsByName))
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -136,6 +136,7 @@ func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Componen
 	return tagsMapping
 }
 
+// RemoveDuplicateMetrics removes duplicate metrics from the given list, keeping the highest priority metric.
 func RemoveDuplicateMetrics(metrics []Metric) []Metric {
 	metricsByName := make(map[string]Metric)
 

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -145,6 +145,8 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 
 	deduplicated := RemoveDuplicateMetrics(metrics)
 	require.Len(t, deduplicated, 2)
-	require.Equal(t, deduplicated[0].Name, "metric1")
-	require.Equal(t, deduplicated[1].Name, "metric2")
+	require.ElementsMatch(t, deduplicated, []Metric{
+		{Name: "metric1", Priority: 2},
+		{Name: "metric2", Priority: 1},
+	})
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -135,3 +135,16 @@ func TestGetDeviceTagsMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveDuplicateMetrics(t *testing.T) {
+	metrics := []Metric{
+		{Name: "metric1", Priority: 0},
+		{Name: "metric2", Priority: 1},
+		{Name: "metric1", Priority: 2},
+	}
+
+	deduplicated := RemoveDuplicateMetrics(metrics)
+	require.Len(t, deduplicated, 2)
+	require.Equal(t, deduplicated[0].Name, "metric1")
+	require.Equal(t, deduplicated[1].Name, "metric2")
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a priority field to NVML metrics, so that we can de-duplicate in case the same metric is provided by different collectors.

### Motivation

The [GPM collector PR](https://github.com/DataDog/datadog-agent/pull/38254) adds metrics that are already being sent by other collectors, but it only works for Hopper and newer architectures. This change allows us to select which metrics to send and support that case.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->