### PR TITLE
usm: lutgen: Fix lutgen for v1.16 or ealier

### DIFF
--- a/pkg/network/go/lutgen/run.go
+++ b/pkg/network/go/lutgen/run.go
@@ -245,7 +245,7 @@ func (g *LookupTableGenerator) getCommand(ctx context.Context, version goversion
 	// so that Go can resolve gcc in case it needs to use cgo.
 	command.Env = append(command.Env, fmt.Sprintf("%s=%s", "PATH", os.Getenv("PATH")))
 
-	err = setupGoModule(ctx, command, g.TestProgramPath)
+	err = setupGoModule(ctx, command, g.TestProgramPath, version)
 	if err != nil {
 		log.Printf("error setting up go module for  %s (%s): %s", g.TestProgramPath, version, err)
 		return nil
@@ -295,7 +295,7 @@ func (g *LookupTableGenerator) inspectAllBinaries(ctx context.Context) (map[arch
 	return resultTable, nil
 }
 
-func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string) error {
+func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string, version goversion.GoVersion) error {
 	moduleDir, err := os.MkdirTemp("", "lut")
 	if err != nil {
 		return err
@@ -315,8 +315,20 @@ func setupGoModule(ctx context.Context, cmd *exec.Cmd, programPath string) error
 		return err
 	}
 
-	// create go.mod file
-	err = os.WriteFile(filepath.Join(moduleDir, "go.mod"), []byte("module foobar"), os.ModePerm)
+	// create go.mod file with appropriate Go version directive and dependency constraints
+	// Use the format "1.X" for compatibility with older Go versions
+	goVersionStr := fmt.Sprintf("1.%d", version.Minor)
+	goModContent := fmt.Sprintf("module foobar\n\ngo %s\n", goVersionStr)
+
+	// For older Go versions, add explicit version constraints for problematic dependencies
+	// that have go.mod files with newer Go version formats
+	if version.Minor <= 16 {
+		// golang.org/x/net v0.35.0 should be compatible with older Go versions
+		// while avoiding the problematic "go 1.23.0" format in newer versions
+		goModContent += "\nrequire golang.org/x/net v0.35.0\n"
+	}
+
+	err = os.WriteFile(filepath.Join(moduleDir, "go.mod"), []byte(goModContent), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error creating go.mod file: %w", err)
 	}


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The change makes the lutgen script to be aware of the breaking change, and for go v1.16 or earlier we are forcing v0.35 of 'x/net'

### Motivation

The lutgen script downloaded the latest version of 'x/net' package, but from v0.36 the package started using the 'go <major>.<minor>.<patch>' synonym in the go.mod, which is not supported by old version of go.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->