### PR TITLE
Do not run regression detector on test, documentation changes

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -75,6 +75,15 @@ single-machine-performance-regression_detector:
     - changes:
         - "**/*.md"
         - "**/*_test.go"
+        - "docs/**/*"
+        - "README*"
+        - ".vscode/**/*"
+        - "examples/**/*"
+        - "LICENSE*"
+        - "NOTICE*"
+        - "CHANGELOG*"
+        - "releasenotes/**/*"
+        - "releasenotes-dca/**/*"
       when: never
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -72,6 +72,10 @@ single-machine-performance-regression_detector:
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a duplicate, specialized artifact that is not useful to run through SMP on every PR
     - !reference [.on_dev_branches]
+    - changes:
+        - "**/*.md"
+        - "**/*_test.go"
+      when: never
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64"]


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the Regression Detector workflow to skip
    runs if the changes are exclusively to test or documentation code.
    We want to be very careful to elide runs when the Agent artifact
    itself changes but it's clear that these changes do not need a
    run.

