### PR TITLE
Exclude 'system.disk.used' and 'system.disk.utilized' from value comparison in windows e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/common.go
@@ -8,6 +8,7 @@ package checkdisk
 
 import (
 	"math"
+	"slices"
 
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	gocmp "github.com/google/go-cmp/cmp"
@@ -25,9 +26,10 @@ import (
 
 type diskCheckSuite struct {
 	e2e.BaseSuite[environments.Host]
-	descriptor            e2eos.Descriptor
-	metricCompareFraction float64
-	metricCompareDecimals int
+	descriptor                  e2eos.Descriptor
+	metricCompareFraction       float64
+	metricCompareDecimals       int
+	excludedFromValueComparison []string
 }
 
 func (v *diskCheckSuite) getSuiteOptions() []e2e.SuiteOption {
@@ -134,6 +136,9 @@ instances:
 				gocmp.Comparer(func(a, b check.Metric) bool {
 					if !checkUtils.EqualMetrics(a, b) {
 						return false
+					}
+					if slices.Contains(v.excludedFromValueComparison, a.Metric) {
+						return true
 					}
 					aValue := a.Points[0][1]
 					bValue := b.Points[0][1]

--- a/test/new-e2e/tests/agent-runtimes/checks/disk/disk_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/disk_nix_test.go
@@ -22,9 +22,10 @@ func TestLinuxDiskSuite(t *testing.T) {
 	t.Parallel()
 	suite := &linuxDiskCheckSuite{
 		diskCheckSuite{
-			descriptor:            e2eos.UbuntuDefault,
-			metricCompareFraction: 0.02,
-			metricCompareDecimals: 1,
+			descriptor:                  e2eos.UbuntuDefault,
+			metricCompareFraction:       0.02,
+			metricCompareDecimals:       1,
+			excludedFromValueComparison: []string{},
 		},
 	}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)

--- a/test/new-e2e/tests/agent-runtimes/checks/disk/disk_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/disk_win_test.go
@@ -25,6 +25,8 @@ func TestWindowsDiskSuite(t *testing.T) {
 			descriptor:            e2eos.WindowsDefault,
 			metricCompareFraction: 0.05,
 			metricCompareDecimals: 1,
+			// system.disk.used and system.disk.utilized are highly flaky. Their values ​​may vary between both executions, so we do not compare them.
+			excludedFromValueComparison: []string{"system.disk.used", "system.disk.utilized"},
 		},
 	}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)

--- a/test/new-e2e/tests/agent-runtimes/checks/disk/disk_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/disk/disk_win_test.go
@@ -23,7 +23,7 @@ func TestWindowsDiskSuite(t *testing.T) {
 	suite := &windowsDiskCheckSuite{
 		diskCheckSuite{
 			descriptor:            e2eos.WindowsDefault,
-			metricCompareFraction: 0.05,
+			metricCompareFraction: 0.02,
 			metricCompareDecimals: 1,
 			// system.disk.used and system.disk.utilized are highly flaky. Their values ​​may vary between both executions, so we do not compare them.
 			excludedFromValueComparison: []string{"system.disk.used", "system.disk.utilized"},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Exclude 'system.disk.used' and 'system.disk.utilized' from value comparison in windows e2e tests

### Motivation
Even after increasing the margin of error to 5%, errors are still observed.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->