### PR TITLE
[AGTMETRICS-307] Use separate channel for configuration changes

### DIFF
--- a/comp/autoscaling/datadogclient/impl/client.go
+++ b/comp/autoscaling/datadogclient/impl/client.go
@@ -130,3 +130,9 @@ func createDatadogClient(cfg configComponent.Component, logger logComp.Component
 	}
 	return newDatadogSingleClient(cfg, logger)
 }
+
+func (d *datadogClientWrapper) getNumberOfRefreshes() int {
+	d.mux.RLock()
+	defer d.mux.RUnlock()
+	return d.numberOfRefreshes
+}

--- a/comp/autoscaling/datadogclient/impl/client_test.go
+++ b/comp/autoscaling/datadogclient/impl/client_test.go
@@ -13,11 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 func TestNewSingleClient(t *testing.T) {
@@ -95,7 +96,7 @@ func TestExternalMetricsProviderEndpointAndRefresh(t *testing.T) {
 	cfg.Set("api_key", newAPIKey, pkgconfigmodel.SourceLocalConfigProcess)
 	cfg.Set("app_key", newAPPKey, pkgconfigmodel.SourceLocalConfigProcess)
 	assert.Eventually(t, func() bool {
-		return datadogClientWithRefresh.numberOfRefreshes > 0
+		return datadogClientWithRefresh.getNumberOfRefreshes() > 0
 	}, 5*time.Second, 200*time.Millisecond)
 	datadogClientWithRefresh.QueryMetrics(0, 1, query)
 	payload2 := <-reqs

--- a/comp/forwarder/defaultforwarder/default_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder_test.go
@@ -8,13 +8,15 @@ package defaultforwarder
 import (
 	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // domainAPIKeyMap used by tests to get API keys from each domain resolver
@@ -54,6 +56,10 @@ func TestDefaultForwarderUpdateAPIKey(t *testing.T) {
 
 	// update the APIKey by setting it on the config
 	mockConfig.Set("api_key", "api_key4", pkgconfigmodel.SourceAgentRuntime)
+
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, mockConfig.Get("api_key"), "api_key4")
+	}, 5*time.Second, 200*time.Millisecond)
 
 	// API keys still match after the update
 	expectData = `{"example1.com":["api_key4","api_key2"],"example2.com":["api_key3"]}`
@@ -95,6 +101,10 @@ func TestDefaultForwarderUpdateAdditionalEndpointAPIKey(t *testing.T) {
 		map[string][]string{"example1.com": {"api_key2"}},
 		pkgconfigmodel.SourceAgentRuntime,
 	)
+
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, mockConfig.Get("additional_endpoints"), map[string][]string{"example1.com": {"api_key2"}})
+	}, 5*time.Second, 200*time.Millisecond)
 
 	// The endpoint has both api keys
 	expectData = `{"example1.com":["api_key1","api_key2"],"example2.com":["api_key3"]}`

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -197,10 +197,12 @@ func TestUpdateAPIKey(t *testing.T) {
 	// update the API Key
 	fh.UpdateAPIKeys(ts1.URL, []string{"api_key1"}, []string{"api_key4"})
 
-	// ensure that keysPerAPIEndpoint has the new API Key
-	data, _ = json.Marshal(fh.keysPerAPIEndpoint)
 	expect = fmt.Sprintf(`{"http://127.0.0.1:%s":["api_key2","api_key4"],"http://127.0.0.1:%s":["api_key3"]}`, ts1Port, ts2Port)
-	assert.Equal(t, expect, string(data))
+	assert.Eventually(t, func() bool {
+		// ensure that keysPerAPIEndpoint has the new API Key
+		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
+		return assert.Equal(t, expect, string(data))
+	}, 5*time.Second, 200*time.Millisecond)
 }
 
 func quoteList(list []string) string {
@@ -278,7 +280,7 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	assert.Eventually(t, func() bool {
 		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
-	}, 5*time.Second, 1*time.Second)
+	}, 5*time.Second, 200*time.Millisecond)
 	endpoints := map[string][]string{
 		ts2.URL: keysAfter,
 	}

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -271,12 +271,12 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	expectAfterFmt := quoteList(expectAfter)
 
 	// forwardHealth's keysPerAPIEndpoint has the given API Keys
