### PR TITLE
Expose Autodiscovery filter errors in status

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -125,7 +125,7 @@ func newProvides(deps dependencies) provides {
 	c := newAutoConfig(deps)
 	return provides{
 		Comp:           c,
-		StatusProvider: status.NewInformationProvider(autodiscoveryStatus.GetProvider(c)),
+		StatusProvider: status.NewInformationProvider(autodiscoveryStatus.GetProvider(c, deps.FilterStore)),
 
 		Endpoint:      api.NewAgentEndpointProvider(c.(*AutoConfig).writeConfigCheck, "/config-check", "GET"),
 		FlareProvider: flaretypes.NewProvider(c.(*AutoConfig).fillFlare),

--- a/comp/core/autodiscovery/status/status.go
+++ b/comp/core/autodiscovery/status/status.go
@@ -12,15 +12,30 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 // populateStatus populates the status stats
-func populateStatus(ac autodiscovery.Component, stats map[string]interface{}) {
+func populateStatus(ac autodiscovery.Component, wf workloadfilter.Component, stats map[string]interface{}) {
 	stats["adEnabledFeatures"] = env.GetDetectedFeatures()
 	stats["adConfigErrors"] = ac.GetAutodiscoveryErrors()
-	stats["filterErrors"] = containers.GetFilterErrors()
+	stats["filterErrors"] = getAutodiscoveryFilterErrors(wf)
+}
+
+// GetAutodiscoveryFilterErrors returns a map of all autodiscovery filter errors
+func getAutodiscoveryFilterErrors(wf workloadfilter.Component) map[string]struct{} {
+	var workloadfilterList []workloadfilter.ContainerFilter
+	for _, filterScope := range []workloadfilter.Scope{workloadfilter.MetricsFilter, workloadfilter.LogsFilter, workloadfilter.GlobalFilter} {
+		workloadfilterList = append(workloadfilterList, workloadfilter.FlattenFilterSets(workloadfilter.GetAutodiscoveryFilters(filterScope))...)
+	}
+	workloadfilterErrors := wf.GetContainerFilterInitializationErrors(workloadfilterList)
+
+	filterErrorsSet := make(map[string]struct{})
+	for _, err := range workloadfilterErrors {
+		filterErrorsSet[err.Error()] = struct{}{}
+	}
+	return filterErrorsSet
 }
 
 //go:embed status_templates
@@ -28,13 +43,14 @@ var templatesFS embed.FS
 
 // Provider provides the functionality to populate the status output
 type Provider struct {
-	ac autodiscovery.Component
+	ac          autodiscovery.Component
+	filterStore workloadfilter.Component
 }
 
 // GetProvider if agent is running in a container environment returns status.Provider otherwise returns nil
-func GetProvider(acComp autodiscovery.Component) status.Provider {
+func GetProvider(acComp autodiscovery.Component, filterStore workloadfilter.Component) status.Provider {
 	if env.IsContainerized() {
-		return Provider{ac: acComp}
+		return Provider{ac: acComp, filterStore: filterStore}
 	}
 
 	return nil
@@ -43,7 +59,7 @@ func GetProvider(acComp autodiscovery.Component) status.Provider {
 func (p Provider) getStatusInfo() map[string]interface{} {
 	stats := make(map[string]interface{})
 
-	populateStatus(p.ac, stats)
+	populateStatus(p.ac, p.filterStore, stats)
 
 	return stats
 }
@@ -60,7 +76,7 @@ func (p Provider) Section() string {
 
 // JSON populates the status map
 func (p Provider) JSON(_ bool, stats map[string]interface{}) error {
-	populateStatus(p.ac, stats)
+	populateStatus(p.ac, p.filterStore, stats)
 
 	return nil
 }

--- a/comp/core/workloadfilter/catalog/utils.go
+++ b/comp/core/workloadfilter/catalog/utils.go
@@ -22,12 +22,12 @@ import (
 func createProgramFromOldFilters(oldFilters []string, objectType workloadfilter.ResourceType) (cel.Program, error) {
 	filterString, err := convertOldToNewFilter(oldFilters, objectType)
 	if err != nil {
-		return nil, fmt.Errorf("error converting filters: %w", err)
+		return nil, err
 	}
 
-	program, progErr := createCELProgram(filterString, objectType)
-	if progErr != nil {
-		return nil, fmt.Errorf("error creating CEL filtering program: %w", progErr)
+	program, err := createCELProgram(filterString, objectType)
+	if err != nil {
+		return nil, err
 	}
 
 	return program, nil
@@ -58,7 +58,6 @@ func createCELProgram(rules string, objectType workloadfilter.ResourceType) (cel
 // getFieldMapping creates a map to associate old filter prefixes with new filter fields
 func getFieldMapping(objectType workloadfilter.ResourceType) map[string]string {
 	return map[string]string{
-		"id":    fmt.Sprintf("%s.id.matches", objectType),
 		"name":  fmt.Sprintf("%s.name.matches", objectType),
 		"image": fmt.Sprintf("%s.image.matches", objectType),
 		"kube_namespace": func() string {
@@ -68,15 +67,6 @@ func getFieldMapping(objectType workloadfilter.ResourceType) map[string]string {
 			return fmt.Sprintf("%s.%s.namespace.matches", objectType, workloadfilter.PodType)
 		}(),
 	}
-}
-
-// getValidKeys returns a slice of valid keys for legacy container filters.
-func getValidKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-	return keys
 }
 
 // convertOldToNewFilter converts the legacy regex ad filter format to cel-go format.
@@ -116,7 +106,7 @@ func convertOldToNewFilter(oldFilters []string, objectType workloadfilter.Resour
 		if newField, ok := legacyFieldMapping[key]; ok {
 			newFilters = append(newFilters, fmt.Sprintf(`%s(%s)`, newField, strconv.Quote(value)))
 		} else {
-			return "", fmt.Errorf("unsupported filter key '%s' must be in %v", key, getValidKeys(legacyFieldMapping))
+			return "", fmt.Errorf("container filter %s:%s is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'", key, value)
 		}
 	}
 	return strings.Join(newFilters, " || "), nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Exposes parsing and creation errors for Autodiscovery related filters from the workloadFilter component

### Motivation

Migrate Autodiscovery to use workloadfilter component instead of pkg/util/containers filters

[CONTP-845]

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Deploy the agent locally with a few configuration errors:

```
datadog:
  kubelet:
    tlsVerify: false
  envDict:
    DD_CONTAINER_EXCLUDE_METRICS: "kube_namespace:datadog-agent invalid_key_gabe:meow"
    DD_CONTAINER_INCLUDE_LOGS: "name:cluster-agent bad_key_gabe:woof"
```

```
k exec -it datadog-agent-linux-xxxxx -n datadog-agent -- agent status
...
=============
Autodiscovery
=============

  Enabled Features
  ================
    docker
    kube_orchestratorexplorer
    kubernetes

  Container Inclusion/Exclusion Errors
  ====================================
    container filter bad_key_gabe:woof is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'
    container filter invalid_key_gabe:meow is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[CONTP-845]: https://datadoghq.atlassian.net/browse/CONTP-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