### PR TITLE
dyninst/ebpf: set up stack with link register on arm64

### DIFF
--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -77,10 +77,10 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   uint64_t stack_hash = 0;
   global_ctx.stack_walk->regs = *regs;
   global_ctx.stack_walk->stack.pcs.pcs[0] = regs->DWARF_PC_REG;
+#if defined(bpf_target_x86)
+  bool frameless = *(volatile bool *)&params->frameless;
   global_ctx.stack_walk->stack.fps[0] = regs->DWARF_BP_REG;
-  // TODO: For arm64 we need to use the link register to properly set up the
-  // stack trace.
-  if (params->frameless) {
+  if (frameless) {
     if (bpf_probe_read_user(&global_ctx.stack_walk->stack.pcs.pcs[1],
                             sizeof(global_ctx.stack_walk->stack.pcs.pcs[1]),
                             (void*)(regs->sp))) {
@@ -89,6 +89,16 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
     global_ctx.stack_walk->stack.fps[1] = regs->DWARF_BP_REG;
     global_ctx.stack_walk->idx_shift = 1;
   }
+#elif defined(bpf_target_arm64)
+  // Use the link register to populate the next frame's pc.
+  global_ctx.stack_walk->stack.pcs.pcs[1] = regs->DWARF_REGISTER(30);
+  // For reasons explained below when setting up the cfa, the BP register is
+  // pointing to the caller's frame pointer at this point.
+  global_ctx.stack_walk->stack.fps[1] = regs->DWARF_BP_REG;
+  global_ctx.stack_walk->idx_shift = 1;
+#else
+  #error "Unsupported architecture"
+#endif
   global_ctx.stack_walk->stack.pcs.len =
       bpf_loop(STACK_DEPTH, populate_stack_frame, &global_ctx.stack_walk, 0) +
       1;
@@ -141,7 +151,7 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
 // return pc, so one word above that is our CFA. If it's not frameless, then the
 // base pointer is pointing to our frame pointer which is 16 bytes less than our
 // CFA.
-    if (params->frameless) {
+    if (frameless) {
       *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_SP_REG + 8;
     } else {
       *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_BP_REG + 16;


### PR DESCRIPTION
Before this change we weren't using the value from the link register in the stack trace. This is a straight-up bug on arm64. Also, in a sense, all the frames in arm64 are frameless because of [golang/go#74357] so we don't need to do the adjustments we have for x86 in those cases.

[golang/go#74357]: https://github.com/golang/go/issues/74357

Follow-up bug fix related to https://datadoghq.atlassian.net/browse/DEBUG-3887
