### PR TITLE
Reapply [CIP] feat: Use s3 clone strategy for datadog-agent CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,6 +252,9 @@ variables:
   DD_PKG_VERSION: "latest"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
+  # Job cloning strategy
+  OVERRIDE_GIT_STRATEGY: "s3"
+
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2
   EXECUTOR_JOB_SECTION_ATTEMPTS: 2
@@ -261,6 +264,7 @@ variables:
   FF_SCRIPT_SECTIONS: 1 # Prevent multiline scripts log collapsing, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3392
   FF_KUBERNETES_HONOR_ENTRYPOINT: true # Honor the entrypoint in the Docker image when running Kubernetes jobs
   FF_TIMESTAMPS: true
+  FF_USE_FASTZIP: true
 
 #
 # Condition mixins for simplification of rules

--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -63,6 +63,7 @@ job-owners:
     - build_otel_agent_binary_arm64
     - build_otel_agent_binary_x64
     - cancel-prev-pipelines
+    - clone
     - close_failing_tests_stale_issues
     - compute_gitlab_ci_config
     - deploy_cluster_agent_cloudfoundry

--- a/.gitlab/.pre/clone.yml
+++ b/.gitlab/.pre/clone.yml
@@ -1,0 +1,27 @@
+# NOTE: Used for the git s3 strategy for the gitlab runners, see
+# https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3622535770/GitLab+Runners+Fork+Features#%F0%9F%AA%A3--Git-S3-Strategy
+clone:
+  stage: .pre
+  tags:
+    - arch:amd64
+  variables:
+    KUBERNETES_MEMORY_REQUEST: "64Mi"
+    KUBERNETES_MEMORY_LIMIT: "64Mi"
+    KUBERNETES_CPU_REQUEST: "0.1"
+    KUBERNETES_CPU_LIMIT: "0.1"
+    OVERRIDE_GIT_STRATEGY: "fetch"
+    DD_METRICS_TAGS: "clone:true"
+    CACHE_COMPRESSION_LEVEL: "fastest"
+    CACHE_COMPRESSION_FORMAT: "tarzstd"
+    CLONE_TO_S3: "true"
+  script: "echo 'Repo is cloned from Gitaly, will upload to s3...'"
+  retry:
+    max: 2
+    when:
+      - api_failure
+      - data_integrity_failure
+      - runner_system_failure
+      - scheduler_failure
+      - unknown_failure
+      - unmet_prerequisites
+

--- a/.gitlab/.pre/include.yml
+++ b/.gitlab/.pre/include.yml
@@ -2,5 +2,6 @@
 # Define preliminary jobs, which can start as soon as possible
 
 include:
+  - .gitlab/.pre/clone.yml
   - .gitlab/.pre/cancel-prev-pipelines.yml
   - .gitlab/.pre/ci_configuration.yml


### PR DESCRIPTION
Reapplies DataDog/datadog-agent#35902.

Since [this](https://datadoghq.atlassian.net/browse/CIP-679) is done, we can now use the s3 clone git strategy since the key is computed thanks to the commit and the ref (was only commit before).