### PR TITLE
Create a release branch in test-infra-definitions after the cut-off

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -1306,9 +1306,9 @@ def get_test_infra_def_version():
     Get TEST_INFRA_DEFINITIONS_BUILDIMAGES from `.gitlab/common/test_infra_version.yml` file
     """
     try:
-        with open(Path(".gitlab/common/test_infra_version.yml")) as test_infra_version_file:
-            test_infra_def = yaml.safe_load(test_infra_version_file)
-            return test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES"]
+        version_file = Path.cwd() / ".gitlab" / "common" / "test_infra_version.yml"
+        test_infra_def = yaml.safe_loads(version_file.read_text(encoding="utf-8"))
+        return test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES"]
     except Exception:
         return "main"
 

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from difflib import Differ
 from functools import lru_cache
 from itertools import product
+from pathlib import Path
 from typing import Any, Literal
 
 import gitlab
@@ -1298,6 +1299,18 @@ def update_test_infra_def(file_path, image_tag, is_dev_image=False, prefix_comme
         # Add explicit_start=True to keep the document start marker ---
         # See "Document Start" in https://www.yaml.info/learn/document.html for more details
         yaml.dump(test_infra_def, test_infra_version_file, explicit_start=True)
+
+
+def get_test_infra_def_version():
+    """
+    Get TEST_INFRA_DEFINITIONS_BUILDIMAGES from `.gitlab/common/test_infra_version.yml` file
+    """
+    try:
+        with open(Path(".gitlab/common/test_infra_version.yml")) as test_infra_version_file:
+            test_infra_def = yaml.safe_load(test_infra_version_file)
+            return test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES"]
+    except Exception:
+        return "main"
 
 
 def update_gitlab_config(file_path, tag, images="", test=True, update=True, windows=False):

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from invoke.exceptions import Exit
 
+from tasks.libs.ciproviders.gitlab_api import get_test_infra_def_version
 from tasks.libs.common.constants import TAG_FOUND_TEMPLATE
 from tasks.libs.common.git import get_default_branch, is_agent6
 from tasks.libs.releasing.documentation import _stringify_config
@@ -35,11 +36,12 @@ UNFREEZE_REPO_AGENT = "datadog-agent"
 INTERNAL_DEPS_REPOS = ["omnibus-ruby"]
 DEPENDENT_REPOS = INTERNAL_DEPS_REPOS + ["integrations-core"]
 ALL_REPOS = DEPENDENT_REPOS + [UNFREEZE_REPO_AGENT]
-UNFREEZE_REPOS = INTERNAL_DEPS_REPOS + [UNFREEZE_REPO_AGENT] + ["datadog-agent-buildimages"]
+UNFREEZE_REPOS = INTERNAL_DEPS_REPOS + [UNFREEZE_REPO_AGENT] + ["datadog-agent-buildimages", "test-infra-definitions"]
 DEFAULT_BRANCHES = {
     "omnibus-ruby": "datadog-5.5.0",
     "datadog-agent": "main",
     "datadog-agent-buildimages": "main",
+    "test-infra-definitions": get_test_infra_def_version(),
 }
 DEFAULT_BRANCHES_AGENT6 = {
     "omnibus-ruby": "6.53.x",

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -761,7 +761,7 @@ def create_and_update_release_branch(
                 or ctx.run(f"git remote show {upstream} | grep \"HEAD branch\" | sed 's/.*: //'").stdout.strip()
             )
             ctx.run(f"git checkout {main_branch}")
-            ctx.run("git pull")
+            ctx.run("git pull", warn=True)
 
             _main()
 
@@ -816,9 +816,8 @@ def create_release_branches(
 
         # Step 1 - Create release branches in all required repositories
 
-        base_branch = get_default_branch() if major_version == 6 else None
-
         for repo in UNFREEZE_REPOS:
+            base_branch = get_default_branch() if major_version == 6 else DEFAULT_BRANCHES[repo]
             create_and_update_release_branch(
                 ctx, repo, release_branch, base_branch=base_branch, base_directory=base_directory, upstream=upstream
             )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Create a release branch in test-infra-defintions after the cut-off, in case we need it later. 

The branch is created on the commit that is currently used in the repo

### Motivation

https://datadoghq.atlassian.net/browse/BARX-1074

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->