### PR TITLE
Skip invalid lines encountered when parsing result json files

### DIFF
--- a/tasks/unit_tests/testdata/test_output_with_invalid.json
+++ b/tasks/unit_tests/testdata/test_output_with_invalid.json
@@ -1,0 +1,61 @@
+{"Time": "2025-06-27T11:28:21.4693584+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693754+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693774+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693814+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage1, action: run", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.4693834+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.5636324+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: start", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636934+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636974+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage1, action: cont", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.5636994+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.7477684+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478204+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: pause", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478264+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7478304+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for test_3 in github.com/DataDog/datadog-agent/testpackage1, action: fail", "Test": "test_3"}
+{"Time": "2025-06-27T11:28:21.7767834+01:00", "Action": "skip", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Test": "test_4"}
+{"Time": "2025-06-27T11:28:21.7768074+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768234+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: run"}
+{"Time": "2025-06-27T11:28:21.7768314+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage1"}
+{"Time": "2025-06-27T11:28:21.7768374+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: pause"}
+{"Time": "2025-06-27T11:28:21.7768404+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: cont"}
+{"Time": "2025-06-27T11:28:21.7768444+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage1", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage1, action: fail"}
+{"Time": "2025-06-27T11:28:21.9620364+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621304+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: pause", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621434+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: cont", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9621504+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage2, action: fail", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:21.9878384+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage2, action: start", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9878984+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9879114+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:21.9879204+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Test": "test_2"}
+{"ImportPath":"./pkg","Action":"build-output","Output":"# ./pkg\n"}
+{"ImportPath":"./pkg","Action":"build-output","Output":"no Go files in /go/src/github.com/DataDog/datadog-agent/pkg\n"}
+{"ImportPath":"./pkg","Action":"build-fail"}
+{"Time":"2025-07-03T09:06:11.435628558Z","Action":"start","Package":"./pkg"}
+{"Time":"2025-07-03T09:06:11.435649694Z","Action":"output","Package":"./pkg","Output":"FAIL\t./pkg [setup failed]\n"}
+{"Time":"2025-07-03T09:06:11.435654498Z","Action":"fail","Package":"./pkg","Elapsed":0,"FailedBuild":"./pkg"}
+{"ImportPath":"./cmd","Action":"build-output","Output":"# ./cmd\n"}
+{"ImportPath":"./cmd","Action":"build-output","Output":"no Go files in /go/src/github.com/DataDog/datadog-agent/cmd\n"}
+{"ImportPath":"./cmd","Action":"build-fail"}
+{"Time":"2025-07-03T09:06:11.43566373Z","Action":"start","Package":"./cmd"}
+{"Time":"2025-07-03T09:06:11.435665677Z","Action":"output","Package":"./cmd","Output":"FAIL\t./cmd [setup failed]\n"}
+{"Time":"2025-07-03T09:06:11.435667411Z","Action":"fail","Package":"./cmd","Elapsed":0,"FailedBuild":"./cmd"}
+{"ImportPath":"./comp","Action":"build-output","Output":"# ./comp\n"}
+{"ImportPath":"./comp","Action":"build-output","Output":"no Go files in /go/src/github.com/DataDog/datadog-agent/comp\n"}
+{"ImportPath":"./comp","Action":"build-fail"}
+{"Time":"2025-07-03T09:06:11.435673747Z","Action":"start","Package":"./comp"}
+{"Time":"2025-07-03T09:06:11.435675467Z","Action":"output","Package":"./comp","Output":"FAIL\t./comp [setup failed]\n"}
+{"Time":"2025-07-03T09:06:11.43567705Z","Action":"fail","Package":"./comp","Elapsed":0,"FailedBuild":"./comp"}
+{"Time": "2025-06-27T11:28:21.9879264+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for test_2 in github.com/DataDog/datadog-agent/testpackage2, action: pass", "Test": "test_2"}
+{"Time": "2025-06-27T11:28:22.0718944+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: start"}
+{"Time": "2025-06-27T11:28:22.0720984+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: run"}
+{"Time": "2025-06-27T11:28:22.0721314+01:00", "Action": "run", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.0721504+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: pause"}
+{"Time": "2025-06-27T11:28:22.0721604+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage2", "Output": "Dummy output for _ in github.com/DataDog/datadog-agent/testpackage2, action: cont"}
+{"Time": "2025-06-27T11:28:22.0721774+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.0721884+01:00", "Action": "fail", "Package": "github.com/DataDog/datadog-agent/testpackage2"}
+{"Time": "2025-06-27T11:28:22.1033644+01:00", "Action": "start", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034464+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034584+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034744+01:00", "Action": "output", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: output", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1034924+01:00", "Action": "pause", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: pause", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1035014+01:00", "Action": "cont", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Output": "Dummy output for test_1 in github.com/DataDog/datadog-agent/testpackage3/inner_package, action: cont", "Test": "test_1"}
+{"Time": "2025-06-27T11:28:22.1035104+01:00", "Action": "pass", "Package": "github.com/DataDog/datadog-agent/testpackage3/inner_package", "Test": "test_1"}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a bit more error handling to `tasks/libs/testing/result_json.py`, introduced in #38227, to avoid noisy error messages and maybe some erroneous failures

### Motivation

There are some possible Result JSON lines that are not parsed properly by the lib, see the artifacts from [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1011655845) for example:

```json
{"ImportPath":"./pkg","Action":"build-output","Output":"# ./pkg\n"}
```
> Here, the Action field does not contain a recognized value, and the required Time field is missing
This resulted in the following confusing error in the job:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/__main__.py", line 3, in <module>
    program.run()
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/custom_task/custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/junit_tasks.py", line 12, in junit_upload
    junit_upload_from_tgz(tgz_path, result_json)
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/junit_upload_core.py", line 84, in junit_upload_from_tgz
    flaky_failures, marked_flaky_tests = get_flaky_failures_and_marked_flaky_tests_from_test_output(result_json)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/junit_upload_core.py", line 120, in get_flaky_failures_and_marked_flaky_tests_from_test_output
    tw = TestWasher(test_output_json_file=result_json)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/testwasher.py", line 38, in __init__
    self.test_output_json = ResultJson.from_file(test_output_json_file)  # type: ignore[attribute-defined-outside-init]
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/testing/result_json.py", line 59, in from_file
    res.append(ResultJsonLine.from_dict(data))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/testing/result_json.py", line 34, in from_dict
    time=datetime.fromisoformat(data["Time"]),
                                ~~~~^^^^^^^^
KeyError: 'Time'
```

To avoid these kinds of errors in the future, we just skip any lines that contain invalid data.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Add new unit tests

### Possible Drawbacks / Trade-offs

Might cause some job to fail silently in the future ? Pretty unlikely imo

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->