### PR TITLE
discovery: Disable automatic enablement if USM is enabled

### DIFF
--- a/pkg/system-probe/config/adjust_usm.go
+++ b/pkg/system-probe/config/adjust_usm.go
@@ -21,8 +21,6 @@ func adjustUSM(cfg model.Config) {
 	if cfg.GetBool(smNS("enabled")) {
 		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
 		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
-
-		applyDefault(cfg, discoveryNS("enabled"), true)
 	}
 
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))

--- a/pkg/system-probe/config/config_test.go
+++ b/pkg/system-probe/config/config_test.go
@@ -95,21 +95,4 @@ func TestEnableDiscovery(t *testing.T) {
 		cfg := mock.NewSystemProbe(t)
 		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
 	})
-
-	t.Run("default enabled with USM", func(t *testing.T) {
-		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-
-		cfg := mock.NewSystemProbe(t)
-		Adjust(cfg)
-		assert.True(t, cfg.GetBool(discoveryNS("enabled")))
-	})
-
-	t.Run("force disabled with USM", func(t *testing.T) {
-		t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-		t.Setenv("DD_DISCOVERY_ENABLED", "false")
-
-		cfg := mock.NewSystemProbe(t)
-		Adjust(cfg)
-		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
-	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reverting #31475

Remove automatic enablement of Agent Discovery if USM is enabled.

### Motivation

Remove redundant connections between the modules.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Verified with @smeso-ddg 
