### PR TITLE
usm: do not enable runtime compiler/kernel header downloading by default

### DIFF
--- a/pkg/system-probe/config/adjust_usm.go
+++ b/pkg/system-probe/config/adjust_usm.go
@@ -29,11 +29,6 @@ func disableProtocolIfUnsupported(cfg model.Config, configKey string, isSupporte
 }
 
 func adjustUSM(cfg model.Config) {
-	if cfg.GetBool(smNS("enabled")) {
-		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
-		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
-	}
-
 	// HTTP configuration migration to tree structure with backward compatibility
 	// Each tree structure key is paired with its deprecated flat versions
 	deprecateBool(cfg, smNS("enable_http_monitoring"), smNS("http", "enabled"))

--- a/releasenotes/notes/usm-no-default-runtime-compilation-776064acd07724ac.yaml
+++ b/releasenotes/notes/usm-no-default-runtime-compilation-776064acd07724ac.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    Enabling Universal Service Monitoring (USM) no longer enables eBPF runtime compilation and kernel headers
+    downloading by default. Please use ``system_probe_config.enable_runtime_compiler`` and
+    ``system_probe_config.enable_kernel_header_download`` to enable those features manually.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Now that most recent kernels support CO-RE, we can remove the automatic enablement of runtime compilation/kernel header downloading when USM is enabled.

The main goal of this PR is to remove one of the big sources of usage of runtime compilations, with the potential end goal of sunsetting this feature fully.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->