### PR TITLE
[CXP-2187] Update process payload headers to include feature enablement info

### DIFF
--- a/comp/process/submitter/submitterimpl/submitter.go
+++ b/comp/process/submitter/submitterimpl/submitter.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/process/agent"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/hostinfo"
@@ -41,11 +42,12 @@ type dependencies struct {
 	Lc  fx.Lifecycle
 	Log log.Component
 
-	Config     config.Component
-	Checks     []types.CheckComponent `group:"check"`
-	Forwarders forwarders.Component
-	HostInfo   hostinfo.Component
-	Statsd     statsd.ClientInterface
+	Config         config.Component
+	SysProbeConfig sysprobeconfig.Component
+	Checks         []types.CheckComponent `group:"check"`
+	Forwarders     forwarders.Component
+	HostInfo       hostinfo.Component
+	Statsd         statsd.ClientInterface
 }
 
 type result struct {
@@ -56,7 +58,7 @@ type result struct {
 }
 
 func newSubmitter(deps dependencies) (result, error) {
-	s, err := processRunner.NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, deps.HostInfo.Object().HostName)
+	s, err := processRunner.NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, deps.HostInfo.Object().HostName, deps.SysProbeConfig)
 	if err != nil {
 		return result{}, err
 	}

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -466,8 +466,8 @@ func runCollectorTestWithAPIKeys(t *testing.T, check checks.Check, epConfig *end
 	assert.NoError(t, err)
 	err = check.Init(nil, hostInfo, true)
 	assert.NoError(t, err)
-	deps := newSubmitterDepsWithConfig(t, mockConfig)
-	submitter, err := NewSubmitter(mockConfig, deps.Log, deps.Forwarders, deps.Statsd, hostInfo.HostName)
+	deps := getSubmitterDeps(t, mockConfig.AllSettings(), nil)
+	submitter, err := NewSubmitter(mockConfig, deps.Log, deps.Forwarders, deps.Statsd, hostInfo.HostName, deps.SysProbeConfig)
 	c.Submitter = submitter
 	require.NoError(t, err)
 

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders"
 	"github.com/DataDog/datadog-agent/comp/process/forwarders/forwardersimpl"
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -36,31 +36,37 @@ import (
 func TestNewCollectorQueueSize(t *testing.T) {
 	tests := []struct {
 		name              string
-		override          bool
+		configOverrides   map[string]interface{}
 		queueSize         int
 		expectedQueueSize int
 	}{
 		{
 			name:              "default queue size",
-			override:          false,
+			configOverrides:   nil,
 			queueSize:         42,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueSize,
 		},
 		{
-			name:              "valid queue size override",
-			override:          true,
+			name: "valid queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.queue_size": 42,
+			},
 			queueSize:         42,
 			expectedQueueSize: 42,
 		},
 		{
-			name:              "invalid negative queue size override",
-			override:          true,
+			name: "invalid negative queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.queue_size": -10,
+			},
 			queueSize:         -10,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueSize,
 		},
 		{
-			name:              "invalid 0 queue size override",
-			override:          true,
+			name: "invalid 0 queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.queue_size": 0,
+			},
 			queueSize:         0,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueSize,
 		},
@@ -68,12 +74,8 @@ func TestNewCollectorQueueSize(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockConfig := configmock.New(t)
-			if tc.override {
-				mockConfig.SetWithoutSource("process_config.queue_size", tc.queueSize)
-			}
-			deps := newSubmitterDepsWithConfig(t, mockConfig)
-			c, err := NewSubmitter(mockConfig, deps.Log, deps.Forwarders, deps.Statsd, testHostName)
+			deps := getSubmitterDeps(t, tc.configOverrides, nil)
+			c, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.processResults.MaxSize())
 		})
@@ -83,31 +85,37 @@ func TestNewCollectorQueueSize(t *testing.T) {
 func TestNewCollectorRTQueueSize(t *testing.T) {
 	tests := []struct {
 		name              string
-		override          bool
+		configOverrides   map[string]interface{}
 		queueSize         int
 		expectedQueueSize int
 	}{
 		{
 			name:              "default queue size",
-			override:          false,
+			configOverrides:   nil,
 			queueSize:         2,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessRTQueueSize,
 		},
 		{
-			name:              "valid queue size override",
-			override:          true,
+			name: "valid queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.rt_queue_size": 2,
+			},
 			queueSize:         2,
 			expectedQueueSize: 2,
 		},
 		{
-			name:              "invalid negative size override",
-			override:          true,
+			name: "invalid negative size override",
+			configOverrides: map[string]interface{}{
+				"process_config.rt_queue_size": -2,
+			},
 			queueSize:         -2,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessRTQueueSize,
 		},
 		{
-			name:              "invalid 0 queue size override",
-			override:          true,
+			name: "invalid 0 queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.rt_queue_size": 0,
+			},
 			queueSize:         0,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessRTQueueSize,
 		},
@@ -115,12 +123,8 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockConfig := configmock.New(t)
-			if tc.override {
-				mockConfig.SetWithoutSource("process_config.rt_queue_size", tc.queueSize)
-			}
-			deps := newSubmitterDepsWithConfig(t, mockConfig)
-			c, err := NewSubmitter(mockConfig, deps.Log, deps.Forwarders, deps.Statsd, testHostName)
+			deps := getSubmitterDeps(t, tc.configOverrides, nil)
+			c, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedQueueSize, c.rtProcessResults.MaxSize())
 		})
