### PR TITLE
Improve linter speed on pre-commit

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -52,6 +52,7 @@ def run_golangci_lint(
     verbose=False,
     golangci_lint_kwargs="",
     headless_mode: bool = False,
+    recursive: bool = True,
 ):
     if isinstance(targets, str):
         # when this function is called from the command line, targets are passed
@@ -79,7 +80,7 @@ def run_golangci_lint(
             tags_arg = " ".join(sorted(set(tags)))
             timeout_arg_value = "25m0s" if not timeout else f"{timeout}m0s"
             res = ctx.run(
-                f'golangci-lint run {verbosity} --timeout {timeout_arg_value} {concurrency_arg} --build-tags "{tags_arg}" --path-prefix "{base_path}" {golangci_lint_kwargs} {target}/...',
+                f'golangci-lint run {verbosity} --timeout {timeout_arg_value} {concurrency_arg} --build-tags "{tags_arg}" --path-prefix "{base_path}" {golangci_lint_kwargs} {target}{"/..." if recursive else ""}',
                 env=env,
                 warn=True,
             )

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -883,8 +883,10 @@ def compute_gotestsum_cli_args(modules: list[GoModule], recursive: bool = True):
             if not target_path.startswith('./'):
                 target_path = f"./{target_path}"
             targets.append(target_path)
-
-    packages = ' '.join(f"{t}/..." if not t.endswith("/...") and recursive else t for t in targets)
+    if recursive:
+        packages = ' '.join(f"{t}/..." if not t.endswith("/...") else t for t in targets)
+    else:
+        packages = ' '.join(targets)
     return packages
 
 

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -389,9 +389,7 @@ def test(
             result_json=result_json,
             test_profiler=test_profiler,
             coverage=coverage,
-            recursive=not (
-                only_modified_packages or only_impacted_packages
-            ),  # Disable recursive tests when only modified packages or only impacted packages is enabled, to avoid testing a package and all its subpackages
+            recursive=not only_modified_packages,  # Disable recursive tests when only modified packages is enabled, to avoid testing a package and all its subpackages
         )
 
     # Output (only if tests ran)

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -119,6 +119,7 @@ def test_flavor(
     test_profiler: TestProfiler,
     coverage: bool = False,
     result_json: str = DEFAULT_TEST_OUTPUT_JSON,
+    recursive: bool = True,
 ):
     """
     Runs unit tests for given flavor, build tags, and modules.
@@ -150,7 +151,7 @@ def test_flavor(
         args["junit_file_flag"] = junit_file_flag
 
     # Compute full list of targets to run tests against
-    packages = compute_gotestsum_cli_args(modules)
+    packages = compute_gotestsum_cli_args(modules, recursive)
 
     with CodecovWorkaround(ctx, result.path, coverage, packages, args) as cov_test_path:
         res = ctx.run(
@@ -388,6 +389,9 @@ def test(
             result_json=result_json,
             test_profiler=test_profiler,
             coverage=coverage,
+            recursive=not (
+                only_modified_packages or only_impacted_packages
+            ),  # Disable recursive tests when only modified packages or only impacted packages is enabled, to avoid testing a package and all its subpackages
         )
 
     # Output (only if tests ran)
@@ -871,7 +875,7 @@ def get_go_modified_files(ctx):
     ]
 
 
-def compute_gotestsum_cli_args(modules: list[GoModule]):
+def compute_gotestsum_cli_args(modules: list[GoModule], recursive: bool = True):
     targets = []
     for module in modules:
         if not module.should_test():
@@ -882,7 +886,7 @@ def compute_gotestsum_cli_args(modules: list[GoModule]):
                 target_path = f"./{target_path}"
             targets.append(target_path)
 
-    packages = ' '.join(f"{t}/..." if not t.endswith("/...") else t for t in targets)
+    packages = ' '.join(f"{t}/..." if not t.endswith("/...") and recursive else t for t in targets)
     return packages
 
 

--- a/tasks/libs/linter/go.py
+++ b/tasks/libs/linter/go.py
@@ -24,6 +24,7 @@ def run_lint_go(
     headless_mode=False,
     include_sds=False,
     verbose=False,
+    recursive=True,
 ):
     linter_tags = build_tags or compute_build_tags_for_flavor(
         flavor=flavor,
@@ -44,6 +45,7 @@ def run_lint_go(
         golangci_lint_kwargs=golangci_lint_kwargs,
         headless_mode=headless_mode,
         verbose=verbose,
+        recursive=recursive,
     )
 
     return lint_result, execution_times
@@ -60,6 +62,7 @@ def lint_flavor(
     golangci_lint_kwargs: str = "",
     headless_mode: bool = False,
     verbose: bool = False,
+    recursive: bool = True,
 ):
     """Runs linters for given flavor, build tags, and modules."""
 
@@ -88,6 +91,7 @@ def lint_flavor(
         golangci_lint_kwargs=golangci_lint_kwargs,
         headless_mode=headless_mode,
         verbose=verbose,
+        recursive=recursive,
     )
     for lint_result in lint_results:
         result.lint_outputs.append(lint_result)

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -123,6 +123,7 @@ def go(
         headless_mode=headless_mode,
         include_sds=include_sds,
         verbose=verbose,
+        recursive=not only_modified_packages,  # Disable recursive linting when only modified packages is enabled, to avoid linting a package and all its subpackages
     )
 
     if not headless_mode:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make sure we do not recursively lint or test everything when `only_modified-packages` or `only_impacted_packages` is activated and should provide the complete list of things to test/lint

### Motivation

Make linter faster

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->