### PR TITLE
Fix `kernel` memory reading when using cgroupv2 and kernel >= 5.19

### DIFF
--- a/pkg/util/cgroups/cgroupv2_memory.go
+++ b/pkg/util/cgroups/cgroupv2_memory.go
@@ -59,6 +59,9 @@ func (c *cgroupV2) GetMemoryStats(stats *MemoryStats) error {
 			kernelStack = &intVal
 		case "slab":
 			slab = &intVal
+			// Requires Kernel >= 5.18
+		case "kernel":
+			stats.KernelMemory = &intVal
 		}
 
 		return nil
@@ -66,7 +69,7 @@ func (c *cgroupV2) GetMemoryStats(stats *MemoryStats) error {
 		reportError(err)
 	}
 
-	if kernelStack != nil && slab != nil {
+	if stats.KernelMemory == nil && kernelStack != nil && slab != nil {
 		stats.KernelMemory = pointer.Ptr(*kernelStack + *slab)
 	}
 
@@ -94,6 +97,7 @@ func (c *cgroupV2) GetMemoryStats(stats *MemoryStats) error {
 	}
 	nilIfZero(&stats.Limit)
 
+	// Requires Kernel >= 5.19
 	if err := parseSingleUnsignedStat(c.fr, c.pathFor("memory.peak"), &stats.Peak); err != nil {
 		reportError(err)
 	}

--- a/pkg/util/cgroups/cgroupv2_memory_test.go
+++ b/pkg/util/cgroups/cgroupv2_memory_test.go
@@ -56,6 +56,64 @@ pglazyfree 0
 pglazyfreed 0
 thp_fault_alloc 0
 thp_collapse_alloc 0`
+
+	sampleCgroupV2MemoryStatKernel6_8 = `anon 15941632
+file 3481600
+kernel 929792
+kernel_stack 147456
+pagetables 348160
+sec_pagetables 0
+percpu 192
+sock 0
+vmalloc 0
+shmem 0
+zswap 0
+zswapped 0
+file_mapped 2301952
+file_dirty 0
+file_writeback 0
+swapcached 0
+anon_thp 0
+file_thp 0
+shmem_thp 0
+inactive_anon 15888384
+active_anon 12288
+inactive_file 1626112
+active_file 1855488
+unevictable 0
+slab_reclaimable 198720
+slab_unreclaimable 199096
+slab 397816
+workingset_refault_anon 0
+workingset_refault_file 850
+workingset_activate_anon 0
+workingset_activate_file 0
+workingset_restore_anon 0
+workingset_restore_file 0
+workingset_nodereclaim 0
+pgscan 0
+pgsteal 0
+pgscan_kswapd 0
+pgscan_direct 0
+pgscan_khugepaged 0
+pgsteal_kswapd 0
+pgsteal_direct 0
+pgsteal_khugepaged 0
+pgfault 8146
+pgmajfault 30
+pgrefill 0
+pgactivate 453
+pgdeactivate 0
+pglazyfree 0
+pglazyfreed 0
+zswpin 0
+zswpout 0
+zswpwb 0
+thp_fault_alloc 0
+thp_collapse_alloc 0
+thp_swpout 0
+thp_swpout_fallback 0`
+
 	sampleCgroupV2MemoryCurrent     = "6193152"
 	sampleCgroupV2MemoryMin         = "0"
 	sampleCgroupV2MemoryLow         = "0"
@@ -74,8 +132,8 @@ oom_kill 0`
 full avg10=0.00 avg60=0.00 avg300=0.00 total=0`
 )
 
-func createCgroupV2FakeMemoryFiles(cfs *cgroupMemoryFS, cg *cgroupV2) {
-	cfs.setCgroupV2File(cg, "memory.stat", sampleCgroupV2MemoryStat)
+func createCgroupV2FakeMemoryFiles(cfs *cgroupMemoryFS, cg *cgroupV2, statContent string) {
+	cfs.setCgroupV2File(cg, "memory.stat", statContent)
 	cfs.setCgroupV2File(cg, "memory.current", sampleCgroupV2MemoryCurrent)
 	cfs.setCgroupV2File(cg, "memory.min", sampleCgroupV2MemoryMin)
 	cfs.setCgroupV2File(cg, "memory.low", sampleCgroupV2MemoryLow)
@@ -111,7 +169,7 @@ func TestCgroupV2MemoryStats(t *testing.T) {
 
 	// Test reading files in memory controllers, all files present
 	tr.reset()
-	createCgroupV2FakeMemoryFiles(cfs, cgFoo1)
+	createCgroupV2FakeMemoryFiles(cfs, cgFoo1, sampleCgroupV2MemoryStat)
 	err = cgFoo1.GetMemoryStats(stats)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []error{}, tr.errors)
@@ -130,6 +188,53 @@ func TestCgroupV2MemoryStats(t *testing.T) {
 		ActiveFile:    pointer.Ptr(uint64(0)),
 		Unevictable:   pointer.Ptr(uint64(0)),
 		KernelMemory:  pointer.Ptr(uint64(49152)),
+		OOMEvents:     pointer.Ptr(uint64(3)),
+		OOMKiilEvents: pointer.Ptr(uint64(0)),
+		Peak:          pointer.Ptr(uint64(7000000)),
+		PSISome: PSIStats{
+			Avg10:  pointer.Ptr(0.0),
+			Avg60:  pointer.Ptr(0.0),
+			Avg300: pointer.Ptr(0.0),
+			Total:  pointer.Ptr(uint64(0)),
+		},
+		PSIFull: PSIStats{
+			Avg10:  pointer.Ptr(0.0),
+			Avg60:  pointer.Ptr(0.0),
+			Avg300: pointer.Ptr(0.0),
+			Total:  pointer.Ptr(uint64(0)),
+		},
+	}, *stats))
+}
+
+func TestCgroupV2MemoryStatsKernel6_8(t *testing.T) {
+	cfs := newCgroupMemoryFS("/test/fs/cgroup")
+
+	var err error
+	stats := &MemoryStats{}
+	cgFoo1 := cfs.createCgroupV2("foo1", containerCgroupKubePod(true))
+
+	// Enable memory controller
+	cfs.enableControllers("memory")
+
+	createCgroupV2FakeMemoryFiles(cfs, cgFoo1, sampleCgroupV2MemoryStatKernel6_8)
+	err = cgFoo1.GetMemoryStats(stats)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []error{}, tr.errors)
+	assert.Empty(t, cmp.Diff(MemoryStats{
+		UsageTotal:    pointer.Ptr(uint64(6193152)),
+		Cache:         pointer.Ptr(uint64(3481600)),
+		Swap:          pointer.Ptr(uint64(0)),
+		RSS:           pointer.Ptr(uint64(15941632)),
+		RSSHuge:       pointer.Ptr(uint64(0)),
+		MappedFile:    pointer.Ptr(uint64(2301952)),
+		Pgfault:       pointer.Ptr(uint64(8146)),
+		Pgmajfault:    pointer.Ptr(uint64(30)),
+		InactiveAnon:  pointer.Ptr(uint64(15888384)),
+		ActiveAnon:    pointer.Ptr(uint64(12288)),
+		InactiveFile:  pointer.Ptr(uint64(1626112)),
+		ActiveFile:    pointer.Ptr(uint64(1855488)),
+		Unevictable:   pointer.Ptr(uint64(0)),
+		KernelMemory:  pointer.Ptr(uint64(929792)),
 		OOMEvents:     pointer.Ptr(uint64(3)),
 		OOMKiilEvents: pointer.Ptr(uint64(0)),
 		Peak:          pointer.Ptr(uint64(7000000)),

--- a/releasenotes/notes/fix-kernel-memory-cgroupv2-57d60cb0cda455e1.yaml
+++ b/releasenotes/notes/fix-kernel-memory-cgroupv2-57d60cb0cda455e1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix incorrect `container.memory.kernel` value when running with Kernel >= 5.19 and cgroupv2


### PR DESCRIPTION
### What does this PR do?

Fix `kernel` memory reading when using cgroupv2 and kernel >= 5.19.
The cgroupv2 parsing relied on the `kernelStack` and `slab` fields, which are only a subset of kernel memory but were the only fields available before Kernel 5.18 (vmalloc was added, then full `kernel` in 5.19).

The value matching cgroupv1 is the "new" `kernel` field, but is only available starting 5.19.

### Motivation

### Describe how you validated your changes

Deploy a workload using significant Kernel memory (eBPF for instance) on a Kernel >= 5.19 with cgroupv2, the full memory usage should be reported by `container.memory.kernel` metric.

### Possible Drawbacks / Trade-offs

### Additional Notes