@@ -130,31 +134,37 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 func TestNewCollectorProcessQueueBytes(t *testing.T) {
 	tests := []struct {
 		name              string
-		override          bool
+		configOverrides   map[string]interface{}
 		queueBytes        int
 		expectedQueueSize int
 	}{
 		{
 			name:              "default queue size",
-			override:          false,
+			configOverrides:   nil,
 			queueBytes:        42000,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueBytes,
 		},
 		{
-			name:              "valid queue size override",
-			override:          true,
+			name: "valid queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.process_queue_bytes": 42000,
+			},
 			queueBytes:        42000,
 			expectedQueueSize: 42000,
 		},
 		{
-			name:              "invalid negative queue size override",
-			override:          true,
+			name: "invalid negative queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.process_queue_bytes": -2,
+			},
 			queueBytes:        -2,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueBytes,
 		},
 		{
-			name:              "invalid 0 queue size override",
-			override:          true,
+			name: "invalid 0 queue size override",
+			configOverrides: map[string]interface{}{
+				"process_config.process_queue_bytes": 0,
+			},
 			queueBytes:        0,
 			expectedQueueSize: pkgconfigsetup.DefaultProcessQueueBytes,
 		},
@@ -162,12 +172,8 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockConfig := configmock.New(t)
-			if tc.override {
-				mockConfig.SetWithoutSource("process_config.process_queue_bytes", tc.queueBytes)
-			}
-			deps := newSubmitterDepsWithConfig(t, mockConfig)
-			s, err := NewSubmitter(mockConfig, deps.Log, deps.Forwarders, deps.Statsd, testHostName)
+			deps := getSubmitterDeps(t, tc.configOverrides, nil)
+			s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(tc.expectedQueueSize), s.processResults.MaxWeight())
 			assert.Equal(t, int64(tc.expectedQueueSize), s.rtProcessResults.MaxWeight())
@@ -181,14 +187,12 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 	defer flavor.SetFlavor(originalFlavor)
 	flavor.SetFlavor(flavor.ProcessAgent)
 
-	deps := newSubmitterDeps(t)
-	submitter, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName)
+	deps := getSubmitterDeps(t, nil, nil)
+	submitter, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 	assert.NoError(t, err)
 
-	now := time.Now()
 	agentVersion, _ := version.Agent()
-
-	requestID := submitter.getRequestID(now, 0)
+	now := time.Now()
 
 	tests := []struct {
 		name          string
@@ -208,7 +212,6 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				headers.ProcessVersionHeader: agentVersion.GetNumber(),
 				headers.ContainerCountHeader: "3",
 				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.RequestIDHeader:      requestID,
 				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
 				headers.PayloadSource:        "process_agent",
 			},
@@ -312,8 +315,8 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 }
 
 func Test_getRequestID(t *testing.T) {
-	deps := newSubmitterDeps(t)
-	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName)
+	deps := getSubmitterDeps(t, nil, nil)
+	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 	assert.NoError(t, err)
 
 	fixedDate1 := time.Date(2022, 9, 1, 0, 0, 1, 0, time.Local)
@@ -350,8 +353,8 @@ func TestSubmitterHeartbeatProcess(t *testing.T) {
 	statsdClient := mockStatsd.NewMockClientInterface(ctrl)
 	statsdClient.EXPECT().Gauge("datadog.process.agent", float64(1), gomock.Any(), float64(1)).MinTimes(1)
 
-	deps := newSubmitterDeps(t)
-	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, statsdClient, testHostName)
+	deps := getSubmitterDeps(t, nil, nil)
+	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, statsdClient, testHostName, deps.SysProbeConfig)
 	assert.NoError(t, err)
 	mockedClock := clock.NewMock()
 	s.clock = mockedClock
@@ -369,8 +372,8 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	statsdClient := mockStatsd.NewMockClientInterface(ctrl)
 	statsdClient.EXPECT().Gauge("datadog.process.agent", float64(1), gomock.Any(), float64(1)).Times(0)
 
