### PR TITLE
pkg/dyninst: Check presence bitset, decoding fixes

### DIFF
--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -337,7 +337,7 @@ func (d *Decoder) encodeValueFields(
 				currentlyEncoding,
 				v.Element,
 				elementData,
-				"",
+				elementType.GetName(),
 			); err != nil {
 				return err
 			}

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -85,7 +85,8 @@ type argumentsData struct {
 // bytes, and presence bits in the bitset correspond with index of
 // the expression in the root ir.
 func expressionIsPresent(bitset []byte, expressionIndex int) bool {
-	return (bitset[expressionIndex/8] & (1 << byte(expressionIndex%8))) != 0
+	idx, bit := expressionIndex/8, expressionIndex%8
+	return idx < len(bitset) && bitset[idx]&(1<<byte(bit)) != 0
 }
 
 func (ad *argumentsData) MarshalJSONTo(enc *jsontext.Encoder) error {
@@ -109,7 +110,7 @@ func (ad *argumentsData) MarshalJSONTo(enc *jsontext.Encoder) error {
 			jsontext.String(expr.Name)); err != nil {
 			return err
 		}
-		if !expressionIsPresent(presenceBitSet, i) {
+		if !expressionIsPresent(presenceBitSet, i) && parameterType.GetByteSize() != 0 {
 			// Set not capture reason
 			if err = writeTokens(enc,
 				jsontext.BeginObject,

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -94,9 +94,15 @@ func TestDyninst(t *testing.T) {
 			t.Logf("%s is not used in integration tests", svc)
 			continue
 		}
-		t.Run(svc, func(t *testing.T) {
-			runIntegrationTestSuite(t, svc, cfgs, rewrite, sem)
-		})
+		for _, cfg := range cfgs {
+			if cfg.GOARCH != runtime.GOARCH {
+				t.Logf("cross-execution is not supported, running on %s, skipping %s", runtime.GOARCH, cfg.GOARCH)
+				continue
+			}
+			t.Run(fmt.Sprintf("%s-%s", svc, cfg), func(t *testing.T) {
+				runIntegrationTestSuite(t, svc, cfg, rewrite, sem)
+			})
+		}
 	}
 }
 
@@ -318,7 +324,7 @@ type probeOutputs map[string][]json.RawMessage
 func runIntegrationTestSuite(
 	t *testing.T,
 	service string,
-	configs []testprogs.Config,
+	cfg testprogs.Config,
 	rewrite bool,
 	sem semaphore,
 ) {
@@ -343,43 +349,33 @@ func runIntegrationTestSuite(
 		expectedOutput, err = getExpectedDecodedOutputOfProbes(service)
 		require.NoError(t, err)
 	}
-	for _, cfg := range configs {
-		if cfg.GOARCH != runtime.GOARCH {
-			t.Skipf(
-				"cross-execution is not supported, running on %s, skipping %s",
-				runtime.GOARCH, cfg.GOARCH,
+	bin := testprogs.MustGetBinary(t, service, cfg)
+	for _, debug := range []bool{false, true} {
+		if testing.Short() && debug {
+			t.Skip("skipping debug mode in short mode")
+		}
+		runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) {
+			t.Parallel()
+			actual := testDyninst(
+				t, service, bin, probeSlice, rewrite, expectedOutput, debug, sem,
 			)
-			continue
-		}
-		bin := testprogs.MustGetBinary(t, service, cfg)
-		for _, debug := range []bool{false, true} {
-			if testing.Short() && debug {
-				t.Skip("skipping debug mode in short mode")
+			if t.Failed() {
+				return
 			}
-			runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) {
-				t.Parallel()
-				actual := testDyninst(
-					t, service, bin, probeSlice, rewrite, expectedOutput, debug,
-					sem,
-				)
-				if t.Failed() {
-					return
-				}
-				outputs.Lock()
-				defer outputs.Unlock()
-				outputs.byTest[t.Name()] = actual
-			}
-			t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
-				t.Parallel()
-				t.Run("all-probes", func(t *testing.T) { runTest(t, probes) })
-				for i := range probes {
-					probeID := probes[i].GetID()
-					t.Run(probeID, func(t *testing.T) {
-						runTest(t, probes[i:i+1])
-					})
-				}
-			})
+			outputs.Lock()
+			defer outputs.Unlock()
+			outputs.byTest[t.Name()] = actual
 		}
+		t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
+			t.Parallel()
+			t.Run("all-probes", func(t *testing.T) { runTest(t, probes) })
+			for i := range probes {
+				probeID := probes[i].GetID()
+				t.Run(probeID, func(t *testing.T) {
+					runTest(t, probes[i:i+1])
+				})
+			}
+		})
 	}
 }
 

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -310,7 +310,7 @@ type EventRootType struct {
 
 	// Bitset tracking successful expression evaluation (one bit per
 	// expression).
-	PresenseBitsetSize uint32
+	PresenceBitsetSize uint32
 	// Expressions is the list of expressions that are used to evaluate the
 	// value of the event.
 	Expressions []*RootExpression

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -667,7 +667,7 @@ func populateEventExpressions(
 			Name:     fmt.Sprintf("Probe[%s]", probe.Subprogram.Name),
 			ByteSize: uint32(byteSize),
 		},
-		PresenseBitsetSize: presenceBitsetSize,
+		PresenceBitsetSize: presenceBitsetSize,
 		Expressions:        expressions,
 	}
 	typeCatalog.typesByID[event.Type.ID] = event.Type

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -842,7 +842,7 @@ Types:
       ID: 53
       Name: Probe[main.intArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
@@ -857,7 +857,7 @@ Types:
       ID: 54
       Name: Probe[main.stringArg]
       ByteSize: 17
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -872,7 +872,7 @@ Types:
       ID: 55
       Name: Probe[main.intSliceArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -887,7 +887,7 @@ Types:
       ID: 56
       Name: Probe[main.intArrayArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -902,7 +902,7 @@ Types:
       ID: 57
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -917,7 +917,7 @@ Types:
       ID: 58
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -932,7 +932,7 @@ Types:
       ID: 59
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -947,7 +947,7 @@ Types:
       ID: 60
       Name: Probe[main.mapArg]
       ByteSize: 1
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
@@ -962,7 +962,7 @@ Types:
       ID: 61
       Name: Probe[main.bigMapArg]
       ByteSize: 1
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
@@ -977,7 +977,7 @@ Types:
       ID: 62
       Name: Probe[main.inlined]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
@@ -992,7 +992,7 @@ Types:
       ID: 63
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: ptr
           Offset: 1
@@ -1007,7 +1007,7 @@ Types:
       ID: 64
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: ptr
           Offset: 1

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -842,7 +842,7 @@ Types:
       ID: 53
       Name: Probe[main.intArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
@@ -857,7 +857,7 @@ Types:
       ID: 54
       Name: Probe[main.stringArg]
       ByteSize: 17
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -872,7 +872,7 @@ Types:
       ID: 55
       Name: Probe[main.intSliceArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -887,7 +887,7 @@ Types:
       ID: 56
       Name: Probe[main.intArrayArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -902,7 +902,7 @@ Types:
       ID: 57
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -917,7 +917,7 @@ Types:
       ID: 58
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -932,7 +932,7 @@ Types:
       ID: 59
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: s
           Offset: 1
@@ -947,7 +947,7 @@ Types:
       ID: 60
       Name: Probe[main.mapArg]
       ByteSize: 1
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
@@ -962,7 +962,7 @@ Types:
       ID: 61
       Name: Probe[main.bigMapArg]
       ByteSize: 1
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: m
           Offset: 1
@@ -977,7 +977,7 @@ Types:
       ID: 62
       Name: Probe[main.inlined]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: x
           Offset: 1
@@ -992,7 +992,7 @@ Types:
       ID: 63
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: ptr
           Offset: 1
@@ -1007,7 +1007,7 @@ Types:
       ID: 64
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
-      PresenseBitsetSize: 1
+      PresenceBitsetSize: 1
       Expressions:
         - Name: ptr
           Offset: 1

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -26,29 +26,32 @@
             "arguments": {
               "a": {
                 "type": "[2][2]int",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "[2]int",
+                    "size": "2",
                     "elements": [
                       {
-                        "type": "",
+                        "type": "int",
                         "value": "1"
                       },
                       {
-                        "type": "",
+                        "type": "int",
                         "value": "2"
                       }
                     ]
                   },
                   {
-                    "type": "",
+                    "type": "[2]int",
+                    "size": "2",
                     "elements": [
                       {
-                        "type": "",
+                        "type": "int",
                         "value": "3"
                       },
                       {
-                        "type": "",
+                        "type": "int",
                         "value": "4"
                       }
                     ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -26,32 +26,36 @@
             "arguments": {
               "b": {
                 "type": "[2][2][2]int",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "[2][2]int",
+                    "size": "2",
                     "elements": [
                       {
-                        "type": "",
+                        "type": "[2]int",
+                        "size": "2",
                         "elements": [
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "1"
                           },
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "2"
                           }
                         ]
                       },
                       {
-                        "type": "",
+                        "type": "[2]int",
+                        "size": "2",
                         "elements": [
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "3"
                           },
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "4"
                           }
                         ]
@@ -59,30 +63,33 @@
                     ]
                   },
                   {
-                    "type": "",
+                    "type": "[2][2]int",
+                    "size": "2",
                     "elements": [
                       {
-                        "type": "",
+                        "type": "[2]int",
+                        "size": "2",
                         "elements": [
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "5"
                           },
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "6"
                           }
                         ]
                       },
                       {
-                        "type": "",
+                        "type": "[2]int",
+                        "size": "2",
                         "elements": [
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "7"
                           },
                           {
-                            "type": "",
+                            "type": "int",
                             "value": "8"
                           }
                         ]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -26,13 +26,14 @@
             "arguments": {
               "a": {
                 "type": "[2]string",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "first"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "second"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]bool",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "bool",
                     "value": "true"
                   },
                   {
-                    "type": "",
+                    "type": "bool",
                     "value": "true"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint8",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint8",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint8",
                     "value": "1"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -34,7 +34,7 @@
               },
               "y": {
                 "type": "float32",
-                "value": "0"
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -26,7 +26,7 @@
             "arguments": {
               "e": {
                 "type": "main.emptyStruct",
-                "fields": {}
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -26,7 +26,7 @@
             "arguments": {
               "e": {
                 "type": "main.emptyStruct",
-                "notCapturedReason": "unavailable"
+                "fields": {}
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int16",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int16",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int16",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int32",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int32",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int32",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int64",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int64",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int64",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int8",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int8",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int8",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]int32",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int32",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int32",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -26,7 +26,7 @@
             "arguments": {
               "x": {
                 "type": "float32",
-                "value": "0"
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -26,7 +26,7 @@
             "arguments": {
               "x": {
                 "type": "float64",
-                "value": "0"
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]string",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "one"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "two"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint16",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint16",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint16",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint32",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint32",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint32",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint64",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint64",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint64",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint8",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint8",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint8",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -26,13 +26,14 @@
             "arguments": {
               "x": {
                 "type": "[2]uint",
+                "size": "2",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "uint",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "uint",
                     "value": "2"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -1,0 +1,440 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testVeryLargeArray",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testVeryLargeArray",
+          "location": {
+            "method": "main.testVeryLargeArray"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "[100]uint",
+                "size": "100",
+                "elements": [
+                  {
+                    "type": "uint",
+                    "value": "1"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "2"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "3"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "4"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "5"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "6"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "7"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "8"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "9"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "10"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "11"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "12"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "13"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "14"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "15"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "16"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "17"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "18"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "19"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "20"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "21"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "22"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "23"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "24"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "25"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "26"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "27"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "28"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "29"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "30"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "31"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "32"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "33"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "34"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "35"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "36"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "37"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "38"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "39"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "40"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "41"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "42"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "43"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "44"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "45"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "46"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "47"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "48"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "49"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "50"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "51"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "52"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "53"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "54"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "55"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "56"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "57"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "58"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "59"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "60"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "61"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "62"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "63"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "64"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "65"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "66"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "67"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "68"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "69"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "70"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "71"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "72"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "73"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "74"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "75"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "76"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "77"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "78"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "79"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "80"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "81"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "82"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "83"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "84"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "85"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "86"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "87"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "88"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "89"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "90"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "91"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "92"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "93"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "94"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "95"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "96"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "97"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "98"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "99"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "100"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -1,0 +1,296 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testVeryLargeSlice",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testVeryLargeSlice",
+          "location": {
+            "method": "main.testVeryLargeSlice"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "xs": {
+                "type": "[]uint",
+                "elements": [
+                  {
+                    "type": "uint",
+                    "value": "1"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "2"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "3"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "4"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "5"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "6"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "7"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "8"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "9"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "10"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "11"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "12"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "13"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "14"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "15"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "16"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "17"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "18"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "19"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "20"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "21"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "22"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "23"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "24"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "25"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "26"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "27"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "28"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "29"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "30"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "31"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "32"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "33"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "34"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "35"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "36"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "37"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "38"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "39"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "40"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "41"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "42"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "43"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "44"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "45"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "46"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "47"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "48"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "49"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "50"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "51"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "52"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "53"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "54"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "55"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "56"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "57"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "58"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "59"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "60"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "61"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "62"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "63"
+                  },
+                  {
+                    "type": "uint",
+                    "value": "64"
+                  }
+                ],
+                "notCapturedReason": "collectionSize"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -26,7 +26,7 @@
             "arguments": {
               "x": {
                 "type": "int",
-                "value": "0"
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -26,17 +26,18 @@
             "arguments": {
               "s": {
                 "type": "[3]int",
+                "size": "3",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "int",
                     "value": "1"
                   },
                   {
-                    "type": "",
+                    "type": "int",
                     "value": "2"
                   },
                   {
-                    "type": "",
+                    "type": "int",
                     "value": "3"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -26,17 +26,18 @@
             "arguments": {
               "s": {
                 "type": "[3]string",
+                "size": "3",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "foo"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "bar"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "baz"
                   }
                 ]

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -26,17 +26,18 @@
             "arguments": {
               "s": {
                 "type": "[3]string",
+                "size": "3",
                 "elements": [
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "a"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "b"
                   },
                   {
-                    "type": "",
+                    "type": "string",
                     "value": "c"
                   }
                 ]

--- a/pkg/dyninst/testprogs/progs/sample/arrays.go
+++ b/pkg/dyninst/testprogs/progs/sample/arrays.go
@@ -91,7 +91,12 @@ func testOverLimitArrayParameters(
 }
 
 //nolint:all
+//go:noinline
+func testVeryLargeArray(a [100]uint) {}
+
+//nolint:all
 func executeArrayFuncs() {
+	testVeryLargeArray([100]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100})
 	testByteArray([2]byte{1, 1})
 	testRuneArray([2]rune{1, 2})
 	testStringArray([2]string{"one", "two"})

--- a/pkg/dyninst/testprogs/progs/sample/slices.go
+++ b/pkg/dyninst/testprogs/progs/sample/slices.go
@@ -61,6 +61,10 @@ func testNilSliceWithOtherParams(a int8, s []bool, x uint) {}
 func testNilSlice(xs []uint16) {}
 
 //nolint:all
+//go:noinline
+func testVeryLargeSlice(xs []uint) {}
+
+//nolint:all
 func executeSliceFuncs() {
 	originalSlice := []int{1, 2, 3}
 	expandSlice(originalSlice)
@@ -71,7 +75,7 @@ func executeSliceFuncs() {
 	testStructSlice([]structWithNoStrings{{42, true}, {24, true}}, 3)
 	testEmptySliceOfStructs([]structWithNoStrings{}, 2)
 	testNilSliceOfStructs(nil, 5)
-
+	testVeryLargeSlice([]uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100})
 	testSliceOfSlices([][]uint{
 		{4},
 		{5, 6},

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -278,6 +278,20 @@ probes:
   where:
     methodName: main.testUintSlice
   captureSnapshot: true
+- id: testVeryLargeSlice
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testVeryLargeSlice
+  captureSnapshot: true
+- id: testVeryLargeArray
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testVeryLargeArray
+  captureSnapshot: true
 - id: testEmptySlice
   type: LOG_PROBE
   tags:


### PR DESCRIPTION
### What does this PR do?

- Adds a check for the presence bitset in root data entries
- Adds population of "type" field in array elements
- Adds "size" field to decoded slices/arrays, and notCaptureReason in case of truncation (only slices)
- Fixes integration test to not skip the entire test suite in cases of mismatching architecture

### Motivation

Correctness in uploaded snapshots

### Describe how you validated your changes

Updated and ran integration tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->