### PR TITLE
[EBPF]: gpum: create collectors only for physical GPU devices

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -91,7 +91,7 @@ func BuildCollectors(deps *CollectorDependencies) ([]Collector, error) {
 func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]subsystemBuilder) ([]Collector, error) {
 	var collectors []Collector
 
-	for _, dev := range deps.DeviceCache.All() {
+	for _, dev := range deps.DeviceCache.AllPhysicalDevices() {
 		for name, builder := range builders {
 			c, err := builder(dev)
 			if errors.Is(err, errUnsupportedDevice) {

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -118,7 +118,7 @@ func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Componen
 
 	tagsMapping := make(map[string][]string, devCount)
 
-	for _, dev := range deviceCache.All() {
+	for _, dev := range deviceCache.AllPhysicalDevices() {
 		uuid := dev.GetDeviceInfo().UUID
 		entityID := taggertypes.NewEntityID(taggertypes.GPU, uuid)
 		tags, err := tagger.Tag(entityID, taggertypes.ChecksConfigCardinality)

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
-func TestCollectorsStillInitIfOneFails(t *testing.T) {
+func TestCollectorsInit(t *testing.T) {
 	succeedCollector := &mockCollector{}
 	factorySucceeded := false
 
@@ -44,7 +44,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	collectorsFactory := map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory}
 	collectors, err := buildCollectors(deps, collectorsFactory)
 	require.NotNil(t, collectors)
-	require.Len(t, collectors, len(deviceCache.AllPhysicalDevices())*len(collectorsFactory))
+	require.Len(t, collectors, len(deviceCache.AllPhysicalDevices()))
 	require.NoError(t, err)
 }
 

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -36,13 +36,15 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 		return nil, errors.New("failure")
 	}
 
-	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
+	nvmlMock := testutil.GetBasicNvmlMockWithOptions()
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache, err := ddnvml.NewDeviceCache()
 	require.NoError(t, err)
 	deps := &CollectorDependencies{DeviceCache: deviceCache}
-	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
+	collectorsFactory := map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory}
+	collectors, err := buildCollectors(deps, collectorsFactory)
 	require.NotNil(t, collectors)
+	require.Len(t, collectors, len(deviceCache.AllPhysicalDevices())*len(collectorsFactory))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
### What does this PR do?

changed collectors factory to create collectors inside the gpum core-check only for the physical devices (skipping the MIG devices for now)

### Motivation

most of the NVML API is not supported for MIG

### Describe how you validated your changes

updated the UTs to validate the change

### Possible Drawbacks / Trade-offs

### Additional Notes
we will need to address MIG in the future as a wide initiative