### PR TITLE
WorkloadFilter Additional Filters Initializations

### DIFF
--- a/comp/core/autodiscovery/listeners/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints_test.go
@@ -16,7 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	filter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestProcessEndpoints(t *testing.T) {
@@ -41,7 +43,7 @@ func TestProcessEndpoints(t *testing.T) {
 		},
 	}
 
-	eps := processEndpoints(kep, []string{"foo:bar"})
+	eps := processEndpoints(kep, []string{"foo:bar"}, workloadfilterfxmock.SetupMockFilter(t))
 
 	// Sort eps to impose the order
 	sort.Slice(eps, func(i, j int) bool {
@@ -399,7 +401,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 		metricsExcluded bool
 		globalExcluded  bool
 		want            bool
-		filterScope     filter.Scope
+		filterScope     workloadfilter.Scope
 	}{
 		{
 			name: "metrics excluded is true",
@@ -428,7 +430,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			},
 			metricsExcluded: true,
 			want:            true,
-			filterScope:     filter.MetricsFilter,
+			filterScope:     workloadfilter.MetricsFilter,
 		},
 		{
 			name: "metrics excluded is false",
@@ -458,7 +460,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			metricsExcluded: false,
 			globalExcluded:  true,
 			want:            false,
-			filterScope:     filter.MetricsFilter,
+			filterScope:     workloadfilter.MetricsFilter,
 		},
 		{
 			name: "metrics excluded is true with logs filter",
@@ -488,7 +490,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			metricsExcluded: true,
 			globalExcluded:  false,
 			want:            false,
-			filterScope:     filter.LogsFilter,
+			filterScope:     workloadfilter.LogsFilter,
 		},
 		{
 			name: "metrics excluded is false with logs filter",
@@ -518,7 +520,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			metricsExcluded: false,
 			globalExcluded:  true,
 			want:            false,
-			filterScope:     filter.LogsFilter,
+			filterScope:     workloadfilter.LogsFilter,
 		},
 		{
 			name: "global excluded is true",
@@ -548,7 +550,7 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			metricsExcluded: true,
 			globalExcluded:  true,
 			want:            true,
-			filterScope:     filter.GlobalFilter,
+			filterScope:     workloadfilter.GlobalFilter,
 		},
 		{
 			name: "metrics excluded is false",
@@ -578,16 +580,142 @@ func TestHasFilterKubeEndpoints(t *testing.T) {
 			metricsExcluded: false,
 			globalExcluded:  false,
 			want:            false,
-			filterScope:     filter.GlobalFilter,
+			filterScope:     workloadfilter.GlobalFilter,
 		},
 	}
+
+	filterStore := workloadfilterfxmock.SetupMockFilter(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := processService(tt.ksvc)
+			svc := processService(tt.ksvc, filterStore)
 			svc.metricsExcluded = tt.metricsExcluded
 			svc.globalExcluded = tt.globalExcluded
 			isFilter := svc.HasFilter(tt.filterScope)
 			assert.Equal(t, isFilter, tt.want)
+		})
+	}
+}
+
+func TestKubeEndpointsFiltering(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("container_exclude_metrics", []string{"kube_namespace:excluded-namespace"})
+	mockConfig.SetWithoutSource("container_exclude", []string{"name:global-excluded"})
+	mockFilterStore := workloadfilterfxmock.SetupMockFilter(t)
+
+	// Create test endpoints with different scenarios
+	testCases := []struct {
+		name                string
+		endpoint            *v1.Endpoints
+		expectedMetricsExcl bool
+		expectedGlobalExcl  bool
+	}{
+		{
+			name: "normal endpoint: not excluded",
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "normal-service",
+					Namespace: "default",
+					UID:       types.UID("normal-uid"),
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.1"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "http", Port: 80},
+						},
+					},
+				},
+			},
+			expectedMetricsExcl: false,
+			expectedGlobalExcl:  false,
+		},
+		{
+			name: "endpoint in excluded namespace: metrics excluded",
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-in-excluded-ns",
+					Namespace: "excluded-namespace",
+					UID:       types.UID("excluded-ns-uid"),
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.2"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "http", Port: 80},
+						},
+					},
+				},
+			},
+			expectedMetricsExcl: true,
+			expectedGlobalExcl:  false,
+		},
+		{
+			name: "globally excluded endpoint",
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "global-excluded",
+					Namespace: "default",
+					UID:       types.UID("global-excluded-uid"),
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.3"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "http", Port: 80},
+						},
+					},
+				},
+			},
+			expectedMetricsExcl: false,
+			expectedGlobalExcl:  true,
+		},
+		{
+			name: "endpoint with AD annotations: metrics excluded",
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ad-excluded",
+					Namespace: "default",
+					UID:       types.UID("ad-excluded-uid"),
+					Annotations: map[string]string{
+						"ad.datadoghq.com/service.check_names": "[\"http_check\"]",
+						"ad.datadoghq.com/metrics_exclude":     "true",
+						"ad.datadoghq.com/exclude":             "false",
+					},
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.4"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "http", Port: 80},
+						},
+					},
+				},
+			},
+			expectedMetricsExcl: true,
+			expectedGlobalExcl:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eps := processEndpoints(tc.endpoint, []string{}, mockFilterStore)
+			assert.NotEmpty(t, eps, "Should have at least one endpoint service")
+			for _, ep := range eps {
+				assert.Equal(t, tc.expectedMetricsExcl, ep.metricsExcluded,
+					"Expected metricsExcluded to be %v for endpoint %s/%s",
+					tc.expectedMetricsExcl, tc.endpoint.Namespace, tc.endpoint.Name)
+				assert.Equal(t, tc.expectedGlobalExcl, ep.globalExcluded,
+					"Expected globalExcluded to be %v for endpoint %s/%s",
+					tc.expectedGlobalExcl, tc.endpoint.Namespace, tc.endpoint.Name)
+			}
 		})
 	}
 }

