### PR TITLE
[CWS] do not create profiles for non-containerized workloads

### DIFF
--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -116,7 +116,8 @@ func (m *Manager) cleanup() {
 		if !ad.Profile.IsEmpty() && ad.Profile.GetWorkloadSelector() != nil {
 			if err := m.persist(ad.Profile, m.configuredStorageRequests); err != nil {
 				seclog.Errorf("couldn't persist dump [%s]: %v", ad.GetSelectorStr(), err)
-			} else if m.config.RuntimeSecurity.SecurityProfileEnabled { // drop the profile if we don't care about using it as a security profile
+			} else if m.config.RuntimeSecurity.SecurityProfileEnabled && ad.Profile.Metadata.CGroupContext.CGroupFlags.IsContainer() {
+				// TODO: remove the IsContainer check once we start handling profiles for non-containerized workloads
 				select {
 				case m.newProfiles <- ad.Profile:
 				default:

--- a/pkg/security/security_profile/grpc.go
+++ b/pkg/security/security_profile/grpc.go
@@ -150,7 +150,8 @@ func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 			if !ad.Profile.IsEmpty() && ad.Profile.GetWorkloadSelector() != nil {
 				if err := m.persist(ad.Profile, m.configuredStorageRequests); err != nil {
 					seclog.Errorf("couldn't persist dump [%s]: %v", ad.GetSelectorStr(), err)
-				} else if m.config.RuntimeSecurity.SecurityProfileEnabled { // drop the profile if we don't care about using it as a security profile
+				} else if m.config.RuntimeSecurity.SecurityProfileEnabled && ad.Profile.Metadata.CGroupContext.CGroupFlags.IsContainer() {
+					// TODO: remove the IsContainer check once we start handling profiles for non-containerized workloads
 					select {
 					case m.newProfiles <- ad.Profile:
 					default:

--- a/pkg/security/security_profile/load_controller.go
+++ b/pkg/security/security_profile/load_controller.go
@@ -189,7 +189,8 @@ func (m *Manager) triggerLoadController() {
 		if !ad.Profile.IsEmpty() && ad.Profile.GetWorkloadSelector() != nil {
 			if err := m.persist(ad.Profile, m.configuredStorageRequests); err != nil {
 				seclog.Errorf("couldn't persist dump [%s]: %v", ad.GetSelectorStr(), err)
-			} else if m.config.RuntimeSecurity.SecurityProfileEnabled { // drop the profile if we don't care about using it as a security profile
+			} else if m.config.RuntimeSecurity.SecurityProfileEnabled && ad.Profile.Metadata.CGroupContext.CGroupFlags.IsContainer() {
+				// TODO: remove the IsContainer check once we start handling profiles for non-containerized workloads
 				select {
 				case m.newProfiles <- ad.Profile:
 				default:

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -364,6 +364,11 @@ func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 		return
 	}
 
+	// TODO: remove the IsContainer check once we start handling profiles for non-containerized workloads
+	if !workload.CGroupFlags.IsContainer() {
+		return
+	}
+
 	defaultConfigs, err := m.getDefaultLoadConfigs()
 	if err != nil {
 		seclog.Errorf("couldn't get default load configs: %v", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Follow up from #38360: avoid creating security profiles for non-containerized workloads.

### Motivation

Security profiles only support containerized workloads for now (profiles are expected to have a 64-bytes container ID in order to be pushed to kernel maps). This change can be reverted once security profiles start handling all kind of cgroups. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->