### PR TITLE
Mark `docker_container_cpu` erratic 

### DIFF
--- a/test/regression/cases/docker_containers_cpu/experiment.yaml
+++ b/test/regression/cases/docker_containers_cpu/experiment.yaml
@@ -1,4 +1,5 @@
 optimization_goal: cpu
+erratic: true
 
 target:
   name: datadog-agent


### PR DESCRIPTION
### What does this PR do?

The CPU load on the agent varies significantly within a single variant of the
    Agent, greater than threshold detection. While this is being worked on and
    understood we do not wish to ding PRs.

