### PR TITLE
CXP-2378 [agent] add new config for process check refactor

### DIFF
--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,6 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
+	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,7 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.linux_use_wlm", false)
+	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,7 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
+	procBindEnvAndSetDefault(config, "process_config.process_collection.linux_use_wlm", false)
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -138,6 +138,11 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.intervals.connections",
 			defaultValue: nil,
 		},
+		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+		{
+			key:          "process_config.process_collection.use_wlm",
+			defaultValue: false,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -453,6 +458,13 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_INTERVALS_CONNECTIONS",
 			value:    "10",
 			expected: "10",
+		},
+		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+		{
+			key:      "process_config.process_collection.use_wlm",
+			env:      "DD_PROCESS_CONFIG_PROCESS_COLLECTION_USE_WLM",
+			value:    "false",
+			expected: false,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -138,9 +138,9 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.intervals.connections",
 			defaultValue: nil,
 		},
-		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+		// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
 		{
-			key:          "process_config.process_collection.use_wlm",
+			key:          "process_config.process_collection.linux_use_wlm",
 			defaultValue: false,
 		},
 	} {
@@ -459,10 +459,10 @@ func TestEnvVarOverride(t *testing.T) {
 			value:    "10",
 			expected: "10",
 		},
-		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+		// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
 		{
-			key:      "process_config.process_collection.use_wlm",
-			env:      "DD_PROCESS_CONFIG_PROCESS_COLLECTION_USE_WLM",
+			key:      "process_config.process_collection.linux_use_wlm",
+			env:      "DD_PROCESS_CONFIG_PROCESS_COLLECTION_LINUX_USE_WLM",
 			value:    "false",
 			expected: false,
 		},

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -138,9 +138,9 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.intervals.connections",
 			defaultValue: nil,
 		},
-		// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
+		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 		{
-			key:          "process_config.process_collection.linux_use_wlm",
+			key:          "process_config.process_collection.use_wlm",
 			defaultValue: false,
 		},
 	} {
@@ -459,10 +459,10 @@ func TestEnvVarOverride(t *testing.T) {
 			value:    "10",
 			expected: "10",
 		},
-		// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
+		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 		{
-			key:      "process_config.process_collection.linux_use_wlm",
-			env:      "DD_PROCESS_CONFIG_PROCESS_COLLECTION_LINUX_USE_WLM",
+			key:      "process_config.process_collection.use_wlm",
+			env:      "DD_PROCESS_CONFIG_PROCESS_COLLECTION_USE_WLM",
 			value:    "false",
 			expected: false,
 		},

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -87,9 +87,9 @@ type ProcessCheck struct {
 	// determine if zombies process will be collected
 	ignoreZombieProcesses bool
 
-	// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
+	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 	// that determines if linux process collection will use WLM
-	useLinuxWLMProcessCollection bool
+	useWLMProcessCollection bool
 
 	hostInfo                   *HostInfo
 	lastCPUTime                cpu.TimesStat
@@ -196,8 +196,8 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo, oneShot bool
 		p.extractors = append(p.extractors, p.workloadMetaExtractor)
 	}
 
-	// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
-	p.useLinuxWLMProcessCollection = p.config.GetBool("process_config.process_collection.linux_use_wlm")
+	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+	p.useWLMProcessCollection = p.useWLMCollection()
 
 	return nil
 }
