### PR TITLE
dyninst: changes ahead of integrating into system-probe

### DIFF
--- a/pkg/dyninst/actuator/actuator_test.go
+++ b/pkg/dyninst/actuator/actuator_test.go
@@ -78,7 +78,7 @@ func testNoSuccessfulProbesError(t *testing.T, cfg testprogs.Config) {
 	}
 	at := a.NewTenant("test", reporter)
 
-	pid := actuator.ProcessID{PID: int32(cmd.Process.Pid), Service: "test"}
+	pid := actuator.ProcessID{PID: int32(cmd.Process.Pid)}
 	at.HandleUpdate(actuator.ProcessesUpdate{
 		Processes: []actuator.ProcessUpdate{{
 			ProcessID:  pid,

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -60,17 +60,13 @@ func (pk *processKey) String() string {
 	if pk.tenantID == 0 {
 		return pk.ProcessID.String()
 	}
-	if pk.Service == "" {
-		return fmt.Sprintf("{PID:%v,Ten:%v}", pk.PID, pk.tenantID)
-	}
-	return fmt.Sprintf("{PID:%v,Ten:%v,Svc:%v}", pk.PID, pk.tenantID, pk.Service)
+	return fmt.Sprintf("{PID:%v,Ten:%v}", pk.PID, pk.tenantID)
 }
 
 func (pk processKey) cmp(other processKey) int {
 	return cmp.Or(
 		cmp.Compare(pk.tenantID, other.tenantID),
 		cmp.Compare(pk.PID, other.PID),
-		cmp.Compare(pk.Service, other.Service),
 	)
 }
 

--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -306,7 +306,6 @@ func (pts *propertyTestState) existingProcesses() []processKey {
 		return cmp.Or(
 			cmp.Compare(a.tenantID, b.tenantID),
 			cmp.Compare(a.PID, b.PID),
-			cmp.Compare(a.Service, b.Service),
 		)
 	})
 	return existingProcesses

--- a/pkg/dyninst/procmon/process.go
+++ b/pkg/dyninst/procmon/process.go
@@ -26,9 +26,6 @@ type ProcessID struct {
 	// PID is the operating system process ID.
 	PID int32
 
-	// Service is the service name for the process.
-	Service string
-
 	// Realistically this should include something about the start time of
 	// the process to be robust to PID wraparound. This is less of a problem
 	// these days now that pids in linux are 32 bits, but technically it's
@@ -37,10 +34,7 @@ type ProcessID struct {
 
 // String returns a string representation of the process ID.
 func (p ProcessID) String() string {
-	if p.Service == "" {
-		return fmt.Sprintf("{PID:%d}", p.PID)
-	}
-	return fmt.Sprintf("{PID:%d,Svc:%s}", p.PID, p.Service)
+	return fmt.Sprintf("{PID:%d}", p.PID)
 }
 
 // FileHandle identifies a file on a device.

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -36,6 +36,7 @@ type ProcessesUpdate struct {
 type ProcessUpdate struct {
 	ProcessID  ProcessID
 	Executable Executable
+	Service    string
 }
 
 // ProcessMonitor encapsulates the logic of processing events from an event

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -11,6 +11,7 @@
 package procmon
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -103,6 +104,8 @@ func (pm *ProcessMonitor) sendEvent(ev event) {
 // Close requests an orderly shutdown and waits for completion.
 func (pm *ProcessMonitor) Close() {
 	pm.shutdownOnce.Do(func() {
+		log.Debugf("closing process monitor")
+		defer log.Debugf("process monitor closed")
 		close(pm.doneCh)
 		pm.wg.Wait()
 	})
@@ -121,7 +124,10 @@ func (pm *ProcessMonitor) analyzeProcess(pid uint32) {
 	go func() {
 		defer pm.wg.Done()
 		pa, err := analyzeProcess(pid, pm.procfsRoot)
-		if err != nil && analysisFailureLogLimiter.Allow() {
+		shouldLog := err != nil &&
+			!os.IsNotExist(err) &&
+			analysisFailureLogLimiter.Allow()
+		if shouldLog {
 			log.Infof("failed to analyze process %d: %v", pid, err)
 		}
 		pm.sendEvent(&analysisResult{

--- a/pkg/dyninst/procmon/state.go
+++ b/pkg/dyninst/procmon/state.go
@@ -101,10 +101,10 @@ func (s *state) handle(ev event, eff effects) {
 		} else {
 			s.updates = append(s.updates, ProcessUpdate{
 				ProcessID: ProcessID{
-					PID:     int32(e.pid),
-					Service: e.service,
+					PID: int32(e.pid),
 				},
 				Executable: e.exe,
+				Service:    e.service,
 			})
 		}
 	}

--- a/pkg/dyninst/rcscrape/debouncer.go
+++ b/pkg/dyninst/rcscrape/debouncer.go
@@ -60,6 +60,9 @@ func (c *debouncer) addInFlight(
 	processID actuator.ProcessID,
 	file remoteConfigFile,
 ) {
+	if file.ConfigContent == "" {
+		return
+	}
 	p, ok := c.processes[processID]
 	if !ok {
 		// Update corresponds to an untracked process.

--- a/pkg/dyninst/rcscrape/debouncer.go
+++ b/pkg/dyninst/rcscrape/debouncer.go
@@ -59,7 +59,7 @@ func (c *debouncer) addInFlight(
 	now time.Time,
 	processID actuator.ProcessID,
 	file remoteConfigFile,
-) (err error) {
+) {
 	p, ok := c.processes[processID]
 	if !ok {
 		// Update corresponds to an untracked process.
@@ -81,7 +81,6 @@ func (c *debouncer) addInFlight(
 			p.ProcessID, file.ConfigPath,
 		)
 	}
-	return nil
 }
 
 func (c *debouncer) coalesceInFlight(now time.Time) []ProcessUpdate {

--- a/pkg/dyninst/rcscrape/scraper.go
+++ b/pkg/dyninst/rcscrape/scraper.go
@@ -65,8 +65,9 @@ func NewScraper(
 // ProcessUpdate is a wrapper around an actuator.ProcessUpdate that includes
 // the runtime ID of the process.
 type ProcessUpdate struct {
-	actuator.ProcessUpdate
+	procmon.ProcessUpdate
 	RuntimeID string
+	Probes    []ir.ProbeDefinition
 }
 
 // GetUpdates returns the current set of updates.
@@ -136,7 +137,7 @@ func (s *Scraper) trackUpdate(update procmon.ProcessesUpdate) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, process := range update.Processes {
-		s.mu.debouncer.track(process.ProcessID, process.Executable)
+		s.mu.debouncer.track(process)
 	}
 	for _, process := range update.Removals {
 		s.mu.debouncer.untrack(process)

--- a/pkg/dyninst/rcscrape/scraper.go
+++ b/pkg/dyninst/rcscrape/scraper.go
@@ -124,7 +124,8 @@ func (s *scraperSink) HandleEvent(ev output.Event) error {
 	}
 	s.scraper.mu.Lock()
 	defer s.scraper.mu.Unlock()
-	return s.scraper.mu.debouncer.addInFlight(now, s.processID, rcFile)
+	s.scraper.mu.debouncer.addInFlight(now, s.processID, rcFile)
+	return nil
 }
 
 func (s *scraperSink) Close() {

--- a/pkg/dyninst/rcscrape/scraper_test.go
+++ b/pkg/dyninst/rcscrape/scraper_test.go
@@ -143,6 +143,7 @@ func runScrapeRemoteConfigTest(t *testing.T, program string, cfg testprogs.Confi
 		require.NoError(t, err)
 		rcsFiles[mkPath(t, probe.GetID())] = marshaled
 	}
+	rcsFiles[mkPath(t, "empty")] = []byte{}
 	rcHandler.UpdateRemoteConfig(rcsFiles)
 	waitForExpected(t, rcScraper, newUpdate)
 }

--- a/pkg/dyninst/rcscrape/scraper_utils_test.go
+++ b/pkg/dyninst/rcscrape/scraper_utils_test.go
@@ -7,16 +7,16 @@
 
 package rcscrape
 
-import "github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+import "github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 
 // GetTrackedProcesses returns the set of processes that the scraper is
 // tracking. This is a utility function for testing.
-func (s *Scraper) GetTrackedProcesses() []actuator.ProcessID {
+func (s *Scraper) GetTrackedProcesses() []procmon.ProcessID {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var processes []actuator.ProcessID
+	var processes []procmon.ProcessID
 	for _, p := range s.mu.debouncer.processes {
-		processes = append(processes, p.processID)
+		processes = append(processes, p.ProcessID)
 	}
 	return processes
 }

--- a/pkg/dyninst/uploader/batcher.go
+++ b/pkg/dyninst/uploader/batcher.go
@@ -85,6 +85,8 @@ func (b *batcher) enqueue(data json.RawMessage) {
 
 func (b *batcher) stop() {
 	b.stopOnce.Do(func() {
+		log.Debugf("stopping batcher %s", b.name)
+		defer log.Debugf("batcher %s stopped", b.name)
 		// Cancel the run loop as well as any goroutines trying to signal it.
 		b.cancel()
 
@@ -100,13 +102,13 @@ func (b *batcher) run() {
 	for {
 		select {
 		case data := <-b.enqueueCh:
-			log.Debugf(
+			log.Tracef(
 				"uploader %s: received enqueue event of %d bytes",
 				b.name, len(data),
 			)
 			b.state.handleEnqueueEvent(data, time.Now(), b)
 		case <-b.timer.C:
-			log.Debugf(
+			log.Tracef(
 				"uploader %s: timer fired event", b.name,
 			)
 			if err := b.state.handleTimerFiredEvent(b); err != nil {
@@ -117,7 +119,7 @@ func (b *batcher) run() {
 			}
 		case result := <-b.sendResultCh:
 			if result.err != nil {
-				log.Infof(
+				log.Debugf(
 					"uploader %s: batch outcome id=%d: err=%v",
 					b.name, result.id, result.err,
 				)

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -16,12 +16,14 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"time"
 )
 
 // DiagnosticMessage is the message sent to the DataDog backend conveying diagnostic information
 type DiagnosticMessage struct {
-	Service  string         `json:"service"`
-	DDSource debuggerSource `json:"ddsource"`
+	Service   string         `json:"service"`
+	DDSource  debuggerSource `json:"ddsource"`
+	Timestamp int64          `json:"timestamp"`
 
 	Debugger struct {
 		Diagnostic `json:"diagnostics"`
@@ -61,9 +63,10 @@ const (
 
 // Diagnostic contains fields relevant for conveying the status of a probe
 type Diagnostic struct {
-	RuntimeID string `json:"runtimeId"`
-	ProbeID   string `json:"probeId"`
-	Status    Status `json:"status"`
+	RuntimeID    string `json:"runtimeId"`
+	ProbeID      string `json:"probeId"`
+	Status       Status `json:"status"`
+	ProbeVersion int    `json:"probeVersion,omitempty"`
 
 	*DiagnosticException `json:"exception,omitempty"`
 }
@@ -93,6 +96,7 @@ func NewDiagnosticsUploader(opts ...Option) *DiagnosticsUploader {
 
 // Enqueue adds a message to the uploader's queue.
 func (u *DiagnosticsUploader) Enqueue(diag *DiagnosticMessage) error {
+	diag.Timestamp = time.Now().UnixMilli()
 	data, err := json.Marshal(diag)
 	if err != nil {
 		return err

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -114,7 +114,9 @@ func TestDiagnosticsUploader(t *testing.T) {
 	computeExpectedBytes := func(messages []*DiagnosticMessage) int {
 		var expectedBytes int
 		for _, msg := range messages {
-			msgBytes, err := json.Marshal(msg)
+			msg := *msg
+			msg.Timestamp = time.Now().UnixMilli()
+			msgBytes, err := json.Marshal(&msg)
 			require.NoError(t, err)
 			expectedBytes += len(msgBytes)
 		}


### PR DESCRIPTION

### What does this PR do?

This pile of commits fixes up bugs or other interface issues in advance of integrating into `system-probe`

#### dyninst/procmon: tweaks for robustness and logs

#### dyninst/rcscrape: handle empty ConfigContent

This happens when a probe is removed. It's worth noting
that dd-trace-go is leaking these entries in the map, but that's
something to fix separately.

#### dyninst/rcscrape: reset lastUpdated

This also refactors the code to make it easier to see what is going on.

#### dyninst/rcscrape: make function infallible

#### dyninst/rcscrape: fix test cleanup logic

Due to a bad refactor, we used to only clean up on failure.

#### dyninst/uploader: unconsequential logging changes

#### dyninst/uploader: add missing fields

This timestamp turned out to be important.

#### dyninst: rework process information

The service as part of the actuator.ProcessID was a half-baked
idea. Instead it should be associated with the process we get
from procmon, but not with the actuator.

Part of https://datadoghq.atlassian.net/browse/DEBUG-4122