### PR TITLE
 [ AGNTLOG-210 ] Extend the logs agent to support a cardinality level config for the tagger 

### DIFF
--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -81,6 +81,8 @@ const (
 	NoneCardinality
 	// ChecksConfigCardinality is an internal cardinality that represents the checks_tag_cardinality setting.
 	ChecksConfigCardinality
+	// LogsConfigCardinality is an internal cardinality that represents the logs_tag_cardinality setting.
+	LogsConfigCardinality
 )
 
 // Entity is an entity ID + tags.
@@ -152,6 +154,11 @@ const (
 // StringToTagCardinality extracts a TagCardinality from a string.
 // In case of failure to parse, returns an error and defaults to Low.
 func StringToTagCardinality(c string) (TagCardinality, error) {
+	return StringToTagCardinalityWithDefault(c, LowCardinality)
+}
+
+// StringToTagCardinalityWithDefault extracts a TagCardinality from a string.
+func StringToTagCardinalityWithDefault(c string, defaultCardinality TagCardinality) (TagCardinality, error) {
 	switch strings.ToLower(c) {
 	case HighCardinalityString:
 		return HighCardinality, nil
@@ -162,7 +169,7 @@ func StringToTagCardinality(c string) (TagCardinality, error) {
 	case NoneCardinalityString:
 		return NoneCardinality, nil
 	default:
-		return LowCardinality, fmt.Errorf("unsupported value %s received for tag cardinality", c)
+		return defaultCardinality, fmt.Errorf("unsupported value %s received for tag cardinality", c)
 	}
 }
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -206,7 +206,7 @@ api_key:
 ## @env DD_LOGS_TAG_CARDINALITY - string - optional - default: high
 ## Configure the level of granularity of tags to send for logs. Choices are:
 ##   * low: add tags about low-cardinality objects (clusters, hosts, deployments, container images, ...)
-##   * orchestrator: add tags about pod, (in Kubernetes), or task (in ECS or Mesos) -level of cardinality
+##   * orchestrator: add tags about pod (in Kubernetes), or task (in ECS or Mesos) level of cardinality
 ##   * high: add tags about high-cardinality objects (individual containers, user IDs in requests, ...)
 ##
 ## WARNING: sending container tags for logs may create larger payloads.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -202,6 +202,18 @@ api_key:
 #
 # dogstatsd_tag_cardinality: low
 
+## @param logs_tag_cardinality - string - optional - default: high
+## @env DD_LOGS_TAG_CARDINALITY - string - optional - default: high
+## Configure the level of granularity of tags to send for logs. Choices are:
+##   * low: add tags about low-cardinality objects (clusters, hosts, deployments, container images, ...)
+##   * orchestrator: add tags about pod, (in Kubernetes), or task (in ECS or Mesos) -level of cardinality
+##   * high: add tags about high-cardinality objects (individual containers, user IDs in requests, ...)
+##
+## WARNING: sending container tags for logs may create larger payloads.
+## This may impact your logs ingestion billing.
+#
+# logs_tag_cardinality: high
+
 ## @param histogram_aggregates - list of strings - optional - default: ["max", "median", "avg", "count"]
 ## @env DD_HISTOGRAM_AGGREGATES - space separated list of strings - optional - default: max median avg count
 ## Configure which aggregated value to compute.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -705,6 +705,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Changing this setting may impact your custom metrics billing.
 	config.BindEnvAndSetDefault("checks_tag_cardinality", "low")
 	config.BindEnvAndSetDefault("dogstatsd_tag_cardinality", "low")
+	config.BindEnvAndSetDefault("logs_tag_cardinality", "high")
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes

--- a/pkg/logs/internal/tag/provider.go
+++ b/pkg/logs/internal/tag/provider.go
@@ -64,7 +64,7 @@ func (p *provider) GetTags() []string {
 		p.clock.Sleep(p.taggerWarmupDuration)
 	})
 
-	tags, err := p.tagAdder.Tag(p.entityID, types.HighCardinality)
+	tags, err := p.tagAdder.Tag(p.entityID, types.LogsConfigCardinality)
 	if err != nil {
 		log.Warnf("Cannot tag container %s: %v", p.entityID, err)
 		return []string{}

--- a/pkg/logs/tailers/journald/docker.go
+++ b/pkg/logs/tailers/journald/docker.go
@@ -33,7 +33,7 @@ func (t *Tailer) getContainerID(entry *sdjournal.JournalEntry) string {
 
 // getContainerTags returns all the tags of a given container.
 func (t *Tailer) getContainerTags(containerID string) []string {
-	tags, err := t.tagger.Tag(types.NewEntityID(types.ContainerID, containerID), types.HighCardinality)
+	tags, err := t.tagger.Tag(types.NewEntityID(types.ContainerID, containerID), types.LogsConfigCardinality)
 	if err != nil {
 		log.Warn(err)
 	}

--- a/releasenotes/notes/kube-cardinality-for-logs-8f6b1a20aaf31f56.yaml
+++ b/releasenotes/notes/kube-cardinality-for-logs-8f6b1a20aaf31f56.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow Kubernetes tag cardinality to be configurable for the Logs Agent.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add support for [tag cardinality](https://datadoghq.atlassian.net/wiki/spaces/AML/pages/3492741848/DD-appended+tags#Tag-Cardinality) configuration in the Logs Agent to mirror the same functionality present in Dogstatsd. This new configuration option will be named DD_LOGS_TAG_CARDINALITY to mirror the checks/dogstatsd equivalents.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

In addition to automated testing expansion, all three levels ("high", "low", and "orchestrator") were tested in a kubernetes environment to confirm the appropriate set of tags were applied to each log. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->