-	data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 	expect := fmt.Sprintf(`{"http://127.0.0.1:%s":["api_key1"],"http://127.0.0.1:%s":[%v]}`,
 		ts1Port, ts2Port,
 		expectBeforeFmt)
 
 	assert.Eventually(t, func() bool {
+		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
 	}, 5*time.Second, 1*time.Second)
 
@@ -287,11 +287,11 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	cfg.SetWithoutSource("additional_endpoints", endpoints)
 
 	// Ensure that keysPerAPIEndpoint has the new API Key
-	data, _ = json.Marshal(fh.keysPerAPIEndpoint)
 	expect = fmt.Sprintf(`{"http://127.0.0.1:%s":["api_key1"],"http://127.0.0.1:%s":[%v]}`,
 		ts1Port, ts2Port,
 		expectAfterFmt)
 	assert.Eventually(t, func() bool {
+		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
 	}, 5*time.Second, 1*time.Second)
 
@@ -319,19 +319,19 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	cfg.SetWithoutSource("additional_endpoints", endpoints)
 
 	// Ensure that keysPerAPIEndpoint are restored to previous
-	data, _ = json.Marshal(fh.keysPerAPIEndpoint)
 	expect = fmt.Sprintf(`{"http://127.0.0.1:%s":["api_key1"],"http://127.0.0.1:%s":[%v]}`,
 		ts1Port, ts2Port,
 		expectBeforeFmt)
 	assert.Eventually(t, func() bool {
+		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
-	}, 5*time.Second, 1*time.Second)
+	}, 10*time.Second, 200*time.Millisecond)
 
 	// Check the old keys are now valid again
 	for _, key := range expectBefore {
 		assert.Eventually(t, func() bool {
 			return assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-		}, 5*time.Second, 1*time.Second)
+		}, 10*time.Second, 200*time.Millisecond)
 	}
 
 	// Check added keys are now not valid
@@ -339,7 +339,7 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 		if !slices.Contains(expectBefore, key) {
 			assert.Eventually(t, func() bool {
 				return assert.Nil(t, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-			}, 5*time.Second, 1*time.Second)
+			}, 10*time.Second, 200*time.Millisecond)
 		}
 	}
 }

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -265,7 +265,7 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	fh.init()
 	assert.Eventually(t, func() bool {
 		return assert.True(t, fh.checkValidAPIKey(), description)
-	}, 5*time.Second, 1*time.Second)
+	}, 5*time.Second, 200*time.Millisecond)
 
 	expectBeforeFmt := quoteList(expectBefore)
 	expectAfterFmt := quoteList(expectAfter)
@@ -279,27 +279,25 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
 	}, 5*time.Second, 1*time.Second)
-
 	endpoints := map[string][]string{
 		ts2.URL: keysAfter,
 	}
 	// Setting the config will send the change to the resolver, which updates the health check
 	cfg.SetWithoutSource("additional_endpoints", endpoints)
 
-	// Ensure that keysPerAPIEndpoint has the new API Key
 	expect = fmt.Sprintf(`{"http://127.0.0.1:%s":["api_key1"],"http://127.0.0.1:%s":[%v]}`,
 		ts1Port, ts2Port,
 		expectAfterFmt)
 	assert.Eventually(t, func() bool {
 		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
-	}, 5*time.Second, 1*time.Second)
+	}, 5*time.Second, 200*time.Millisecond)
 
 	// Check the new keys are now valid
 	for _, key := range expectAfter {
 		assert.Eventually(t, func() bool {
 			return assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-		}, 5*time.Second, 1*time.Second)
+		}, 5*time.Second, 200*time.Millisecond)
 	}
 
 	// Check removed keys are not valid
