### PR TITLE
dyninst/uploader: remove stale testdata fields

### DIFF
--- a/pkg/dyninst/uploader/testdata/snapshot/failed_batch_outcome.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/failed_batch_outcome.yaml
@@ -1,7 +1,6 @@
 config:
   max_items: 2
   max_size_bytes: 50
-  idle_flush_ms: 100
   max_buffer_ms: 200
 events:
   - !enqueue {value: "x"}

--- a/pkg/dyninst/uploader/testdata/snapshot/stop_partial_flush.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/stop_partial_flush.yaml
@@ -1,7 +1,6 @@
 config:
   max_items: 10
   max_size_bytes: 50
-  idle_flush_ms: 100
   max_buffer_ms: 200
 events:
   - !enqueue {value: "p"}

--- a/pkg/dyninst/uploader/testdata/snapshot/successful_batch_outcome.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/successful_batch_outcome.yaml
@@ -1,7 +1,6 @@
 config:
   max_items: 2
   max_size_bytes: 50
-  idle_flush_ms: 100
   max_buffer_ms: 200
 events:
   - !enqueue {value: "x"}


### PR DESCRIPTION
Followup related to https://datadoghq.atlassian.net/browse/DEBUG-4110. 