@@ -357,7 +357,7 @@ func (p *ProcessCheck) runWLM(groupID int32, collectRealTime bool) (RunResult, e
 }
 
 func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, error) {
-	if p.useLinuxWLMProcessCollection {
+	if p.useWLMProcessCollection {
 		return p.runWLM(groupID, collectRealTime)
 	}
 

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -87,9 +87,9 @@ type ProcessCheck struct {
 	// determine if zombies process will be collected
 	ignoreZombieProcesses bool
 
-	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
-	// that determines if process collection will use WLM
-	useWLMProcessCollection bool
+	// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
+	// that determines if linux process collection will use WLM
+	useLinuxWLMProcessCollection bool
 
 	hostInfo                   *HostInfo
 	lastCPUTime                cpu.TimesStat
@@ -196,8 +196,8 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo, oneShot bool
 		p.extractors = append(p.extractors, p.workloadMetaExtractor)
 	}
 
-	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
-	p.useWLMProcessCollection = p.config.GetBool("process_config.process_collection.use_wlm")
+	// TODO: process_config.process_collection.linux_use_wlm is a temporary configuration for refactoring purposes
+	p.useLinuxWLMProcessCollection = p.config.GetBool("process_config.process_collection.linux_use_wlm")
 
 	return nil
 }
@@ -357,7 +357,7 @@ func (p *ProcessCheck) runWLM(groupID int32, collectRealTime bool) (RunResult, e
 }
 
 func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, error) {
-	if p.useWLMProcessCollection {
+	if p.useLinuxWLMProcessCollection {
 		return p.runWLM(groupID, collectRealTime)
 	}
 

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -87,6 +87,10 @@ type ProcessCheck struct {
 	// determine if zombies process will be collected
 	ignoreZombieProcesses bool
 
+	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+	// that determines if process collection will use WLM
+	useWLMProcessCollection bool
+
 	hostInfo                   *HostInfo
 	lastCPUTime                cpu.TimesStat
 	lastProcs                  map[int32]*procutil.Process
@@ -191,6 +195,10 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo, oneShot bool
 
 		p.extractors = append(p.extractors, p.workloadMetaExtractor)
 	}
+
+	// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+	p.useWLMProcessCollection = p.config.GetBool("process_config.process_collection.use_wlm")
+
 	return nil
 }
 
@@ -224,7 +232,135 @@ func (p *ProcessCheck) Cleanup() {
 	}
 }
 