@@ -307,7 +305,7 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 		if !slices.Contains(expectAfter, key) {
 			assert.Eventually(t, func() bool {
 				return assert.Nil(t, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-			}, 5*time.Second, 1*time.Second)
+			}, 5*time.Second, 200*time.Millisecond)
 		}
 	}
 
@@ -325,13 +323,13 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 	assert.Eventually(t, func() bool {
 		data, _ := json.Marshal(fh.keysPerAPIEndpoint)
 		return assert.Equal(t, expect, string(data), description)
-	}, 10*time.Second, 200*time.Millisecond)
+	}, 5*time.Second, 200*time.Millisecond)
 
 	// Check the old keys are now valid again
 	for _, key := range expectBefore {
 		assert.Eventually(t, func() bool {
 			return assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-		}, 10*time.Second, 200*time.Millisecond)
+		}, 5*time.Second, 200*time.Millisecond)
 	}
 
 	// Check added keys are now not valid
@@ -339,7 +337,7 @@ func runUpdateAPIKeysTest(t *testing.T, description string, keysBefore, keysAfte
 		if !slices.Contains(expectBefore, key) {
 			assert.Eventually(t, func() bool {
 				return assert.Nil(t, apiKeyStatus.Get("API key ending with "+key[len(key)-5:]), key)
-			}, 10*time.Second, 200*time.Millisecond)
+			}, 5*time.Second, 200*time.Millisecond)
 		}
 	}
 }

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -110,10 +110,16 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
-	suite.Equal("azerty", endpoint.GetAPIKey())
-	suite.Equal("", endpoint.Host)
-	suite.Equal(1234, endpoint.Port)
-	suite.True(endpoint.UseSSL())
+	assert.Eventually(suite.T(), func() bool {
+		suite.Equal("azerty", endpoint.GetAPIKey())
+		return assert.Equal(suite.T(), "", endpoint.Host)
+	}, 5*time.Second, 1*time.Second)
+	assert.Eventually(suite.T(), func() bool {
+		return assert.Equal(suite.T(), 1234, endpoint.Port)
+	}, 5*time.Second, 1*time.Second)
+	assert.Eventually(suite.T(), func() bool {
+		return assert.True(suite.T(), endpoint.UseSSL())
+	}, 5*time.Second, 1*time.Second)
 	suite.Equal("boz:1234", endpoint.ProxyAddress)
 	suite.Equal(1, len(endpoints.Endpoints))
 }
