### PR TITLE
Revert "Update lading to 0.26, update and add RD experiments"

### DIFF
--- a/test/regression/cases/ddot_metrics/datadog-agent/datadog.yaml
+++ b/test/regression/cases/ddot_metrics/datadog-agent/datadog.yaml
@@ -17,11 +17,3 @@ process_config:
 telemetry:
   enabled: true
   checks: '*'
-
-otelcollector:
-  converter:
-    enabled: true
-  enabled: true
-  extension_timeout: 0
-  flare:
-    timeout: 60

--- a/test/regression/cases/ddot_metrics/datadog-agent/otel-config.yaml
+++ b/test/regression/cases/ddot_metrics/datadog-agent/otel-config.yaml
@@ -8,49 +8,51 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-        - job_name: "otelcol"
-          scrape_interval: 10s
-          static_configs:
-            - targets: ["0.0.0.0:8888"]
+      - job_name: 'otelcol'
+        scrape_interval: 10s
+        static_configs:
+          - targets: ['0.0.0.0:8888']
 exporters:
-  hostname: "smp-regression"
   datadog:
+    traces:
+      span_name_as_resource_name: true
+      endpoint: "http://127.0.0.1:9091"
+    hostname: "smp-regression"    
     api:
-      key: ${env:DD_API_KEY}
-      site: datadoghq.com
+      key: "123456789"
+      site: 127.0.0.1:9091
     metrics:
       resource_attributes_as_tags: true
-      endpoint: "http://127.0.0.1:9091"
-    traces:
-      endpoint: "http://127.0.0.1:9091"
+      endpoint: http://127.0.0.1:9091
     logs:
-      endpoint: "http://127.0.0.1:9091"
-    sending_queue:
-      queue_size: 50
+      endpoint: http://127.0.0.1:9091
+      
+
 processors:
-  infraattributes:
-    cardinality: 2
   batch:
-    send_batch_size: 4096
-    timeout: 10s
 connectors:
+  # Use datadog connector to compute stats for pre-sampled traces
   datadog/connector:
-    trace:
+    traces:
+      span_name_as_resource_name: true
+      compute_stats_by_span_kind: true
+      compute_top_level_by_span_kind: true
+      peer_tags_aggregation: true
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
       exporters: [datadog/connector]
-    traces/otlp:
+    traces/send:
       receivers: [otlp]
-      processors: [infraattributes, batch]
+      processors: [batch]
       exporters: [datadog]
     metrics:
-      receivers: [otlp, datadog/connector, prometheus]
-      processors: [infraattributes, batch]
+      receivers: [otlp, datadog/connector]
+      processors: [batch]
       exporters: [datadog]
     logs:
       receivers: [otlp]
-      processors: [infraattributes, batch]
+      processors: [batch]
       exporters: [datadog]

--- a/test/regression/cases/ddot_metrics/experiment.yaml
+++ b/test/regression/cases/ddot_metrics/experiment.yaml
@@ -4,11 +4,12 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 7.5 GiB
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
+    DD_AUTH_TOKEN_FILE_PATH: /tmp/agent-auth-token
     DD_OTELCOLLECTOR_ENABLED: true
 
   profiling_environment:
@@ -20,7 +21,7 @@ target:
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
     # destination
     DD_INTERNAL_PROFILING_UNIX_SOCKET: /smp-host/apm.socket
-
+    
     # tags
     DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:ddot_metrics
     DD_SYSTEM_PROBE_CONFIG_INTERNAL_PROFILING_EXTRA_TAGS: experiment:ddot_metrics

--- a/test/regression/cases/ddot_metrics/lading/lading.yaml
+++ b/test/regression/cases/ddot_metrics/lading/lading.yaml
@@ -5,45 +5,12 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/metrics"
-      bytes_per_second: "25 MiB"
+      bytes_per_second: "6 MiB"
       parallel_connections: 5
       method:
         post:
           maximum_prebuild_cache_size_bytes: "512 MiB"
