### PR TITLE
Adding additional debugging for Windows Certificate e2e test

### DIFF
--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -124,10 +124,13 @@ func (v *multiVMSuite) SetupSuite() {
 	// Wait for the LanmanServer service to be running
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		output, err := windowsCommon.GetServiceStatus(certificateHost, "LanmanServer")
+		if err != nil {
+			v.T().Logf("Getting LanmanServer status failed %v", err)
+		}
 		assert.NoError(c, err)
 		assert.Contains(c, output, "Running")
 		v.T().Logf("LanmanServer status: %s", output)
-	}, 5*time.Minute, 10*time.Second)
+	}, 10*time.Minute, 10*time.Second)
 
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
 	v.Require().NoError(err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds additional debug logs when checking the `LanmanServer` status.

### Motivation
This is to help mitigate tests that are failing when getting the `LanmanServer` status:
https://datadoghq.atlassian.net/browse/WINA-1578

Should getting the status fail a debug log will print out the error so that we can further troubleshoot.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Just run the e2e test for Windows Certificate

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->