### PR TITLE
Revert "Set timezone of test to fix serialization"

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/dump_test.go
+++ b/pkg/clusteragent/autoscaling/workload/dump_test.go
@@ -174,12 +174,6 @@ Settings: map[key:value]
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
-	// set timezone to UTC so that test output doesn't depend upon local timezone
-	originalTZ := time.Local
-	time.Local = time.UTC
-	defer func() {
-		time.Local = originalTZ
-	}()
 	// json serialization drops nanoseconds; strip it here
 	testTime := time.Unix(time.Now().Unix(), 0).UTC()
 	fakeDpai := createFakePodAutoscaler(testTime)


### PR DESCRIPTION
Reverts DataDog/datadog-agent#38560

#incident-40494