### PR TITLE
[kubelet] Collect ephemeral containers

### DIFF
--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -61,7 +61,7 @@ func NewKubeletListener(options ServiceListernerDeps) (ServiceListener, error) {
 func (l *KubeletListener) processPod(entity workloadmeta.Entity) {
 	pod := entity.(*workloadmeta.KubernetesPod)
 
-	wlmContainers := pod.GetAllContainers()
+	wlmContainers := pod.GetContainersAndInitContainers()
 	containers := make([]*workloadmeta.Container, 0, len(wlmContainers))
 	for _, podContainer := range wlmContainers {
 		container, err := l.Store().GetContainer(podContainer.ID)

--- a/comp/core/autodiscovery/providers/container.go
+++ b/comp/core/autodiscovery/providers/container.go
@@ -187,7 +187,7 @@ func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integ
 	case *workloadmeta.KubernetesPod:
 		containerIdentifiers := map[string]struct{}{}
 		containerNames := map[string]struct{}{}
-		for _, podContainer := range entity.GetAllContainers() {
+		for _, podContainer := range entity.GetContainersAndInitContainers() {
 			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
 			if err != nil {
 				log.Debugf("Pod %q has reference to non-existing container %q", entity.Name, podContainer.ID)

--- a/comp/core/autodiscovery/providers/container_test.go
+++ b/comp/core/autodiscovery/providers/container_test.go
@@ -427,7 +427,7 @@ func TestGenerateConfig(t *testing.T) {
 			))
 
 			if pod, ok := tt.entity.(*workloadmeta.KubernetesPod); ok {
-				for _, c := range pod.GetAllContainers() {
+				for _, c := range pod.GetContainersAndInitContainers() {
 					store.Set(&workloadmeta.Container{
 						EntityID: workloadmeta.EntityID{
 							Kind: workloadmeta.KindContainer,

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -17,6 +17,7 @@ import (
 
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/internal/third_party/golang/expansion"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -36,21 +37,29 @@ const (
 	dockerImageIDPrefix = "docker-pullable://"
 )
 
+type dependencies struct {
+	fx.In
+
+	Config config.Component
+}
+
 type collector struct {
-	id         string
-	catalog    workloadmeta.AgentType
-	watcher    *kubelet.PodWatcher
-	store      workloadmeta.Component
-	lastExpire time.Time
-	expireFreq time.Duration
+	id                         string
+	catalog                    workloadmeta.AgentType
+	watcher                    *kubelet.PodWatcher
+	store                      workloadmeta.Component
+	lastExpire                 time.Time
+	expireFreq                 time.Duration
+	collectEphemeralContainers bool
 }
 
 // NewCollector returns a kubelet CollectorProvider that instantiates its collector
-func NewCollector() (workloadmeta.CollectorProvider, error) {
+func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
-			id:      collectorID,
-			catalog: workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			id:                         collectorID,
+			catalog:                    workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			collectEphemeralContainers: deps.Config.GetBool("include_ephemeral_containers"),
 		},
 	}, nil
 }
@@ -84,7 +93,7 @@ func (c *collector) Pull(ctx context.Context) error {
 		return err
 	}
 
-	events := parsePods(updatedPods)
+	events := parsePods(updatedPods, c.collectEphemeralContainers)
 
 	if time.Since(c.lastExpire) >= c.expireFreq {
 		var expiredIDs []string
@@ -108,7 +117,7 @@ func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 	return c.catalog
 }
 
-func parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent {
+func parsePods(pods []*kubelet.Pod, collectEphemeralContainers bool) []workloadmeta.CollectorEvent {
 	events := []workloadmeta.CollectorEvent{}
 
 	for _, pod := range pods {
@@ -146,12 +155,16 @@ func parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent {
 			&podID,
 		)
 
-		podEphemeralContainers, ephemeralContainerEvents := parsePodContainers(
-			pod,
-			pod.Spec.EphemeralContainers,
-			pod.Status.EphemeralContainers,
-			&podID,
-		)
+		var podEphemeralContainers []workloadmeta.OrchestratorContainer
+		var ephemeralContainerEvents []workloadmeta.CollectorEvent
+		if collectEphemeralContainers {
+			podEphemeralContainers, ephemeralContainerEvents = parsePodContainers(
+				pod,
+				pod.Spec.EphemeralContainers,
+				pod.Status.EphemeralContainers,
+				&podID,
+			)
+		}
 
 		GPUVendors := getGPUVendorsFromContainers(initContainerEvents, containerEvents)
 

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet_test.go
@@ -121,7 +121,7 @@ func TestPodParser(t *testing.T) {
 		},
 	}
 
-	events := parsePods(referencePod)
+	events := parsePods(referencePod, true)
 	containerEvent, ephemeralContainerEvent, podEvent := events[0], events[1], events[2]
 
 	expectedContainer := &workloadmeta.Container{

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -714,6 +714,7 @@ type KubernetesPod struct {
 	PersistentVolumeClaimNames []string
 	InitContainers             []OrchestratorContainer
 	Containers                 []OrchestratorContainer
+	EphemeralContainers        []OrchestratorContainer
 	Ready                      bool
 	Phase                      string
 	IP                         string
@@ -779,6 +780,13 @@ func (p KubernetesPod) String(verbose bool) string {
 		}
 	}
 
+	if len(p.EphemeralContainers) > 0 {
+		_, _ = fmt.Fprintln(&sb, "----------- Ephemeral Containers -----------")
+		for _, c := range p.EphemeralContainers {
+			_, _ = fmt.Fprint(&sb, c.String(verbose))
+		}
+	}
+
 	_, _ = fmt.Fprintln(&sb, "----------- Pod Info -----------")
 	_, _ = fmt.Fprintln(&sb, "Ready:", p.Ready)
 	_, _ = fmt.Fprintln(&sb, "Phase:", p.Phase)
@@ -808,8 +816,13 @@ func (p KubernetesPod) String(verbose bool) string {
 	return sb.String()
 }
 
-// GetAllContainers returns init containers and containers.
+// GetAllContainers returns all containers, including init containers and ephemeral containers.
 func (p KubernetesPod) GetAllContainers() []OrchestratorContainer {
+	return append(append(p.InitContainers, p.Containers...), p.EphemeralContainers...)
+}
+
+// GetContainersAndInitContainers returns init containers and containers.
+func (p KubernetesPod) GetContainersAndInitContainers() []OrchestratorContainer {
 	return append(p.InitContainers, p.Containers...)
 }
 

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -351,6 +351,11 @@ func protoKubernetesPodFromWorkloadmetaKubernetesPod(kubernetesPod *workloadmeta
 		protoInitContainers = append(protoInitContainers, toProtoOrchestratorContainer(container))
 	}
 
+	var protoEphemeralContainers []*pb.OrchestratorContainer
+	for _, container := range kubernetesPod.EphemeralContainers {
+		protoEphemeralContainers = append(protoEphemeralContainers, toProtoOrchestratorContainer(container))
+	}
+
 	return &pb.KubernetesPod{
 		EntityId:                   protoEntityID,
 		EntityMeta:                 toProtoEntityMetaFromKubernetesPod(kubernetesPod),
@@ -358,6 +363,7 @@ func protoKubernetesPodFromWorkloadmetaKubernetesPod(kubernetesPod *workloadmeta
 		PersistentVolumeClaimNames: kubernetesPod.PersistentVolumeClaimNames,
 		InitContainers:             protoInitContainers,
 		Containers:                 protoOrchestratorContainers,
+		EphemeralContainers:        protoEphemeralContainers,
 		Ready:                      kubernetesPod.Ready,
 		Phase:                      kubernetesPod.Phase,
 		Ip:                         kubernetesPod.IP,
@@ -791,12 +797,18 @@ func toWorkloadmetaKubernetesPod(protoKubernetesPod *pb.KubernetesPod) (*workloa
 		containers = append(containers, toWorkloadmetaOrchestratorContainer(protoContainer))
 	}
 
+	var ephemeralContainers []workloadmeta.OrchestratorContainer
+	for _, protoContainer := range protoKubernetesPod.EphemeralContainers {
+		ephemeralContainers = append(ephemeralContainers, toWorkloadmetaOrchestratorContainer(protoContainer))
+	}
+
 	return &workloadmeta.KubernetesPod{
 		EntityID:                   entityID,
 		EntityMeta:                 toWorkloadmetaEntityMeta(protoKubernetesPod.EntityMeta),
 		Owners:                     owners,
 		PersistentVolumeClaimNames: protoKubernetesPod.PersistentVolumeClaimNames,
 		Containers:                 containers,
+		EphemeralContainers:        ephemeralContainers,
 		Ready:                      protoKubernetesPod.Ready,
 		Phase:                      protoKubernetesPod.Phase,
 		IP:                         protoKubernetesPod.Ip,

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -190,6 +190,19 @@ func TestConversions(t *testing.T) {
 							},
 						},
 					},
+					EphemeralContainers: []workloadmeta.OrchestratorContainer{
+						{
+							ID:   "ephemeralID",
+							Name: "ephemeralName",
+							Image: workloadmeta.ContainerImage{
+								ID:        "456",
+								RawName:   "busybox:latest",
+								Name:      "busybox",
+								ShortName: "busybox",
+								Tag:       "latest",
+							},
+						},
+					},
 					Ready:         true,
 					Phase:         "Running",
 					IP:            "127.0.0.1",
@@ -241,6 +254,19 @@ func TestConversions(t *testing.T) {
 								Name:      "datadog/agent",
 								ShortName: "agent",
 								Tag:       "7",
+							},
+						},
+					},
+					EphemeralContainers: []*pb.OrchestratorContainer{
+						{
+							Id:   "ephemeralID",
+							Name: "ephemeralName",
+							Image: &pb.ContainerImage{
+								Id:        "456",
+								RawName:   "busybox:latest",
+								Name:      "busybox",
+								ShortName: "busybox",
+								Tag:       "latest",
 							},
 						},
 					},

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1254,6 +1254,7 @@ func autoconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoconf_config_files_poll", false)
 	config.BindEnvAndSetDefault("autoconf_config_files_poll_interval", 60)
 	config.BindEnvAndSetDefault("exclude_pause_container", true)
+	config.BindEnvAndSetDefault("include_ephemeral_containers", false)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})
 	// ac_load_timeout is used to delay the introduction of sources other than

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -192,7 +192,7 @@ func (tf *factory) getPodAndContainer(containerID string) (*workloadmeta.Orchest
 	}
 
 	var container *workloadmeta.OrchestratorContainer
-	for _, pc := range pod.GetAllContainers() {
+	for _, pc := range pod.GetContainersAndInitContainers() {
 		if pc.ID == containerID {
 			container = &pc
 			break

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -143,6 +143,7 @@ message KubernetesPod {
   map<string, string> namespaceLabels = 12;
   repeated OrchestratorContainer InitContainers = 13;
   string runtimeClass = 14;
+  repeated OrchestratorContainer ephemeralContainers = 15;
 }
 
 enum ECSLaunchType {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -1173,6 +1173,7 @@ type KubernetesPod struct {
 	NamespaceLabels            map[string]string        `protobuf:"bytes,12,rep,name=namespaceLabels,proto3" json:"namespaceLabels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	InitContainers             []*OrchestratorContainer `protobuf:"bytes,13,rep,name=InitContainers,proto3" json:"InitContainers,omitempty"`
 	RuntimeClass               string                   `protobuf:"bytes,14,opt,name=runtimeClass,proto3" json:"runtimeClass,omitempty"`
+	EphemeralContainers        []*OrchestratorContainer `protobuf:"bytes,15,rep,name=ephemeralContainers,proto3" json:"ephemeralContainers,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1303,6 +1304,13 @@ func (x *KubernetesPod) GetRuntimeClass() string {
 		return x.RuntimeClass
 	}
 	return ""
+}
+
+func (x *KubernetesPod) GetEphemeralContainers() []*OrchestratorContainer {
+	if x != nil {
+		return x.EphemeralContainers
+	}
+	return nil
 }
 
 type ECSTask struct {
@@ -1634,7 +1642,7 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\x15OrchestratorContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12:\n" +
-	"\x05image\x18\x03 \x01(\v2$.datadog.workloadmeta.ContainerImageR\x05image\"\xab\x06\n" +
+	"\x05image\x18\x03 \x01(\v2$.datadog.workloadmeta.ContainerImageR\x05image\"\x8a\a\n" +
 	"\rKubernetesPod\x12F\n" +
 	"\bentityId\x18\x01 \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\bentityId\x12@\n" +
 	"\n" +
@@ -1654,7 +1662,8 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\fkubeServices\x18\v \x03(\tR\fkubeServices\x12b\n" +
 	"\x0fnamespaceLabels\x18\f \x03(\v28.datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntryR\x0fnamespaceLabels\x12S\n" +
 	"\x0eInitContainers\x18\r \x03(\v2+.datadog.workloadmeta.OrchestratorContainerR\x0eInitContainers\x12\"\n" +
-	"\fruntimeClass\x18\x0e \x01(\tR\fruntimeClass\x1aB\n" +
+	"\fruntimeClass\x18\x0e \x01(\tR\fruntimeClass\x12]\n" +
+	"\x13ephemeralContainers\x18\x0f \x03(\v2+.datadog.workloadmeta.OrchestratorContainerR\x13ephemeralContainers\x1aB\n" +
 	"\x14NamespaceLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x91\x06\n" +
@@ -1802,22 +1811,23 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	17, // 22: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
 	26, // 23: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
 	17, // 24: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	9,  // 25: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
-	10, // 26: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	27, // 27: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
-	28, // 28: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
-	6,  // 29: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
-	17, // 30: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	2,  // 31: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
-	15, // 32: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
-	18, // 33: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
-	19, // 34: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
-	20, // 35: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
-	36, // [36:36] is the sub-list for method output_type
-	36, // [36:36] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	17, // 25: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	9,  // 26: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	10, // 27: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
+	27, // 28: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
+	28, // 29: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	6,  // 30: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
+	17, // 31: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	2,  // 32: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
+	15, // 33: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
+	18, // 34: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
+	19, // 35: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
+	20, // 36: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
+	37, // [37:37] is the sub-list for method output_type
+	37, // [37:37] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadmeta_workloadmeta_proto_init() }

--- a/pkg/util/containers/metrics/kubelet/collector.go
+++ b/pkg/util/containers/metrics/kubelet/collector.go
@@ -103,15 +103,20 @@ func (kc *kubeletCollector) ContainerIDForPodUIDAndContName(podUID, contName str
 		}
 		return "", err
 	}
-	containers := pod.Containers
+
+	var containers []workloadmeta.OrchestratorContainer
 	if initCont {
 		containers = pod.InitContainers
+	} else {
+		containers = append(pod.Containers, pod.EphemeralContainers...)
 	}
+
 	for _, container := range containers {
 		if container.Name == contName {
 			return container.ID, nil
 		}
 	}
+
 	return "", nil
 }
 

--- a/pkg/util/containers/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/metrics/kubelet/collector_test.go
@@ -265,6 +265,29 @@ func TestContainerIDForPodUIDAndContName(t *testing.T) {
 			expectedCid: "cID1",
 		},
 		{
+			name: "pod with ephemeral container",
+			pod: &workloadmeta.KubernetesPod{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesPod,
+					ID:   "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "kube-dns-5877696fb4-m6cvp",
+					Namespace: "kube-system",
+				},
+				EphemeralContainers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:   "ephemeralID",
+						Name: "ephemeralContainer",
+					},
+				},
+			},
+			podUID:      "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+			contName:    "ephemeralContainer",
+			initCont:    false,
+			expectedCid: "ephemeralID",
+		},
+		{
 			name:        "not found",
 			podUID:      "poduid",
 			contName:    "contname",

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -271,9 +271,10 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 					pod.Metadata.UID, len(pod.Status.Containers), len(pod.Status.InitContainers))
 				continue
 			}
-			allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers))
+			allContainers := make([]ContainerStatus, 0, len(pod.Status.InitContainers)+len(pod.Status.Containers)+len(pod.Status.EphemeralContainers))
 			allContainers = append(allContainers, pod.Status.InitContainers...)
 			allContainers = append(allContainers, pod.Status.Containers...)
+			allContainers = append(allContainers, pod.Status.EphemeralContainers...)
 			pod.Status.AllContainers = allContainers
 			tmpSlice = append(tmpSlice, pod)
 		}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -48,15 +48,16 @@ type PodOwner struct {
 
 // Spec contains fields for unmarshalling a Pod.Spec
 type Spec struct {
-	HostNetwork       bool                    `json:"hostNetwork,omitempty"`
-	NodeName          string                  `json:"nodeName,omitempty"`
-	InitContainers    []ContainerSpec         `json:"initContainers,omitempty"`
-	Containers        []ContainerSpec         `json:"containers,omitempty"`
-	Volumes           []VolumeSpec            `json:"volumes,omitempty"`
-	PriorityClassName string                  `json:"priorityClassName,omitempty"`
-	SecurityContext   *PodSecurityContextSpec `json:"securityContext,omitempty"`
-	RuntimeClassName  *string                 `json:"runtimeClassName,omitempty"`
-	Tolerations       []Toleration            `json:"tolerations,omitempty"`
+	HostNetwork         bool                    `json:"hostNetwork,omitempty"`
+	NodeName            string                  `json:"nodeName,omitempty"`
+	InitContainers      []ContainerSpec         `json:"initContainers,omitempty"`
+	Containers          []ContainerSpec         `json:"containers,omitempty"`
+	EphemeralContainers []ContainerSpec         `json:"ephemeralContainers,omitempty"`
+	Volumes             []VolumeSpec            `json:"volumes,omitempty"`
+	PriorityClassName   string                  `json:"priorityClassName,omitempty"`
+	SecurityContext     *PodSecurityContextSpec `json:"securityContext,omitempty"`
+	RuntimeClassName    *string                 `json:"runtimeClassName,omitempty"`
+	Tolerations         []Toleration            `json:"tolerations,omitempty"`
 }
 
 // PodSecurityContextSpec contains fields for unmarshalling a Pod.Spec.SecurityContext
@@ -196,16 +197,17 @@ type VolumeClaimTemplateSpec struct {
 
 // Status contains fields for unmarshalling a Pod.Status
 type Status struct {
-	Phase          string            `json:"phase,omitempty"`
-	HostIP         string            `json:"hostIP,omitempty"`
-	PodIP          string            `json:"podIP,omitempty"`
-	Containers     []ContainerStatus `json:"containerStatuses,omitempty"`
-	InitContainers []ContainerStatus `json:"initContainerStatuses,omitempty"`
-	AllContainers  []ContainerStatus
-	Conditions     []Conditions `json:"conditions,omitempty"`
-	QOSClass       string       `json:"qosClass,omitempty"`
-	StartTime      time.Time    `json:"startTime,omitempty"`
-	Reason         string       `json:"reason,omitempty"`
+	Phase               string            `json:"phase,omitempty"`
+	HostIP              string            `json:"hostIP,omitempty"`
+	PodIP               string            `json:"podIP,omitempty"`
+	Containers          []ContainerStatus `json:"containerStatuses,omitempty"`
+	InitContainers      []ContainerStatus `json:"initContainerStatuses,omitempty"`
+	EphemeralContainers []ContainerStatus `json:"ephemeralContainerStatuses,omitempty"`
+	AllContainers       []ContainerStatus
+	Conditions          []Conditions `json:"conditions,omitempty"`
+	QOSClass            string       `json:"qosClass,omitempty"`
+	StartTime           time.Time    `json:"startTime,omitempty"`
+	Reason              string       `json:"reason,omitempty"`
 }
 
 // GetAllContainers returns the list of init and regular containers

--- a/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
+++ b/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    ``container.*`` and ``kubernetes.*`` metrics that refer to ephemeral
+    containers now include all the expected tags.
+

--- a/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
+++ b/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
@@ -6,8 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-fixes:
+features:
   - |
-    ``container.*`` and ``kubernetes.*`` metrics that refer to ephemeral
-    containers now include all the expected tags.
-
+    Added new config option ``include_ephemeral_containers`` to collect
+    Kubernetes ephemeral containers. The option is disabled by default.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new configuration option (`include_ephemeral_containers`) to collect [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/). It's disabled by default.

When the option is enabled, `container.*` and `kubernetes.*` metrics that refer to ephemeral containers include all the expected tags (`kube_namespace`, `kube_container_name`, etc.).

### Describe how you validated your changes

Unit tests plus manual tests to verify that the metrics mentioned above include all the expected tags.