### PR TITLE
[ABLD-94][BARX-847][incident-40404] Verify `notarytool`'s resulting status

### DIFF
--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -114,8 +114,9 @@ if [ "$SIGN" = true ]; then
     export LATEST_DMG
     # shellcheck disable=SC2016
     ./tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" bash -c '
+        set -euo pipefail
         EXIT_CODE=0
-        RESULT=$(xcrun notarytool submit --timeout "$NOTARIZATION_TIMEOUT" --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait || EXIT_CODE=$?)
+        RESULT=$(xcrun notarytool submit --timeout "$NOTARIZATION_TIMEOUT" --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait) || EXIT_CODE=$?
         echo "Results: $RESULT"
         SUBMISSION_ID="$(echo "$RESULT" | awk "\$1 == \"id:\"{print \$2; exit}")"
         echo "Submission ID: $SUBMISSION_ID"
@@ -123,7 +124,9 @@ if [ "$SIGN" = true ]; then
         sleep 1
         echo "Submission logs:"
         # Always show logs even if notarization fails to have more context
-        xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID"
+        STATUS=$(xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" | tee /dev/stderr | jq --raw-output .status)
+        set -x
+        [ "$STATUS" = Accepted ]  # Fail on any other status like Expired, Invalid, Rejected, Unknown, etc.
         exit "$EXIT_CODE"
     '
     echo -e "\e[0Ksection_end:`date +%s`:notarization\r\e[0K"

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -125,8 +125,10 @@ if [ "$SIGN" = true ]; then
         echo "Submission logs:"
         # Always show logs even if notarization fails to have more context
         STATUS=$(xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" | tee /dev/stderr | jq --raw-output .status)
-        set -x
-        [ "$STATUS" = Accepted ]  # Fail on any other status like Expired, Invalid, Rejected, Unknown, etc.
+        if [ "$STATUS" != Accepted ]; then
+            echo "Submission was not accepted, got: ${STATUS}"
+            exit 1
+        fi
         exit "$EXIT_CODE"
     '
     echo -e "\e[0Ksection_end:`date +%s`:notarization\r\e[0K"


### PR DESCRIPTION
### What does this PR do?
First, The fallback expression `|| EXIT_CODE=$?` was evaluated in a subshell, which caused it to be swallowed from the perspective of the parent shell. The fix simply consists in moving it to the parent shell.

In addition, it turns out that `notarytool submit [...] --wait` doesn't return a `nonzero` exit code on `Invalid` statuses, which might be by design (or might be fixed in a later `Xcode` version).

The present change therefore changes the approach to fail fast(er) by:
- first enabling [recommended shell flags](https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail),
- and then verifying `notarytool log`'s resulting status which should be exactly `Accepted` as per https://keith.github.io/xcode-man-pages/notarytool.1.html#wait.

This used to fail as intended until #38565 got merged and became an ancestor to the present change.

### Describe how you validated your changes
For instance, should `notarytool log`'s resulting status be `Invalid`, the `agent_dmg-x64-a7` job would then terminate as follows:
```
Submission was not accepted, got: Invalid
Attempt #3 failed with error code 1
Running after_script
Cleaning up project directory and file based variables
ERROR: Job failed: exit status 1
```
Conversely, for an `Accepted` resulting status:
```
\e[0K
Built signed package
$ $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/version-manifest.json $S3_SBOM_STORAGE_URI/$CI_JOB_NAME/version-manifest.json
upload: omnibus/pkg/version-manifest.json to s3://sbom-root-us1-ddbuild-io/datadog-agent/99999999/agent_dmg-x64-a7/version-manifest.json
Running after_script
Saving cache for successful job
Uploading artifacts for successful job
Cleaning up project directory and file based variables
Job succeeded
```

### Motivation
Swallowed errors led to #[incident-40404](https://dd.enterprise.slack.com/archives/C094FAPT2DV), which we don't want to happen again.