### PR TITLE
[ AGNTLOG-245 ] Allow users to configure the http timeout for the logs agent

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1035,6 +1035,11 @@ api_key:
   ## The transport type to use for sending logs. Possible values are "auto" or "http1".
   # http_protocol: auto
 
+  ## @param http_timeout - integer - optional - default: 10
+  ## @env DD_LOGS_CONFIG_HTTP_TIMEOUT - integer - optional - default: 10
+  ## The HTTP timeout to use for sending logs, in seconds.
+  # http_timeout: 10
+
   ## @param force_use_tcp - boolean - optional - default: false
   ## @env DD_LOGS_CONFIG_FORCE_USE_TCP - boolean - optional - default: false
   ## By default, logs are sent through HTTPS if possible, set this parameter

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1613,6 +1613,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 	// Transport protocol for log payloads
 	config.BindEnvAndSetDefault("logs_config.http_protocol", "auto")
+	config.BindEnvAndSetDefault("logs_config.http_timeout", 10)
 
 	bindEnvAndSetLogsConfigKeys(config, "logs_config.")
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.")

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -153,7 +153,7 @@ func newDestination(endpoint config.Endpoint,
 		url:                 buildURL(endpoint),
 		endpoint:            endpoint,
 		contentType:         contentType,
-		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(timeout, cfg)),
+		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(cfg)),
 		destinationsContext: destinationsContext,
 		workerPool:          workerPool,
 		wg:                  sync.WaitGroup{},
@@ -414,10 +414,11 @@ func (d *Destination) updateRetryState(err error, isRetrying chan bool) bool {
 	}
 }
 
-func httpClientFactory(timeout time.Duration, cfg pkgconfigmodel.Reader) func() *http.Client {
+func httpClientFactory(cfg pkgconfigmodel.Reader) func() *http.Client {
 	var transport *http.Transport
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
+	timeout := time.Second * time.Duration(cfg.GetInt("logs_config.http_timeout"))
 
 	// Configure transport based on user setting
 	switch transportConfig {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -389,10 +389,10 @@ func TestTransportProtocol_HTTP1(t *testing.T) {
 	s := NewTestHTTPSServer(false)
 	defer s.Close()
 
-	timeout := 5 * time.Second
-	// Force HTTP/1 transport
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	// Create an HTTP/1.1 request
 	req, err := http.NewRequest("POST", s.URL, nil)
 	if err != nil {
@@ -422,9 +422,10 @@ func TestTransportProtocol_HTTP2(t *testing.T) {
 	s := NewTestHTTPSServer(false)
 	defer s.Close()
 
-	timeout := 5 * time.Second
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", s.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
@@ -454,9 +455,10 @@ func TestTransportProtocol_InvalidProtocol(t *testing.T) {
 	server := NewTestHTTPSServer(false)
 	defer server.Close()
 
-	timeout := 5 * time.Second
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
@@ -485,9 +487,10 @@ func TestTransportProtocol_HTTP1FallBack(t *testing.T) {
 	server := NewTestHTTPSServer(true)
 	defer server.Close()
 
-	timeout := 5 * time.Second
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
@@ -517,9 +520,10 @@ func TestTransportProtocol_HTTP2WhenUsingProxy(t *testing.T) {
 	server := NewTestHTTPSServer(false)
 	defer server.Close()
 
-	timeout := 5 * time.Second
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
@@ -549,9 +553,10 @@ func TestTransportProtocol_HTTP1FallBackWhenUsingProxy(t *testing.T) {
 	server := NewTestHTTPSServer(true)
 	defer server.Close()
 
-	timeout := 5 * time.Second
-	client := httpClientFactory(timeout, c)()
+	c.SetWithoutSource("logs_config.http_timeout", 5)
+	client := httpClientFactory(c)()
 
+	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)

--- a/releasenotes/notes/logs-agent-http-timeout-9e2b1e0b3e3e2db9.yaml
+++ b/releasenotes/notes/logs-agent-http-timeout-9e2b1e0b3e3e2db9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow users to configure the HTTP timeout for the Logs Agent.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
For network/bandwidth setups that cannot transfer the entirety of a payload within 10 seconds, the inability to configure the http client timeout results in log loss. While there would likely need to be an underlying issue to cause such a delay in payload transfer, having the option to increase the timeout can be a valuable patch while such an issue is investigated.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->