### PR TITLE
Fix the s3 strategy in datadog-agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ variables:
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy
-  OVERRIDE_GIT_STRATEGY: "s3"
+  GIT_STRATEGY: "s3"
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2

--- a/.gitlab/trigger_distribution/conditions.yml
+++ b/.gitlab/trigger_distribution/conditions.yml
@@ -151,6 +151,9 @@
 # Use in jobs that need to run on Windows Server 2019 runners.
 .windows_docker_2019:
   tags: ["windows-v2:2019"]
+  variables:
+    # Windows runners don't support the s3 strategy and benefit from persisting the repository
+    OVERRIDE_GIT_STRATEGY: "fetch"
 
 # windows_docker_2022 configures the job to use the Windows Server 2022 runners.
 # Use in jobs that need to run on Windows Server 2022 runners.
@@ -166,6 +169,8 @@
   variables:
     # Full image name for Agent windows build image, for use in docker run command
     WINBUILDIMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_${ARCH}${CI_IMAGE_WIN_LTSC2022_X64_SUFFIX}:${CI_IMAGE_WIN_LTSC2022_X64}
+    # Windows runners don't support the s3 strategy and benefit from persisting the repository
+    OVERRIDE_GIT_STRATEGY: "fetch"
 
 # windows_docker_default configures the job to use the default Windows Server runners
 # Use in jobs that may need to have their version updated in the future.


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

> Note: The OVERRIDE_ variables should strictly only be used in a job’s variable section. Using them anywhere else might lead to replicating the original problem but with the OVERRIDE_ variables.
From https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3622535770/GitLab+Runners+Fork+Features#%3Apipe%3A-Support-to-Override-Parent%E2%80%99s-Variables-in-Child-Pipelines

No need to use override variables at the top level
Windows doesn't support the s3 strategy so the value should be overriden

</details>

<details open><summary>

# Solution
</summary>

Use GIT_STRATEGY: s3 for the global variable
User OVERRIDE_GIT_STRATEGY: fetch for the windows setup

</details>
