### PR TITLE
usm: Fix verifier error on kernel 4.14 with debug enabled

### DIFF
--- a/pkg/network/usm/usm_http_monitor_test.go
+++ b/pkg/network/usm/usm_http_monitor_test.go
@@ -95,6 +95,19 @@ func TestHTTPScenarios(t *testing.T) {
 	})
 }
 
+func (s *usmHTTPSuite) TestLoadHTTPBinary() {
+	t := s.T()
+
+	cfg := s.getCfg()
+
+	for _, debug := range map[string]bool{"enabled": true, "disabled": false} {
+		t.Run(fmt.Sprintf("debug %v", debug), func(t *testing.T) {
+			cfg.BPFDebug = debug
+			setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+		})
+	}
+}
+
 func (s *usmHTTPSuite) TestSimple() {
 	t := s.T()
 	for name, isIPv6 := range map[string]bool{"IPv4": false, "IPv6": true} {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a test to load HTTP binary (debug/no debug x tls/no tls)

Fixes a verifier error on kernel 4.14 with TLS and Debug enabled.

### Motivation

Found the verifier error while working on another feature

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->