### PR TITLE
Set timezone of test to fix serialization

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/dump_test.go
+++ b/pkg/clusteragent/autoscaling/workload/dump_test.go
@@ -174,6 +174,12 @@ Settings: map[key:value]
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	// set timezone to UTC so that test output doesn't depend upon local timezone
+	originalTZ := time.Local
+	time.Local = time.UTC
+	defer func() {
+		time.Local = originalTZ
+	}()
 	// json serialization drops nanoseconds; strip it here
 	testTime := time.Unix(time.Now().Unix(), 0).UTC()
 	fakeDpai := createFakePodAutoscaler(testTime)


### PR DESCRIPTION
### What does this PR do?

This test output includes timestamps that are affected by the local timezone. Setting it explicitly to UTC makes the test portable.

### Motivation

### Describe how you validated your changes

Unit test

### Possible Drawbacks / Trade-offs

### Additional Notes
