### PR TITLE
Unify noop stream compressor

### DIFF
--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -105,9 +105,6 @@ func (s *batchStrategy) MakeCompressor() {
 	s.serializer.Reset()
 	var encodedPayload bytes.Buffer
 	compressor := s.compression.NewStreamCompressor(&encodedPayload)
-	if compressor == nil {
-		compressor = &compression.NoopStreamCompressor{Writer: &encodedPayload}
-	}
 
 	wc := newWriterWithCounter(compressor)
 	s.writeCounter = wc

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -7,7 +7,6 @@
 package serializer
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"expvar"
@@ -131,8 +130,6 @@ type Serializer struct {
 
 // NewSerializer returns a new Serializer initialized
 func NewSerializer(forwarder forwarder.Forwarder, orchestratorForwarder orchestratorForwarder.Component, compressor compression.Compressor, config config.Component, logger log.Component, hostName string) *Serializer {
-	streamAvailable := compressor.NewStreamCompressor(&bytes.Buffer{}) != nil
-
 	s := &Serializer{
 		Forwarder:                           forwarder,
 		orchestratorForwarder:               orchestratorForwarder,
@@ -143,10 +140,10 @@ func NewSerializer(forwarder forwarder.Forwarder, orchestratorForwarder orchestr
 		enableServiceChecks:                 config.GetBool("enable_payloads.service_checks"),
 		enableSketches:                      config.GetBool("enable_payloads.sketches"),
 		enableJSONToV1Intake:                config.GetBool("enable_payloads.json_to_v1_intake"),
-		enableJSONStream:                    streamAvailable && config.GetBool("enable_stream_payload_serialization"),
-		enableServiceChecksJSONStream:       streamAvailable && config.GetBool("enable_service_checks_stream_payload_serialization"),
-		enableEventsJSONStream:              streamAvailable && config.GetBool("enable_events_stream_payload_serialization"),
-		enableSketchProtobufStream:          streamAvailable && config.GetBool("enable_sketch_stream_payload_serialization"),
+		enableJSONStream:                    config.GetBool("enable_stream_payload_serialization"),
+		enableServiceChecksJSONStream:       config.GetBool("enable_service_checks_stream_payload_serialization"),
+		enableEventsJSONStream:              config.GetBool("enable_events_stream_payload_serialization"),
+		enableSketchProtobufStream:          config.GetBool("enable_sketch_stream_payload_serialization"),
 		hostname:                            hostName,
 		Strategy:                            compressor,
 		jsonExtraHeaders:                    make(http.Header),

--- a/pkg/util/compression/compression.go
+++ b/pkg/util/compression/compression.go
@@ -51,21 +51,3 @@ type StreamCompressor interface {
 
 // ZstdCompressionLevel is a wrapper type over int for the compression level for zstd compression, if that is selected.
 type ZstdCompressionLevel int
-
-// NoopStreamCompressor is a no-op implementation of StreamCompressor
-type NoopStreamCompressor struct {
-	io.Writer
-}
-
-// Close closes the underlying writer
-func (n *NoopStreamCompressor) Close() error {
-	if c, ok := n.Writer.(io.Closer); ok {
-		return c.Close()
-	}
-	return nil
-}
-
-// Flush is a no-op
-func (n *NoopStreamCompressor) Flush() error {
-	return nil
-}

--- a/pkg/util/compression/impl-noop/no_strategy.go
+++ b/pkg/util/compression/impl-noop/no_strategy.go
@@ -40,7 +40,7 @@ func (s *NoopStrategy) ContentEncoding() string {
 	return "identity"
 }
 
-// NewStreamCompressor returns a nil when there is no compression implementation.
+// NewStreamCompressor implements the NewStreamCompressor method for NoopStrategy to satisfy the Compressor interface
 func (s *NoopStrategy) NewStreamCompressor(buf *bytes.Buffer) compression.StreamCompressor {
 	return &noopStreamCompressor{buf}
 }

--- a/pkg/util/compression/impl-noop/no_strategy.go
+++ b/pkg/util/compression/impl-noop/no_strategy.go
@@ -41,6 +41,21 @@ func (s *NoopStrategy) ContentEncoding() string {
 }
 
 // NewStreamCompressor returns a nil when there is no compression implementation.
-func (s *NoopStrategy) NewStreamCompressor(_ *bytes.Buffer) compression.StreamCompressor {
+func (s *NoopStrategy) NewStreamCompressor(buf *bytes.Buffer) compression.StreamCompressor {
+	return &noopStreamCompressor{buf}
+}
+
+// NoopStreamCompressor is a no-op implementation of StreamCompressor
+type noopStreamCompressor struct {
+	*bytes.Buffer
+}
+
+// Close closes the underlying writer
+func (n *noopStreamCompressor) Close() error {
+	return nil
+}
+
+// Flush is a no-op
+func (n *noopStreamCompressor) Flush() error {
 	return nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make the noop compressor implementation return an instance of the already existing `NoopStreamCompressor` instead of nil, and remove corresponding nil checks.

This changes metrics serializer to use streaming json serializer when used on serverless (the only flavor without any compression built in) and disabled v2 api.

### Motivation

Remove obstacles for removing non-streaming v1 json serialization from the metrics serializer.

### Describe how you validated your changes

Tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->