### PR TITLE
[netlink] Loosen timing requirements for TestConsumerKeepsRunningAfterCircuitBreakerTrip

### DIFF
--- a/pkg/network/netlink/consumer_test.go
+++ b/pkg/network/netlink/consumer_test.go
@@ -62,8 +62,9 @@ func TestConsumerKeepsRunningAfterCircuitBreakerTrip(t *testing.T) {
 	// `tickInterval` seconds (3s currently) for
 	// the circuit breaker to detect the over-limit
 	// rate of updates
-	sleepAmt := 100 * time.Millisecond
-	loopCount := (cfg.ConntrackRateLimitInterval.Nanoseconds() / sleepAmt.Nanoseconds()) + 1
+	sleepAmt := 50 * time.Millisecond
+	loopTime := 2 * cfg.ConntrackRateLimitInterval
+	loopCount := loopTime.Nanoseconds() / sleepAmt.Nanoseconds()
 
 	for i := int64(0); i < loopCount; i++ {
 		conn, err := net.Dial("tcp", l.Addr().String())
@@ -79,11 +80,11 @@ func TestConsumerKeepsRunningAfterCircuitBreakerTrip(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			assert.False(collect, isRecvLoopRunning(), "receive loop should not be running")
 			assert.True(collect, c.breaker.IsOpen(), "breaker should be open")
-		}, 2*cfg.ConntrackRateLimitInterval, 100*time.Millisecond)
+		}, 2*time.Second, 100*time.Millisecond)
 	} else {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			assert.Lessf(collect, c.samplingRate, 1.0, "sampling rate should be less than 1.0")
-		}, 2*cfg.ConntrackRateLimitInterval, 100*time.Millisecond)
+		}, 2*time.Second, 100*time.Millisecond)
 		require.True(t, isRecvLoopRunning())
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR makes the connection rate more aggressive and loosens timing for TestConsumerKeepsRunningAfterCircuitBreakerTrip

### Motivation
There was a flake:
```
2025-07-09T15:33:49.867162Z 01O === FAIL: pkg/network/netlink TestConsumerKeepsRunningAfterCircuitBreakerTrip (2.07s)
2025-07-09T15:33:49.867185Z 01O 1752075223734233424 [Warn] exceeded maximum number of netlink messages per second. expected=1 actual=201
2025-07-09T15:33:49.867197Z 01O     consumer_test.go:84: 
2025-07-09T15:33:49.867206Z 01O         	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/netlink/consumer_test.go:85
2025-07-09T15:33:49.867224Z 01O         	            				/usr/local/go/src/runtime/asm_amd64.s:1700
2025-07-09T15:33:49.867230Z 01O         	Error:      	"1" is not less than "1"
2025-07-09T15:33:49.867235Z 01O         	Messages:   	sampling rate should be less than 1.0
2025-07-09T15:33:49.867241Z 01O     consumer_test.go:84: 
2025-07-09T15:33:49.867244Z 01O         	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/netlink/consumer_test.go:84
2025-07-09T15:33:49.867248Z 01O         	Error:      	Condition never satisfied
2025-07-09T15:33:49.867253Z 01O         	Test:       	TestConsumerKeepsRunningAfterCircuitBreakerTrip
```
As you can see, the circuit breaker tripped, but I think the timing was such that it didn't get reset (which would adjust the sampling rate) in time for the test to pass.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran the test repeatedly, although the flake is rare enough that I wasn't able to trigger it locally:
```
sudo go test -count=10 -tags=linux,linux_bpf,npm,process,test ./pkg/network/netlink --run TestConsumerKeepsRunningAfterCircuitBreakerTrip
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->