### PR TITLE
Remove obsolete fallback options

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -67,10 +67,6 @@ func setupForwarder(config pkgconfigmodel.Config) {
 
 func setupSerializer(config pkgconfigmodel.Config, cfg *ExporterConfig) {
 	// Serializer
-	config.Set("enable_stream_payload_serialization", true, pkgconfigmodel.SourceDefault)
-	config.Set("enable_service_checks_stream_payload_serialization", true, pkgconfigmodel.SourceDefault)
-	config.Set("enable_events_stream_payload_serialization", true, pkgconfigmodel.SourceDefault)
-	config.Set("enable_sketch_stream_payload_serialization", true, pkgconfigmodel.SourceDefault)
 	config.Set("enable_json_stream_shared_compressor_buffers", true, pkgconfigmodel.SourceDefault)
 
 	// Warning: do not change the following values. Your payloads will get dropped by Datadog's intake.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1367,10 +1367,6 @@ func telemetry(config pkgconfigmodel.Setup) {
 
 func serializer(config pkgconfigmodel.Setup) {
 	// Serializer
-	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
-	config.BindEnvAndSetDefault("enable_service_checks_stream_payload_serialization", true)
-	config.BindEnvAndSetDefault("enable_events_stream_payload_serialization", true)
-	config.BindEnvAndSetDefault("enable_sketch_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("enable_json_stream_shared_compressor_buffers", true)
 
 	// Warning: do not change the following values. Your payloads will get dropped by Datadog's intake.

--- a/pkg/serializer/internal/metrics/events.go
+++ b/pkg/serializer/internal/metrics/events.go
@@ -12,10 +12,8 @@ import (
 	"expvar"
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	jsoniter "github.com/json-iterator/go"
 
-	agentpayload "github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -39,31 +37,6 @@ var (
 type Events struct {
 	EventsArr []*event.Event
 	Hostname  string
-}
-
-// Marshal serialize events using agent-payload definition
-func (events Events) Marshal() ([]byte, error) {
-	payload := &agentpayload.EventsPayload{
-		Events:   []*agentpayload.EventsPayload_Event{},
-		Metadata: &agentpayload.CommonMetadata{},
-	}
-
-	for _, e := range events.EventsArr {
-		payload.Events = append(payload.Events,
-			&agentpayload.EventsPayload_Event{
-				Title:          e.Title,
-				Text:           e.Text,
-				Ts:             e.Ts,
-				Priority:       string(e.Priority),
-				Host:           e.Host,
-				Tags:           e.Tags,
-				AlertType:      string(e.AlertType),
-				AggregationKey: e.AggregationKey,
-				SourceTypeName: e.SourceTypeName,
-			})
-	}
-
-	return proto.Marshal(payload)
 }
 
 func (events Events) getEventsBySourceType() map[string][]*event.Event {

--- a/pkg/serializer/internal/metrics/service_checks.go
+++ b/pkg/serializer/internal/metrics/service_checks.go
@@ -6,8 +6,6 @@
 package metrics
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -15,7 +13,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
-	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	utiljson "github.com/DataDog/datadog-agent/pkg/util/json"
 )
@@ -30,47 +27,7 @@ var (
 // ServiceChecks represents a list of service checks ready to be serialize
 type ServiceChecks []*servicecheck.ServiceCheck
 
-// MarshalJSON serializes service checks to JSON so it can be sent to V1 endpoints
-// FIXME(olivier): to be removed when v2 endpoints are available
-func (sc ServiceChecks) MarshalJSON() ([]byte, error) {
-	// use an alias to avoid infinite recursion while serializing
-	type ServiceChecksAlias ServiceChecks
-
-	reqBody := &bytes.Buffer{}
-	err := json.NewEncoder(reqBody).Encode(ServiceChecksAlias(sc))
-	return reqBody.Bytes(), err
-}
-
-// SplitPayload breaks the payload into times number of pieces
-func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
-	serviceCheckExpvar.Add("TimesSplit", 1)
-	tlmServiceCheck.Inc("times_split")
-	// only split it up as much as possible
-	if len(sc) < times {
-		serviceCheckExpvar.Add("ServiceChecksShorter", 1)
-		tlmServiceCheck.Inc("shorter")
-		times = len(sc)
-	}
-	splitPayloads := make([]marshaler.AbstractMarshaler, times)
-	batchSize := len(sc) / times
-	n := 0
-	for i := 0; i < times; i++ {
-		var end int
-		// the batch size will not be perfect, only split it as much as possible
-		if i < times-1 {
-			end = n + batchSize
-		} else {
-			end = len(sc)
-		}
-		newSC := sc[n:end]
-		splitPayloads[i] = newSC
-		n += batchSize
-	}
-	return splitPayloads, nil
-}
-
-//// The following methods implement the StreamJSONMarshaler interface
-//// for support of the enable_service_checks_stream_payload_serialization option.
+//// The following methods implement the StreamJSONMarshaler interface,
 
 // WriteHeader writes the payload header for this type
 func (sc ServiceChecks) WriteHeader(stream *jsoniter.Stream) error {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -115,13 +115,13 @@ type Serializer struct {
 	// might collect data considered too sensitive (database IP and
 	// such). By default every kind of payload is enabled since
 	// almost every user won't fall into this use case.
-	enableEvents                  bool
-	enableSeries                  bool
-	enableServiceChecks           bool
-	enableSketches                bool
-	enableJSONToV1Intake          bool
-	hostname                      string
-	logger                        log.Component
+	enableEvents         bool
+	enableSeries         bool
+	enableServiceChecks  bool
+	enableSketches       bool
+	enableJSONToV1Intake bool
+	hostname             string
+	logger               log.Component
 }
 
 // NewSerializer returns a new Serializer initialized

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -263,7 +263,6 @@ func TestSendV1Events(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("enable_events_stream_payload_serialization", false)
 			mockConfig.SetWithoutSource("serializer_compressor_kind", tc.kind)
 			f := &forwarder.MockedForwarder{}
 
@@ -291,7 +290,6 @@ func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("enable_events_stream_payload_serialization", true)
 			mockConfig.SetWithoutSource("serializer_compressor_kind", tc.kind)
 			f := &forwarder.MockedForwarder{}
 
@@ -332,7 +330,6 @@ func TestSendV1ServiceChecks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := &forwarder.MockedForwarder{}
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("enable_service_checks_stream_payload_serialization", false)
 			mockConfig.SetWithoutSource("serializer_compressor_kind", tc.kind)
 
 			compressor := metricscompressionimpl.NewCompressorReq(metricscompressionimpl.Requires{Cfg: mockConfig}).Comp
@@ -359,7 +356,6 @@ func TestSendV1Series(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := &forwarder.MockedForwarder{}
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("enable_stream_payload_serialization", false)
 			mockConfig.SetWithoutSource("use_v2_api.series", false)
 			mockConfig.SetWithoutSource("serializer_compressor_kind", tc.kind)
 

--- a/releasenotes/notes/serializer-stream-cleanup-a205a5b3fbcebe90.yaml
+++ b/releasenotes/notes/serializer-stream-cleanup-a205a5b3fbcebe90.yaml
@@ -1,0 +1,8 @@
+deprecations:
+  - |
+    Remove deprecated serializer options.
+    
+    * ``enable_stream_payload_serialization``
+    * ``enable_service_checks_stream_payload_serialization``
+    * ``enable_events_stream_payload_serialization``
+    * ``enable_sketch_stream_payload_serialization``


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove obsolete fallback options

* enable_stream_payload_serialization
* enable_service_checks_stream_payload_serialization
* enable_events_stream_payload_serialization
* enable_sketch_stream_payload_serialization

These has been enabled by default for years and used everywhere, except on builds with no compression.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->