### PR TITLE
disable THP by default in system-probe and the security-agent

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -954,7 +954,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("security_agent.cmd_port", DefaultSecurityAgentCmdPort)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", DefaultSecurityAgentLogFile)
-	config.BindEnvAndSetDefault("security_agent.disable_thp", false)
+	config.BindEnvAndSetDefault("security_agent.disable_thp", true)
 
 	// debug config to enable a remote client to receive data from the workloadmeta agent without a timeout
 	config.BindEnvAndSetDefault("workloadmeta.remote.recv_without_timeout", true)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -67,7 +67,7 @@ var (
 func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), false)
+	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), true)
 
 	// SBOM configuration
 	cfg.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/releasenotes/notes/sysprobe-secagent-disable-thp-9e34012727ff917c.yaml
+++ b/releasenotes/notes/sysprobe-secagent-disable-thp-9e34012727ff917c.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Transparent Huge Pages (THP) usage is now disabled by default
+    in the System Probe and Security Agent. To re-enable their usage,
+    set the `system_probe_config.disable_thp` or `security_agent.disable_thp`
+    configuration options to `false`.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR disables THP usage in the system-probe and the security-agent by default. After running a lot of benchmarks and  internal deployments, we showed that the impact of disabling THPs was neutral or positive, especially in the SMP environment.

Internally we deploy the agent on nodes configured with transparent huge pages configed in madvise mode. This means that only pages that have an additional `madvise` call on them with `MADV_HUGEPAGE` will make use of huge pages. The go runtime does not make this call in the general case, meaning that we have deployed the agent internally with THP disabled since basically forever.

In SMP benchmarks, the impact of disabling THP allows the system-probe and the security agent to not exhibit extra memory usage at the end of the 10 min run:
baseline:
<img width="1464" alt="image" src="https://github.com/user-attachments/assets/935c4d09-887e-4f0d-9580-1b3e06bc9989" />
comparison:
<img width="1464" alt="image" src="https://github.com/user-attachments/assets/ff9c989a-50da-42dd-ae48-db8f90d54ef7" />
in this particular benchmark the maximum PSS for the total container going from 545MiB to 517MiB with THPs disabled.


Re-enabling THP usage is still possible using the `system_probe_config.disable_thp` or `security_agent.disable_thp` configuration options.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->