### PR TITLE
[autodiscovery] Add support for ephemeral containers

### DIFF
--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -61,7 +61,7 @@ func NewKubeletListener(options ServiceListernerDeps) (ServiceListener, error) {
 func (l *KubeletListener) processPod(entity workloadmeta.Entity) {
 	pod := entity.(*workloadmeta.KubernetesPod)
 
-	wlmContainers := pod.GetContainersAndInitContainers()
+	wlmContainers := pod.GetAllContainers()
 	containers := make([]*workloadmeta.Container, 0, len(wlmContainers))
 	for _, podContainer := range wlmContainers {
 		container, err := l.Store().GetContainer(podContainer.ID)

--- a/comp/core/autodiscovery/providers/container.go
+++ b/comp/core/autodiscovery/providers/container.go
@@ -187,7 +187,7 @@ func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integ
 	case *workloadmeta.KubernetesPod:
 		containerIdentifiers := map[string]struct{}{}
 		containerNames := map[string]struct{}{}
-		for _, podContainer := range entity.GetContainersAndInitContainers() {
+		for _, podContainer := range entity.GetAllContainers() {
 			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
 			if err != nil {
 				log.Debugf("Pod %q has reference to non-existing container %q", entity.Name, podContainer.ID)

--- a/comp/core/autodiscovery/providers/container_test.go
+++ b/comp/core/autodiscovery/providers/container_test.go
@@ -410,6 +410,47 @@ func TestGenerateConfig(t *testing.T) {
 			},
 			containerCollectAll: true,
 		},
+		{
+			name: "check defined for ephemeral container",
+			entity: &workloadmeta.KubernetesPod{
+				EntityMeta: workloadmeta.EntityMeta{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.checks": `{
+							"http_check": {
+								"instances": [
+									{
+										"name": "My service",
+										"url": "http://%%host%%",
+										"timeout": 1
+									}
+								]
+							}
+						}`,
+					},
+				},
+				EphemeralContainers: []workloadmeta.OrchestratorContainer{ // Targeted by the annotation
+					{
+						Name: "apache",
+						ID:   "ephemeral-id",
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{ // Not targeted by the annotation
+					{
+						Name: "nginx",
+						ID:   "non-ephemeral-id",
+					},
+				},
+			},
+			expectedConfigs: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://ephemeral-id"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					Source:        "container:docker://ephemeral-id",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -427,7 +468,7 @@ func TestGenerateConfig(t *testing.T) {
 			))
 
 			if pod, ok := tt.entity.(*workloadmeta.KubernetesPod); ok {
-				for _, c := range pod.GetContainersAndInitContainers() {
+				for _, c := range pod.GetAllContainers() {
 					store.Set(&workloadmeta.Container{
 						EntityID: workloadmeta.EntityID{
 							Kind: workloadmeta.KindContainer,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -821,11 +821,6 @@ func (p KubernetesPod) GetAllContainers() []OrchestratorContainer {
 	return append(append(p.InitContainers, p.Containers...), p.EphemeralContainers...)
 }
 
-// GetContainersAndInitContainers returns init containers and containers.
-func (p KubernetesPod) GetContainersAndInitContainers() []OrchestratorContainer {
-	return append(p.InitContainers, p.Containers...)
-}
-
 var _ Entity = &KubernetesPod{}
 
 // KubernetesPodOwner is extracted from a pod's owner references.

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -192,7 +192,7 @@ func (tf *factory) getPodAndContainer(containerID string) (*workloadmeta.Orchest
 	}
 
 	var container *workloadmeta.OrchestratorContainer
-	for _, pc := range pod.GetContainersAndInitContainers() {
+	for _, pc := range pod.GetAllContainers() {
 		if pc.ID == containerID {
 			container = &pc
 			break

--- a/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
+++ b/releasenotes/notes/contp-827-ephemeral-containers-1580450521335ca5.yaml
@@ -9,4 +9,7 @@
 features:
   - |
     Added new config option ``include_ephemeral_containers`` to collect
-    Kubernetes ephemeral containers. The option is disabled by default.
+    Kubernetes ephemeral containers. The option is disabled by default. When
+    enabled, the Agent will report ``container.*`` and ``kubernetes.*`` metrics
+    for ephemeral containers. It will also collect logs and schedule checks for
+    ephemeral containers when configured to do so.


### PR DESCRIPTION
### What does this PR do?

Adds support for collecting logs and scheduling checks for Kubernetes ephemeral containers. This functionality requires the `include_ephemeral_containers` setting to be set to true in the Agent configuration (it was introduced in https://github.com/DataDog/datadog-agent/pull/38465).


### Describe how you validated your changes

Unit tests and also manual.

I deployed in Kubernetes with `include_ephemeral_containers` set to true and and I also enabled log collection for all containers:
```yaml
datadog:
  kubelet:
    tlsVerify: false # for local testing
  logs:
    enabled: true
    containerCollectAll: true
agents:
  containers:
    agent:
      env:
        - name: "DD_INCLUDE_EPHEMERAL_CONTAINERS"
          value: true
```

I deployed an nginx pod and targeted it with an ephemeral container that uses Redis (just as an example. It could be anything for which there's an integration): `kubectl debug -it nginx --image=redis --target=nginx -- redis-server`. I verified that I got logs and metrics for the ephemeral container.

I also confirmed that defining the check config in an annotation works. The only thing to keep in mind is that the container name must match the one used in `kubectl debug`. You can set this with the -c option: `kubectl debug -c redis -it nginx --image=redis --target=nginx -- redis-server`:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  labels:
    app: nginx
  annotations:
    ad.datadoghq.com/redis.check_names: '["redisdb"]'
    ad.datadoghq.com/redis.init_configs: '[{}]'
    ad.datadoghq.com/redis.instances: |
      [
        {
          "host": "%%host%%",
          "port":"6379"
        }
      ]
spec:
  containers:
    - name: nginx
      image: nginx:latest
      ports:
        - containerPort: 80
```