### PR TITLE
[ AGNTLOG-246 ] Force http if a user specifies a logs_dd_url prefixed with http/https

### DIFF
--- a/releasenotes/notes/logs-dd-url-no-fallback-8e2f0537584c83a0.yaml
+++ b/releasenotes/notes/logs-dd-url-no-fallback-8e2f0537584c83a0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    No longer have the Logs Agent fall back to TCP when configuring logs_config.logs_dd_url with a http(s):// prefix.

--- a/releasenotes/notes/logs-dd-url-no-fallback-8e2f0537584c83a0.yaml
+++ b/releasenotes/notes/logs-dd-url-no-fallback-8e2f0537584c83a0.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    No longer have the Logs Agent fall back to TCP when configuring logs_config.logs_dd_url with a http(s):// prefix.
+    No longer have the Logs Agent fall back to TCP when configuring `logs_config.logs_dd_url` with a http(s):// prefix.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The logs_config.logs_dd_url configuration option allows users to specify proxies with an http(s):// prefix. However, if the proxy is unavailable at agent start up, the agent will automatically fallback to TCP connectivity for the duration of its runtime. This is obviously invalid for addresses with the http(s) prefix. This PR adjusts behavior to prevent fallback to TCP if HTTP(S) is explicitly requested. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->