### PR TITLE
use domain controller as ntp source

### DIFF
--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -122,8 +122,9 @@ func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() (
 		localNtpServers, err = getLocalServers()
 		if err != nil {
 			log.Warnf("Could not get local NTP servers, falling back to configured hosts: %v", err)
+		} else {
+			log.Debugf("Detected local defined servers: [ %s ]", strings.Join(localNtpServers, ", "))
 		}
-		log.Debugf("Detected local defined servers: [ %s ]", strings.Join(localNtpServers, ", "))
 	}
 
 	if len(localNtpServers) > 0 {

--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -32,7 +32,7 @@ import (
 const (
 	// CheckName is the name of the check
 	CheckName                    = "ntp"
-	defaultMinCollectionInterval = 90 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
+	defaultMinCollectionInterval = 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
 )
 
 var (

--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -121,7 +121,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() (
 	if c.instance.UseLocalDefinedServers {
 		localNtpServers, err = getLocalServers()
 		if err != nil {
-			return err
+			log.Warnf("Could not get local NTP servers, falling back to configured hosts: %v", err)
 		}
 		log.Debugf("Detected local defined servers: [ %s ]", strings.Join(localNtpServers, ", "))
 	}
@@ -195,6 +195,9 @@ func (c *NTPCheck) Run() error {
 			log.Warnf("Could not re-discover NTP servers: %v", err)
 		} else if len(servers) > 0 {
 			// Check if servers have changed
+			// Sort slices for order-insensitive comparison
+			sort.Strings(c.cfg.instance.Hosts)
+			sort.Strings(servers)
 			if !stringSlicesEqual(c.cfg.instance.Hosts, servers) {
 				log.Infof("NTP servers changed from [%s] to [%s]",
 					strings.Join(c.cfg.instance.Hosts, ", "),

--- a/pkg/collector/corechecks/net/ntp/ntp.go
+++ b/pkg/collector/corechecks/net/ntp/ntp.go
@@ -32,7 +32,7 @@ import (
 const (
 	// CheckName is the name of the check
 	CheckName                    = "ntp"
-	defaultMinCollectionInterval = 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
+	defaultMinCollectionInterval = 90 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
 )
 
 var (
@@ -200,9 +200,8 @@ func (c *NTPCheck) Run() error {
 					strings.Join(c.cfg.instance.Hosts, ", "),
 					strings.Join(servers, ", "))
 				c.cfg.instance.Hosts = servers // Update the list of hosts for this run
-			} else {
-				log.Debugf("Re-discovered same NTP servers: [%s]", strings.Join(servers, ", "))
 			}
+			// Silent when no change - removed repetitive debug logging
 		}
 	}
 

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
@@ -37,6 +37,7 @@ var (
 const (
 	DS_PDC_REQUIRED    = 0x00000080
 	DS_RETURN_DNS_NAME = 0x40000000
+	DS_AVOID_SELF      = 0x00004000
 )
 
 // DOMAIN_CONTROLLER_INFO structure
@@ -54,6 +55,7 @@ type DOMAIN_CONTROLLER_INFO struct {
 
 func getLocalDefinedNTPServers() ([]string, error) {
 	// Use native Windows registry API to get the Type value
+	// https://learn.microsoft.com/en-us/windows-server/networking/windows-time-service/windows-time-service-tools-and-settings?tabs=parameters
 	regKeyPath := `SYSTEM\CurrentControlSet\Services\W32Time\Parameters`
 	k, err := registryOpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
 	if err != nil {
@@ -111,7 +113,7 @@ func discoverPDC() ([]string, error) {
 		0, // DomainName (NULL = primary domain)
 		0, // DomainGuid (NULL)
 		0, // SiteName (NULL)
-		uintptr(DS_PDC_REQUIRED|DS_RETURN_DNS_NAME),
+		uintptr(DS_PDC_REQUIRED|DS_RETURN_DNS_NAME|DS_AVOID_SELF),
 		uintptr(unsafe.Pointer(&dcInfo)),
 	)
 

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
@@ -44,7 +44,7 @@ const (
 )
 
 // DOMAIN_CONTROLLER_INFO structure
-// Name is intended to match the Windows API name see MSDN: https://learn.microsoft.com/en-us/windows/win32/api/dsgetdc/ns-dsgetdc-domain_controller_infoa
+// Name is intended to match the Windows API name see MSDN: https://learn.microsoft.com/en-us/windows/win32/api/dsgetdc/ns-dsgetdc-domain_controller_infow
 type DOMAIN_CONTROLLER_INFO struct {
 	DomainControllerName        *uint16
 	DomainControllerAddress     *uint16

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
@@ -74,12 +74,14 @@ func getLocalDefinedNTPServers() ([]string, error) {
 		log.Debug("NT5DS detected, attempting PDC discovery")
 
 		// First, try proactive PDC discovery
-		if servers, err := discoverPDC(); err == nil && len(servers) > 0 {
+		servers, err := discoverPDC()
+		if err == nil && len(servers) > 0 {
 			log.Infof("Successfully discovered PDC: %s", strings.Join(servers, ", "))
 			return servers, nil
-		} else {
-			return nil, fmt.Errorf("PDC discovery failed: %v", err)
 		}
+		// If PDC discovery fails, log a warning and fall through to the registry method.
+		// This handles cases where a machine is configured for NT5DS but is off-domain.
+		log.Warnf("PDC discovery failed (%v), falling back to registry NTP servers.", err)
 
 	case "NOSYNC":
 		// Go directly to registry method

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
@@ -11,26 +11,139 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"syscall"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+var (
+	netapi32             = windows.NewLazySystemDLL("netapi32.dll")
+	procDsGetDcName      = netapi32.NewProc("DsGetDcNameW")
+	procNetApiBufferFree = netapi32.NewProc("NetApiBufferFree")
+	// These variables set up:
+	// Lazy loading of Windows DLL functions from netapi32.dll
+	// Function pointers for dependency injection (allows mocking in tests)
+	// Windows API calls for domain controller discovery
+	// Function variables for testing - can be overridden in tests
+	registryOpenKey = registry.OpenKey
+	dsGetDcNameCall = procDsGetDcName.Call
+)
+
+// Constants for DsGetDcName
+const (
+	DS_PDC_REQUIRED    = 0x00000080
+	DS_RETURN_DNS_NAME = 0x40000000
+)
+
+// DOMAIN_CONTROLLER_INFO structure
+type DOMAIN_CONTROLLER_INFO struct {
+	DomainControllerName        *uint16
+	DomainControllerAddress     *uint16
+	DomainControllerAddressType uint32
+	DomainGuid                  syscall.GUID
+	DomainName                  *uint16
+	DnsForestName               *uint16
+	Flags                       uint32
+	DcSiteName                  *uint16
+	ClientSiteName              *uint16
+}
+
 func getLocalDefinedNTPServers() ([]string, error) {
+	// Use native Windows registry API to get the Type value
 	regKeyPath := `SYSTEM\CurrentControlSet\Services\W32Time\Parameters`
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
+	k, err := registryOpenKey(registry.LOCAL_MACHINE, regKeyPath, registry.QUERY_VALUE)
 	if err != nil {
-		return nil, errors.New("Cannot open registry key: " + regKeyPath)
+		return nil, fmt.Errorf("Cannot open registry key %s: %s", regKeyPath, err)
 	}
 	defer k.Close()
 
-	regKeyName := "NtpServer"
-	s, _, err := k.GetStringValue(regKeyName)
+	// Read the Type value
+	typeValue, _, err := k.GetStringValue("Type")
 	if err != nil {
-		return nil, fmt.Errorf("Cannot get the value %s in registry key: %s (%s)", regKeyName, regKeyPath, err)
+		return nil, fmt.Errorf("Cannot get Type value from registry: %s", err)
 	}
-	servers, err := getNptServersFromRegKeyValue(s)
+
+	// Based on Type value, decide how to get NTP servers
+	switch strings.ToUpper(typeValue) {
+	case "NT5DS":
+		// AD Domain Hierarchy - prioritize PDC discovery
+		log.Debug("NT5DS detected, attempting PDC discovery")
+
+		// First, try proactive PDC discovery
+		if servers, err := discoverPDC(); err == nil && len(servers) > 0 {
+			log.Infof("Successfully discovered PDC: %s", strings.Join(servers, ", "))
+			return servers, nil
+		} else {
+			return nil, fmt.Errorf("PDC discovery failed: %v", err)
+		}
+
+	case "NOSYNC":
+		// Go directly to registry method
+		// Fall through to registry method
+
+	case "NTP":
+		// Standard NTP - use registry method
+		// Fall through to registry method
+
+	default:
+		// Unknown type, try registry method
+		log.Debugf("Unknown W32Time Type value: %s, using registry method", typeValue)
+		// Fall through to registry method
+	}
+
+	// Standard registry method for NTP servers
+	return getNTPServersFromRegistry(k)
+}
+
+func discoverPDC() ([]string, error) {
+	// Use DsGetDcName to find the PDC Emulator
+	var dcInfo *DOMAIN_CONTROLLER_INFO
+
+	// Call DsGetDcName with DS_PDC_REQUIRED flag to get the PDC
+	ret, _, err := dsGetDcNameCall(
+		0, // ComputerName (NULL = local computer)
+		0, // DomainName (NULL = primary domain)
+		0, // DomainGuid (NULL)
+		0, // SiteName (NULL)
+		uintptr(DS_PDC_REQUIRED|DS_RETURN_DNS_NAME),
+		uintptr(unsafe.Pointer(&dcInfo)),
+	)
+
+	if ret != 0 {
+		return nil, fmt.Errorf("DsGetDcName failed with error code: %d (%v)", ret, err)
+	}
+
+	// Ensure we free the buffer when done
+	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(dcInfo)))
+
+	// Convert the PDC name to a Go string
+	if dcInfo.DomainControllerName != nil {
+		pdcName := windows.UTF16PtrToString(dcInfo.DomainControllerName)
+		// Remove leading backslashes if present
+		pdcName = strings.TrimPrefix(pdcName, "\\\\")
+
+		if pdcName != "" {
+			return []string{pdcName}, nil
+		}
+	}
+
+	return nil, errors.New("PDC discovery returned empty controller name")
+}
+
+func getNTPServersFromRegistry(k registry.Key) ([]string, error) {
+	// Read NtpServer value from already open registry key
+	ntpServerValue, _, err := k.GetStringValue("NtpServer")
 	if err != nil {
-		return nil, fmt.Errorf("Cannot detect NTP server in registry: LOCAL_MACHINE\\%s (%s)", regKeyPath, err)
+		return nil, fmt.Errorf("Cannot get NtpServer value from registry: %s", err)
+	}
+
+	servers, err := getNptServersFromRegKeyValue(ntpServerValue)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse NTP servers from registry value: %s", err)
 	}
 	return servers, nil
 }
@@ -43,11 +156,13 @@ func getNptServersFromRegKeyValue(regKeyValue string) ([]string, error) {
 	var servers []string
 	for _, f := range fields {
 		server := strings.Split(f, ",")[0]
-		servers = append(servers, server)
+		if server != "" {
+			servers = append(servers, server)
+		}
 	}
 
 	if len(servers) == 0 {
-		return nil, errors.New("No NTP server found")
+		return nil, errors.New("No NTP server found in registry value")
 	}
 
 	return servers, nil

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows.go
@@ -7,6 +7,7 @@
 
 package ntp
 
+//revive:disable:var-naming  All names in this file match Windows API identifiers
 import (
 	"errors"
 	"fmt"
@@ -21,8 +22,9 @@ import (
 )
 
 var (
-	netapi32             = windows.NewLazySystemDLL("netapi32.dll")
-	procDsGetDcName      = netapi32.NewProc("DsGetDcNameW")
+	netapi32        = windows.NewLazySystemDLL("netapi32.dll")
+	procDsGetDcName = netapi32.NewProc("DsGetDcNameW")
+	// Name is intended to match the Windows API name see MSDN: https://learn.microsoft.com/en-us/windows/win32/api/lmapibuf/nf-lmapibuf-netapibufferfree
 	procNetApiBufferFree = netapi32.NewProc("NetApiBufferFree")
 	// These variables set up:
 	// Lazy loading of Windows DLL functions from netapi32.dll
@@ -34,6 +36,7 @@ var (
 )
 
 // Constants for DsGetDcName
+// Name is intended to match the Windows API name see MSDN: https://learn.microsoft.com/en-us/windows/win32/api/dsgetdc/nf-dsgetdc-dsgetdcnamew
 const (
 	DS_PDC_REQUIRED    = 0x00000080
 	DS_RETURN_DNS_NAME = 0x40000000
@@ -41,6 +44,7 @@ const (
 )
 
 // DOMAIN_CONTROLLER_INFO structure
+// Name is intended to match the Windows API name see MSDN: https://learn.microsoft.com/en-us/windows/win32/api/dsgetdc/ns-dsgetdc-domain_controller_infoa
 type DOMAIN_CONTROLLER_INFO struct {
 	DomainControllerName        *uint16
 	DomainControllerAddress     *uint16
@@ -121,8 +125,8 @@ func discoverPDC() ([]string, error) {
 		return nil, fmt.Errorf("DsGetDcName failed with error code: %d (%v)", ret, err)
 	}
 
-	// Ensure we free the buffer when done
-	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(dcInfo)))
+	// Ensure we free the buffer when done, error is ignored as it is not critical
+	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(dcInfo))) //nolint:errcheck
 
 	// Convert the PDC name to a Go string
 	if dcInfo.DomainControllerName != nil {

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows_test.go
@@ -13,25 +13,95 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetLocalDefinedNTPServers(t *testing.T) {
-	servers, err := getLocalDefinedNTPServers()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, servers)
+// Test the helper function that parses registry values
+func TestGetNptServersFromRegKeyValue(t *testing.T) {
+	testCases := []struct {
+		name            string
+		regKeyValue     string
+		expectedServers []string
+		expectError     bool
+	}{
+		{
+			name:            "Single server with flags",
+			regKeyValue:     "time.windows.com,0x9",
+			expectedServers: []string{"time.windows.com"},
+			expectError:     false,
+		},
+		{
+			name:            "Multiple servers space-separated",
+			regKeyValue:     "pool.ntp.org time.windows.com time.apple.com time.google.com",
+			expectedServers: []string{"pool.ntp.org", "time.windows.com", "time.apple.com", "time.google.com"},
+			expectError:     false,
+		},
+		{
+			name:            "Multiple servers with flags",
+			regKeyValue:     "ntp1.example.com,0x1 ntp2.example.com,0x9",
+			expectedServers: []string{"ntp1.example.com", "ntp2.example.com"},
+			expectError:     false,
+		},
+		{
+			name:            "Empty string",
+			regKeyValue:     "",
+			expectedServers: nil,
+			expectError:     true,
+		},
+		{
+			name:            "Whitespace only",
+			regKeyValue:     "   \t\n   ",
+			expectedServers: nil,
+			expectError:     true,
+		},
+		{
+			name:            "Server with port",
+			regKeyValue:     "ntp.example.com:123,0x9",
+			expectedServers: []string{"ntp.example.com:123"},
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			servers, err := getNptServersFromRegKeyValue(tc.regKeyValue)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedServers, servers)
+		})
+	}
 }
 
-func TestGetNptServersFromRegKeyValue(t *testing.T) {
-	// time.windows.com,0x9
-	// pool.ntp.org time.windows.com time.apple.com time.google.com
+// Integration test for getLocalDefinedNTPServers
+// This test will only work on Windows systems with proper registry permissions
+func TestGetLocalDefinedNTPServers_Integration(t *testing.T) {
+	// Skip this test in CI or on non-Windows systems
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
 
-	servers, err := getNptServersFromRegKeyValue("time.windows.com,0x9")
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"time.windows.com"}, servers)
+	// This test attempts to read the actual registry
+	// It may fail if:
+	// - Not running on Windows
+	// - No NTP servers configured
+	// - Insufficient permissions
+	servers, err := getLocalDefinedNTPServers()
 
-	servers, err = getNptServersFromRegKeyValue("pool.ntp.org time.windows.com")
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"pool.ntp.org", "time.windows.com"}, servers)
+	// We can't predict what servers will be configured, but we can check
+	// that the function handles various registry states gracefully
+	if err != nil {
+		// Error is acceptable - might not have permissions or NTP not configured
+		t.Logf("Registry read failed (this may be expected): %v", err)
+		assert.Contains(t, err.Error(), "Cannot")
+	} else {
+		// If successful, we should have at least one server
+		assert.NotEmpty(t, servers)
+		t.Logf("Found NTP servers: %v", servers)
 
-	servers, err = getNptServersFromRegKeyValue("")
-	assert.Error(t, err)
-	assert.Equal(t, []string(nil), servers)
+		// Each server should be a non-empty string
+		for _, server := range servers {
+			assert.NotEmpty(t, server)
+		}
+	}
 }

--- a/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows_test.go
+++ b/pkg/collector/corechecks/net/ntp/ntp_local_defined_server_windows_test.go
@@ -51,12 +51,6 @@ func TestGetNptServersFromRegKeyValue(t *testing.T) {
 			expectedServers: nil,
 			expectError:     true,
 		},
-		{
-			name:            "Server with port",
-			regKeyValue:     "ntp.example.com:123,0x9",
-			expectedServers: []string{"ntp.example.com:123"},
-			expectError:     false,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
+++ b/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
@@ -6,16 +6,11 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
+features:
+  - |
+    The NTP check on Windows now discovers and queries the primary domain controller (PDC) for time on domain-joined hosts when `use_local_defined_servers` is enabled. If the PDC is unavailable, it automatically falls back to registry-defined servers. The check also now performs order-insensitive server list comparisons to reduce log noise and avoids using itself as a time source when running on a domain controller.
 
 fixes:
   - |
-    The NTP check on Windows is now more resilient. If a machine is configured to use an Active Directory domain controller for time (`NT5DS`) but cannot reach it, the check will now automatically fall back to using the NTP servers listed in the Windows registry instead of failing completely.
-  - |
-    The check is now smarter about detecting changes to the NTP server list. It will no longer create a log entry if the discovered servers are the same but in a different order, reducing log noise.
-  - |
-    When discovering a domain controller for time synchronization, the check will now avoid using the machine itself if it is also a domain controller.
-  - |
-    Fixed a misleading log message that occurred when NTP domain controller discovery failed on Windows. The log will no longer include ``(The operation completed successfully.)`` alongside the error code.
-  - |
-    The NTP check will no longer fail to start if the initial discovery of local NTP servers fails. It will instead log a warning and retry on the next run.
+    The NTP check will no longer fail to start if the initial discovery of local NTP servers fails at agent startup.
 

--- a/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
+++ b/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    The NTP check on Windows now discovers and queries the primary domain controller (PDC) for time on domain-joined hosts when `use_local_defined_servers` is enabled. If the PDC is unavailable, it automatically falls back to registry-defined servers. The check also now performs order-insensitive server list comparisons to reduce log noise and avoids using itself as a time source when running on a domain controller.
+    The NTP check on Windows now discovers the primary domain controller (PDC) on domain-joined hosts when `use_local_defined_servers` is enabled. If the PDC is unavailable, it automatically falls back to registry-defined servers. Check now performs order-insensitive server list comparisons, reduces log noise and avoids using itself as a time source when running on a domain controller.
 
 fixes:
   - |

--- a/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
+++ b/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
@@ -1,0 +1,21 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+    The NTP check on Windows is now more resilient. If a machine is configured to use an Active Directory domain controller for time (`NT5DS`) but cannot reach it, the check will now automatically fall back to using the NTP servers listed in the Windows registry instead of failing completely.
+  - |
+    The check is now smarter about detecting changes to the NTP server list. It will no longer create a log entry if the discovered servers are the same but in a different order, reducing log noise.
+  - |
+    When discovering a domain controller for time synchronization, the check will now avoid using the machine itself if it is also a domain controller.
+  - |
+    Fixed a misleading log message that occurred when NTP domain controller discovery failed on Windows. The log will no longer include ``(The operation completed successfully.)`` alongside the error code.
+  - |
+    The NTP check will no longer fail to start if the initial discovery of local NTP servers fails. It will instead log a warning and retry on the next run.
+

--- a/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
+++ b/releasenotes/notes/ntp-windows-resiliency-fixes-17c350b623dc859d.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    The NTP check on Windows now discovers the primary domain controller (PDC) on domain-joined hosts when `use_local_defined_servers` is enabled. If the PDC is unavailable, it automatically falls back to registry-defined servers. Check now performs order-insensitive server list comparisons, reduces log noise and avoids using itself as a time source when running on a domain controller.
+    The NTP check on Windows now discovers the primary domain controller (PDC) on domain-joined hosts when `use_local_defined_servers` is enabled. If the PDC is unavailable, it automatically falls back to registry-defined servers. Check now performs order-insensitive server list comparisons, reduces log noise, and avoids using itself as a time source when running on a domain controller.
 
 fixes:
   - |


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Enhaces Windows NTP check for `use_local_defined_servers: true`, enabling it to correctly discover and query the Primary Domain Controller (PDC) for time on domain-joined machines. It includes an intelligent fallback to registry-configured NTP servers if the PDC is unavailable. Additionally, it improves startup resilience, reduces log noise by making server list comparisons order-insensitive, and clarifies error messages.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1549
Fix offset reported by domain joined hosts as previous check did not account for NT5DS time synchronization in domain environments, leading to inaccurate ntp.offset metrics.

### Describe how you validated your changes
The changes were validated through specific unit tests and manual end-to-end tests
Manual test was performed on 2 Windows hyper V hosts, one being a Domain Controller and the other a Domain Client connected to the DC. 
Tested to ensure:
On a domain-joined host, the system successfully identified and queried the Primary Domain Controller (PDC).
On a domain-joined host that was disconnected from the network, the system successfully fell back to using registry-configured NTP servers.
On a non-domain-joined host, the system correctly utilized the registry for NTP server information.
On a domain controller, the system correctly avoided using itself as a time source.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
reopened from https://github.com/DataDog/datadog-agent/pull/38030