### PR TITLE
Orchestrator Check Load Integration Tag Data

### DIFF
--- a/releasenotes/notes/orch-check-tags-b4b1aa4d319e185b.yaml
+++ b/releasenotes/notes/orch-check-tags-b4b1aa4d319e185b.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Load check tags onto the orchestrator check configured
+    to be dispatched and run as a cluster check


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Loads in the check integration tag data into the orchestrator check config

### Motivation

Allows tags detected by the DCA and attached to the dispatched check to be loaded into the orchestrator check config that runs on a CLC runner.

[CONTP-770]

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

(1) First, you must modify the cluster-agent to be able to dispatch the orchestrator check to the CLC runner. This can be done by modifying the file at `/etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default` and adding `cluster_check:true` at the start.

One can use a `Dockerfile` to edit the contents of the check configuration.
```
RUN mkdir -p /etc/datadog-agent/conf.d/orchestrator.d

RUN cat <<EOF > /etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default
cluster_check: true
init_config:
instances:
  - collectors:
    - namespaces
    - nodes
    skip_leader_election: true
EOF
```
`docker build -t personal/repo:custom-tag .`

(2) You then need to also give the CLC runner the proper RBACs to access the namespaces and nodes. You can `kubectl apply` the following:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: datadog-cluster-checks-reader
rules:
  - apiGroups: [""]
    resources: ["nodes", "pods", "namespaces"]
    verbs: ["get", "list", "watch"]

apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: datadog-cluster-checks-binding
subjects:
  - kind: ServiceAccount
    name: datadog-agent-linux-cluster-checks
    namespace: datadog-agent
roleRef:
  kind: ClusterRole
  name: datadog-cluster-checks-reader
  apiGroup: rbac.authorization.k8s.io
```

(3) Deploy the agent with CLC runners enabled
```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: <INSERT_NAME>
  clusterChecks:
    enabled: true
  envDict:
    DD_TAGS: "gabe:dd_tags gabe:t1"
    DD_EXTRA_TAGS: "gabe:extra_tags"
    DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS: "gabe:orch_extra"
clusterChecksRunner:
  replicas: 2
  enabled: true
clusterAgent:
  envDict:
    DD_TAGS: "gabe:dd_tags_dca"
    DD_EXTRA_TAGS: "gabe:extra_tags_dca"
    DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS: "gabe:orch_extra_dca"
  enabled: true
  replicas: 1
```

(3b)
You can verify that the orch check is properly dispatched as a cluster check
```
k exec -it datadog-agent-linux-cluster-agent-6759546f6d-tzchz -n datadog-agent -- agent clusterchecks
...
=== 2 agents reporting ===

Name                                                 Running checks
datadog-agent-linux-clusterchecks-568747457f-5xtqk   0
datadog-agent-linux-clusterchecks-568747457f-bpmm9   1

===== Checks on datadog-agent-linux-clusterchecks-568747457f-bpmm9 =====

=== orchestrator check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default
Config for instance ID: orchestrator:cca8d862d7af0999
collectors:
- pods
- namespaces
- nodes
empty_default_hostname: true
skip_leader_election: true
tags:
- gabe:orch_extra_dca
- cluster_name:gabedos-cluster-v2
- orch_cluster_id:3fa7c3a1-358d-46e0-b7f3-baf193f0832d
- kube_cluster_name:gabedos-cluster-v2
- gabe:dd_tags_dca
- gabe:extra_tags_dca
===
```

(4) Finally go to the orchestrator explorer and verify that each item has it's expected tags. The node agent level entities like pods should have `gabe:dd_tags, extra_tags, orch_extra` and the cluster level entities like namespaces and nodes should have the DCA tags like `gabe:dd_tags_dca, extra_tags_dca, orch_extra_dca`

<img width="909" height="431" alt="image" src="https://github.com/user-attachments/assets/d8bbb219-21b3-4723-8002-f5eb57da2c0e" />

<img width="908" height="339" alt="image" src="https://github.com/user-attachments/assets/9a1b83f5-d7b7-4d9b-b67b-ab81a6381fc4" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[CONTP-770]: https://datadoghq.atlassian.net/browse/CONTP-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