-          variant:
-            # all numbers arbitraray
-            opentelemetry_metrics:
-              metric_weights:
-                gauge: 50
-                sum: 50
-              contexts:
-                total_contexts:
-                  constant: 10000
-                # host., service. etc
-                attributes_per_resource:
-                  inclusive:
-                    min: 8
-                    max: 64
-                # auto-instrumentation in client libraries, DB connection etc
-                scopes_per_resource:
-                  inclusive:
-                    min: 1
-                    max: 32
-                # rare? build info possibly
-                attributes_per_scope:
-                  inclusive:
-                    min: 0
-                    max: 4
-                # exported instruments / telemetry by libraries and custom code
-                metrics_per_scope:
-                  inclusive:
-                    min: 10
-                    max: 128
-                # stuff like exit code, user id, cgroup id
-                attributes_per_metric:
-                  inclusive:
-                    min: 0
-                    max: 255
+          variant: "opentelemetry_metrics"
 
 blackhole:
   - http:

--- a/test/regression/cases/otlp_ingest_metrics/datadog-agent/datadog.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/datadog-agent/datadog.yaml
@@ -11,28 +11,22 @@ logs_config:
   logs_no_ssl: true
   force_use_http: true
 
-log_level: info
-
 dd_url: http://127.0.0.1:9091
 process_config:
   process_dd_url: http://localhost:9093
 telemetry:
   enabled: true
   checks: '*'
-
-otelcollector:
-  enabled: false
-
 otlp_config:
   receiver:
     protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: 127.0.0.1:4318
+      grpc:
+        endpoint: 127.0.0.1:4317
   metrics:
     enabled: true
   traces:
-    enabled: false
+    enabled: true
   logs:
-    enabled: false
+    enabled: true

--- a/test/regression/cases/otlp_ingest_metrics/experiment.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/experiment.yaml
@@ -4,20 +4,11 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 7.5 GiB
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: a0000001
     DD_HOSTNAME: smp-regression
-    # Enable the built-in OTLP receiver
-    DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: 0.0.0.0:4317
-    DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: 0.0.0.0:4318
-    # Configure metrics
-    DD_OTLP_CONFIG_METRICS_ENABLED: true
-    DD_OTLP_CONFIG_METRICS_RESOURCE_ATTRIBUTES_AS_TAGS: true
-    DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_SCOPE_METADATA_AS_TAGS: true
-    # Disable DDOT to ensure we use built-in OTLP
-    DD_OTELCOLLECTOR_ENABLED: false
 
   profiling_environment:
     # internal profiling
@@ -28,7 +19,7 @@ target:
     DD_INTERNAL_PROFILING_CPU_DURATION: 1m
     # destination
     DD_INTERNAL_PROFILING_UNIX_SOCKET: /smp-host/apm.socket
-
+    
     # tags
     DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:otlp_ingest_metrics
     DD_SYSTEM_PROBE_CONFIG_INTERNAL_PROFILING_EXTRA_TAGS: experiment:otlp_ingest_metrics

--- a/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
@@ -5,45 +5,12 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/metrics"
-      bytes_per_second: "25 MiB"
+      bytes_per_second: "6 MiB"
       parallel_connections: 5
       method:
         post:
           maximum_prebuild_cache_size_bytes: "512 MiB"
-          variant:
-            # all numbers arbitraray
-            opentelemetry_metrics:
-              metric_weights:
-                gauge: 50
-                sum: 50
-              contexts:
-                total_contexts:
-                  constant: 10000
-                # host., service. etc
-                attributes_per_resource:
-                  inclusive:
-                    min: 8
-                    max: 64
-                # auto-instrumentation in client libraries, DB connection etc
-                scopes_per_resource:
-                  inclusive:
-                    min: 1
-                    max: 32
-                # rare? build info possibly
-                attributes_per_scope:
-                  inclusive:
-                    min: 0
-                    max: 4
-                # exported instruments / telemetry by libraries and custom code
-                metrics_per_scope:
-                  inclusive:
-                    min: 10
-                    max: 128
-                # stuff like exit code, user id, cgroup id
-                attributes_per_metric:
-                  inclusive:
-                    min: 0
-                    max: 255
+          variant: "opentelemetry_metrics"
 
 blackhole:
   - http:

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.26.0
+  version: 0.25.9
 
 target:
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#38338

We spotted an issue in the latest lading which needs to be reverted to avoid regression detector & quality gate false positives from being reported.