### PR TITLE
[ABLD-94][BARX-847][incident-40404] Gather files to `codesign` more exhaustively

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -180,14 +180,22 @@ build do
                 # Sometimes the timestamp service is not available, so we retry
                 codesign = "../tools/ci/retry.sh codesign"
 
-                # Codesign everything
-                command "find #{install_dir} -type f | grep -E '(\\.so|\\.dylib)' | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
-                command "find #{install_dir}/embedded/bin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
-                command "find #{install_dir}/embedded/sbin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
-                command "find #{install_dir}/bin -perm +111 -type f | xargs -I{} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '{}'", cwd: Dir.pwd
-                #TODO(regis.desgroppes): reconsider below short-term countermeasure (hardcoded path) taken to mitigate incident-40404
-                command "#{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe-unknown-x86_64'", cwd: Dir.pwd
-                command "#{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}' '#{install_dir}/Datadog Agent.app'", cwd: Dir.pwd
+                # Codesign all Mach-O binaries leveraging parallelism (~280 binaries out of ~28000 files)
+                command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
+                    set -euo pipefail
+                    find #{install_dir} -type f -print0 |
+                        xargs -0 -n1000 -P#{workers} file -n --mime-type |
+                        awk -F: '$0 ~ /[^)]:[[:space:]]*application\\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
+                        xargs -0 -n10 -P#{workers} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
+                SH
+                # Also sequentially codesign PNGs (`Contents/MacOS/agent.png` out of ~20 files under 'Datadog Agent.app')
+                command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
+                    set -euo pipefail
+                    find '#{install_dir}/Datadog Agent.app' -type f -print0 |
+                        xargs -0 file --mime-type |
+                        awk -F: '$2 ~ /image\\/png/ { printf "%s%c", $1, 0 }' |
+                        xargs -0 #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
+                SH
             end
         end
     end