-	deps := newSubmitterDeps(t)
-	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, statsdClient, testHostName)
+	deps := getSubmitterDeps(t, nil, nil)
+	s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, statsdClient, testHostName, deps.SysProbeConfig)
 	assert.NoError(t, err)
 	mockedClock := clock.NewMock()
 	s.clock = mockedClock
@@ -379,27 +382,86 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	s.Stop()
 }
 
+func TestSubmitterFeatureFlags(t *testing.T) {
+	tests := []struct {
+		name                       string
+		configOverrides            map[string]interface{}
+		sysprobeconfigOverrides    map[string]interface{}
+		expProcessesEnabled        string
+		expServiceDiscoveryEnabled string
+	}{
+		{
+			name: "just processes enabled",
+			configOverrides: map[string]interface{}{
+				"process_config.process_collection.enabled": "true",
+			},
+			sysprobeconfigOverrides: map[string]interface{}{
+				"discovery.enabled": "false",
+			},
+			expProcessesEnabled:        "true",
+			expServiceDiscoveryEnabled: "false",
+		},
+		{
+			name: "just service discovery enabled",
+			configOverrides: map[string]interface{}{
+				"process_config.process_collection.enabled": "false",
+			},
+			sysprobeconfigOverrides: map[string]interface{}{
+				"discovery.enabled": "true",
+			},
+			expProcessesEnabled:        "false",
+			expServiceDiscoveryEnabled: "true",
+		},
+		{
+			name: "both enabled",
+			configOverrides: map[string]interface{}{
+				"process_config.process_collection.enabled": "true",
+			},
+			sysprobeconfigOverrides: map[string]interface{}{
+				"discovery.enabled": "true",
+			},
+			expProcessesEnabled:        "true",
+			expServiceDiscoveryEnabled: "true",
+		},
+		{
+			name: "both disabled",
+			configOverrides: map[string]interface{}{
+				"process_config.process_collection.enabled": "false",
+			},
+			sysprobeconfigOverrides: map[string]interface{}{
+				"discovery.enabled": "false",
+			},
+			expProcessesEnabled:        "false",
+			expServiceDiscoveryEnabled: "false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := getSubmitterDeps(t, tc.configOverrides, tc.sysprobeconfigOverrides)
+			s, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expProcessesEnabled, s.processesEnabled)
+			assert.Equal(t, tc.expServiceDiscoveryEnabled, s.serviceDiscoveryEnabled)
+		})
+	}
+}
+
 type submitterDeps struct {
 	fx.In
-	Config     config.Component
-	Log        log.Component
-	Forwarders forwarders.Component
-	Statsd     statsd.ClientInterface
+	Config         config.Component
+	SysProbeConfig sysprobeconfig.Component
+	Log            log.Component
+	Forwarders     forwarders.Component
+	Statsd         statsd.ClientInterface
 }
 
-func newSubmitterDeps(t *testing.T) submitterDeps {
-	return fxutil.Test[submitterDeps](t, getForwardersMockModules(t, nil))
-}
-
-func newSubmitterDepsWithConfig(t *testing.T, config pkgconfigmodel.Config) submitterDeps {
-	overrides := config.AllSettings()
-	return fxutil.Test[submitterDeps](t, getForwardersMockModules(t, overrides))
-}
-
-func getForwardersMockModules(t *testing.T, configOverrides map[string]interface{}) fx.Option {
-	return fx.Options(
+func getSubmitterDeps(t *testing.T, configOverrides map[string]interface{}, sysprobeconfigOverrides map[string]interface{}) submitterDeps {
+	return fxutil.Test[submitterDeps](t, fx.Options(
 		config.MockModule(),
 		fx.Replace(config.MockParams{Overrides: configOverrides}),
+		sysprobeconfigimpl.MockModule(),
+		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysprobeconfigOverrides}),
 		forwardersimpl.MockModule(),
 		fx.Provide(func() log.Component {
 			return logmock.New(t)
@@ -407,5 +469,5 @@ func getForwardersMockModules(t *testing.T, configOverrides map[string]interface
 		fx.Provide(func() statsd.ClientInterface {
 			return &statsd.NoOpClient{}
 		}),
-	)
+	))
 }

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -187,12 +187,20 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 	defer flavor.SetFlavor(originalFlavor)
 	flavor.SetFlavor(flavor.ProcessAgent)
 
-	deps := getSubmitterDeps(t, nil, nil)
+	configOverrides := map[string]interface{}{
+		"process_config.process_collection.enabled": "false",
+	}
+	sysprobeconfigOverrides := map[string]interface{}{
+		"discovery.enabled": "false",
+	}
+	deps := getSubmitterDeps(t, configOverrides, sysprobeconfigOverrides)
 	submitter, err := NewSubmitter(deps.Config, deps.Log, deps.Forwarders, deps.Statsd, testHostName, deps.SysProbeConfig)
 	assert.NoError(t, err)
 
 	agentVersion, _ := version.Agent()
 	now := time.Now()
+
+	requestID := submitter.getRequestID(now, 0)
 
 	tests := []struct {
 		name          string
@@ -207,13 +215,16 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				},
 			},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:      strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:           testHostName,
-				headers.ProcessVersionHeader: agentVersion.GetNumber(),
-				headers.ContainerCountHeader: "3",
-				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:        "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "3",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.RequestIDHeader:         requestID,
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 		{
@@ -224,13 +235,15 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				},
 			},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:      strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:           testHostName,