--- a/comp/core/workloadfilter/catalog/container.go
+++ b/comp/core/workloadfilter/catalog/container.go
@@ -165,9 +165,9 @@ func createContainerADAnnotationsProgram(programName, annotationKey string, logg
 	// Use 'in' operator to safely check if annotation exists before accessing it
 	excludeFilter := fmt.Sprintf(`
 		(("ad.datadoghq.com/" + container.name + ".%s") in container.pod.annotations && 
-		 container.pod.annotations["ad.datadoghq.com/" + container.name + ".%s"] == "true") ||
+		 container.pod.annotations["ad.datadoghq.com/" + container.name + ".%s"] in ["1", "t", "T", "true", "TRUE", "True"]) ||
 		(("ad.datadoghq.com/%s") in container.pod.annotations && 
-		 container.pod.annotations["ad.datadoghq.com/%s"] == "true")
+		 container.pod.annotations["ad.datadoghq.com/%s"] in ["1", "t", "T", "true", "TRUE", "True"])
 	`, annotationKey, annotationKey, annotationKey, annotationKey)
 
 	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.ContainerType)

--- a/comp/core/workloadfilter/catalog/image.go
+++ b/comp/core/workloadfilter/catalog/image.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package catalog contains the implementation of the filtering catalogs.
+package catalog
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// LegacyImageProgram creates a program for filtering legacy images.
+func LegacyImageProgram(config config.Component, loggger log.Component) program.FilterProgram {
+	programName := "LegacyImageProgram"
+	var initErrors []error
+
+	includeList := config.GetStringSlice("container_include")
+	excludeList := config.GetStringSlice("container_exclude")
+	includeList = append(includeList, config.GetStringSlice("container_include_metrics")...)
+	excludeList = append(excludeList, config.GetStringSlice("container_exclude_metrics")...)
+
+	if len(includeList) == 0 {
+		// support legacy "ac_include" config
+		includeList = config.GetStringSlice("ac_include")
+	}
+	if len(excludeList) == 0 {
+		// support legacy "ac_exclude" config
+		excludeList = config.GetStringSlice("ac_exclude")
+	}
+
+	includeProgram, includeErr := createProgramFromOldFilters(includeList, workloadfilter.ImageType)
+	if includeErr != nil {
+		initErrors = append(initErrors, includeErr)
+		loggger.Warnf("Error creating include program for %s: %v", programName, includeErr)
+	}
+	excludeProgram, excludeErr := createProgramFromOldFilters(excludeList, workloadfilter.ImageType)
+	if excludeErr != nil {
+		initErrors = append(initErrors, excludeErr)
+		loggger.Warnf("Error creating exclude program for %s: %v", programName, excludeErr)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Include:              includeProgram,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}
+
+// ImageSBOMProgram creates a program for filtering legacy image SBOMs.
+func ImageSBOMProgram(config config.Component, logger log.Component) program.CELProgram {
+	programName := "LegacyImageSBOMProgram"
+	var initErrors []error
+
+	includeProgram, includeErr := createProgramFromOldFilters(config.GetStringSlice("sbom.container_image.container_include"), workloadfilter.ImageType)
+	if includeErr != nil {
+		initErrors = append(initErrors, includeErr)
+		logger.Warnf("Error creating include program for %s: %v", programName, includeErr)
+	}
+
+	excludeProgram, excludeErr := createProgramFromOldFilters(config.GetStringSlice("sbom.container_image.container_exclude"), workloadfilter.ImageType)
+	if excludeErr != nil {
+		initErrors = append(initErrors, excludeErr)
+		logger.Warnf("Error creating exclude program for %s: %v", programName, excludeErr)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Include:              includeProgram,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}
+
+// ImagePausedProgram creates a program for filtering paused images.
+func ImagePausedProgram(config config.Component, logger log.Component) program.FilterProgram {
+	programName := "ImagePausedProgram"
+	var initErrors []error
+	var excludeList []string
+	if config.GetBool("exclude_pause_container") {
+		excludeList = containers.GetPauseContainerExcludeList()
+	}
+
+	excludeProgram, excludeErr := createProgramFromOldFilters(excludeList, workloadfilter.ImageType)
+	if excludeErr != nil {
+		initErrors = append(initErrors, excludeErr)
+		logger.Warnf("Error creating exclude program for %s: %v", programName, excludeErr)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}

--- a/comp/core/workloadfilter/catalog/kube_endpoints.go
+++ b/comp/core/workloadfilter/catalog/kube_endpoints.go
@@ -81,7 +81,7 @@ func EndpointsADAnnotationsProgram(_ config.Component, logger log.Component) pro
 	var initErrors []error
 	// Use 'in' operator to safely check if annotation exists before accessing it
 	excludeFilter := `(("ad.datadoghq.com/exclude") in endpoint.annotations && 
-		 endpoint.annotations["ad.datadoghq.com/exclude"] == "true")`
+		 endpoint.annotations["ad.datadoghq.com/exclude"] in ["1", "t", "T", "true", "TRUE", "True"])`
 
 	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.EndpointType)
 	if err != nil {
@@ -103,7 +103,7 @@ func EndpointsADAnnotationsMetricsProgram(_ config.Component, logger log.Compone
 	var initErrors []error
 	// Use 'in' operator to safely check if annotation exists before accessing it
 	excludeFilter := `(("ad.datadoghq.com/metrics_exclude") in endpoint.annotations && 
-		 endpoint.annotations["ad.datadoghq.com/metrics_exclude"] == "true")`
+		 endpoint.annotations["ad.datadoghq.com/metrics_exclude"] in ["1", "t", "T", "true", "TRUE", "True"])`
 
 	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.EndpointType)
 	if err != nil {

--- a/comp/core/workloadfilter/catalog/kube_endpoints.go
+++ b/comp/core/workloadfilter/catalog/kube_endpoints.go
@@ -73,3 +73,47 @@ func LegacyEndpointsGlobalProgram(config config.Component, logger log.Component)
 		InitializationErrors: initErrors,
 	}
 }
