### PR TITLE
[USMON-1328] usm: tests: Support IPv6 in external unix socket proxy

### DIFF
--- a/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
+++ b/pkg/network/tracer/testutil/proxy/external_unix_proxy_server/external_unix_proxy_server.go
@@ -23,12 +23,14 @@ func main() {
 	var useTLS bool
 	var useControl bool
 	var useSplice bool
+	var useIPv6 bool
 
 	flag.StringVar(&remoteAddr, "remote", "", "Remote server address to forward connections to")
 	flag.StringVar(&unixPath, "unix", "/tmp/transparent.sock", "A local unix socket to listen on")
 	flag.BoolVar(&useTLS, "tls", false, "Use TLS to connect to the remote server")
 	flag.BoolVar(&useControl, "control", false, "Use control messages")
 	flag.BoolVar(&useSplice, "splice", false, "Use splice(2) to transfer data")
+	flag.BoolVar(&useIPv6, "ipv6", false, "Use IPv6 to connect to the remote server")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -36,7 +38,7 @@ func main() {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT)
 
-	srv := proxy.NewUnixTransparentProxyServer(unixPath, remoteAddr, useTLS, useControl, useSplice)
+	srv := proxy.NewUnixTransparentProxyServer(unixPath, remoteAddr, useTLS, useControl, useSplice, useIPv6)
 	defer srv.Stop()
 
 	if err := srv.Run(); err != nil {

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_builder.go
@@ -24,7 +24,7 @@ const (
 	serverSrcPath = "external_unix_proxy_server"
 )
 
-func newExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS, useControl bool) (*exec.Cmd, context.CancelFunc) {
+func newExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS, useControl, useIPv6 bool) (*exec.Cmd, context.CancelFunc) {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 	serverBin, err := usmtestutil.BuildGoBinaryWrapper(curDir, serverSrcPath)
@@ -36,6 +36,9 @@ func newExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr st
 	}
 	if useControl {
 		args = append(args, "-control")
+	}
+	if useIPv6 {
+		args = append(args, "-ipv6")
 	}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	commandLine := strings.Join(args, " ")
@@ -51,12 +54,12 @@ func newExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr st
 }
 
 // NewExternalUnixTransparentProxyServer triggers an external unix transparent proxy (plaintext or TLS) server.
-func NewExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS bool) (*exec.Cmd, context.CancelFunc) {
-	return newExternalUnixTransparentProxyServer(t, unixPath, remoteAddr, useTLS, false)
+func NewExternalUnixTransparentProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS, useIPv6 bool) (*exec.Cmd, context.CancelFunc) {
+	return newExternalUnixTransparentProxyServer(t, unixPath, remoteAddr, useTLS, false, useIPv6)
 }
 
 // NewExternalUnixControlProxyServer triggers an external unix proxy (plaintext or TLS) server with control
 // messages.
-func NewExternalUnixControlProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS bool) (*exec.Cmd, context.CancelFunc) {
-	return newExternalUnixTransparentProxyServer(t, unixPath, remoteAddr, useTLS, true)
+func NewExternalUnixControlProxyServer(t *testing.T, unixPath, remoteAddr string, useTLS, useIPv6 bool) (*exec.Cmd, context.CancelFunc) {
+	return newExternalUnixTransparentProxyServer(t, unixPath, remoteAddr, useTLS, true, useIPv6)
 }

--- a/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
+++ b/pkg/network/tracer/testutil/proxy/unix_transparent_proxy_test.go
@@ -38,7 +38,7 @@ func TestUnixTransparentParentProxy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Start the proxy server.
-			_, cancel := NewExternalUnixTransparentProxyServer(t, unixPath, remoteServerAddr, tt.useTLS)
+			_, cancel := NewExternalUnixTransparentProxyServer(t, unixPath, remoteServerAddr, tt.useTLS, false)
 			t.Cleanup(cancel)
 
 			// Start the remote server.

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -608,7 +608,7 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 		},
 	}
 
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, serverAddress, tls)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, serverAddress, tls, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -849,7 +849,7 @@ func (can *CannedClientServer) runServer() {
 }
 
 func (can *CannedClientServer) runProxy() int {
-	proxyProcess, cancel := proxy.NewExternalUnixControlProxyServer(can.t, can.unixPath, can.address, can.tls)
+	proxyProcess, cancel := proxy.NewExternalUnixControlProxyServer(can.t, can.unixPath, can.address, can.tls, false)
 	can.t.Cleanup(cancel)
 	require.NoError(can.t, proxy.WaitForConnectionReady(can.unixPath))
 

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -141,7 +141,7 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -203,7 +203,7 @@ func (s *usmHTTP2Suite) TestSimpleHTTP2() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -398,7 +398,7 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -528,7 +528,7 @@ func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -595,7 +595,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -1357,7 +1357,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -1438,7 +1438,7 @@ func (s *usmHTTP2Suite) TestIncompleteFrameTable() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
@@ -1512,7 +1512,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 	t.Cleanup(usmhttp2.StartH2CServer(t, authority, s.isTLS))
 
 	// Start the proxy server.
-	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS)
+	proxyProcess, cancel := proxy.NewExternalUnixTransparentProxyServer(t, unixPath, authority, s.isTLS, false)
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introducing the ability to use IPv6 in the unix-proxy server

### Motivation

Preliminary change for a future PR, refactoring our GO-TLS uprobes.
In that PR we will need to test both IPv4 and IPv6 scenarios.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->