### PR TITLE
[CXP-2231] Add hostname to metric samples from core agent statsd client

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -490,8 +490,8 @@ func getSharedFxOption() fx.Option {
 		snmptraps.Bundle(),
 		snmpscanfx.Module(),
 		collectorimpl.Module(),
-		fx.Provide(func(demux demultiplexer.Component) (ddgostatsd.ClientInterface, error) {
-			return aggregator.NewStatsdDirect(demux)
+		fx.Provide(func(demux demultiplexer.Component, hostname hostnameinterface.Component) (ddgostatsd.ClientInterface, error) {
+			return aggregator.NewStatsdDirect(demux, hostname)
 		}),
 		process.Bundle(),
 		guiimpl.Module(),

--- a/pkg/aggregator/statsd.go
+++ b/pkg/aggregator/statsd.go
@@ -37,7 +37,6 @@ func NewStatsdDirect(demux DemultiplexerWithAggregator, hostnameComp hostnameint
 		origin: taggertypes.OriginInfo{
 			LocalData:     origindetection.LocalData{ProcessID: uint32(os.Getpid())},
 			ProductOrigin: origindetection.ProductOriginDogStatsD,
-			Cardinality:   types.HighCardinalityString,
 		},
 		hostname: hostname,
 	}, nil

--- a/pkg/aggregator/statsd.go
+++ b/pkg/aggregator/statsd.go
@@ -6,21 +6,30 @@
 package aggregator
 
 import (
+	"context"
 	"os"
 	"time"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	taggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // NewStatsdDirect creates a direct interface to the dogstatsd demultiplexer, but exposing the statsd.ClientInterface
-func NewStatsdDirect(demux DemultiplexerWithAggregator) (ddgostatsd.ClientInterface, error) {
+func NewStatsdDirect(demux DemultiplexerWithAggregator, hostnameComp hostnameinterface.Component) (ddgostatsd.ClientInterface, error) {
 	eventsChan, serviceCheckChan := demux.GetEventsAndServiceChecksChannels()
+	hostname, err := hostnameComp.Get(context.TODO())
+	if err != nil {
+		log.Warnf("error getting hostname for statsd direct client: %s", err)
+		hostname = ""
+	}
 	return &statsdDirect{
 		demux:            demux,
 		eventsChan:       eventsChan,
@@ -28,7 +37,9 @@ func NewStatsdDirect(demux DemultiplexerWithAggregator) (ddgostatsd.ClientInterf
 		origin: taggertypes.OriginInfo{
 			LocalData:     origindetection.LocalData{ProcessID: uint32(os.Getpid())},
 			ProductOrigin: origindetection.ProductOriginDogStatsD,
+			Cardinality:   types.HighCardinalityString,
 		},
+		hostname: hostname,
 	}, nil
 }
 
@@ -39,6 +50,7 @@ type statsdDirect struct {
 	eventsChan       chan []*event.Event
 	serviceCheckChan chan []*servicecheck.ServiceCheck
 	origin           taggertypes.OriginInfo
+	hostname         string
 }
 
 func (s statsdDirect) Gauge(name string, value float64, tags []string, rate float64) error {
@@ -47,6 +59,7 @@ func (s statsdDirect) Gauge(name string, value float64, tags []string, rate floa
 		Value:      value,
 		Mtype:      metrics.GaugeType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,
@@ -60,6 +73,7 @@ func (s statsdDirect) GaugeWithTimestamp(name string, value float64, tags []stri
 		Value:      value,
 		Mtype:      metrics.GaugeType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(timestamp.Unix()),
 		OriginInfo: s.origin,
@@ -73,6 +87,7 @@ func (s statsdDirect) Count(name string, value int64, tags []string, rate float6
 		Value:      float64(value),
 		Mtype:      metrics.CountType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,
@@ -86,6 +101,7 @@ func (s statsdDirect) CountWithTimestamp(name string, value int64, tags []string
 		Value:      float64(value),
 		Mtype:      metrics.CountType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(timestamp.Unix()),
 		OriginInfo: s.origin,
@@ -99,6 +115,7 @@ func (s statsdDirect) Histogram(name string, value float64, tags []string, rate 
 		Value:      value,
 		Mtype:      metrics.HistogramType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,
@@ -112,6 +129,7 @@ func (s statsdDirect) Distribution(name string, value float64, tags []string, ra
 		Value:      value,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,
@@ -133,6 +151,7 @@ func (s statsdDirect) Set(name string, value string, tags []string, rate float64
 		RawValue:   value,
 		Mtype:      metrics.SetType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,
@@ -150,6 +169,7 @@ func (s statsdDirect) TimeInMilliseconds(name string, value float64, tags []stri
 		Value:      value,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
+		Host:       s.hostname,
 		SampleRate: rate,
 		Timestamp:  float64(time.Now().Unix()),
 		OriginInfo: s.origin,

--- a/pkg/aggregator/statsd.go
+++ b/pkg/aggregator/statsd.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"

--- a/pkg/aggregator/statsd_test.go
+++ b/pkg/aggregator/statsd_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestStatsdDirect(t *testing.T) {
+	opts := DefaultAgentDemultiplexerOptions()
+	opts.FlushInterval = time.Hour
+	opts.DontStartForwarders = true
+	demuxDeps := createDemultiplexerAgentTestDeps(t)
+	demux := initAgentDemultiplexer(demuxDeps.Log, NewForwarderTest(demuxDeps.Log), demuxDeps.OrchestratorFwd, opts, demuxDeps.EventPlatform, demuxDeps.HaAgent, demuxDeps.Compressor, demuxDeps.Tagger, "")
+
+	hostnameComp := fxutil.Test[hostnameinterface.Mock](t,
+		fx.Options(
+			hostnameinterface.MockModule(),
+			fx.Replace(hostnameinterface.MockHostname("my-hostname")),
+		),
+	)
+
+	statsd, err := NewStatsdDirect(demux, hostnameComp)
+	require.NoError(t, err)
+
+	err = statsd.Gauge("test.gauge", 1.0, []string{"tag1:value1", "tag2:value2"}, 1.0)
+	require.NoError(t, err)
+
+	samples := <-demux.statsd.workers[0].samplesChan
+	require.Len(t, samples, 1)
+
+	sample := samples[0]
+	require.Equal(t, "test.gauge", sample.Name)
+	require.Equal(t, 1.0, sample.Value)
+	require.Equal(t, []string{"tag1:value1", "tag2:value2"}, sample.Tags)
+	require.Equal(t, "my-hostname", sample.Host)
+	require.Equal(t, 1.0, sample.SampleRate)
+	require.Equal(t, metrics.GaugeType, sample.Mtype)
+}

--- a/releasenotes/notes/fix-process-check-core-agent-metric-host-tagging-6ebcace5e44ca3d0.yaml
+++ b/releasenotes/notes/fix-process-check-core-agent-metric-host-tagging-6ebcace5e44ca3d0.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Metrics sent from the process check on the core agent now have the host tag.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes host tagging for `datadog.process.*` metrics when reported from the core agent by adding the hostname to the metric sample. 

### Motivation

https://github.com/DataDog/datadog-agent/issues/36921

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Metrics from the core agent now have the host tag
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/161a9053-00e6-42b7-82f1-dddb16bcfab3" />

Added unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->