### PR TITLE
Increase -all-features memory limit to 610MiB

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "582 MiB"
+      upper_bound: "610 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

We increased the memory limit for this experiment in PR #38497. That limit increase demonstrates median instance behavior based on the 2025/07/09 nightly run of Quality Gates. We believe 610 MiB represents a comfortable overhead based on that nightly and as we gather more understanding of Agent's new behavior in this experiment we can reduce.

