### PR TITLE
Fix wrong logic in `filter_only_leaf_tests` function used in e2e test retries

### DIFF
--- a/tasks/libs/testing/e2e.py
+++ b/tasks/libs/testing/e2e.py
@@ -26,12 +26,14 @@ def filter_only_leaf_tests(tests: Iterable[tuple[str, str]]) -> set[tuple[str, s
     Given some (package, test_name) tuples, return only the leaf tests.
     A test is a leaf if it is not a parent of any other test in the list (within the same package).
     """
-    # Sort tests by descending depth (number of '/' in test name)
-    tests_sorted = sorted(tests, key=lambda t: len(t[1].split('/')))
+    # Sort tests by depth (number of '/' in test name) - deepest tests first
+    tests_sorted = sorted(tests, key=lambda t: len(t[1].split('/')), reverse=True)
     leaf_tests: set[tuple[str, str]] = set()
     for candidate_test in tests_sorted:
-        # If none of the known leaf tests is a child of the candidate test, then the candidate test is a leaf
-        is_leaf = all(not _is_child(candidate_test, known_leaf_test) for known_leaf_test in leaf_tests)
+        # Check if candidate_test is a leaf test
+        # candidate_test will itself be a leaf if no known leaf test is a child of it.
+        # This works because we are iterating from deepest to shallowest test
+        is_leaf = all(not _is_child(known_leaf_test, candidate_test) for known_leaf_test in leaf_tests)
         if is_leaf:
             leaf_tests.add(candidate_test)
     return leaf_tests

--- a/tasks/libs/testing/e2e.py
+++ b/tasks/libs/testing/e2e.py
@@ -33,25 +33,25 @@ def filter_only_leaf_tests(tests: Iterable[tuple[str, str]]) -> set[tuple[str, s
         # Check if candidate_test is a leaf test
         # candidate_test will itself be a leaf if no known leaf test is a child of it.
         # This works because we are iterating from deepest to shallowest test
-        is_leaf = all(not _is_child(known_leaf_test, candidate_test) for known_leaf_test in leaf_tests)
+        is_leaf = all(not _is_child(candidate_test, known_leaf_test) for known_leaf_test in leaf_tests)
         if is_leaf:
             leaf_tests.add(candidate_test)
     return leaf_tests
 
 
-def _is_child(test1: tuple[str, str], test2: tuple[str, str]) -> bool:
+def _is_child(candidate_parent: tuple[str, str], candidate_child: tuple[str, str]) -> bool:
     """
-    Returns True if test1 is a child of test2.
-    Example: is_child(("pkg", "TestAgent/TestFeatureA"), ("pkg", "TestAgent")) == True
+    Returns True if candidate_child is a child of candidate_parent.
+    Example: is_child(("pkg", "TestAgent"), ("pkg", "TestAgent/TestFeatureA")) == True
     """
-    if test1[0] != test2[0]:
+    if candidate_parent[0] != candidate_child[0]:
         return False
-    splitted_test1 = test1[1].split('/')
-    splitted_test2 = test2[1].split('/')
-    if len(splitted_test2) > len(splitted_test1):
+    child_test_parts = candidate_child[1].split('/')
+    parent_test_parts = candidate_parent[1].split('/')
+    if len(parent_test_parts) > len(child_test_parts):
         return False
 
-    for part1, part2 in zip(splitted_test1, splitted_test2, strict=False):
+    for part1, part2 in zip(child_test_parts, parent_test_parts, strict=False):
         if part1 != part2:
             return False
     return True

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -439,9 +439,10 @@ def run(
                 to_teardown.update(known_flaky_failures)
 
             if to_retry:
+                failed_tests_printout = '\n- '.join(f'{package} {test_name}' for package, test_name in sorted(to_retry))
                 print(
                     color_message(
-                        f"Retrying {len(to_retry)} failed tests:\n- {'\n- '.join(f'{package} {test_name}' for package, test_name in sorted(to_retry))}",
+                        f"Retrying {len(to_retry)} failed tests:\n- {failed_tests_printout}",
                         "yellow",
                     )
                 )

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -410,6 +410,7 @@ def run(
             junit_tar=junit_tar,
             result_json=partial_result_json,
             test_profiler=None,
+            attempt_number=attempt,
         )
 
         washer = TestWasher(test_output_json_file=partial_result_json)

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -111,6 +111,9 @@ func TestPackages(t *testing.T) {
 			suite := test.t(flavor, flavor.Architecture, method)
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
+				if suite.Name() == "agent_ubuntu_24_04_arm64_install_script" {
+					t.Fail()
+				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes two bugs:
- The `sorted_tests` list in `filter_only_leaf_tests` was sorted in ascending order instead of the expected descending, causing the function to return unexpected results. This in turn caused more tests to be selected for retrial than needed, causing lost time in CI. See [this job run](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1016592569) for example
- We pass the `attempt_number` argument to the call to `test_flavor` - without this parameter being passed, the default value of `0` is always used. In turn, this makes it so that the filename for the JUnit file containing all test results is the same across all retries, so it gets overwritten. By passing the attempt number we avoid this overwrite and so correctly report all test runs to DataDog.

Additionally add a couple more unit tests and refactor the arguments to the `_is_child` function.

### Motivation

Make sure #37862 works properly !

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

- Unit test for `filter_only_leaf_tests`
- Force failure of a test (fc0664e2e5) and run CI, check that everything happens as expected (only this test is retried + we get the right junit files in the artifact, and we see failing jobs in Datadog UI)

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->