### PR TITLE
Properly parse account for GCP config

### DIFF
--- a/test/new-e2e/pkg/runner/parameters/store_config_file.go
+++ b/test/new-e2e/pkg/runner/parameters/store_config_file.go
@@ -183,6 +183,9 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		if s.config.ConfigParams.Azure.Account != "" {
 			value = value + fmt.Sprintf("az/%s ", s.config.ConfigParams.Azure.Account)
 		}
+		if s.config.ConfigParams.GCP.Account != "" {
+			value = value + fmt.Sprintf("gcp/%s ", s.config.ConfigParams.GCP.Account)
+		}
 		value = strings.TrimSpace(value)
 
 	case VerifyCodeSignature:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make sure the gcp account is properly parsed in `~/.test_infra_config.yml` when running GCP e2e tests locally.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->