### PR TITLE
dyninst/actuator: fix segfault when failing to generate program

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -248,7 +248,7 @@ func (a *effects) loadProgram(
 		if err != nil {
 			tenant.reporter.ReportIRGenFailed(processID, err, probes)
 			a.sendEvent(eventProgramLoadingFailed{
-				programID: ir.ID,
+				programID: programID,
 				err:       err,
 			})
 			return


### PR DESCRIPTION
### What does this PR do?

This fixes a segfault that can happen if IR generation fails. 

### Motivation

We saw this on staging.

### Describe how you validated your changes
Wrote a test that repro'd the issue.

