### PR TITLE
Add retry handling for SSH dial failures during cloud-init

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -66,5 +66,10 @@ func getKnownErrors() []knownError {
 			errorMessage: `error: .*ssh: rejected: connect failed (No route to host)`,
 			retryType:    ReCreate,
 		},
+		{
+			// SSH dial failures during cloud-init waiting
+			errorMessage: `Dial \d+/\d+ failed: retrying`,
+			retryType:    ReCreate,
+		},
 	}
 }

--- a/test/new-e2e/pkg/utils/infra/stack_manager_test.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager_test.go
@@ -268,6 +268,11 @@ func TestStackManager(t *testing.T) {
 				errMessage:        "waiting for ECS Service (arn:aws:ecs:us-east-1:669783387624:service/fakeintake-ecs/ci-633219896-4670-e2e-dockersuite-80f62edf7bcc6194-aws-fakeintake-dockervm-srv) create: timeout while waiting for state to become 'tfSTABLE' (last state: 'tfPENDING', timeout: 20m0s)",
 				expectedRetryType: ReCreate,
 			},
+			{
+				name:              "ssh-dial-failure",
+				errMessage:        "command:remote:Command remote-aws-dockervm-cmd-wait-cloud-init creating (50s) Dial 9/100 failed: retrying",
+				expectedRetryType: ReCreate,
+			},
 		}
 
 		for _, te := range testErrors {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b6b29997-6c9c-4e8f-af37-51056b1ec3c5","source":"chat","resourceId":"d38f6f2b-0806-405e-986d-38c586b48be4","workflowId":"3e4851bc-636f-4602-8b4e-4525082e4e15","codeChangeId":"3e4851bc-636f-4602-8b4e-4525082e4e15","sourceType":"test-optimization"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=b6b29997-6c9c-4e8f-af37-51056b1ec3c5) for chat [d38f6f2b-0806-405e-986d-38c586b48be4](https://app.datadoghq.com/code/d38f6f2b-0806-405e-986d-38c586b48be4).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds retry handling for SSH dial failures that occur during cloud-init waiting in E2E tests. The fix identifies SSH connection failures with the pattern `Dial X/100 failed: retrying` and marks them as retriable errors that should trigger a stack recreation.

### Motivation

The TestDocker E2E test was failing due to SSH dial failures during the cloud-init waiting phase. These failures were occurring when the test infrastructure attempted to establish SSH connections to newly created EC2 instances before cloud-init had fully completed. The current retry logic didn't recognize these specific dial failures as retriable errors, causing the entire test to fail instead of recreating the stack.

### Describe how you validated your changes

- Added a unit test case `ssh-dial-failure` in `TestStackManager` to verify the new error pattern is correctly identified as a retriable error with `ReCreate` retry type
- The test validates that the regex pattern `Dial \d+/\d+ failed: retrying` matches the actual error message format from the failing test
- Unit tests pass and confirm the new error handling logic works as expected

### Possible Drawbacks / Trade-offs

- Adding another retriable error pattern may increase the overall test runtime if SSH dial failures occur frequently
- The fix uses stack recreation rather than a lighter retry mechanism, which may be more resource-intensive but ensures a clean state

### Additional Notes

- The error pattern uses a regex to match various dial attempt counts (e.g., "Dial 9/100 failed", "Dial 15/100 failed")
- This addresses infrastructure flakiness rather than application logic issues
- The ReCreate retry type ensures the entire stack is recreated when these SSH connectivity issues occur, providing the best chance for recovery