### PR TITLE
[otel] support db.namespace semantic for OTel

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -624,6 +624,14 @@ func (o *OTLPReceiver) convertSpan(res pcommon.Resource, lib pcommon.Instrumenta
 			transform.SetMetaOTLP(span, "env", normalize.NormalizeTag(env))
 		}
 	}
+
+	// Check for db.namespace and conditionally set db.name
+	if _, ok := span.Meta["db.name"]; !ok {
+		if dbNamespace := traceutil.GetOTelAttrValInResAndSpanAttrs(in, res, false, string(semconv127.DBNamespaceKey)); dbNamespace != "" {
+			transform.SetMetaOTLP(span, "db.name", dbNamespace)
+		}
+	}
+
 	if in.TraceState().AsRaw() != "" {
 		transform.SetMetaOTLP(span, "w3c.tracestate", in.TraceState().AsRaw())
 	}

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -444,7 +444,7 @@ func OtelSpanToDDSpan(
 
 	// Check for db.namespace and conditionally set db.name
 	if _, ok := ddspan.Meta["db.name"]; !ok {
-		if dbNamespace := traceutil.GetOTelAttrFromEitherMap(otelres.Attributes(), otelspan.Attributes(), false, string(semconv127.DBNamespaceKey)); dbNamespace != "" {
+		if dbNamespace := traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, false, string(semconv127.DBNamespaceKey)); dbNamespace != "" {
 			ddspan.Meta["db.name"] = dbNamespace
 		}
 	}

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -19,14 +19,15 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	semconv127 "go.opentelemetry.io/otel/semconv/v1.27.0"
 
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
+
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	normalizeutil "github.com/DataDog/datadog-agent/pkg/trace/traceutil/normalize"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 )
 
 const (
@@ -439,6 +440,13 @@ func OtelSpanToDDSpan(
 
 	for k, v := range lib.Attributes().Range {
 		ddspan.Meta[k] = v.AsString()
+	}
+
+	// Check for db.namespace and conditionally set db.name
+	if _, ok := ddspan.Meta["db.name"]; !ok {
+		if dbNamespace := traceutil.GetOTelAttrFromEitherMap(otelres.Attributes(), otelspan.Attributes(), false, string(semconv127.DBNamespaceKey)); dbNamespace != "" {
+			ddspan.Meta["db.name"] = dbNamespace
+		}
 	}
 
 	return ddspan

--- a/releasenotes/notes/support-db-namespace-semantic-fb9b1b20e3c23f37.yaml
+++ b/releasenotes/notes/support-db-namespace-semantic-fb9b1b20e3c23f37.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OTLP spans support `db.namespace` semantic and map to `db.name` for DBM support.
+


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
adds code for OTLP to map `db.namespace` to `db.name`
### Motivation
properly support required DBM semantics
### Describe how you validated your changes
add unit tests
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
make spans slightly longer (shouldn't be more than the name of the database)
### Additional Notes
if `db.name` and `db.namespace` are included, leaves `db.name` alone
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->