+
+// EndpointsADAnnotationsProgram creates a program for filtering endpoints based on AD annotations
+func EndpointsADAnnotationsProgram(_ config.Component, logger log.Component) program.CELProgram {
+	programName := "EndpointsADAnnotationsProgram"
+
+	var initErrors []error
+	// Use 'in' operator to safely check if annotation exists before accessing it
+	excludeFilter := `(("ad.datadoghq.com/exclude") in endpoint.annotations && 
+		 endpoint.annotations["ad.datadoghq.com/exclude"] == "true")`
+
+	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.EndpointType)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		logger.Warnf("Error creating CEL filtering program for %s: %v", programName, err)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}
+
+// EndpointsADAnnotationsMetricsProgram creates a program for filtering endpoints metrics based on AD annotations
+func EndpointsADAnnotationsMetricsProgram(_ config.Component, logger log.Component) program.CELProgram {
+	programName := "EndpointsADAnnotationsMetricsProgram"
+
+	var initErrors []error
+	// Use 'in' operator to safely check if annotation exists before accessing it
+	excludeFilter := `(("ad.datadoghq.com/metrics_exclude") in endpoint.annotations && 
+		 endpoint.annotations["ad.datadoghq.com/metrics_exclude"] == "true")`
+
+	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.EndpointType)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		logger.Warnf("Error creating CEL filtering program for %s: %v", programName, err)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}

--- a/comp/core/workloadfilter/catalog/kube_service.go
+++ b/comp/core/workloadfilter/catalog/kube_service.go
@@ -81,7 +81,7 @@ func ServiceADAnnotationsProgram(_ config.Component, logger log.Component) progr
 	var initErrors []error
 	// Use 'in' operator to safely check if annotation exists before accessing it
 	excludeFilter := `(("ad.datadoghq.com/exclude") in service.annotations && 
-		 service.annotations["ad.datadoghq.com/exclude"] == "true")`
+		 service.annotations["ad.datadoghq.com/exclude"] in ["1", "t", "T", "true", "TRUE", "True"])`
 
 	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.ServiceType)
 	if err != nil {
@@ -103,7 +103,7 @@ func ServiceADAnnotationsMetricsProgram(_ config.Component, logger log.Component
 	var initErrors []error
 	// Use 'in' operator to safely check if annotation exists before accessing it
 	excludeFilter := `(("ad.datadoghq.com/metrics_exclude") in service.annotations && 
-		 service.annotations["ad.datadoghq.com/metrics_exclude"] == "true")`
+		 service.annotations["ad.datadoghq.com/metrics_exclude"] in ["1", "t", "T", "true", "TRUE", "True"])`
 
 	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.ServiceType)
 	if err != nil {

--- a/comp/core/workloadfilter/catalog/kube_service.go
+++ b/comp/core/workloadfilter/catalog/kube_service.go
@@ -73,3 +73,47 @@ func LegacyServiceGlobalProgram(config config.Component, logger log.Component) p
 		InitializationErrors: initErrors,
 	}
 }
+
+// ServiceADAnnotationsProgram creates a program for filtering services based on AD annotations
+func ServiceADAnnotationsProgram(_ config.Component, logger log.Component) program.CELProgram {
+	programName := "ServiceADAnnotationsProgram"
+
+	var initErrors []error
+	// Use 'in' operator to safely check if annotation exists before accessing it
+	excludeFilter := `(("ad.datadoghq.com/exclude") in service.annotations && 
+		 service.annotations["ad.datadoghq.com/exclude"] == "true")`
+
+	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.ServiceType)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		logger.Warnf("Error creating CEL filtering program for %s: %v", programName, err)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}
+
+// ServiceADAnnotationsMetricsProgram creates a program for filtering services metrics based on AD annotations
+func ServiceADAnnotationsMetricsProgram(_ config.Component, logger log.Component) program.CELProgram {
+	programName := "ServiceADAnnotationsMetricsProgram"
+
+	var initErrors []error
+	// Use 'in' operator to safely check if annotation exists before accessing it
+	excludeFilter := `(("ad.datadoghq.com/metrics_exclude") in service.annotations && 
+		 service.annotations["ad.datadoghq.com/metrics_exclude"] == "true")`
+
+	excludeProgram, err := createCELProgram(excludeFilter, workloadfilter.ServiceType)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		logger.Warnf("Error creating CEL filtering program for %s: %v", programName, err)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}

