### PR TITLE
dyninst/procmon: cheaply filter binaries without dd-trace-go

### DIFF
--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
@@ -78,7 +79,7 @@ func analyzeProcess(
 	}
 	defer exeFile.Close()
 
-	isGo, err := isGoElfBinary(exeFile)
+	isGo, err := isGoElfBinaryWithDDTraceGo(exeFile)
 	if errors.Is(err, os.ErrNotExist) {
 		isGo, err = false, nil
 	}
@@ -183,34 +184,58 @@ var goSections = map[string]struct{}{
 	".go.buildinfo": {},
 }
 
-// isGoElfBinary returns true if the given executable is an ELF file that
-// contains go sections and debug info.
+// isGoElfBinaryWithDDTraceGo returns true if the given executable is an ELF
+// file that contains go sections and debug info, and contains the relevant
+// dd-trace-go symbols we need to instrument.
 //
 // In the future we may want to look and see here if there's a relevant
 // version of the trace agent that we care about, but for now we leave
 // that to later analysis of dwarf.
-func isGoElfBinary(f *os.File) (bool, error) {
-	elfFile, err := safeelf.NewFile(f)
+func isGoElfBinaryWithDDTraceGo(f *os.File) (bool, error) {
+	elfFile, err := object.NewMMappingElfFile(f.Name())
 	if err != nil {
 		log.Tracef("isGoElfBinary(%s): not an ELF file: %v", f.Name(), err)
 		return false, nil
 	}
 	defer elfFile.Close() // no-op, but why not
 
+	var symtabSection *safeelf.Section
 	var hasDebugInfo, hasGoSections bool
-	for _, section := range elfFile.Sections {
+	for _, section := range elfFile.Elf.Sections {
 		if _, ok := goSections[section.Name]; ok {
 			hasGoSections = true
 		}
 		if section.Name == ".debug_info" {
 			hasDebugInfo = true
 		}
+		if section.Name == ".symtab" {
+			symtabSection = section
+		}
 	}
 	if log.ShouldLog(log.TraceLvl) {
 		log.Tracef(
-			"isGoElfBinary(%s): hasGoSections: %v, hasDebugInfo: %v",
-			f.Name(), hasGoSections, hasDebugInfo,
+			"isGoElfBinary(%s): hasGoSections: %v, hasDebugInfo: %v, symtabSection: %v",
+			f.Name(), hasGoSections, hasDebugInfo, symtabSection == nil,
 		)
 	}
-	return hasGoSections && hasDebugInfo, nil
+	if !hasGoSections || !hasDebugInfo || symtabSection == nil {
+		return false, nil
+	}
+
+	// This is a pretty rough heuristic but it's cheap. The way it works is to
+	// find the string table for the symbol table and then scan it for the
+	// strings corresponding to the symbols we might care about.
+	symtabStringsSectionIdx := symtabSection.Link
+	if symtabStringsSectionIdx >= uint32(len(elfFile.Elf.Sections)) {
+		return false, nil
+	}
+	symtabStringsSection := elfFile.Elf.Sections[symtabStringsSectionIdx]
+	symtabStrings, err := elfFile.MMap(symtabStringsSection, 0, symtabStringsSection.Size)
+	if err != nil {
+		return false, fmt.Errorf("failed to get symbols: %w", err)
+	}
+	defer symtabStrings.Close()
+	return bytes.Contains(symtabStrings.Data, ddTraceSymbolSuffix), nil
 }
+
+var ddTraceSymbolSuffix = []byte("ddtrace/tracer.passProbeConfiguration")

--- a/pkg/dyninst/rcscrape/scraper_test.go
+++ b/pkg/dyninst/rcscrape/scraper_test.go
@@ -257,8 +257,15 @@ func testNoDdTraceGo(t *testing.T, cfg testprogs.Config) {
 		_ = child.Wait()
 	}()
 
-	procMon := procmon.NewProcessMonitor(rcScraper.AsProcMonHandler())
-	procMon.NotifyExec(uint32(child.Process.Pid))
+	rcScraper.AsProcMonHandler().HandleUpdate(procmon.ProcessesUpdate{
+		Processes: []procmon.ProcessUpdate{
+			{
+				ProcessID:  procmon.ProcessID{PID: int32(child.Process.Pid)},
+				Executable: procmon.Executable{Path: prog},
+				Service:    "simple",
+			},
+		},
+	})
 	require.Eventually(t, func() bool {
 		processes := rcScraper.GetTrackedProcesses()
 		return len(processes) > 0

--- a/pkg/dyninst/testprogs/test_progs.go
+++ b/pkg/dyninst/testprogs/test_progs.go
@@ -39,21 +39,21 @@ import (
 const helpMsg = "consider running `dda inv system-probe.build-dyninst-test-programs`"
 
 // MustGetCommonConfigs calls GetCommonConfigs and checks for an error..
-func MustGetCommonConfigs(t *testing.T) []Config {
+func MustGetCommonConfigs(t testing.TB) []Config {
 	cfgs, err := GetCommonConfigs()
 	require.NoError(t, err)
 	return cfgs
 }
 
 // MustGetPrograms calls GetPrograms and checks for an error.
-func MustGetPrograms(t *testing.T) []string {
+func MustGetPrograms(t testing.TB) []string {
 	programs, err := GetPrograms()
 	require.NoError(t, err)
 	return programs
 }
 
 // MustGetBinary calls GetBinary and checks for an error.
-func MustGetBinary(t *testing.T, name string, cfg Config) string {
+func MustGetBinary(t testing.TB, name string, cfg Config) string {
 	bin, err := GetBinary(name, cfg)
 	require.NoError(t, err)
 	return bin


### PR DESCRIPTION
We are running into issues where there are binaries without dd-trace-go that we end up analyzing and that's using a bunch of memory. Let's filter those binaries cheaply and quickly.

Relates to https://app.datadoghq.com/incidents/40534 and [DEBUG-4122](https://datadoghq.atlassian.net/browse/DEBUG-4122).

[DEBUG-4122]: https://datadoghq.atlassian.net/browse/DEBUG-4122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