+func (p *ProcessCheck) runWLM(groupID int32, collectRealTime bool) (RunResult, error) {
+	log.Debugf("Running new WLM process check")
+	start := time.Now()
+	cpuTimes, err := cpu.Times(false)
+	if err != nil {
+		return nil, err
+	}
+	if len(cpuTimes) == 0 {
+		return nil, errEmptyCPUTime
+	}
+
+	procs, err := p.probe.ProcessesByPID(time.Now(), true)
+	if err != nil {
+		return nil, err
+	}
+
+	// stores lastPIDs to be used by RTProcess
+	p.lastPIDs = p.lastPIDs[:0]
+	for pid := range procs {
+		p.lastPIDs = append(p.lastPIDs, pid)
+	}
+
+	if p.sysprobeClient != nil && p.sysProbeConfig.ProcessModuleEnabled {
+		pStats, err := net.GetProcStats(p.sysprobeClient, p.lastPIDs)
+		if err == nil {
+			mergeProcWithSysprobeStats(procs, pStats)
+		} else {
+			log.Debugf("cannot do GetProcStats from system-probe for process check: %s", err)
+		}
+	}
+
+	var containers []*model.Container
+	var pidToCid map[int]string
+	var lastContainerRates map[string]*proccontainers.ContainerRateMetrics
+	cacheValidity := cacheValidityNoRT
+	if collectRealTime {
+		cacheValidity = cacheValidityRT
+	}
+
+	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidity, p.lastContainerRates)
+	if err == nil {
+		p.lastContainerRates = lastContainerRates
+	} else {
+		log.Debugf("Unable to gather stats for containers, err: %v", err)
+	}
+
+	// Notify the workload meta extractor that the mapping between pid and cid has changed
+	if p.workloadMetaExtractor != nil {
+		p.workloadMetaExtractor.SetLastPidToCid(pidToCid)
+	}
+
+	for _, extractor := range p.extractors {
+		extractor.Extract(procs)
+	}
+
+	// End check early if this is our first run.
+	if p.lastProcs == nil {
+		p.lastProcs = procs
+		p.lastCPUTime = cpuTimes[0]
+		p.lastRun = time.Now()
+
+		if collectRealTime {
+			p.realtimeLastCPUTime = p.lastCPUTime
+			p.realtimeLastProcs = procsToStats(p.lastProcs)
+			p.realtimeLastRun = p.lastRun
+		}
+		return CombinedRunResult{}, nil
+	}
+
+	collectorProcHints := p.generateHints()
+	p.checkCount++
+
+	pidToGPUTags := p.gpuSubscriber.GetGPUTags()
+
+	procsByCtr := fmtProcesses(p.scrubber, p.disallowList, procs, p.lastProcs, pidToCid, cpuTimes[0], p.lastCPUTime, p.lastRun, p.lookupIdProbe, p.ignoreZombieProcesses, p.serviceExtractor, pidToGPUTags)
+	messages, totalProcs, totalContainers := createProcCtrMessages(p.hostInfo, procsByCtr, containers, p.maxBatchSize, p.maxBatchBytes, groupID, p.networkID, collectorProcHints)
+
+	// Store the last state for comparison on the next run.
+	// Note: not storing the filtered in case there are new processes that haven't had a chance to show up twice.
+	p.lastProcs = procs
+	p.lastCPUTime = cpuTimes[0]
+	p.lastRun = time.Now()
+
+	result := &CombinedRunResult{
+		Standard: messages,
+	}
+	if collectRealTime {
+		stats := procsToStats(p.lastProcs)
+
+		if p.realtimeLastProcs != nil {
+			// TODO: deduplicate chunking with RT collection
+			chunkedStats := fmtProcessStats(p.maxBatchSize, stats, p.realtimeLastProcs, pidToCid, cpuTimes[0], p.realtimeLastCPUTime, p.realtimeLastRun)
+			groupSize := len(chunkedStats)
+			chunkedCtrStats := convertAndChunkContainers(containers, groupSize)
+
+			messages := make([]model.MessageBody, 0, groupSize)
+			for i := 0; i < groupSize; i++ {
+				messages = append(messages, &model.CollectorRealTime{
+					HostName:          p.hostInfo.HostName,
+					Stats:             chunkedStats[i],
+					ContainerStats:    chunkedCtrStats[i],
+					GroupId:           groupID,
+					GroupSize:         int32(groupSize),
+					NumCpus:           int32(len(p.hostInfo.SystemInfo.Cpus)),
+					TotalMemory:       p.hostInfo.SystemInfo.TotalMemory,
+					ContainerHostType: p.hostInfo.ContainerHostType,
+				})
+			}
+			result.Realtime = messages
+		}
+
+		p.realtimeLastCPUTime = p.lastCPUTime
+		p.realtimeLastProcs = stats
+		p.realtimeLastRun = p.lastRun
+	}
+
+	agentNameTag := fmt.Sprintf("agent:%s", flavor.GetFlavor())
+	_ = p.statsd.Gauge("datadog.process.containers.host_count", float64(totalContainers), []string{agentNameTag}, 1)
+	_ = p.statsd.Gauge("datadog.process.processes.host_count", float64(totalProcs), []string{agentNameTag}, 1)
+	log.Debugf("collected processes in %s", time.Since(start))
+
+	return result, nil
+}
+
 func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, error) {
+	if p.useWLMProcessCollection {
+		return p.runWLM(groupID, collectRealTime)
+	}
+
 	start := time.Now()
 	cpuTimes, err := cpu.Times(false)
 	if err != nil {

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -89,3 +89,9 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	pct = math.Max(pct, 0.0)
 	return float32(pct)
 }
+
+// useWLMCollection checks the configuration to use the workloadmeta process collector or not in linux
+// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+func (p *ProcessCheck) useWLMCollection() bool {
+	return p.config.GetBool("process_config.process_collection.use_wlm")
+}

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -67,3 +67,10 @@ func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
 	overalPct = math.Max(overalPct, 0.0)
 	return float32(overalPct)
 }
