### PR TITLE
Restart static quality gates on image pull failure

### DIFF
--- a/tasks/static_quality_gates/lib/docker_agent_lib.py
+++ b/tasks/static_quality_gates/lib/docker_agent_lib.py
@@ -2,12 +2,15 @@ import os
 import sys
 
 from tasks.libs.common.color import color_message
+from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.lib.gates_lib import argument_extractor, read_byte_input
 
 
 def calculate_image_on_disk_size(ctx, url):
     # Pull image locally to get on disk size
-    ctx.run(f"crane pull {url} output.tar")
+    crane_output = ctx.run(f"crane pull {url} output.tar", warn=True)
+    if crane_output.exited != 0:
+        raise InfraError(f"Crane pull failed to retrieve {url}. Retrying... (infra flake)")
     # The downloaded image contains some metadata files and another tar.gz file. We are computing the sum of
     # these metadata files and the uncompressed size of the tar.gz inside of output.tar.
     ctx.run("tar -xf output.tar")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `static_quality_gates` job is now auto restarting on infra failure preventing `crane pull` to fetch needed docker images.

### Motivation

Handle infrastructure failure

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