@@ -678,13 +684,21 @@ func (suite *EndpointsTestSuite) TestLogsConfigApiKeyRotation() {
 
 	// change API key at runtime
 	suite.config.SetWithoutSource("api_key", "5678")
-	suite.Equal("1234", tcp.GetAPIKey())
-	suite.Equal("1234", http.GetAPIKey())
+	assert.Eventually(suite.T(), func() bool {
+		return assert.Equal(suite.T(), "1234", tcp.GetAPIKey())
+	}, 5*time.Second, 1*time.Second)
+	assert.Eventually(suite.T(), func() bool {
+		return assert.Equal(suite.T(), "1234", http.GetAPIKey())
+	}, 5*time.Second, 1*time.Second)
 
 	// change API key at runtime
 	suite.config.SetWithoutSource("logs_config.api_key", "5678")
-	suite.Equal("5678", tcp.GetAPIKey())
-	suite.Equal("5678", http.GetAPIKey())
+	assert.Eventually(suite.T(), func() bool {
+		return assert.Equal(suite.T(), "5678", tcp.GetAPIKey())
+	}, 5*time.Second, 1*time.Second)
+	assert.Eventually(suite.T(), func() bool {
+		return assert.Equal(suite.T(), "5678", http.GetAPIKey())
+	}, 5*time.Second, 1*time.Second)
 }
 
 func (suite *EndpointsTestSuite) TestEndpointOnUpdate() {
@@ -722,9 +736,11 @@ func (suite *EndpointsTestSuite) TestEndpointOnUpdate() {
 			additionalEndpoints := additionalEndpointsLoader(mainEndpoint, logsConfig)
 			suite.Suite.Require().Len(additionalEndpoints, 2)
 
-			suite.Equal("1234", mainEndpoint.GetAPIKey())
-			suite.Equal("abcd", additionalEndpoints[0].GetAPIKey())
-			suite.Equal("defg", additionalEndpoints[1].GetAPIKey())
+			assert.Eventually(suite.T(), func() bool {
+				return assert.Equal(suite.T(), "1234", mainEndpoint.GetAPIKey()) &&
+					assert.Equal(suite.T(), "abcd", additionalEndpoints[0].GetAPIKey()) &&
+					assert.Equal(suite.T(), "defg", additionalEndpoints[1].GetAPIKey())
+			}, 5*time.Second, 1*time.Second)
 
 			// Setting new values in the config will notify the endpoints and update them
 			suite.config.SetWithoutSource("logs_config.api_key", "1234_updated")
@@ -744,23 +760,29 @@ func (suite *EndpointsTestSuite) TestEndpointOnUpdate() {
 			"is_reliable": false
 			}]`)
 
-			suite.Equal("1234_updated", mainEndpoint.GetAPIKey())
-			suite.Equal("abcd_updated", additionalEndpoints[0].GetAPIKey())
-			suite.Equal("defg_updated", additionalEndpoints[1].GetAPIKey())
+			assert.Eventually(suite.T(), func() bool {
+				return assert.Equal(suite.T(), "1234_updated", mainEndpoint.GetAPIKey()) &&
+					assert.Equal(suite.T(), "abcd_updated", additionalEndpoints[0].GetAPIKey()) &&
+					assert.Equal(suite.T(), "defg_updated", additionalEndpoints[1].GetAPIKey())
+			}, 5*time.Second, 1*time.Second)
 
 			// We trigger an unrelated update and verify that it was correctly ignored
 			suite.config.SetWithoutSource("api_key", "top_key_update")
 
-			suite.Equal("1234_updated", mainEndpoint.GetAPIKey())
-			suite.Equal("abcd_updated", additionalEndpoints[0].GetAPIKey())
-			suite.Equal("defg_updated", additionalEndpoints[1].GetAPIKey())
+			assert.Eventually(suite.T(), func() bool {
+				return assert.Equal(suite.T(), "1234_updated", mainEndpoint.GetAPIKey()) &&
+					assert.Equal(suite.T(), "abcd_updated", additionalEndpoints[0].GetAPIKey()) &&
+					assert.Equal(suite.T(), "defg_updated", additionalEndpoints[1].GetAPIKey())
+			}, 5*time.Second, 1*time.Second)
 
 			// We trigger an update with invalid types
 			suite.config.SetWithoutSource("logs_config.api_key", 0.1)
 
-			suite.Equal("1234_updated", mainEndpoint.GetAPIKey())
-			suite.Equal("abcd_updated", additionalEndpoints[0].GetAPIKey())
-			suite.Equal("defg_updated", additionalEndpoints[1].GetAPIKey())
+			assert.Eventually(suite.T(), func() bool {
+				return assert.Equal(suite.T(), "1234_updated", mainEndpoint.GetAPIKey()) &&
+					assert.Equal(suite.T(), "abcd_updated", additionalEndpoints[0].GetAPIKey()) &&
+					assert.Equal(suite.T(), "defg_updated", additionalEndpoints[1].GetAPIKey())
+			}, 5*time.Second, 1*time.Second)
 		})
 	}
 }

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -646,13 +646,17 @@ func (suite *EndpointsTestSuite) TestMainApiKeyRotation() {
 	tcp := newTCPEndpoint(logsConfig)
 	http := newHTTPEndpoint(logsConfig)
 
-	suite.Equal("1234", tcp.GetAPIKey())
-	suite.Equal("1234", http.GetAPIKey())
+	suite.Eventually(func() bool {
+		return assert.Equal(suite.T(), "1234", tcp.GetAPIKey()) &&
+			assert.Equal(suite.T(), "1234", http.GetAPIKey())
+	}, 5*time.Second, 200*time.Millisecond)
 
 	// change API key at runtime
 	suite.config.SetWithoutSource("api_key", "5678")
-	suite.Equal("5678", tcp.GetAPIKey())
-	suite.Equal("5678", http.GetAPIKey())
+	suite.Eventually(func() bool {
+		return assert.Equal(suite.T(), "5678", tcp.GetAPIKey()) &&
+			assert.Equal(suite.T(), "5678", http.GetAPIKey())
+	}, 5*time.Second, 200*time.Millisecond)
 }
 
 func (suite *EndpointsTestSuite) TestLogCompressionKind() {

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -282,7 +282,9 @@ func TestConfigRefresh(t *testing.T) {
 
 	assert.False(t, ia.RefreshTriggered())
 	cfg.Set("inventories_max_interval", 10*60, pkgconfigmodel.SourceAgentRuntime)
-	assert.True(t, ia.RefreshTriggered())
+	assert.Eventually(t, func() bool {
+		return assert.True(t, ia.RefreshTriggered())
+	}, 5*time.Second, 1*time.Second)
 }
 
 func TestStatusHeaderProvider(t *testing.T) {

--- a/comp/metadata/inventoryotel/inventoryotelimpl/inventoryotel_test.go
+++ b/comp/metadata/inventoryotel/inventoryotelimpl/inventoryotel_test.go
@@ -82,5 +82,7 @@ func TestConfigRefresh(t *testing.T) {
 
 	assert.False(t, io.RefreshTriggered())
 	cfg.Set("inventories_max_interval", 10*60, pkgconfigmodel.SourceAgentRuntime)
-	assert.True(t, io.RefreshTriggered())
+	assert.Eventually(t, func() bool {
+		return assert.True(t, io.RefreshTriggered())
+	}, 5*time.Second, 200*time.Millisecond)
 }

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -132,6 +132,7 @@ type ConfigChangeNotification struct {
 	PreviousValue any
 	NewValue      any
 	SequenceID    uint64
+	Receivers     []NotificationReceiver
 }
 
 // Reader is a subset of Config that only allows reading of configuration

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -126,6 +126,14 @@ type Proxy struct {
 // 'NotificationReceiver' should not be blocking.
 type NotificationReceiver func(setting string, oldValue, newValue any, sequenceID uint64)
 
+// ConfigChangeNotification stores the information about a change in the configuration and is sent to the listeners.
+type ConfigChangeNotification struct {
+	Key           string
+	PreviousValue any
+	NewValue      any
+	SequenceID    uint64
+}
+
 // Reader is a subset of Config that only allows reading of configuration
 type Reader interface {
 	Get(key string) interface{}
@@ -157,6 +165,7 @@ type Reader interface {
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string
+	AllSettingsWithSequenceID() (map[string]interface{}, uint64)
 
 	// SetTestOnlyDynamicSchema is used by tests to disable validation of the config schema
 	// This lets tests use the config is more flexible ways (can add to the schema at any point,

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -129,8 +129,8 @@ type NotificationReceiver func(setting string, oldValue, newValue any, sequenceI
 // ConfigChangeNotification stores the information about a change in the configuration and is sent to the listeners.
 type ConfigChangeNotification struct {
 	Key           string
-	PreviousValue any
-	NewValue      any
+	PreviousValue interface{}
+	NewValue      interface{}
 	SequenceID    uint64
 	Receivers     []NotificationReceiver
 }

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -948,12 +948,16 @@ func TestWithApiKeyUpdate(t *testing.T) {
 	service.uptane = uptaneClient
 
 	cfg.SetWithoutSource("api_key", "updated")
-	assert.Equal(t, "updated", updatedKey)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, "updated", updatedKey)
+	}, 5*time.Second, 1*time.Second)
 
 	// We still use the new key even if the new org doesn't match the old org.
 	orgResponse.Uuid = "badUuid"
 	cfg.SetWithoutSource("api_key", "BAD_ORG")
-	assert.Equal(t, "BAD_ORG", updatedKey)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, "BAD_ORG", updatedKey)
+	}, 5*time.Second, 1*time.Second)
 
 }
 

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -921,14 +921,12 @@ func TestWithApiKeyUpdate(t *testing.T) {
 	api := &mockAPI{}
 	uptaneClient := &mockCoreAgentUptane{}
 	updatedKey := "notUpdated"
-
+	notifications := make(chan string, 10)
 	api.On("UpdateAPIKey", mock.Anything).Run(func(args mock.Arguments) {
 		updatedKey = args.Get(0).(string)
+		notifications <- updatedKey
 	})
-	orgResponse := pbgo.OrgDataResponse{
-		Uuid: "firstUuid",
-	}
-	api.On("FetchOrgData", mock.Anything).Return(&orgResponse, nil)
+	api.On("FetchOrgData", mock.Anything).Return(&pbgo.OrgDataResponse{Uuid: "firstUuid"}, nil)
 	uptaneClient.On("StoredOrgUUID").Return("firstUuid", nil)
 
 	cfg := configmock.New(t)
@@ -948,17 +946,22 @@ func TestWithApiKeyUpdate(t *testing.T) {
 	service.uptane = uptaneClient
 
 	cfg.SetWithoutSource("api_key", "updated")
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, "updated", updatedKey)
-	}, 5*time.Second, 1*time.Second)
+	select {
+	case <-notifications:
+		assert.Equal(t, "updated", updatedKey)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for notification")
+	}
 
 	// We still use the new key even if the new org doesn't match the old org.
-	orgResponse.Uuid = "badUuid"
+	api.On("FetchOrgData", mock.Anything).Return(&pbgo.OrgDataResponse{Uuid: "badUuid"}, nil)
 	cfg.SetWithoutSource("api_key", "BAD_ORG")
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, "BAD_ORG", updatedKey)
-	}, 5*time.Second, 1*time.Second)
-
+	select {
+	case <-notifications:
+		assert.Equal(t, "BAD_ORG", updatedKey)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for notification")
+	}
 }
 
 func TestServiceGetRefreshIntervalTooSmall(t *testing.T) {

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -434,6 +434,15 @@ func (t *teeConfig) AllSettingsBySource() map[model.Source]interface{} {
 
 }
 
+// AllSettingsWithSequenceID returns the settings and the sequence ID.
+func (t *teeConfig) AllSettingsWithSequenceID() (map[string]interface{}, uint64) {
+	base, baseSequenceID := t.baseline.AllSettingsWithSequenceID()
+	compare, compareSequenceID := t.compare.AllSettingsWithSequenceID()
+	t.compareResult("", "AllSettingsWithSequenceID (settings)", base, compare)
+	t.compareResult("", "AllSettingsWithSequenceID (sequenceID)", baseSequenceID, compareSequenceID)
+	return base, baseSequenceID
+}
+
 // AddConfigPath wraps Viper for concurrent access
 func (t *teeConfig) AddConfigPath(in string) {
 	t.baseline.AddConfigPath(in)

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -15,7 +15,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -82,12 +81,6 @@ func (c *safeConfig) sendNotification(key string, oldValue, newValue interface{}
 	}
 
 	c.notificationChannel <- notification
-}
-
-func getCallerLocation(nbStack int) string {
-	_, file, line, _ := runtime.Caller(nbStack + 1)
-	fileParts := strings.Split(file, "DataDog/datadog-agent/")
-	return fmt.Sprintf("%s:%d", fileParts[len(fileParts)-1], line)
 }
 
 // Set wraps Viper for concurrent access

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -147,7 +147,7 @@ func (c *safeConfig) UnsetForSource(key string, source model.Source) {
 	c.configSources[source].Set(key, nil)
 	c.mergeViperInstances(key)
 	newValue := c.Viper.Get(key) // Can't use nil, so we get the newly computed value
-	if previousValue != nil && reflect.DeepEqual(previousValue, newValue) {
+	if previousValue != nil && !reflect.DeepEqual(previousValue, newValue) {
 		c.sequenceID++
 		notification := model.ConfigChangeNotification{
 			Key:           key,

--- a/pkg/config/viperconfig/viper_test.go
+++ b/pkg/config/viperconfig/viper_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -212,14 +213,20 @@ func TestNotification(t *testing.T) {
 	config.OnUpdate(func(key string, _, _ any, _ uint64) { updatedKeyCB1 = append(updatedKeyCB1, key) })
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Equal(t, []string{"foo"}, updatedKeyCB1)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
 
 	config.OnUpdate(func(key string, _, _ any, _ uint64) { updatedKeyCB2 = append(updatedKeyCB2, key) })
 
 	config.Set("foo", "bar2", model.SourceFile)
 	config.Set("foo2", "bar2", model.SourceFile)
-	assert.Equal(t, []string{"foo", "foo", "foo2"}, updatedKeyCB1)
-	assert.Equal(t, []string{"foo", "foo2"}, updatedKeyCB2)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo", "foo", "foo2"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo", "foo2"}, updatedKeyCB2)
+	}, 5*time.Second, 1*time.Second)
 }
 
 func TestNotificationNoChange(t *testing.T) {
@@ -232,16 +239,24 @@ func TestNotificationNoChange(t *testing.T) {
 	})
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
 
 	config.Set("foo", "baz", model.SourceAgentRuntime)
-	assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
 
 	config.Set("foo", "bar2", model.SourceFile)
-	assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
+	}, 5*time.Second, 1*time.Second)
 }
 
 func TestCheckKnownKey(t *testing.T) {
@@ -383,7 +398,9 @@ func TestListenersUnsetForSource(t *testing.T) {
 	config.Set("log_level", "debug", model.SourceRC)
 	config.UnsetForSource("log_level", model.SourceRC)
 
-	assert.Equal(t, []string{"info", "debug", "info"}, logLevels)
+	assert.Eventually(t, func() bool {
+		return assert.Equal(t, []string{"info", "debug", "info"}, logLevels)
+	}, 5*time.Second, 1*time.Second)
 }
 
 func TestUnsetForSourceRemoveIfNotPrevious(t *testing.T) {

--- a/pkg/config/viperconfig/viper_test.go
+++ b/pkg/config/viperconfig/viper_test.go
@@ -207,56 +207,86 @@ foo: bar
 func TestNotification(t *testing.T) {
 	config := NewViperConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
 
-	updatedKeyCB1 := []string{}
-	updatedKeyCB2 := []string{}
-
-	config.OnUpdate(func(key string, _, _ any, _ uint64) { updatedKeyCB1 = append(updatedKeyCB1, key) })
+	notifications1 := make(chan string, 3)
+	config.OnUpdate(func(key string, _, _ any, _ uint64) {
+		notifications1 <- key
+	})
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
 
-	config.OnUpdate(func(key string, _, _ any, _ uint64) { updatedKeyCB2 = append(updatedKeyCB2, key) })
+	notifications2 := make(chan string, 2)
+	config.OnUpdate(func(key string, _, _ any, _ uint64) {
+		notifications2 <- key
+	})
 
 	config.Set("foo", "bar2", model.SourceFile)
 	config.Set("foo2", "bar2", model.SourceFile)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo", "foo", "foo2"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo", "foo2"}, updatedKeyCB2)
-	}, 5*time.Second, 1*time.Second)
+
+	collected1 := []string{}
+	for i := 0; i < 3; i++ {
+		select {
+		case key := <-notifications1:
+			collected1 = append(collected1, key)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for notification %d for listener 1", i+1)
+		}
+	}
+	assert.Equal(t, []string{"foo", "foo", "foo2"}, collected1)
+
+	collected2 := []string{}
+	for i := 0; i < 2; i++ {
+		select {
+		case key := <-notifications2:
+			collected2 = append(collected2, key)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for notification %d for listener 2", i+1)
+		}
+	}
+	assert.Equal(t, []string{"foo", "foo2"}, collected2)
 }
 
 func TestNotificationNoChange(t *testing.T) {
 	config := NewViperConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
-
 	updatedKeyCB1 := []string{}
-
+	notifications := make(chan string, 10)
 	config.OnUpdate(func(key string, _, newValue any, _ uint64) {
-		updatedKeyCB1 = append(updatedKeyCB1, key+":"+newValue.(string))
+		notifications <- key + ":" + newValue.(string)
 	})
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
+	for len(updatedKeyCB1) < 1 {
+		select {
+		case key := <-notifications:
+			updatedKeyCB1 = append(updatedKeyCB1, key)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for notification")
+		}
+	}
+	assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
 
 	config.Set("foo", "bar", model.SourceFile)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
+	for len(updatedKeyCB1) < 1 {
+		select {
+		case <-notifications:
+			t.Fatalf("received unexpected notification")
+		case <-time.After(2 * time.Second):
+		}
+	}
+	assert.Equal(t, []string{"foo:bar"}, updatedKeyCB1)
 
 	config.Set("foo", "baz", model.SourceAgentRuntime)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
+	for len(updatedKeyCB1) < 2 {
+		select {
+		case key := <-notifications:
+			updatedKeyCB1 = append(updatedKeyCB1, key)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for notification")
+		}
+	}
+	assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
 
 	config.Set("foo", "bar2", model.SourceFile)
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
-	}, 5*time.Second, 1*time.Second)
+	assert.Equal(t, []string{"foo:bar", "foo:baz"}, updatedKeyCB1)
 }
 
 func TestCheckKnownKey(t *testing.T) {
@@ -389,18 +419,27 @@ func TestListenersUnsetForSource(t *testing.T) {
 
 	// Create a listener that will keep track of the changes
 	logLevels := []string{}
+	notifications := make(chan string, 10)
+
 	config.OnUpdate(func(_ string, _, next any, _ uint64) {
 		nextString := next.(string)
-		logLevels = append(logLevels, nextString)
+		notifications <- nextString
 	})
 
 	config.Set("log_level", "info", model.SourceFile)
 	config.Set("log_level", "debug", model.SourceRC)
 	config.UnsetForSource("log_level", model.SourceRC)
+	timeout := time.After(5 * time.Second)
 
-	assert.Eventually(t, func() bool {
-		return assert.Equal(t, []string{"info", "debug", "info"}, logLevels)
-	}, 5*time.Second, 1*time.Second)
+	for len(logLevels) < 3 {
+		select {
+		case level := <-notifications:
+			logLevels = append(logLevels, level)
+		case <-timeout:
+			t.Fatal("Timeout waiting for notifications")
+		}
+	}
+	assert.Equal(t, []string{"info", "debug", "info"}, logLevels)
 }
 
 func TestUnsetForSourceRemoveIfNotPrevious(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Two changes:
1. Instead of notifying the receivers in the `Set` / `Unset` , we send the configuration update to a separate channel. In another go routine, we process these updates and notify the receivers. 

It is important to note that `Set` / `Unset` does not wait for the notification to be processed.

2. Introduces `AllSettingsWithSequenceID` method that returns the settings along with the sequence id associated with the settings.

### Motivation
The purpose of the new change is to ensure that notification receiver call backs are processed sequentially.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Existing unit tests
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
