### PR TITLE
[incident-40404] Pass `ddtrace`'s `crashtracker` to `codesign`

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -185,6 +185,8 @@ build do
                 command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
                 command "find #{install_dir}/embedded/sbin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
                 command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
+                #TODO(regis.desgroppes): reconsider below short-term countermeasure (hardcoded path) taken to mitigate incident-40404
+                command "#{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe-unknown-x86_64'", cwd: Dir.pwd
                 command "#{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'", cwd: Dir.pwd
             end
         end


### PR DESCRIPTION
### What does this PR do?
Add `ddtrace`'s `crashtracker` tool to the list of files to process by Apple's code signing.

### Motivation
Notarization requests started failing silently seemingly due to an error code being swallowed, so we didn't notice the binary was not `codesign`ed.
Current macOS deliverables (as of Agent release 7.68.0) are therefore affected, hence the need for a short-term countermeasure that will buy us some time for a proper fix.

### Describe how you validated your changes
Notarization request [succeeds](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1018504482):
```
Sending notarization request.
Results: Conducting pre-submission checks for datadog-agent-7.69.0-devel.git.340.7e6d3e4.pipeline.69918768-1.dmg and initiating connection to the Apple notary service...
Submission ID received
  id: feece83d-242a-4130-9bde-059acb6e6a77
Successfully uploaded file
  id: feece83d-242a-4130-9bde-059acb6e6a77
  path: /Users/ec2-user/builds/S5mXwxTmW/0/DataDog/datadog-agent/omnibus/pkg/datadog-agent-7.69.0-devel.git.340.7e6d3e4.pipeline.69918768-1.dmg
Waiting for processing to complete. Wait timeout is set to 900.0 second(s).
Current status: Accepted....................................Processing complete
  id: feece83d-242a-4130-9bde-059acb6e6a77
  status: Accepted
Submission ID: feece83d-242a-4130-9bde-059acb6e6a77
```

### Possible Drawbacks / Trade-offs
This is obviously a short-term countermeasure: `crashtracker`'s path is hardcoded, notarization failures still pass silently (fixed by #38567), etc.

### Additional Notes
Join the #[incident-40404](https://dd.enterprise.slack.com/archives/C094FAPT2DV) channel.