### PR TITLE
Remove dependency on msi_and_bosh job in deploy_staging job

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -28,7 +28,7 @@ deploy_staging_windows_tags-7:
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
+  needs: ["windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -75,7 +75,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
   timeout: 2h
 
 
-# cloudfoundry IoT build for Windows
+# azure-app-services build for Windows
 windows_zip_agent_binaries_x64-a7:
   stage: package_build
   rules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove dependency on `windows_msi_and_bosh_zip_x64-a7` job in `deploy_staging_windows_tags-7` job.

### Motivation
`deploy_staging_windows_tags-7` uploads artifacts matching `"agent-binaries-7.*.zip"` to s3.
 `windows_msi_and_bosh_zip_x64-a7` doesn't have artifacts matching this regex (only `windows_zip_agent_binaries_x64-a7` does), so the dependency is useless, it's a leftover of https://github.com/DataDog/datadog-agent/pull/36830/s.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Let me know if I got something wrong 😄 