### PR TITLE
[CWS-4845] Report filtered rules in `ruleset_loaded` events

### DIFF
--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -105,7 +105,7 @@ func evalRule(provider rules.PolicyProvider, decoder *json.Decoder, evalArgs Eva
 		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 	}
 
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
+	if _, err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
 		return report, err
 	}
 
@@ -431,7 +431,7 @@ func CheckPoliciesLocal(args CheckPoliciesLocalParams, writer io.Writer) error {
 		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
 		ruleSet.SetFakeEventCtor(newFakeEvent)
 	}
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
+	if _, err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
 		return err
 	}
 

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -162,15 +162,18 @@ type PolicyMetadata struct {
 // RuleState defines a loaded rule
 // easyjson:json
 type RuleState struct {
-	ID          string            `json:"id"`
-	Version     string            `json:"version,omitempty"`
-	Expression  string            `json:"expression"`
-	Status      string            `json:"status"`
-	Message     string            `json:"message,omitempty"`
-	Tags        map[string]string `json:"tags,omitempty"`
-	ProductTags []string          `json:"product_tags,omitempty"`
-	Actions     []RuleAction      `json:"actions,omitempty"`
-	ModifiedBy  []*PolicyMetadata `json:"modified_by,omitempty"`
+	ID                     string            `json:"id"`
+	Version                string            `json:"version,omitempty"`
+	Expression             string            `json:"expression"`
+	Status                 string            `json:"status"`
+	Message                string            `json:"message,omitempty"`
+	FilterType             string            `json:"filter_type,omitempty"`
+	AgentVersionConstraint string            `json:"agent_version,omitempty"`
+	Filters                []string          `json:"filters,omitempty"`
+	Tags                   map[string]string `json:"tags,omitempty"`
+	ProductTags            []string          `json:"product_tags,omitempty"`
+	Actions                []RuleAction      `json:"actions,omitempty"`
+	ModifiedBy             []*PolicyMetadata `json:"modified_by,omitempty"`
 }
 
 // PolicyStatus defines the status of a policy
@@ -179,10 +182,14 @@ type PolicyStatus string
 const (
 	// PolicyStatusLoaded indicates that the policy was loaded successfully
 	PolicyStatusLoaded PolicyStatus = "loaded"
-	// PolicyStatusPartiallyLoaded indicates that the policy was loaded with some errors
+	// PolicyStatusPartiallyFiltered indicates that some rules in the policy were filtered out
+	PolicyStatusPartiallyFiltered PolicyStatus = "partially_filtered"
+	// PolicyStatusPartiallyLoaded indicates that some rules in the policy couldn't be loaded
 	PolicyStatusPartiallyLoaded PolicyStatus = "partially_loaded"
 	// PolicyStatusFullyRejected indicates that all rules in the policy couldn't be loaded
 	PolicyStatusFullyRejected PolicyStatus = "fully_rejected"
+	// PolicyStatusFullyFiltered indicates that all rules in the policy were filtered out
+	PolicyStatusFullyFiltered PolicyStatus = "fully_filtered"
 	// PolicyStatusError indicates that the policy was not loaded due to an error
 	PolicyStatusError PolicyStatus = "error"
 )
@@ -299,13 +306,15 @@ func NewPolicyState(name, source, version string, status PolicyStatus, message s
 // RuleStateFromRule returns a rule state based on the given rule
 func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status string, message string) *RuleState {
 	ruleState := &RuleState{
-		ID:          rule.Def.ID,
-		Version:     rule.Policy.Version,
-		Expression:  rule.Def.Expression,
-		Status:      status,
-		Message:     message,
-		Tags:        rule.Def.Tags,
-		ProductTags: rule.Def.ProductTags,
+		ID:                     rule.Def.ID,
+		Version:                rule.Policy.Version,
+		Expression:             rule.Def.Expression,
+		Status:                 status,
+		Message:                message,
+		Tags:                   rule.Def.Tags,
+		ProductTags:            rule.Def.ProductTags,
+		AgentVersionConstraint: rule.Def.AgentVersionConstraint,
+		Filters:                rule.Def.Filters,
 	}
 
 	for _, action := range rule.Actions {
@@ -361,22 +370,30 @@ func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status 
 		ruleState.ModifiedBy = append(ruleState.ModifiedBy, NewPolicyMetadata(pInfo.Name, pInfo.Source, pInfo.Version))
 	}
 
+	if !rule.Accepted {
+		ruleState.FilterType = string(rule.FilterType)
+		switch rule.FilterType {
+		case rules.FilterTypeRuleID:
+			ruleState.Message = "rule ID was filtered out"
+		case rules.FilterTypeAgentVersion:
+			ruleState.Message = "this agent version doesn't support this rule"
+		case rules.FilterTypeRuleFilter:
+			ruleState.Message = "none of the rule filters matched the host or configuration of this agent"
+		}
+	}
+
 	return ruleState
 }
 
 // NewPoliciesState returns the states of policies and rules
-func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalPolicies bool) []*PolicyState {
+func NewPoliciesState(rs *rules.RuleSet, filteredRules []*rules.PolicyRule, err *multierror.Error, includeInternalPolicies bool) []*PolicyState {
 	mp := make(map[string]*PolicyState)
 
 	var policyState *PolicyState
 	var exists bool
 
 	for _, rule := range rs.GetRules() {
-		for pInfo := range rule.Policies() {
-			if pInfo.IsInternal && !includeInternalPolicies {
-				continue
-			}
-
+		for pInfo := range rule.Policies(includeInternalPolicies) {
 			if policyState, exists = mp[pInfo.Name]; !exists {
 				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, PolicyStatusLoaded, "")
 				mp[pInfo.Name] = policyState
@@ -389,11 +406,7 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 	if err != nil && err.Errors != nil {
 		for _, err := range err.Errors {
 			if rerr, ok := err.(*rules.ErrRuleLoad); ok {
-				for pInfo := range rerr.Rule.Policies() {
-					if pInfo.IsInternal && !includeInternalPolicies {
-						continue
-					}
-
+				for pInfo := range rerr.Rule.Policies(includeInternalPolicies) {
 					policyName := pInfo.Name
 					if policyState, exists = mp[policyName]; !exists {
 						// if the policy is not in the map, this means that no rule from this policy was loaded successfully
@@ -415,6 +428,20 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 					}
 				}
 			}
+		}
+	}
+
+	for _, rule := range filteredRules {
+		for pInfo := range rule.Policies(includeInternalPolicies) {
+			policyName := pInfo.Name
+			if policyState, exists = mp[policyName]; !exists {
+				// if the policy is not in the map, this means that no rule from this policy was loaded successfully
+				policyState = NewPolicyState(pInfo.Name, pInfo.Source, pInfo.Version, PolicyStatusFullyFiltered, "")
+				mp[policyName] = policyState
+			} else if policyState.Status == PolicyStatusLoaded {
+				policyState.Status = PolicyStatusPartiallyFiltered
+			}
+			policyState.Rules = append(policyState.Rules, RuleStateFromRule(rule, pInfo, "filtered", ""))
 		}
 	}
 

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -954,6 +954,33 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 			out.Status = string(in.String())
 		case "message":
 			out.Message = string(in.String())
+		case "filter_type":
+			out.FilterType = string(in.String())
+		case "agent_version":
+			out.AgentVersionConstraint = string(in.String())
+		case "filters":
+			if in.IsNull() {
+				in.Skip()
+				out.Filters = nil
+			} else {
+				in.Delim('[')
+				if out.Filters == nil {
+					if !in.IsDelim(']') {
+						out.Filters = make([]string, 0, 4)
+					} else {
+						out.Filters = []string{}
+					}
+				} else {
+					out.Filters = (out.Filters)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v28 string
+					v28 = string(in.String())
+					out.Filters = append(out.Filters, v28)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "tags":
 			if in.IsNull() {
 				in.Skip()
@@ -967,9 +994,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v28 string
-					v28 = string(in.String())
-					(out.Tags)[key] = v28
+					var v29 string
+					v29 = string(in.String())
+					(out.Tags)[key] = v29
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -990,9 +1017,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.ProductTags = (out.ProductTags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v29 string
-					v29 = string(in.String())
-					out.ProductTags = append(out.ProductTags, v29)
+					var v30 string
+					v30 = string(in.String())
+					out.ProductTags = append(out.ProductTags, v30)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1013,9 +1040,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 RuleAction
-					(v30).UnmarshalEasyJSON(in)
-					out.Actions = append(out.Actions, v30)
+					var v31 RuleAction
+					(v31).UnmarshalEasyJSON(in)
+					out.Actions = append(out.Actions, v31)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1036,17 +1063,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.ModifiedBy = (out.ModifiedBy)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 *PolicyMetadata
+					var v32 *PolicyMetadata
 					if in.IsNull() {
 						in.Skip()
-						v31 = nil
+						v32 = nil
 					} else {
-						if v31 == nil {
-							v31 = new(PolicyMetadata)
+						if v32 == nil {
+							v32 = new(PolicyMetadata)
 						}
-						easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(in, v31)
+						easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(in, v32)
 					}
-					out.ModifiedBy = append(out.ModifiedBy, v31)
+					out.ModifiedBy = append(out.ModifiedBy, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1090,21 +1117,45 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		out.String(string(in.Message))
 	}
+	if in.FilterType != "" {
+		const prefix string = ",\"filter_type\":"
+		out.RawString(prefix)
+		out.String(string(in.FilterType))
+	}
+	if in.AgentVersionConstraint != "" {
+		const prefix string = ",\"agent_version\":"
+		out.RawString(prefix)
+		out.String(string(in.AgentVersionConstraint))
+	}
+	if len(in.Filters) != 0 {
+		const prefix string = ",\"filters\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v33, v34 := range in.Filters {
+				if v33 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v34))
+			}
+			out.RawByte(']')
+		}
+	}
 	if len(in.Tags) != 0 {
 		const prefix string = ",\"tags\":"
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v32First := true
-			for v32Name, v32Value := range in.Tags {
-				if v32First {
-					v32First = false
+			v35First := true
+			for v35Name, v35Value := range in.Tags {
+				if v35First {
+					v35First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v32Name))
+				out.String(string(v35Name))
 				out.RawByte(':')
-				out.String(string(v32Value))
+				out.String(string(v35Value))
 			}
 			out.RawByte('}')
 		}
@@ -1114,11 +1165,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v33, v34 := range in.ProductTags {
-				if v33 > 0 {
+			for v36, v37 := range in.ProductTags {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v34))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -1128,11 +1179,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v35, v36 := range in.Actions {
-				if v35 > 0 {
+			for v38, v39 := range in.Actions {
+				if v38 > 0 {
 					out.RawByte(',')
 				}
-				(v36).MarshalEasyJSON(out)
+				(v39).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -1142,14 +1193,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v37, v38 := range in.ModifiedBy {
-				if v37 > 0 {
+			for v40, v41 := range in.ModifiedBy {
+				if v40 > 0 {
 					out.RawByte(',')
 				}
-				if v38 == nil {
+				if v41 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(out, *v38)
+					easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor2(out, *v41)
 				}
 			}
 			out.RawByte(']')
@@ -1685,17 +1736,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 					out.Rules = (out.Rules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v39 *RuleState
+					var v42 *RuleState
 					if in.IsNull() {
 						in.Skip()
-						v39 = nil
+						v42 = nil
 					} else {
-						if v39 == nil {
-							v39 = new(RuleState)
+						if v42 == nil {
+							v42 = new(RuleState)
 						}
-						(*v39).UnmarshalEasyJSON(in)
+						(*v42).UnmarshalEasyJSON(in)
 					}
-					out.Rules = append(out.Rules, v39)
+					out.Rules = append(out.Rules, v42)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1735,14 +1786,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v40, v41 := range in.Rules {
-				if v40 > 0 {
+			for v43, v44 := range in.Rules {
+				if v43 > 0 {
 					out.RawByte(',')
 				}
-				if v41 == nil {
+				if v44 == nil {
 					out.RawString("null")
 				} else {
-					(*v41).MarshalEasyJSON(out)
+					(*v44).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -7,6 +7,7 @@
 package monitor
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -16,6 +17,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -26,13 +28,15 @@ type testPolicy struct {
 	def  rules.PolicyDef
 }
 
+type testCase struct {
+	name                 string
+	policies             []*testPolicy
+	expectedPolicyStates []*PolicyState
+}
+
 func TestPolicyMonitorPolicyState(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		policies             []*testPolicy
-		testPolicyStatesCb   func(t *testing.T, states []*PolicyState)
-		expectedPolicyStates []*PolicyState
-	}{
+
+	testCases := []*testCase{
 		{
 			name:                 "no policy",
 			policies:             nil,
@@ -378,12 +382,278 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "multiple rules with one agent constraint passing",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar"`,
+								AgentVersionConstraint: "< 0.0.1",
+							},
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar" && exec.file.name == "bar"`,
+								AgentVersionConstraint: "< 0.0.2",
+							},
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar" && exec.file.name == "bar" && exec.pid == 42`,
+								AgentVersionConstraint: "~7.x",
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusLoaded,
+					Rules: []*RuleState{
+						{
+							ID:                     "rule_a",
+							Expression:             `exec.file.path == "/etc/foo/bar" && exec.file.name == "bar" && exec.pid == 42`,
+							Status:                 "loaded",
+							AgentVersionConstraint: "~7.x",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple policies with same rules but different constraints",
+			policies: []*testPolicy{
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar"`,
+								AgentVersionConstraint: "< 0.0.1",
+							},
+							{
+								ID:                     "rule_b",
+								Expression:             `exec.file.path == "/etc/foo/baz"`,
+								AgentVersionConstraint: "< 0.0.2",
+							},
+						},
+					},
+				},
+				{
+					info: rules.PolicyInfo{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					def: rules.PolicyDef{
+						Rules: []*rules.RuleDefinition{
+							{
+								ID:                     "rule_a",
+								Expression:             `exec.file.path == "/etc/foo/bar" && exec.pid == 42`,
+								AgentVersionConstraint: "~7.x",
+							},
+							{
+								ID:                     "rule_b",
+								Expression:             `exec.file.path == "/etc/foo/baz"`,
+								AgentVersionConstraint: "< 0.0.2",
+							},
+							{
+								ID:                     "rule_c",
+								Expression:             `exec.file.path == "/etc/foo/qwak"`,
+								AgentVersionConstraint: ">= 7.42.0",
+							},
+						},
+					},
+				},
+			},
+			expectedPolicyStates: []*PolicyState{
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy A",
+						Source: "test",
+					},
+					Status: PolicyStatusFullyFiltered,
+					Rules: []*RuleState{
+						{
+							ID:                     "rule_a",
+							Expression:             `exec.file.path == "/etc/foo/bar"`,
+							Status:                 "filtered",
+							Message:                "this agent version doesn't support this rule",
+							FilterType:             string(rules.FilterTypeAgentVersion),
+							AgentVersionConstraint: "< 0.0.1",
+						},
+						{
+							ID:                     "rule_b",
+							Expression:             `exec.file.path == "/etc/foo/baz"`,
+							Status:                 "filtered",
+							Message:                "this agent version doesn't support this rule",
+							FilterType:             string(rules.FilterTypeAgentVersion),
+							AgentVersionConstraint: "< 0.0.2",
+						},
+					},
+				},
+				{
+					PolicyMetadata: PolicyMetadata{
+						Name:   "Policy B",
+						Source: "test",
+					},
+					Status: PolicyStatusPartiallyFiltered,
+					Rules: []*RuleState{
+						{
+							ID:                     "rule_a",
+							Expression:             `exec.file.path == "/etc/foo/bar" && exec.pid == 42`,
+							Status:                 "loaded",
+							AgentVersionConstraint: "~7.x",
+						},
+						{
+							ID:                     "rule_b",
+							Expression:             `exec.file.path == "/etc/foo/baz"`,
+							Status:                 "filtered",
+							Message:                "this agent version doesn't support this rule",
+							FilterType:             string(rules.FilterTypeAgentVersion),
+							AgentVersionConstraint: "< 0.0.2",
+						},
+						{
+							ID:                     "rule_c",
+							Expression:             `exec.file.path == "/etc/foo/qwak"`,
+							Status:                 "loaded",
+							AgentVersionConstraint: ">= 7.42.0",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if runtime.GOOS == "linux" {
+		testCases = append(testCases, []*testCase{
+			{
+				name: "policy with os filters",
+				policies: []*testPolicy{
+					{
+						info: rules.PolicyInfo{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						def: rules.PolicyDef{
+							Rules: []*rules.RuleDefinition{
+								{
+									ID:         "rule_a",
+									Expression: `exec.file.path == "/etc/foo/bar"`,
+									Filters:    []string{"os == \"linux\""},
+								},
+								{
+									ID:         "rule_b",
+									Expression: `exec.file.path == "/etc/foo/baz"`,
+									Filters:    []string{"os == \"windows\""},
+								},
+							},
+						},
+					},
+				},
+				expectedPolicyStates: []*PolicyState{
+					{
+						PolicyMetadata: PolicyMetadata{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						Status: PolicyStatusPartiallyFiltered,
+						Rules: []*RuleState{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+								Status:     "loaded",
+								Filters:    []string{"os == \"linux\""},
+							},
+							{
+								ID:         "rule_b",
+								Expression: `exec.file.path == "/etc/foo/baz"`,
+								Status:     "filtered",
+								Message:    "none of the rule filters matched the host or configuration of this agent",
+								FilterType: string(rules.FilterTypeRuleFilter),
+								Filters:    []string{"os == \"windows\""},
+							},
+						},
+					},
+				},
+			},
+		}...)
+	} else if runtime.GOOS == "windows" {
+		testCases = append(testCases, []*testCase{
+			{
+				name: "policy with os filters",
+				policies: []*testPolicy{
+					{
+						info: rules.PolicyInfo{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						def: rules.PolicyDef{
+							Rules: []*rules.RuleDefinition{
+								{
+									ID:         "rule_a",
+									Expression: `exec.file.path == "/etc/foo/bar"`,
+									Filters:    []string{"os == \"linux\""},
+								},
+								{
+									ID:         "rule_b",
+									Expression: `exec.file.path == "/etc/foo/baz"`,
+									Filters:    []string{"os == \"windows\""},
+								},
+							},
+						},
+					},
+				},
+				expectedPolicyStates: []*PolicyState{
+					{
+						PolicyMetadata: PolicyMetadata{
+							Name:   "Policy A",
+							Source: "test",
+						},
+						Status: PolicyStatusPartiallyFiltered,
+						Rules: []*RuleState{
+							{
+								ID:         "rule_a",
+								Expression: `exec.file.path == "/etc/foo/bar"`,
+								Status:     "filtered",
+								Message:    "none of the rule filters matched the host or configuration of this agent",
+								FilterType: string(rules.FilterTypeRuleFilter),
+								Filters:    []string{"os == \"linux\""},
+							},
+							{
+								ID:         "rule_b",
+								Expression: `exec.file.path == "/etc/foo/baz"`,
+								Status:     "loaded",
+								Filters:    []string{"os == \"windows\""},
+							},
+						},
+					},
+				},
+			},
+		}...)
 	}
 
 	var macroFilters []rules.MacroFilter
 	var ruleFilters []rules.RuleFilter
 
-	agentVersionFilter, err := rules.NewAgentVersionFilter(semver.MustParse("7.21.0"))
+	seclRuleFilter := rules.NewSECLRuleFilter(filtermodel.NewOSOnlyFilterModel(runtime.GOOS))
+
+	macroFilters = append(macroFilters, seclRuleFilter)
+	ruleFilters = append(ruleFilters, seclRuleFilter)
+
+	agentVersionFilter, err := rules.NewAgentVersionFilter(semver.MustParse("7.42.0"))
 	if err != nil {
 		t.Fatal("failed to create agent version filter:", err)
 	} else {
@@ -413,7 +683,7 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 			filteredRules, errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})
 			policyStates := NewPoliciesState(rs, filteredRules, errs, false)
 
-			assert.True(t, gocmp.Equal(tc.expectedPolicyStates, policyStates, goCmpOpts...), gocmp.Diff(tc.expectedPolicyStates, policyStates, goCmpOpts...), "policy states mismatch")
+			assert.True(t, gocmp.Equal(tc.expectedPolicyStates, policyStates, goCmpOpts...), gocmp.Diff(tc.expectedPolicyStates, policyStates, goCmpOpts...))
 		})
 	}
 }

--- a/pkg/security/rules/monitor/policy_monitor_test.go
+++ b/pkg/security/rules/monitor/policy_monitor_test.go
@@ -381,8 +381,8 @@ func TestPolicyMonitorPolicyState(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			rs := rules.NewRuleSet(&model.Model{}, eventCtor, ruleOpts, evalOpts)
 			loader := rules.NewPolicyLoader(newTestPolicyProvider(tc.policies...))
-			errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})
-			policyStates := NewPoliciesState(rs, errs, false)
+			filteredRules, errs := rs.LoadPolicies(loader, rules.PolicyLoaderOpts{MacroFilters: macroFilters, RuleFilters: ruleFilters})
+			policyStates := NewPoliciesState(rs, filteredRules, errs, false)
 
 			assert.True(t, gocmp.Equal(tc.expectedPolicyStates, policyStates, goCmpOpts...), gocmp.Diff(tc.expectedPolicyStates, policyStates, goCmpOpts...), "policy states mismatch")
 		})

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -84,7 +84,7 @@ func TestMacroMerge(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if errs := rs.LoadPolicies(loader, PolicyLoaderOpts{}); errs.ErrorOrNil() != nil {
+	if _, errs := rs.LoadPolicies(loader, PolicyLoaderOpts{}); errs.ErrorOrNil() != nil {
 		t.Error(err)
 	}
 
@@ -99,7 +99,7 @@ func TestMacroMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -159,7 +159,7 @@ func TestRuleMerge(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if errs := rs.LoadPolicies(loader, PolicyLoaderOpts{}); errs.ErrorOrNil() != nil {
+	if _, errs := rs.LoadPolicies(loader, PolicyLoaderOpts{}); errs.ErrorOrNil() != nil {
 		t.Error(err)
 	}
 
@@ -175,7 +175,7 @@ func TestRuleMerge(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+		if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -293,7 +293,7 @@ func TestActionSetVariable(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -407,7 +407,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -557,7 +557,7 @@ func TestActionSetVariableSize(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -675,7 +675,7 @@ func TestActionSetEmptyScope(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -737,7 +737,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err == nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err == nil {
 		t.Error("expected policy to fail to load")
 	}
 }
@@ -774,7 +774,7 @@ func TestActionSetVariableInitialValue(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -872,7 +872,7 @@ func TestActionSetVariableInherited(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1053,7 +1053,7 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1314,7 +1314,7 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1478,7 +1478,7 @@ func TestActionSetVariableExpression(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 
@@ -1598,7 +1598,9 @@ func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts
 
 	loader := NewPolicyLoader(provider)
 
-	return rs, rs.LoadPolicies(loader, policyOpts)
+	_, errs := rs.LoadPolicies(loader, policyOpts)
+
+	return rs, errs
 }
 
 func TestRuleErrorLoading(t *testing.T) {
@@ -2019,7 +2021,7 @@ func TestActionSetVariableLength(t *testing.T) {
 	loader := NewPolicyLoader(provider)
 
 	rs := newRuleSet()
-	if err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
+	if _, err := rs.LoadPolicies(loader, PolicyLoaderOpts{}); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -16,9 +16,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
 )
 
+// FilterType defines the type of a rule filter
+type FilterType string
+
+const (
+	// FilterTypeRuleID defines a rule ID based filter
+	FilterTypeRuleID FilterType = "rule_id"
+	// FilterTypeAgentVersion defines a agent version based filter
+	FilterTypeAgentVersion FilterType = "agent_version"
+	// FilterTypeRuleFilter defines a SECL rule based filter
+	FilterTypeRuleFilter FilterType = "rule_filter"
+)
+
 // RuleFilter definition of a rule filter
 type RuleFilter interface {
 	IsRuleAccepted(*RuleDefinition) (bool, error)
+	GetType() FilterType
 }
 
 // MacroFilter definition of a macro filter
@@ -34,6 +47,11 @@ type RuleIDFilter struct {
 // IsRuleAccepted checks whether the rule is accepted
 func (r *RuleIDFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 	return r.ID == rule.ID, nil
+}
+
+// GetType returns the type of this rule filter
+func (r *RuleIDFilter) GetType() FilterType {
+	return FilterTypeRuleID
 }
 
 // AgentVersionFilter defines a agent version filter
@@ -68,6 +86,11 @@ func (r *AgentVersionFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) 
 	return constraint.Check(r.version), nil
 }
 
+// GetType returns the type of this rule filter
+func (r *AgentVersionFilter) GetType() FilterType {
+	return FilterTypeAgentVersion
+}
+
 // IsMacroAccepted checks whether the macro is accepted
 func (r *AgentVersionFilter) IsMacroAccepted(macro *MacroDefinition) (bool, error) {
 	constraint, err := validators.ValidateAgentVersionConstraint(macro.AgentVersionConstraint)
@@ -93,6 +116,11 @@ func NewSECLRuleFilter(model eval.Model) *SECLRuleFilter {
 // IsRuleAccepted checks whether the rule is accepted
 func (r *SECLRuleFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 	return r.inner.IsAccepted(rule.Filters)
+}
+
+// GetType returns the type of this rule filter
+func (r *SECLRuleFilter) GetType() FilterType {
+	return FilterTypeRuleFilter
 }
 
 // IsMacroAccepted checks whether the macro is accepted

--- a/pkg/security/secl/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/secl/schemas/ruleset_loaded.schema.json
@@ -47,8 +47,10 @@
                     "type": "string",
                     "enum": [
                         "loaded",
+                        "partially_filtered",
                         "partially_loaded",
                         "fully_rejected",
+                        "fully_filtered",
                         "error"
                     ]
                 },
@@ -97,6 +99,7 @@
                         "agent_version_error",
                         "event_type_disabled",
                         "syntax_error",
+                        "filtered",
                         "error"
                     ]
                 },
@@ -125,6 +128,23 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/$defs/policyinfo"
+                    }
+                },
+                "filter_type": {
+                    "type": "string",
+                    "enum": [
+                        "rule_id",
+                        "agent_version",
+                        "rule_filter"
+                    ]
+                },
+                "agent_version": {
+                    "type": "string"
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             },


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Makes it so `ruleset_loaded` events start reporting filtered rules along side those that were successfully loaded.
It also starts reporting the `agent_version` and `filters` fields of rules.

Filtered rules are reported with a `status` field set to "filtered".
In this case, an extra `filter_type` field indicates the reason the rule was filtered out: 
- "agent_version" indicates that the rule's `agent_version` field didn't match the version of the agent
- "rule_filter" indicates that none of the rule's filters from the `filters` field matched the host or agent configuration.

Currently the "filters" field is only used to filter rules based on the host OS.

### Motivation

Being able to track rules that cannot be loaded due to outdated agent in the future.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->