### PR TITLE
usm: kafka: tests: Enable kafka tests on ubuntu 24.10

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -102,19 +102,6 @@ type groupInfo struct {
 	msgs    []Message
 }
 
-// isUnsupportedUbuntu checks if the test is running on an unsupported Ubuntu version.
-// As of now, we don’t support Kafka TLS with Ubuntu 24.10, so this function identifies
-// if the current platform and version match this unsupported configuration.
-func isUnsupportedUbuntu(t *testing.T) bool {
-	platform, err := kernel.Platform()
-	require.NoError(t, err)
-	platformVersion, err := kernel.PlatformVersion()
-	require.NoError(t, err)
-	arch := kernel.Arch()
-
-	return platform == ubuntuPlatform && platformVersion == "24.10" && arch == "x86"
-}
-
 func skipTestIfKernelNotSupported(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
@@ -166,9 +153,6 @@ func (s *KafkaProtocolParsingSuite) TestKafkaProtocolParsing() {
 		t.Run(name, func(t *testing.T) {
 			if mode && !gotlsutils.GoTLSSupported(t, utils.NewUSMEmptyConfig()) {
 				t.Skip("GoTLS not supported for this setup")
-			}
-			if mode && isUnsupportedUbuntu(t) {
-				t.Skip("Kafka TLS not supported on Ubuntu 24.10")
 			}
 			for _, version := range versions {
 				t.Run(versionName(version), func(t *testing.T) {
@@ -1330,9 +1314,6 @@ func (s *KafkaProtocolParsingSuite) TestKafkaFetchRaw() {
 		if !gotlsutils.GoTLSSupported(t, utils.NewUSMEmptyConfig()) {
 			t.Skip("GoTLS not supported for this setup")
 		}
-		if isUnsupportedUbuntu(t) {
-			t.Skip("Kafka TLS not supported on Ubuntu 24.10")
-		}
 
 		for _, version := range versions {
 			t.Run(fmt.Sprintf("api%d", version), func(t *testing.T) {
@@ -1559,9 +1540,6 @@ func (s *KafkaProtocolParsingSuite) TestKafkaProduceRaw() {
 	t.Run("with TLS", func(t *testing.T) {
 		if !gotlsutils.GoTLSSupported(t, utils.NewUSMEmptyConfig()) {
 			t.Skip("GoTLS not supported for this setup")
-		}
-		if isUnsupportedUbuntu(t) {
-			t.Skip("Kafka TLS not supported on Ubuntu 24.10")
 		}
 
 		for _, version := range versions {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enabling kafka tests on top of ubuntu 24.10

### Motivation

We believed there was issue with kafka-tls on top of ubuntu 24.10, hence we disabled those tests when we run on ubuntu 24.10. however, we discovered the issue was due to a breaking change in our GoTLS monitoring on kernels 6.11 and later.

The original issue was fixed, so we can enable kafka tests again on ubuntu 24.10

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->