+
+// useWLMCollection checks the configuration to use the workloadmeta process collector or not in linux
+// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
+func (p *ProcessCheck) useWLMCollection() bool {
+	log.Info("process_config.process_collection.use_wlm is not supported on windows")
+	return false
+}

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -16,6 +16,7 @@ import (
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (

--- a/test/new-e2e/tests/process/config/process_check_in_core_agent_wlm_process_collector.yaml
+++ b/test/new-e2e/tests/process/config/process_check_in_core_agent_wlm_process_collector.yaml
@@ -1,0 +1,11 @@
+process_config:
+  process_collection:
+    enabled: true
+    use_wlm: true
+  container_collection:
+    enabled: false
+  process_discovery:
+    enabled: false
+
+  run_in_core_agent:
+    enabled: true

--- a/test/new-e2e/tests/process/config/process_check_in_core_agent_wlm_process_collector.yaml
+++ b/test/new-e2e/tests/process/config/process_check_in_core_agent_wlm_process_collector.yaml
@@ -1,7 +1,7 @@
 process_config:
   process_collection:
     enabled: true
-    use_wlm: true
+    linux_use_wlm: true
   container_collection:
     enabled: false
   process_discovery:

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -268,6 +268,39 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
 	requireProcessNotCollected(t, payloads, "process-agent")
 }
 
+func (s *linuxTestSuite) TestProcessChecksInCoreAgentWLMProcessCollector() {
+	t := s.T()
+	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentWLMProcessCollectorConfigStr))))
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{}, false)
+	}, 1*time.Minute, 5*time.Second)
+
+	// Verify that the process agent is not running
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status := s.Env().RemoteHost.MustExecute("sudo /opt/datadog-agent/embedded/bin/process-agent status")
+		assert.Contains(c, status, "The Process Agent is not running")
+	}, 1*time.Minute, 5*time.Second)
+
+	// Flush fake intake to remove any payloads which may have
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	var payloads []*aggregator.ProcessPayload
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var err error
+		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
+		assert.NoError(c, err, "failed to get process payloads from fakeintake")
+
+		// Wait for two payloads, as processes must be detected in two check runs to be returned
+		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
+	}, 2*time.Minute, 10*time.Second)
+
+	assertProcessCollected(t, payloads, false, "stress")
+
+	// check that the process agent is not collected as it should not be running
+	requireProcessNotCollected(t, payloads, "process-agent")
+}
+
 func (s *linuxTestSuite) TestProcessChecksInCoreAgentWithNPM() {
 	t := s.T()
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr), agentparams.WithSystemProbeConfig(systemProbeNPMConfigStr))))

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -268,7 +268,7 @@ func (s *linuxTestSuite) TestProcessChecksInCoreAgent() {
 	requireProcessNotCollected(t, payloads, "process-agent")
 }
 
-func (s *linuxTestSuite) TestProcessChecksInCoreAgentWLMProcessCollector() {
+func (s *linuxTestSuite) TestProcessChecksWLM() {
 	t := s.T()
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentWLMProcessCollectorConfigStr))))
 

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -31,6 +31,9 @@ var processDiscoveryCheckConfigStr string
 //go:embed config/process_check_in_core_agent.yaml
 var processCheckInCoreAgentConfigStr string
 
+//go:embed config/process_check_in_core_agent_wlm_process_collector.yaml
+var processCheckInCoreAgentWLMProcessCollectorConfigStr string
+
 //go:embed config/system_probe.yaml
 var systemProbeConfigStr string
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- adds a new non-public facing configuration `process_config.process_collection.use_wlm` with build flag os separation for unix and disabled for windows
- adds the new check `runWLM` which duplicates the existing `run` code such that future PRs can easily see the difference
- duplicates an e2e test with this configuration
    - unit tests will be added for the new check once new code will be written as copying the existing unit tests would be significantly changed in the next pr (work that would reverted soon)
- adds configuration unit test

### Motivation
- as part of the processes + service discovery consolidation, we need to refactor the process check to use the new WLM process collector. This config will help streamline + automate testing while we finish the refactor. Eventually this config will be replaced by a build flag that only runs this for linux
    - RFC - https://datadoghq.atlassian.net/wiki/spaces/cxg/pages/5013111768/RFC+Processes+and+Service+Discovery+Agent+Consolidation
    - WLM process collector work currently hardcoded to be disabled https://github.com/DataDog/datadog-agent/blob/fbdd1bbd7ee4d151620c6a88c17fcbf1c632cf71/comp/core/workloadmeta/collectors/internal/process/process_collector.go#L139

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- run agent locally with debug mode on to see function process collection 
```
2025-07-08 16:10:05 UTC | CORE | DEBUG | (pkg/process/checks/process.go:228 in runWLM) | Running new WLM process check
2025-07-08 16:10:05 UTC | CORE | DEBUG | (pkg/process/checks/process.go:346 in runWLM) | collected processes in 6.766542ms
```
- added e2e test

### Possible Drawbacks / Trade-offs
- config can potentially be enabled for all non-windows platforms 
- however, if an attentive customer decides to enable the config, behavior should stay the same
    - when the refactor is finished, there should be a linux specific build flag file with the new check

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->