### PR DESCRIPTION
### What does this PR do?
Exhaustively gather Mach-O binaries to `codesign` instead of having to maintain hardcoded paths, subdirectories (btw, `embedded/sbin` didn't exist), file patterns (`*.so`, `*.dylib`) nor permissions (a few shared libraries turn out to be without executable bits).
To avoid `codesign`ing Mach-O binaries under `Datadog Agent.app` **twice**, a second pass is performed against a few PNG files (only `Contents/MacOS/agent.png` as of now) we've been happening to `codesign` specifically under `Datadog Agent.app` (unlike PNG files under sibling subdirectories).

### Motivation
A very trivial countermeasure was taken to mitigate #[incident-40404](https://dd.enterprise.slack.com/archives/C094FAPT2DV) in the short-term: #38565.
The present change makes it more maintainable by scanning files under the installation directory, retaining and signing all Mach-O binaries.

### Describe how you validated your changes
<details><summary>The list of paths in the notarization response is identical to the one obtained prior to the change</summary>

#### DMG
1. datadog-agent-7[...]-1.dmg

#### PKG
2. datadog-agent-7[...]-1.dmg/datadog-agent-7[...]-1.pkg

#### PNG
3. /opt/datadog-agent/Datadog Agent.app/Contents/MacOS/agent.png

#### Mach-O single arch binaries _for another architecture_ (from `universal2` wheels embedding a distinct shared library for the target architecture)
4. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bson/_cbson.cpython-310-darwin.so - arch: {'arm64'}
5. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bson/_cbson.cpython-311-darwin.so - arch: {'arm64'}
6. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bson/_cbson.cpython-38-darwin.so - arch: {'arm64'}
7. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bson/_cbson.cpython-39-darwin.so - arch: {'arm64'}
8. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_cmessage.cpython-310-darwin.so - arch: {'arm64'}
9. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_cmessage.cpython-311-darwin.so - arch: {'arm64'}
10. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_cmessage.cpython-38-darwin.so - arch: {'arm64'}
11. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_cmessage.cpython-39-darwin.so - arch: {'arm64'}

#### Mach-O **multiarch** binaries (from `intel` or `universal2` wheels where the shared library embeds both architectures)
12. /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar/jni/Darwin/libjffi-1.2.jnilib - arch: {'i386', 'x86_64'}
13. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bcrypt/_bcrypt.abi3.so - arch: {'arm64', 'x86_64'}
14. /opt/datadog-agent/embedded/lib/python3.12/site-packages/charset_normalizer/md.cpython-312-darwin.so - arch: {'arm64', 'x86_64'}
15. /opt/datadog-agent/embedded/lib/python3.12/site-packages/charset_normalizer/md__mypyc.cpython-312-darwin.so - arch: {'arm64', 'x86_64'}
16. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/cimpl.cpython-312-darwin.so - arch: {'arm64', 'x86_64'}
17. /opt/datadog-agent/embedded/lib/python3.12/site-packages/cryptography/hazmat/bindings/_rust.abi3.so - arch: {'arm64', 'x86_64'}
18. /opt/datadog-agent/embedded/lib/python3.12/site-packages/google/_upb/_message.abi3.so - arch: {'arm64', 'x86_64'}
19. /opt/datadog-agent/embedded/lib/python3.12/site-packages/nacl/_sodium.abi3.so - arch: {'arm64', 'x86_64'}
20. /opt/datadog-agent/embedded/lib/python3.12/site-packages/orjson/orjson.cpython-312-darwin.so - arch: {'arm64', 'x86_64'}
21. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymqi/pymqe.cpython-312-darwin.so - arch: {'arm64', 'x86_64'}

#### Mach-O single arch binaries _for the target architecture_
22. /opt/datadog-agent/Datadog Agent.app - arch: {'x86_64'}
23. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftAppKit.dylib - arch: {'x86_64'}
24. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftCore.dylib - arch: {'x86_64'}
25. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftCoreData.dylib - arch: {'x86_64'}
26. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftCoreFoundation.dylib - arch: {'x86_64'}
27. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftCoreGraphics.dylib - arch: {'x86_64'}
28. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftCoreImage.dylib - arch: {'x86_64'}
29. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftDarwin.dylib - arch: {'x86_64'}
30. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftDispatch.dylib - arch: {'x86_64'}
31. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftFoundation.dylib - arch: {'x86_64'}
32. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftIOKit.dylib - arch: {'x86_64'}
33. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftMetal.dylib - arch: {'x86_64'}
34. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftObjectiveC.dylib - arch: {'x86_64'}
35. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftQuartzCore.dylib - arch: {'x86_64'}
36. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftXPC.dylib - arch: {'x86_64'}
37. /opt/datadog-agent/Datadog Agent.app/Contents/Frameworks/libswiftos.dylib - arch: {'x86_64'}
38. /opt/datadog-agent/Datadog Agent.app/Contents/MacOS/gui - arch: {'x86_64'}
39. /opt/datadog-agent/bin/agent/agent - arch: {'x86_64'}
40. /opt/datadog-agent/embedded/bin/openssl - arch: {'x86_64'}
41. /opt/datadog-agent/embedded/bin/process-agent - arch: {'x86_64'}
42. /opt/datadog-agent/embedded/bin/python3.12 - arch: {'x86_64'}
43. /opt/datadog-agent/embedded/bin/secret-generic-connector - arch: {'x86_64'}
44. /opt/datadog-agent/embedded/bin/security-agent - arch: {'x86_64'}
45. /opt/datadog-agent/embedded/bin/system-probe - arch: {'x86_64'}
46. /opt/datadog-agent/embedded/bin/trace-agent - arch: {'x86_64'}
47. /opt/datadog-agent/embedded/lib/engines-3/capi.dylib - arch: {'x86_64'}
48. /opt/datadog-agent/embedded/lib/engines-3/loader_attic.dylib - arch: {'x86_64'}
49. /opt/datadog-agent/embedded/lib/engines-3/padlock.dylib - arch: {'x86_64'}
50. /opt/datadog-agent/embedded/lib/libbz2.so.1.0.8 - arch: {'x86_64'}
51. /opt/datadog-agent/embedded/lib/libcrypt.2.dylib - arch: {'x86_64'}
52. /opt/datadog-agent/embedded/lib/libcrypto.3.dylib - arch: {'x86_64'}
53. /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.0.1.0.dylib - arch: {'x86_64'}
54. /opt/datadog-agent/embedded/lib/libdatadog-agent-three.dylib - arch: {'x86_64'}
55. /opt/datadog-agent/embedded/lib/libffi.8.dylib - arch: {'x86_64'}
56. /opt/datadog-agent/embedded/lib/libltdl.7.dylib - arch: {'x86_64'}
57. /opt/datadog-agent/embedded/lib/liblzma.5.dylib - arch: {'x86_64'}
58. /opt/datadog-agent/embedded/lib/libpython3.12.dylib - arch: {'x86_64'}
59. /opt/datadog-agent/embedded/lib/libsqlite3.0.dylib - arch: {'x86_64'}
60. /opt/datadog-agent/embedded/lib/libssl.3.dylib - arch: {'x86_64'}
61. /opt/datadog-agent/embedded/lib/libyaml-0.2.dylib - arch: {'x86_64'}
62. /opt/datadog-agent/embedded/lib/libz.1.3.1.dylib - arch: {'x86_64'}
63. /opt/datadog-agent/embedded/lib/ossl-modules/legacy.dylib - arch: {'x86_64'}
64. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_asyncio.cpython-312-darwin.so - arch: {'x86_64'}
65. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_bisect.cpython-312-darwin.so - arch: {'x86_64'}
66. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_blake2.cpython-312-darwin.so - arch: {'x86_64'}
67. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_bz2.cpython-312-darwin.so - arch: {'x86_64'}
68. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_cn.cpython-312-darwin.so - arch: {'x86_64'}
69. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_hk.cpython-312-darwin.so - arch: {'x86_64'}
70. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_iso2022.cpython-312-darwin.so - arch: {'x86_64'}
71. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_jp.cpython-312-darwin.so - arch: {'x86_64'}
72. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_kr.cpython-312-darwin.so - arch: {'x86_64'}
73. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_codecs_tw.cpython-312-darwin.so - arch: {'x86_64'}
74. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_contextvars.cpython-312-darwin.so - arch: {'x86_64'}
75. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_crypt.cpython-312-darwin.so - arch: {'x86_64'}
76. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_csv.cpython-312-darwin.so - arch: {'x86_64'}
77. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ctypes.cpython-312-darwin.so - arch: {'x86_64'}
78. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ctypes_test.cpython-312-darwin.so - arch: {'x86_64'}
79. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_curses.cpython-312-darwin.so - arch: {'x86_64'}
80. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_curses_panel.cpython-312-darwin.so - arch: {'x86_64'}
81. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_datetime.cpython-312-darwin.so - arch: {'x86_64'}
82. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_decimal.cpython-312-darwin.so - arch: {'x86_64'}
83. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_elementtree.cpython-312-darwin.so - arch: {'x86_64'}
84. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_hashlib.cpython-312-darwin.so - arch: {'x86_64'}
85. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_heapq.cpython-312-darwin.so - arch: {'x86_64'}
86. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_json.cpython-312-darwin.so - arch: {'x86_64'}
87. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_lsprof.cpython-312-darwin.so - arch: {'x86_64'}
88. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_lzma.cpython-312-darwin.so - arch: {'x86_64'}
89. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_md5.cpython-312-darwin.so - arch: {'x86_64'}
90. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_multibytecodec.cpython-312-darwin.so - arch: {'x86_64'}
91. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_multiprocessing.cpython-312-darwin.so - arch: {'x86_64'}
92. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_opcode.cpython-312-darwin.so - arch: {'x86_64'}
93. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_pickle.cpython-312-darwin.so - arch: {'x86_64'}
94. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_posixshmem.cpython-312-darwin.so - arch: {'x86_64'}
95. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_posixsubprocess.cpython-312-darwin.so - arch: {'x86_64'}
96. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_queue.cpython-312-darwin.so - arch: {'x86_64'}
97. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_random.cpython-312-darwin.so - arch: {'x86_64'}
98. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_scproxy.cpython-312-darwin.so - arch: {'x86_64'}
99. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_sha1.cpython-312-darwin.so - arch: {'x86_64'}
100. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_sha2.cpython-312-darwin.so - arch: {'x86_64'}
101. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_sha3.cpython-312-darwin.so - arch: {'x86_64'}
102. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_socket.cpython-312-darwin.so - arch: {'x86_64'}
103. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_sqlite3.cpython-312-darwin.so - arch: {'x86_64'}
104. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ssl.cpython-312-darwin.so - arch: {'x86_64'}
105. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_statistics.cpython-312-darwin.so - arch: {'x86_64'}
106. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_struct.cpython-312-darwin.so - arch: {'x86_64'}
107. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testbuffer.cpython-312-darwin.so - arch: {'x86_64'}
108. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testcapi.cpython-312-darwin.so - arch: {'x86_64'}
109. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testclinic.cpython-312-darwin.so - arch: {'x86_64'}
110. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testimportmultiple.cpython-312-darwin.so - arch: {'x86_64'}
111. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testinternalcapi.cpython-312-darwin.so - arch: {'x86_64'}
112. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testmultiphase.cpython-312-darwin.so - arch: {'x86_64'}
113. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_testsinglephase.cpython-312-darwin.so - arch: {'x86_64'}
114. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_uuid.cpython-312-darwin.so - arch: {'x86_64'}
115. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_xxinterpchannels.cpython-312-darwin.so - arch: {'x86_64'}
116. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_xxsubinterpreters.cpython-312-darwin.so - arch: {'x86_64'}
117. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_xxtestfuzz.cpython-312-darwin.so - arch: {'x86_64'}
118. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_zoneinfo.cpython-312-darwin.so - arch: {'x86_64'}
119. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/array.cpython-312-darwin.so - arch: {'x86_64'}
120. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/audioop.cpython-312-darwin.so - arch: {'x86_64'}
121. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/binascii.cpython-312-darwin.so - arch: {'x86_64'}
122. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/cmath.cpython-312-darwin.so - arch: {'x86_64'}
123. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/fcntl.cpython-312-darwin.so - arch: {'x86_64'}
124. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/grp.cpython-312-darwin.so - arch: {'x86_64'}
125. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/math.cpython-312-darwin.so - arch: {'x86_64'}
126. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/mmap.cpython-312-darwin.so - arch: {'x86_64'}
127. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/nis.cpython-312-darwin.so - arch: {'x86_64'}
128. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/pyexpat.cpython-312-darwin.so - arch: {'x86_64'}
129. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/resource.cpython-312-darwin.so - arch: {'x86_64'}
130. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/select.cpython-312-darwin.so - arch: {'x86_64'}
131. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/syslog.cpython-312-darwin.so - arch: {'x86_64'}
132. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/termios.cpython-312-darwin.so - arch: {'x86_64'}
133. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/unicodedata.cpython-312-darwin.so - arch: {'x86_64'}
134. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/xxlimited.cpython-312-darwin.so - arch: {'x86_64'}
135. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/xxlimited_35.cpython-312-darwin.so - arch: {'x86_64'}
136. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/xxsubtype.cpython-312-darwin.so - arch: {'x86_64'}
137. /opt/datadog-agent/embedded/lib/python3.12/lib-dynload/zlib.cpython-312-darwin.so - arch: {'x86_64'}
138. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_ARC4.abi3.so - arch: {'x86_64'}
139. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_Salsa20.abi3.so - arch: {'x86_64'}
140. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_chacha20.abi3.so - arch: {'x86_64'}
141. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_pkcs1_decode.abi3.so - arch: {'x86_64'}
142. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_aes.abi3.so - arch: {'x86_64'}
143. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_aesni.abi3.so - arch: {'x86_64'}
144. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_arc2.abi3.so - arch: {'x86_64'}
145. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_blowfish.abi3.so - arch: {'x86_64'}
146. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_cast.abi3.so - arch: {'x86_64'}
147. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_cbc.abi3.so - arch: {'x86_64'}
148. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_cfb.abi3.so - arch: {'x86_64'}
149. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_ctr.abi3.so - arch: {'x86_64'}
150. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_des.abi3.so - arch: {'x86_64'}
151. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_des3.abi3.so - arch: {'x86_64'}
152. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_ecb.abi3.so - arch: {'x86_64'}
153. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_eksblowfish.abi3.so - arch: {'x86_64'}
154. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_ocb.abi3.so - arch: {'x86_64'}
155. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Cipher/_raw_ofb.abi3.so - arch: {'x86_64'}
156. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_BLAKE2b.abi3.so - arch: {'x86_64'}
157. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_BLAKE2s.abi3.so - arch: {'x86_64'}
158. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_MD2.abi3.so - arch: {'x86_64'}
159. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_MD4.abi3.so - arch: {'x86_64'}
160. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_MD5.abi3.so - arch: {'x86_64'}
161. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_RIPEMD160.abi3.so - arch: {'x86_64'}
162. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_SHA1.abi3.so - arch: {'x86_64'}
163. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_SHA224.abi3.so - arch: {'x86_64'}
164. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_SHA256.abi3.so - arch: {'x86_64'}
165. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_SHA384.abi3.so - arch: {'x86_64'}
166. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_SHA512.abi3.so - arch: {'x86_64'}
167. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_ghash_clmul.abi3.so - arch: {'x86_64'}
168. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_ghash_portable.abi3.so - arch: {'x86_64'}
169. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_keccak.abi3.so - arch: {'x86_64'}
170. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Hash/_poly1305.abi3.so - arch: {'x86_64'}
171. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Math/_modexp.abi3.so - arch: {'x86_64'}
172. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Protocol/_scrypt.abi3.so - arch: {'x86_64'}
173. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/PublicKey/_curve25519.abi3.so - arch: {'x86_64'}
174. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/PublicKey/_curve448.abi3.so - arch: {'x86_64'}
175. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/PublicKey/_ec_ws.abi3.so - arch: {'x86_64'}
176. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/PublicKey/_ed25519.abi3.so - arch: {'x86_64'}
177. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/PublicKey/_ed448.abi3.so - arch: {'x86_64'}
178. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Util/_cpuid_c.abi3.so - arch: {'x86_64'}
179. /opt/datadog-agent/embedded/lib/python3.12/site-packages/Cryptodome/Util/_strxor.abi3.so - arch: {'x86_64'}
180. /opt/datadog-agent/embedded/lib/python3.12/site-packages/_cffi_backend.cpython-312-darwin.so - arch: {'x86_64'}
181. /opt/datadog-agent/embedded/lib/python3.12/site-packages/bson/_cbson.cpython-312-darwin.so - arch: {'x86_64'}
182. /opt/datadog-agent/embedded/lib/python3.12/site-packages/clickhouse_cityhash/cityhash.cpython-312-darwin.so - arch: {'x86_64'}
183. /opt/datadog-agent/embedded/lib/python3.12/site-packages/clickhouse_driver/bufferedreader.cpython-312-darwin.so - arch: {'x86_64'}
184. /opt/datadog-agent/embedded/lib/python3.12/site-packages/clickhouse_driver/bufferedwriter.cpython-312-darwin.so - arch: {'x86_64'}
185. /opt/datadog-agent/embedded/lib/python3.12/site-packages/clickhouse_driver/columns/largeint.cpython-312-darwin.so - arch: {'x86_64'}
186. /opt/datadog-agent/embedded/lib/python3.12/site-packages/clickhouse_driver/varint.cpython-312-darwin.so - arch: {'x86_64'}
187. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/libcrypto.3.dylib - arch: {'x86_64'}
188. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/libcurl.4.dylib - arch: {'x86_64'}
189. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/liblmdb.so - arch: {'x86_64'}
190. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/librdkafka.1.dylib - arch: {'x86_64'}
191. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/libssl.3.dylib - arch: {'x86_64'}
192. /opt/datadog-agent/embedded/lib/python3.12/site-packages/confluent_kafka/.dylibs/libz.1.3.1.dylib - arch: {'x86_64'}
193. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/appsec/_ddwaf/libddwaf/x86_64/lib/libddwaf.dylib - arch: {'x86_64'}
194. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/appsec/_iast/_ast/iastpatch.cpython-312-darwin.so - arch: {'x86_64'}
195. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/appsec/_iast/_stacktrace.cpython-312-darwin.so - arch: {'x86_64'}
196. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/appsec/_iast/_taint_tracking/_native.cpython-312-darwin.so - arch: {'x86_64'}
197. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/_encoding.cpython-312-darwin.so - arch: {'x86_64'}
198. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/_rand.cpython-312-darwin.so - arch: {'x86_64'}
199. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/_tagset.cpython-312-darwin.so - arch: {'x86_64'}
200. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/_threads.cpython-312-darwin.so - arch: {'x86_64'}
201. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/crashtracker/_crashtracker.cpython-312-darwin.so - arch: {'x86_64'}
202. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe-unknown-x86_64 - arch: {'x86_64'}
203. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/ddup/_ddup.cpython-312-darwin.so - arch: {'x86_64'}
204. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/libdd_wrapper-unknown-x86_64.dylib - arch: {'x86_64'}
205. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/stack_v2/_stack_v2.cpython-312-darwin.so - arch: {'x86_64'}
206. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/native/_native.cpython-312-darwin.so - arch: {'x86_64'}
207. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/internal/telemetry/metrics_namespaces.cpython-312-darwin.so - arch: {'x86_64'}
208. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/_threading.cpython-312-darwin.so - arch: {'x86_64'}
209. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/collector/_memalloc.cpython-312-darwin.so - arch: {'x86_64'}
210. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/collector/_task.cpython-312-darwin.so - arch: {'x86_64'}
211. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/collector/_traceback.cpython-312-darwin.so - arch: {'x86_64'}
212. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/collector/stack.cpython-312-darwin.so - arch: {'x86_64'}
213. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/profiling/exporter/pprof.cpython-312-darwin.so - arch: {'x86_64'}
214. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/vendor/psutil/_psutil_osx.cpython-312-darwin.so - arch: {'x86_64'}
215. /opt/datadog-agent/embedded/lib/python3.12/site-packages/ddtrace/vendor/psutil/_psutil_posix.cpython-312-darwin.so - arch: {'x86_64'}
216. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/_enum_extensions/ext_dce.cpython-312-darwin.so - arch: {'x86_64'}
217. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/chan_bindings.cpython-312-darwin.so - arch: {'x86_64'}
218. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/creds.cpython-312-darwin.so - arch: {'x86_64'}
219. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/cython_converters.cpython-312-darwin.so - arch: {'x86_64'}
220. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/exceptions.cpython-312-darwin.so - arch: {'x86_64'}
221. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_cred_imp_exp.cpython-312-darwin.so - arch: {'x86_64'}
222. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_dce.cpython-312-darwin.so - arch: {'x86_64'}
223. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_ggf.cpython-312-darwin.so - arch: {'x86_64'}
224. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_krb5.cpython-312-darwin.so - arch: {'x86_64'}
225. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_password.cpython-312-darwin.so - arch: {'x86_64'}
226. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_rfc5587.cpython-312-darwin.so - arch: {'x86_64'}
227. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_rfc5801.cpython-312-darwin.so - arch: {'x86_64'}
228. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/ext_set_cred_opt.cpython-312-darwin.so - arch: {'x86_64'}
229. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/mech_krb5.cpython-312-darwin.so - arch: {'x86_64'}
230. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/message.cpython-312-darwin.so - arch: {'x86_64'}
231. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/misc.cpython-312-darwin.so - arch: {'x86_64'}
232. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/names.cpython-312-darwin.so - arch: {'x86_64'}
233. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/oids.cpython-312-darwin.so - arch: {'x86_64'}
234. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/sec_contexts.cpython-312-darwin.so - arch: {'x86_64'}
235. /opt/datadog-agent/embedded/lib/python3.12/site-packages/gssapi/raw/types.cpython-312-darwin.so - arch: {'x86_64'}
236. /opt/datadog-agent/embedded/lib/python3.12/site-packages/jellyfish/_rustyfish.cpython-312-darwin.so - arch: {'x86_64'}
237. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_ccache.cpython-312-darwin.so - arch: {'x86_64'}
238. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_ccache_match.cpython-312-darwin.so - arch: {'x86_64'}
239. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_ccache_support_switch.cpython-312-darwin.so - arch: {'x86_64'}
240. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_cccol.cpython-312-darwin.so - arch: {'x86_64'}
241. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_context.cpython-312-darwin.so - arch: {'x86_64'}
242. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_creds.cpython-312-darwin.so - arch: {'x86_64'}
243. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_creds_opt.cpython-312-darwin.so - arch: {'x86_64'}
244. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_creds_opt_heimdal.cpython-312-darwin.so - arch: {'x86_64'}
245. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_creds_opt_set_pac_request.cpython-312-darwin.so - arch: {'x86_64'}
246. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_exceptions.cpython-312-darwin.so - arch: {'x86_64'}
247. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_keyblock.cpython-312-darwin.so - arch: {'x86_64'}
248. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_kt.cpython-312-darwin.so - arch: {'x86_64'}
249. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_kt_have_content.cpython-312-darwin.so - arch: {'x86_64'}
250. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_kt_heimdal.cpython-312-darwin.so - arch: {'x86_64'}
251. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_principal.cpython-312-darwin.so - arch: {'x86_64'}
252. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_principal_heimdal.cpython-312-darwin.so - arch: {'x86_64'}
253. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_set_password.cpython-312-darwin.so - arch: {'x86_64'}
254. /opt/datadog-agent/embedded/lib/python3.12/site-packages/krb5/_string.cpython-312-darwin.so - arch: {'x86_64'}
255. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/_elementpath.cpython-312-darwin.so - arch: {'x86_64'}
256. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/builder.cpython-312-darwin.so - arch: {'x86_64'}
257. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/etree.cpython-312-darwin.so - arch: {'x86_64'}
258. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/html/clean.cpython-312-darwin.so - arch: {'x86_64'}
259. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/html/diff.cpython-312-darwin.so - arch: {'x86_64'}
260. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/objectify.cpython-312-darwin.so - arch: {'x86_64'}
261. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lxml/sax.cpython-312-darwin.so - arch: {'x86_64'}
262. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lz4/_version.cpython-312-darwin.so - arch: {'x86_64'}
263. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lz4/block/_block.cpython-312-darwin.so - arch: {'x86_64'}
264. /opt/datadog-agent/embedded/lib/python3.12/site-packages/lz4/frame/_frame.cpython-312-darwin.so - arch: {'x86_64'}
265. /opt/datadog-agent/embedded/lib/python3.12/site-packages/mmh3.cpython-312-darwin.so - arch: {'x86_64'}
266. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psutil/_psutil_osx.abi3.so - arch: {'x86_64'}
267. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psutil/_psutil_posix.abi3.so - arch: {'x86_64'}
268. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libcom_err.3.0.dylib - arch: {'x86_64'}
269. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libcrypto.3.dylib - arch: {'x86_64'}
270. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libgssapi_krb5.2.2.dylib - arch: {'x86_64'}
271. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libk5crypto.3.1.dylib - arch: {'x86_64'}
272. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libkrb5.3.3.dylib - arch: {'x86_64'}
273. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libkrb5support.1.1.dylib - arch: {'x86_64'}
274. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/liblber.2.dylib - arch: {'x86_64'}
275. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libldap.2.dylib - arch: {'x86_64'}
276. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libpq.5.dylib - arch: {'x86_64'}
277. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libsasl2.3.dylib - arch: {'x86_64'}
278. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/.dylibs/libssl.3.dylib - arch: {'x86_64'}
279. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/_psycopg.cpython-312-darwin.so - arch: {'x86_64'}
280. /opt/datadog-agent/embedded/lib/python3.12/site-packages/psycopg_binary/pq.cpython-312-darwin.so - arch: {'x86_64'}
281. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pydantic_core/_pydantic_core.cpython-312-darwin.so - arch: {'x86_64'}
282. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pymongo/_cmessage.cpython-312-darwin.so - arch: {'x86_64'}
283. /opt/datadog-agent/embedded/lib/python3.12/site-packages/pyodbc.cpython-312-darwin.so - arch: {'x86_64'}
284. /opt/datadog-agent/embedded/lib/python3.12/site-packages/simplejson/_speedups.cpython-312-darwin.so - arch: {'x86_64'}
285. /opt/datadog-agent/embedded/lib/python3.12/site-packages/snowflake/connector/nanoarrow_arrow_iterator.cpython-312-darwin.so - arch: {'x86_64'}
286. /opt/datadog-agent/embedded/lib/python3.12/site-packages/wrapt/_wrappers.cpython-312-darwin.so - arch: {'x86_64'}
287. /opt/datadog-agent/embedded/lib/python3.12/site-packages/yaml/_yaml.cpython-312-darwin.so - arch: {'x86_64'}

</details>

### Possible Drawbacks / Trade-offs
<details><summary>Timings</summary>

#### Before: ~56.4s
1. ~41.5s for `find /tmp/datadog-agent-build/bin -type f | grep -E '(\.so|\.dylib)' | xargs -I{} ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '{}'`
2. ~10.4s for `find /tmp/datadog-agent-build/bin/embedded/bin -perm +111 -type f | xargs -I{} ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '{}'`
3. ~0.1s (w/ **swallowed error**: `No such file or directory`) for `find /tmp/datadog-agent-build/bin/embedded/sbin -perm +111 -type f | xargs -I{} ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '{}'`
4. ~2.4s for `find /tmp/datadog-agent-build/bin/bin -perm +111 -type f | xargs -I{} ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '{}'`
5. ~0.2s for `../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '/tmp/datadog-agent-build/bin/embedded/lib/python3.12/site-packages/ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe-unknown-x86_64'`
6. ~1.8s for `../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)' '/tmp/datadog-agent-build/bin/Datadog Agent.app'`

#### After: ~14.2s
1. ~13.9s for: (parallelized because sequential would take ~400s)
```
set -euo pipefail
find /tmp/datadog-agent-build/bin -type f -print0 |
    xargs -0 -n1000 -P13 file -n --mime-type |
    awk -F: '$0 ~ /[^)]:[[:space:]]*application\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
    xargs -0 -n10 -P13 ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)'
```
2. ~0.3s for: (sequential)
```
set -euo pipefail
find '/tmp/datadog-agent-build/bin/Datadog Agent.app' -type f -print0 |
    xargs -0 file --mime-type |
    awk -F: '$2 ~ /image\/png/ { printf "%s%c", $1, 0 }' |
    xargs -0 ../tools/ci/retry.sh codesign -o runtime --entitlements /[...]/DataDog/datadog-agent/omnibus/files/macos/Entitlements.plist --force --timestamp --deep -s 'Developer ID Application: Datadog, Inc. (...)'
```
</details>