-				headers.ProcessVersionHeader: agentVersion.GetNumber(),
-				headers.ContainerCountHeader: "3",
-				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:        "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "3",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 		{
@@ -241,13 +254,15 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				},
 			},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:      strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:           testHostName,
-				headers.ProcessVersionHeader: agentVersion.GetNumber(),
-				headers.ContainerCountHeader: "2",
-				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:        "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "2",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 		{
@@ -258,41 +273,47 @@ func TestCollectorMessagesToCheckResult(t *testing.T) {
 				},
 			},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:      strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:           testHostName,
-				headers.ProcessVersionHeader: agentVersion.GetNumber(),
-				headers.ContainerCountHeader: "5",
-				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:        "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "5",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 		{
 			name:    "process_discovery",
 			message: &model.CollectorProcDiscovery{},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:      strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:           testHostName,
-				headers.ProcessVersionHeader: agentVersion.GetNumber(),
-				headers.ContainerCountHeader: "0",
-				headers.ContentTypeHeader:    headers.ProtobufContentType,
-				headers.AgentStartTime:       strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:        "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "0",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 		{
 			name:    "process_events",
 			message: &model.CollectorProcEvent{},
 			expectHeaders: map[string]string{
-				headers.TimestampHeader:        strconv.Itoa(int(now.Unix())),
-				headers.HostHeader:             testHostName,
-				headers.ProcessVersionHeader:   agentVersion.GetNumber(),
-				headers.ContainerCountHeader:   "0",
-				headers.ContentTypeHeader:      headers.ProtobufContentType,
-				headers.EVPOriginHeader:        "process-agent",
-				headers.EVPOriginVersionHeader: version.AgentVersion,
-				headers.AgentStartTime:         strconv.Itoa(int(submitter.agentStartTime)),
-				headers.PayloadSource:          "process_agent",
+				headers.TimestampHeader:         strconv.Itoa(int(now.Unix())),
+				headers.HostHeader:              testHostName,
+				headers.ProcessVersionHeader:    agentVersion.GetNumber(),
+				headers.ContainerCountHeader:    "0",
+				headers.ContentTypeHeader:       headers.ProtobufContentType,
+				headers.EVPOriginHeader:         "process-agent",
+				headers.EVPOriginVersionHeader:  version.AgentVersion,
+				headers.AgentStartTime:          strconv.Itoa(int(submitter.agentStartTime)),
+				headers.PayloadSource:           "process_agent",
+				headers.ProcessesEnabled:        "false",
+				headers.ServiceDiscoveryEnabled: "false",
 			},
 		},
 	}

--- a/pkg/process/runner/submitter_test.go
+++ b/pkg/process/runner/submitter_test.go
@@ -403,7 +403,7 @@ func TestSubmitterHeartbeatCore(t *testing.T) {
 	s.Stop()
 }
 
-func TestSubmitterFeatureFlags(t *testing.T) {
+func TestSubmitterFeatureHeaders(t *testing.T) {
 	tests := []struct {
 		name                       string
 		configOverrides            map[string]interface{}

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -35,4 +35,8 @@ const (
 	AgentStartTime = "X-DD-Agent-Start-Time"
 	// PayloadSource describes which agent process sent the payload (i.e. process or core agent)
 	PayloadSource = "X-DD-Payload-Source"
+	// ProcessesEnabled is a boolean value that indicates if the processes feature is enabled
+	ProcessesEnabled = "X-DD-Processes-Enabled"
+	// ServiceDiscoveryEnabled is a boolean value that indicates if the service discovery feature is enabled
+	ServiceDiscoveryEnabled = "X-DD-Service-Discovery-Enabled"
 )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds header to payloads sent to Processes backend to determine if processes and/or service discovery is enabled. This will help with filtering on the backend, if necessary.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->