--- a/comp/core/workloadfilter/catalog/utils.go
+++ b/comp/core/workloadfilter/catalog/utils.go
@@ -58,7 +58,7 @@ func createCELProgram(rules string, objectType workloadfilter.ResourceType) (cel
 // getFieldMapping creates a map to associate old filter prefixes with new filter fields
 func getFieldMapping(objectType workloadfilter.ResourceType) map[string]string {
 	if objectType == workloadfilter.ImageType {
-		// only support "id" which is the image name
+		// only support "image" which is the image name
 		return map[string]string{
 			"image": fmt.Sprintf("%s.name.matches", objectType),
 		}
@@ -109,7 +109,7 @@ func convertOldToNewFilter(oldFilters []string, objectType workloadfilter.Resour
 			return "", fmt.Errorf("invalid filter format: %s", oldFilter)
 		}
 
-		// Check if the key is in the excluded
+		// Check if the key applies for the particular workload type
 		if objectType != workloadfilter.ContainerType && objectType != workloadfilter.ImageType && key == "image" {
 			continue
 		}

--- a/comp/core/workloadfilter/catalog/utils_test.go
+++ b/comp/core/workloadfilter/catalog/utils_test.go
@@ -75,6 +75,12 @@ func TestConvertOldToNewFilter_Success(t *testing.T) {
 			[]string{"name:foo-.*", "image:nginx.*"},
 			`endpoint.name.matches("foo-.*")`,
 		},
+		{
+			"image filter on image type",
+			workloadfilter.ImageType,
+			[]string{"image:nginx.*"},
+			`image.name.matches("nginx.*")`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/comp/core/workloadfilter/def/component.go
+++ b/comp/core/workloadfilter/def/component.go
@@ -18,6 +18,7 @@ type Component interface {
 	IsPodExcluded(pod *Pod, podFilters [][]PodFilter) bool
 	IsServiceExcluded(service *Service, serviceFilters [][]ServiceFilter) bool
 	IsEndpointExcluded(endpoint *Endpoint, endpointFilters [][]EndpointFilter) bool
+	IsImageExcluded(image *Image, imageFilters [][]ImageFilter) bool
 
-	GetContainerFilterInitializationErrors(filter []ContainerFilter) []error
+	GetContainerFilterInitializationErrors(filters []ContainerFilter) []error
 }

--- a/comp/core/workloadfilter/def/proto/filter.pb.go
+++ b/comp/core/workloadfilter/def/proto/filter.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.6
 // 	protoc        v5.29.3
-// source: comp/core/filter/def/proto/filter.proto
+// source: comp/core/workloadfilter/def/proto/filter.proto
 
 package proto
 
@@ -37,7 +37,7 @@ type FilterContainer struct {
 
 func (x *FilterContainer) Reset() {
 	*x = FilterContainer{}
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[0]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -49,7 +49,7 @@ func (x *FilterContainer) String() string {
 func (*FilterContainer) ProtoMessage() {}
 
 func (x *FilterContainer) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[0]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62,7 +62,7 @@ func (x *FilterContainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterContainer.ProtoReflect.Descriptor instead.
 func (*FilterContainer) Descriptor() ([]byte, []int) {
-	return file_comp_core_filter_def_proto_filter_proto_rawDescGZIP(), []int{0}
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *FilterContainer) GetId() string {
@@ -139,7 +139,7 @@ type FilterPod struct {
 
 func (x *FilterPod) Reset() {
 	*x = FilterPod{}
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[1]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -151,7 +151,7 @@ func (x *FilterPod) String() string {
 func (*FilterPod) ProtoMessage() {}
 
 func (x *FilterPod) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[1]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -164,7 +164,7 @@ func (x *FilterPod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterPod.ProtoReflect.Descriptor instead.
 func (*FilterPod) Descriptor() ([]byte, []int) {
-	return file_comp_core_filter_def_proto_filter_proto_rawDescGZIP(), []int{1}
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *FilterPod) GetId() string {
@@ -205,7 +205,7 @@ type FilterECSTask struct {
 
 func (x *FilterECSTask) Reset() {
 	*x = FilterECSTask{}
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[2]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -217,7 +217,7 @@ func (x *FilterECSTask) String() string {
 func (*FilterECSTask) ProtoMessage() {}
 
 func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[2]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -230,7 +230,7 @@ func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterECSTask.ProtoReflect.Descriptor instead.
 func (*FilterECSTask) Descriptor() ([]byte, []int) {
-	return file_comp_core_filter_def_proto_filter_proto_rawDescGZIP(), []int{2}
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *FilterECSTask) GetId() string {
@@ -258,7 +258,7 @@ type FilterKubeService struct {
 
 func (x *FilterKubeService) Reset() {
 	*x = FilterKubeService{}
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[3]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -270,7 +270,7 @@ func (x *FilterKubeService) String() string {
 func (*FilterKubeService) ProtoMessage() {}
 
 func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[3]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -283,7 +283,7 @@ func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeService.ProtoReflect.Descriptor instead.
 func (*FilterKubeService) Descriptor() ([]byte, []int) {
-	return file_comp_core_filter_def_proto_filter_proto_rawDescGZIP(), []int{3}
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *FilterKubeService) GetName() string {
@@ -318,7 +318,7 @@ type FilterKubeEndpoint struct {
 
 func (x *FilterKubeEndpoint) Reset() {
 	*x = FilterKubeEndpoint{}
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[4]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -330,7 +330,7 @@ func (x *FilterKubeEndpoint) String() string {
 func (*FilterKubeEndpoint) ProtoMessage() {}
 
 func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_filter_def_proto_filter_proto_msgTypes[4]
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -343,7 +343,7 @@ func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeEndpoint.ProtoReflect.Descriptor instead.
 func (*FilterKubeEndpoint) Descriptor() ([]byte, []int) {
-	return file_comp_core_filter_def_proto_filter_proto_rawDescGZIP(), []int{4}
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *FilterKubeEndpoint) GetName() string {
@@ -367,11 +367,55 @@ func (x *FilterKubeEndpoint) GetAnnotations() map[string]string {
 	return nil
 }
 
-var File_comp_core_filter_def_proto_filter_proto protoreflect.FileDescriptor
+type FilterImage struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
 
-const file_comp_core_filter_def_proto_filter_proto_rawDesc = "" +
+func (x *FilterImage) Reset() {
+	*x = FilterImage{}
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FilterImage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FilterImage) ProtoMessage() {}
+
+func (x *FilterImage) ProtoReflect() protoreflect.Message {
+	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FilterImage.ProtoReflect.Descriptor instead.
+func (*FilterImage) Descriptor() ([]byte, []int) {
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *FilterImage) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+var File_comp_core_workloadfilter_def_proto_filter_proto protoreflect.FileDescriptor
+
+const file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc = "" +
 	"\n" +
-	"'comp/core/filter/def/proto/filter.proto\x12\x0edatadog.filter\"\xbf\x01\n" +
+	"/comp/core/workloadfilter/def/proto/filter.proto\x12\x0edatadog.filter\"\xbf\x01\n" +
 	"\x0fFilterContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -403,37 +447,40 @@ const file_comp_core_filter_def_proto_filter_proto_rawDesc = "" +
 	"\vannotations\x18\x03 \x03(\v23.datadog.filter.FilterKubeEndpoint.AnnotationsEntryR\vannotations\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x1cZ\x1acomp/core/filter/def/protob\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"!\n" +
+	"\vFilterImage\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04nameB$Z\"comp/core/workloadfilter/def/protob\x06proto3"
 
 var (
-	file_comp_core_filter_def_proto_filter_proto_rawDescOnce sync.Once
-	file_comp_core_filter_def_proto_filter_proto_rawDescData []byte
+	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescOnce sync.Once
+	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData []byte
 )
 
-func file_comp_core_filter_def_proto_filter_proto_rawDescGZIP() []byte {
-	file_comp_core_filter_def_proto_filter_proto_rawDescOnce.Do(func() {
-		file_comp_core_filter_def_proto_filter_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_comp_core_filter_def_proto_filter_proto_rawDesc), len(file_comp_core_filter_def_proto_filter_proto_rawDesc)))
+func file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP() []byte {
+	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescOnce.Do(func() {
+		file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc), len(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc)))
 	})
-	return file_comp_core_filter_def_proto_filter_proto_rawDescData
+	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData
 }
 
-var file_comp_core_filter_def_proto_filter_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
-var file_comp_core_filter_def_proto_filter_proto_goTypes = []any{
+var file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_comp_core_workloadfilter_def_proto_filter_proto_goTypes = []any{
 	(*FilterContainer)(nil),    // 0: datadog.filter.FilterContainer
 	(*FilterPod)(nil),          // 1: datadog.filter.FilterPod
 	(*FilterECSTask)(nil),      // 2: datadog.filter.FilterECSTask
 	(*FilterKubeService)(nil),  // 3: datadog.filter.FilterKubeService
 	(*FilterKubeEndpoint)(nil), // 4: datadog.filter.FilterKubeEndpoint
-	nil,                        // 5: datadog.filter.FilterPod.AnnotationsEntry
-	nil,                        // 6: datadog.filter.FilterKubeService.AnnotationsEntry
-	nil,                        // 7: datadog.filter.FilterKubeEndpoint.AnnotationsEntry
+	(*FilterImage)(nil),        // 5: datadog.filter.FilterImage
+	nil,                        // 6: datadog.filter.FilterPod.AnnotationsEntry
+	nil,                        // 7: datadog.filter.FilterKubeService.AnnotationsEntry
+	nil,                        // 8: datadog.filter.FilterKubeEndpoint.AnnotationsEntry
 }
-var file_comp_core_filter_def_proto_filter_proto_depIdxs = []int32{
+var file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs = []int32{
 	1, // 0: datadog.filter.FilterContainer.pod:type_name -> datadog.filter.FilterPod
 	2, // 1: datadog.filter.FilterContainer.ecs_task:type_name -> datadog.filter.FilterECSTask
-	5, // 2: datadog.filter.FilterPod.annotations:type_name -> datadog.filter.FilterPod.AnnotationsEntry
-	6, // 3: datadog.filter.FilterKubeService.annotations:type_name -> datadog.filter.FilterKubeService.AnnotationsEntry
-	7, // 4: datadog.filter.FilterKubeEndpoint.annotations:type_name -> datadog.filter.FilterKubeEndpoint.AnnotationsEntry
+	6, // 2: datadog.filter.FilterPod.annotations:type_name -> datadog.filter.FilterPod.AnnotationsEntry
+	7, // 3: datadog.filter.FilterKubeService.annotations:type_name -> datadog.filter.FilterKubeService.AnnotationsEntry
+	8, // 4: datadog.filter.FilterKubeEndpoint.annotations:type_name -> datadog.filter.FilterKubeEndpoint.AnnotationsEntry
 	5, // [5:5] is the sub-list for method output_type
 	5, // [5:5] is the sub-list for method input_type
 	5, // [5:5] is the sub-list for extension type_name
@@ -441,12 +488,12 @@ var file_comp_core_filter_def_proto_filter_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_comp_core_filter_def_proto_filter_proto_init() }
-func file_comp_core_filter_def_proto_filter_proto_init() {
-	if File_comp_core_filter_def_proto_filter_proto != nil {
+func init() { file_comp_core_workloadfilter_def_proto_filter_proto_init() }
+func file_comp_core_workloadfilter_def_proto_filter_proto_init() {
+	if File_comp_core_workloadfilter_def_proto_filter_proto != nil {
 		return
 	}
-	file_comp_core_filter_def_proto_filter_proto_msgTypes[0].OneofWrappers = []any{
+	file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0].OneofWrappers = []any{
 		(*FilterContainer_Pod)(nil),
 		(*FilterContainer_EcsTask)(nil),
 	}
@@ -454,17 +501,17 @@ func file_comp_core_filter_def_proto_filter_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_comp_core_filter_def_proto_filter_proto_rawDesc), len(file_comp_core_filter_def_proto_filter_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc), len(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_comp_core_filter_def_proto_filter_proto_goTypes,
-		DependencyIndexes: file_comp_core_filter_def_proto_filter_proto_depIdxs,
-		MessageInfos:      file_comp_core_filter_def_proto_filter_proto_msgTypes,
+		GoTypes:           file_comp_core_workloadfilter_def_proto_filter_proto_goTypes,
+		DependencyIndexes: file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs,
+		MessageInfos:      file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes,
 	}.Build()
-	File_comp_core_filter_def_proto_filter_proto = out.File
-	file_comp_core_filter_def_proto_filter_proto_goTypes = nil
-	file_comp_core_filter_def_proto_filter_proto_depIdxs = nil
+	File_comp_core_workloadfilter_def_proto_filter_proto = out.File
+	file_comp_core_workloadfilter_def_proto_filter_proto_goTypes = nil
+	file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs = nil
 }

--- a/comp/core/workloadfilter/def/proto/filter.proto
+++ b/comp/core/workloadfilter/def/proto/filter.proto
@@ -38,3 +38,7 @@ message FilterKubeEndpoint {
   string namespace = 2;
   map<string, string> annotations = 3;
 }
+
+message FilterImage {
+  string name = 1;
+}

--- a/comp/core/workloadfilter/def/types.go
+++ b/comp/core/workloadfilter/def/types.go
@@ -37,6 +37,7 @@ const (
 	PodType       ResourceType = "pod"
 	ServiceType   ResourceType = "service"
 	EndpointType  ResourceType = "endpoint"
+	ImageType     ResourceType = "image"
 )
 
 //
@@ -220,6 +221,8 @@ type ServiceFilter int
 const (
 	LegacyServiceMetrics ServiceFilter = iota
 	LegacyServiceGlobal
+	ServiceADAnnotationsMetrics
+	ServiceADAnnotations
 )
 
 //
@@ -261,4 +264,46 @@ type EndpointFilter int
 const (
 	LegacyEndpointMetrics EndpointFilter = iota
 	LegacyEndpointGlobal
+	EndpointADAnnotationsMetrics
+	EndpointADAnnotations
+)
+
+//
+// Image Definition
+//
+
+// Image represents a filterable image object.
+type Image struct {
+	*typedef.FilterImage
+}
+
+// CreateImage creates a Filterable Image object.
+func CreateImage(name string) *Image {
+	return &Image{
+		FilterImage: &typedef.FilterImage{
+			Name: name,
+		},
+	}
+}
+
+var _ Filterable = &Image{}
+
+// Serialize converts the Image object to a filterable object.
+func (i *Image) Serialize() any {
+	return i.FilterImage
+}
+
+// Type returns the resource type of the image.
+func (i *Image) Type() ResourceType {
+	return ImageType
+}
+
+// ImageFilter defines the type of image filter.
+type ImageFilter int
+
+// Defined Image filter kinds
+const (
+	LegacyImage ImageFilter = iota
+	ImagePaused
+	ImageSBOM
 )

--- a/comp/core/workloadfilter/impl/filter.go
+++ b/comp/core/workloadfilter/impl/filter.go
@@ -96,6 +96,8 @@ func newFilter(config config.Component, logger log.Component, telemetry coretele
 	// Service Filters
 	filter.registerProgram(workloadfilter.ServiceType, int(workloadfilter.LegacyServiceGlobal), catalog.LegacyServiceGlobalProgram(config, logger))
 	filter.registerProgram(workloadfilter.ServiceType, int(workloadfilter.LegacyServiceMetrics), catalog.LegacyServiceMetricsProgram(config, logger))
+	filter.registerProgram(workloadfilter.ServiceType, int(workloadfilter.ServiceADAnnotations), catalog.ServiceADAnnotationsProgram(config, logger))
+	filter.registerProgram(workloadfilter.ServiceType, int(workloadfilter.ServiceADAnnotationsMetrics), catalog.ServiceADAnnotationsMetricsProgram(config, logger))
 
 	// Endpoints Filters
 	filter.registerProgram(workloadfilter.EndpointType, int(workloadfilter.LegacyEndpointGlobal), catalog.LegacyEndpointsGlobalProgram(config, logger))

--- a/comp/core/workloadfilter/impl/filter.go
+++ b/comp/core/workloadfilter/impl/filter.go
@@ -100,6 +100,13 @@ func newFilter(config config.Component, logger log.Component, telemetry coretele
 	// Endpoints Filters
 	filter.registerProgram(workloadfilter.EndpointType, int(workloadfilter.LegacyEndpointGlobal), catalog.LegacyEndpointsGlobalProgram(config, logger))
 	filter.registerProgram(workloadfilter.EndpointType, int(workloadfilter.LegacyEndpointMetrics), catalog.LegacyEndpointsMetricsProgram(config, logger))
+	filter.registerProgram(workloadfilter.EndpointType, int(workloadfilter.EndpointADAnnotations), catalog.EndpointsADAnnotationsProgram(config, logger))
+	filter.registerProgram(workloadfilter.EndpointType, int(workloadfilter.EndpointADAnnotationsMetrics), catalog.EndpointsADAnnotationsMetricsProgram(config, logger))
+
+	// Image Filters
+	filter.registerProgram(workloadfilter.ImageType, int(workloadfilter.LegacyImage), catalog.LegacyImageProgram(config, logger))
+	filter.registerProgram(workloadfilter.ImageType, int(workloadfilter.ImagePaused), catalog.ImagePausedProgram(config, logger))
+	filter.registerProgram(workloadfilter.ImageType, int(workloadfilter.ImageSBOM), catalog.ImageSBOMProgram(config, logger))
 
 	// WIP: Pod Filters
 
@@ -122,6 +129,10 @@ func (f *filter) IsServiceExcluded(service *workloadfilter.Service, serviceFilte
 
 func (f *filter) IsEndpointExcluded(endpoint *workloadfilter.Endpoint, endpointFilters [][]workloadfilter.EndpointFilter) bool {
 	return evaluateResource(f, endpoint, endpointFilters) == workloadfilter.Excluded
+}
+
+func (f *filter) IsImageExcluded(image *workloadfilter.Image, imageFilters [][]workloadfilter.ImageFilter) bool {
+	return evaluateResource(f, image, imageFilters) == workloadfilter.Excluded
 }
 
 // evaluateResource checks if a resource is excluded based on the provided filters.

--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -559,25 +559,177 @@ func TestSpecialCharacters(t *testing.T) {
 }
 
 func TestServiceFiltering(t *testing.T) {
-	mockConfig := configmock.New(t)
-	mockConfig.SetWithoutSource("container_include", []string{`name:svc1`})
-	f := newFilterObject(t, mockConfig)
+	tests := []struct {
+		name        string
+		include     []string
+		exclude     []string
+		serviceName string
+		namespace   string
+		annotations map[string]string
+		filters     [][]workloadfilter.ServiceFilter
+		expected    workloadfilter.Result
+	}{
+		{
+			name:        "Exclude by name",
+			exclude:     []string{"name:svc1"},
+			serviceName: "svc1",
+			namespace:   "",
+			annotations: nil,
+			filters:     [][]workloadfilter.ServiceFilter{{workloadfilter.LegacyServiceGlobal}},
+			expected:    workloadfilter.Excluded,
+		},
+		{
+			name:        "Exclude by namespace",
+			exclude:     []string{"kube_namespace:test"},
+			serviceName: "my-service",
+			namespace:   "test",
+			annotations: nil,
+			filters:     [][]workloadfilter.ServiceFilter{{workloadfilter.LegacyServiceGlobal}},
+			expected:    workloadfilter.Excluded,
+		},
+		{
+			name:        "AD annotation exclude",
+			serviceName: "annotated-service",
+			namespace:   "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/exclude": "true",
+			},
+			filters:  [][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotations}},
+			expected: workloadfilter.Excluded,
+		},
+		{
+			name:        "AD annotation metrics exclude",
+			serviceName: "metrics-excluded-service",
+			namespace:   "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/metrics_exclude": "true",
+			},
+			filters:  [][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotationsMetrics}},
+			expected: workloadfilter.Excluded,
+		},
+	}
 
-	service := workloadfilter.CreateService("svc1", "", nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			if len(tt.exclude) > 0 {
+				mockConfig.SetWithoutSource("container_exclude", tt.exclude)
+			}
+			f := newFilterObject(t, mockConfig)
 
-	res := evaluateResource(f, service, [][]workloadfilter.ServiceFilter{{workloadfilter.LegacyServiceGlobal}})
-	assert.Equal(t, workloadfilter.Included, res)
+			service := workloadfilter.CreateService(tt.serviceName, tt.namespace, tt.annotations)
+
+			res := evaluateResource(f, service, tt.filters)
+			assert.Equal(t, tt.expected, res)
+		})
+	}
 }
 
 func TestEndpointFiltering(t *testing.T) {
-	mockConfig := configmock.New(t)
-	mockConfig.SetWithoutSource("container_include", []string{`name:ep1`})
-	f := newFilterObject(t, mockConfig)
+	tests := []struct {
+		name         string
+		include      []string
+		exclude      []string
+		endpointName string
+		namespace    string
+		annotations  map[string]string
+		filters      [][]workloadfilter.EndpointFilter
+		expected     workloadfilter.Result
+	}{
+		{
+			name:         "Exclude by name",
+			exclude:      []string{"name:ep1"},
+			endpointName: "ep1",
+			namespace:    "",
+			annotations:  nil,
+			filters:      [][]workloadfilter.EndpointFilter{{workloadfilter.LegacyEndpointGlobal}},
+			expected:     workloadfilter.Excluded,
+		},
+		{
+			name:         "Exclude by namespace",
+			exclude:      []string{"kube_namespace:test"},
+			endpointName: "my-endpoint",
+			namespace:    "test",
+			annotations:  nil,
+			filters:      [][]workloadfilter.EndpointFilter{{workloadfilter.LegacyEndpointGlobal}},
+			expected:     workloadfilter.Excluded,
+		},
+		{
+			name:         "AD annotation exclude",
+			endpointName: "annotated-endpoint",
+			namespace:    "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/exclude": "true",
+			},
+			filters:  [][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotations}},
+			expected: workloadfilter.Excluded,
+		},
+		{
+			name:         "AD annotation metrics exclude",
+			endpointName: "metrics-excluded-endpoint",
+			namespace:    "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/metrics_exclude": "true",
+			},
+			filters:  [][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotationsMetrics}},
+			expected: workloadfilter.Excluded,
+		},
+	}
 
-	endpoint := workloadfilter.CreateEndpoint("ep1", "", nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			if len(tt.exclude) > 0 {
+				mockConfig.SetWithoutSource("container_exclude", tt.exclude)
+			}
+			f := newFilterObject(t, mockConfig)
 
-	res := evaluateResource(f, endpoint, [][]workloadfilter.EndpointFilter{{workloadfilter.LegacyEndpointGlobal}})
-	assert.Equal(t, workloadfilter.Included, res)
+			endpoint := workloadfilter.CreateEndpoint(tt.endpointName, tt.namespace, tt.annotations)
+
+			res := evaluateResource(f, endpoint, tt.filters)
+			assert.Equal(t, tt.expected, res)
+		})
+	}
+}
+
+func TestImageFiltering(t *testing.T) {
+	tests := []struct {
+		name      string
+		include   []string
+		exclude   []string
+		imageName string
+		expected  workloadfilter.Result
+	}{
+		{
+			name:      "Include by image",
+			include:   []string{"image:dd-agent"},
+			exclude:   []string{"image:nginx"},
+			imageName: "dd-agent",
+			expected:  workloadfilter.Included,
+		},
+		{
+			name:      "Exclude by image",
+			include:   []string{"image:dd-agent"},
+			exclude:   []string{"image:nginx"},
+			imageName: "nginx-123",
+			expected:  workloadfilter.Excluded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("container_include", tt.include)
+			mockConfig.SetWithoutSource("container_exclude", tt.exclude)
+
+			f := newFilterObject(t, mockConfig)
+
+			image := workloadfilter.CreateImage(tt.imageName)
+
+			res := evaluateResource(f, image, [][]workloadfilter.ImageFilter{{workloadfilter.LegacyImage}})
+			assert.Equal(t, tt.expected, res)
+		})
+	}
 }
 
 // containsErrorWithMessage checks if any error in the slice contains the specified message

--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -607,6 +607,16 @@ func TestServiceFiltering(t *testing.T) {
 			filters:  [][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotationsMetrics}},
 			expected: workloadfilter.Excluded,
 		},
+		{
+			name:        "AD annotation exclude truthy values",
+			serviceName: "annotated-service",
+			namespace:   "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/exclude": "T",
+			},
+			filters:  [][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotations}},
+			expected: workloadfilter.Excluded,
+		},
 	}
 
 	for _, tt := range tests {
@@ -670,6 +680,16 @@ func TestEndpointFiltering(t *testing.T) {
 			namespace:    "default",
 			annotations: map[string]string{
 				"ad.datadoghq.com/metrics_exclude": "true",
+			},
+			filters:  [][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotationsMetrics}},
+			expected: workloadfilter.Excluded,
+		},
+		{
+			name:         "AD annotation exclude truthy values",
+			endpointName: "metrics-excluded-endpoint",
+			namespace:    "default",
+			annotations: map[string]string{
+				"ad.datadoghq.com/metrics_exclude": "1",
 			},
 			filters:  [][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotationsMetrics}},
 			expected: workloadfilter.Excluded,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Add support for Image filtering
* Add support for service/endpoint annotation filtering
* Extend ad annotation to cover all _truthy_ values

### Motivation

Migrate container filtering mechanisms to use workloadfilter component

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit-tests and CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Potential future improvement: we can look into how to have 1 CEL program work for multiple different entities. For example, the service and endpoint entities have the same exact fields and they have duplicated programs with just the words "service" and "endpoint" substituted.

Currently separate input rules are created like `service.annotations[...] == "true"` and `endpoint.annotations[...] == "true"` but we can trick the CEL engine to process a generic object variable via `object.annotations[...] == "true"`. Only works when the fields across different objects are the exact same, which would be the case in services and endpoints.