### PR TITLE
[CONTP-696] Allow user to override type_socket_volumes config using pod labels

### DIFF
--- a/pkg/clusteragent/admission/common/const.go
+++ b/pkg/clusteragent/admission/common/const.go
@@ -30,6 +30,9 @@ const (
 	// InjectionModeLabelKey pod label to choose the config injection at the pod level.
 	InjectionModeLabelKey = "admission.datadoghq.com/config.mode"
 
+	// TypeSocketVolumesLabelKey pod label to decide if socket volume type should be used.
+	TypeSocketVolumesLabelKey = "admission.datadoghq.com/config.type_socket_volumes"
+
 	// LibVersionAnnotKeyFormat is the format of the library version annotation
 	LibVersionAnnotKeyFormat = "admission.datadoghq.com/%s-lib.version"
 

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -158,7 +158,7 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod, withCSI bool) bool {
 	var injectedVolNames []string
 	var injectedVolumeMount bool
 
-	if i.config.typeSocketVolumes {
+	if shouldUseSocketVolumeType(pod, i.config.typeSocketVolumes) {
 		volumes := map[string]struct {
 			socketpath    string
 			csiVolumeType csiInjectionType
@@ -242,6 +242,22 @@ func injectionMode(pod *corev1.Pod, globalMode string, csiEnabled bool) string {
 	}
 
 	return decidedMode
+}
+
+// shouldUseSocketVolumeType determines if socket volume type should be used for the pod under mutation.
+func shouldUseSocketVolumeType(pod *corev1.Pod, globalTypeSocketVolumes bool) bool {
+	if val, found := pod.GetLabels()[common.TypeSocketVolumesLabelKey]; found {
+		normalisedValue := strings.ToLower(val)
+
+		if normalisedValue != "true" && normalisedValue != "false" {
+			log.Warnf("Invalid value for %q: %q. Expected values are `true` and `false`.", common.TypeSocketVolumesLabelKey, normalisedValue)
+			return globalTypeSocketVolumes
+		}
+
+		return normalisedValue == "true"
+	}
+
+	return globalTypeSocketVolumes
 }
 
 // buildExternalEnv generate an External Data environment variable.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allows users to override the global `type_socket_volumes` DCA config by setting `"admission.datadoghq.com/config.type_socket_volumes"` pod label to `true` or `false`.

### Motivation

When the cluster agent is configured with `socket` config injection mode, the config webhook mounts dsd and apm sockets using a hostpath volume. 

The type of the volume is by default `DirectoryOrCreate`.

[A previous PR ](https://github.com/DataDog/datadog-agent/pull/29076)allowed users to change the volume type to `Socket` by setting an env var on the cluster agent to change this configuration.

However, the user can not choose to apply this override for a specific pod. 

This improvement can also help fixing an internal issue where apm and dsd sockets are not placed within the same directory, preventing us from testing it with CSI volumes. With this change we will be able to mount both sockets separately by setting a label on the service.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests were updated.

E2E tests are already in place to test the default documented behavior.

Manual testing:

When adding the mentioned label to the pod, the following volume and volume mounts are injected:

```
volumes:
  - hostPath:
      path: /var/run/datadog/dsd.socket
      type: Socket
    name: datadog-dogstatsd
  - hostPath:
      path: /var/run/datadog/apm.socket
      type: Socket
    name: datadog-trace-agent
```

```
volumeMounts:
    - mountPath: /var/run/datadog/dsd.socket
      name: datadog-dogstatsd
      readOnly: true
      recursiveReadOnly: Disabled
    - mountPath: /var/run/datadog/apm.socket
      name: datadog-trace-agent
      readOnly: true
      recursiveReadOnly: Disabled
```

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

