### PR TITLE
dyninst/procmon,uploader: scrape and send container info

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -512,7 +512,7 @@ func (a *Actuator) shutdown(err error) {
 	a.shutdownOnce.Do(func() {
 		defer log.Debugf("actuator shut down")
 		if err != nil {
-			log.Infof("shutting down actuator due to error: %v", err)
+			log.Warnf("shutting down actuator due to error: %v", err)
 		} else {
 			log.Debugf("shutting down actuator")
 		}

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -23,16 +23,17 @@ import (
 
 type procRuntimeID struct {
 	procmon.ProcessID
-	service   string
-	runtimeID string
-	gitInfo   *procmon.GitInfo
+	service       string
+	runtimeID     string
+	gitInfo       *procmon.GitInfo
+	containerInfo *procmon.ContainerInfo
 }
 
 type controller struct {
 	rcScraper    *rcscrape.Scraper
 	actuator     *actuator.Tenant
 	diagUploader *uploader.DiagnosticsUploader
-	logUploader  *uploader.LogsUploader
+	logUploader  *uploader.LogsUploaderFactory
 	store        *processStore
 	diagnostics  *diagnosticsManager
 
@@ -41,7 +42,7 @@ type controller struct {
 
 func newController(
 	a *actuator.Actuator,
-	logUploader *uploader.LogsUploader,
+	logUploader *uploader.LogsUploaderFactory,
 	diagUploader *uploader.DiagnosticsUploader,
 	rcScraper *rcscrape.Scraper,
 ) *controller {

--- a/pkg/dyninst/module/diagnostics.go
+++ b/pkg/dyninst/module/diagnostics.go
@@ -38,7 +38,7 @@ func (e *diagnosticTracker) mark(runtimeID string, probeID string) (first bool) 
 	}
 	_, ok := byProbeID.LoadOrStore(probeID, struct{}{})
 	if !ok {
-		log.Debugf(
+		log.Tracef(
 			"mark %s: probeId %v marked for runtimeId %v",
 			e.name, probeID, runtimeID,
 		)

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -32,7 +32,7 @@ type Module struct {
 	actuator      *actuator.Actuator
 	controller    *controller
 	cancel        context.CancelFunc
-	logUploader   *uploader.LogsUploader
+	logUploader   *uploader.LogsUploaderFactory
 	diagsUploader *uploader.DiagnosticsUploader
 
 	close struct {
@@ -55,7 +55,7 @@ func NewModule(config *Config, subscriber process.Subscriber) (_ *Module, retErr
 	if err != nil {
 		return nil, fmt.Errorf("error parsing log uploader URL: %w", err)
 	}
-	logUploader := uploader.NewLogsUploader(uploader.WithURL(logUploaderURL))
+	logUploader := uploader.NewLogsUploaderFactory(uploader.WithURL(logUploaderURL))
 
 	diagsUploaderURL, err := url.Parse(config.DiagsUploaderURL)
 	if err != nil {

--- a/pkg/dyninst/module/reporter.go
+++ b/pkg/dyninst/module/reporter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -104,13 +105,23 @@ func (c *controllerReporter) ReportLoaded(
 			gi.CommitSha, gi.RepositoryURL,
 		)
 	}
+	var containerID, entityID string
+	if ci := runtimeID.containerInfo; ci != nil {
+		containerID = ci.ContainerID
+		entityID = ci.EntityID
+	}
+
 	s := &sink{
 		controller:   ctrl,
 		decoder:      decoder,
 		symbolicator: ctrl.store.getSymbolicator(program.ID),
 		programID:    program.ID,
 		service:      runtimeID.service,
-		logUploader:  ctrl.logUploader.GetUploader(tags),
+		logUploader: ctrl.logUploader.GetUploader(uploader.LogsUploaderMetadata{
+			Tags:        tags,
+			EntityID:    entityID,
+			ContainerID: containerID,
+		}),
 	}
 	return s, nil
 }

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -28,7 +28,7 @@ type sink struct {
 	symbolicator symbol.Symbolicator
 	programID    ir.ProgramID
 	service      string
-	logUploader  *uploader.TaggedLogsUploader
+	logUploader  *uploader.LogsUploader
 }
 
 var _ actuator.Sink = &sink{}

--- a/pkg/dyninst/module/state.go
+++ b/pkg/dyninst/module/state.go
@@ -73,6 +73,9 @@ func (ps *processStore) ensureExists(update *rcscrape.ProcessUpdate) procRuntime
 		if update.GitInfo != (procmon.GitInfo{}) {
 			proc.procRuntimeID.gitInfo = &proc.gitInfo
 		}
+		if update.Container != (procmon.ContainerInfo{}) {
+			proc.procRuntimeID.containerInfo = &update.Container
+		}
 		ps.processes[update.ProcessID] = proc
 	}
 	return proc.procRuntimeID

--- a/pkg/dyninst/procmon/state.go
+++ b/pkg/dyninst/procmon/state.go
@@ -28,10 +28,11 @@ type processEvent struct {
 }
 
 type processAnalysis struct {
-	service     string
-	exe         Executable
-	interesting bool
-	gitInfo     GitInfo
+	service       string
+	exe           Executable
+	interesting   bool
+	gitInfo       GitInfo
+	containerInfo ContainerInfo
 }
 
 type analysisResult struct {
@@ -107,6 +108,7 @@ func (s *state) handle(ev event, eff effects) {
 				Executable: e.exe,
 				Service:    e.service,
 				GitInfo:    e.gitInfo,
+				Container:  e.containerInfo,
 			})
 		}
 	}

--- a/pkg/dyninst/rcscrape/scraper.go
+++ b/pkg/dyninst/rcscrape/scraper.go
@@ -151,7 +151,7 @@ func (s *scraperReporter) ReportAttached(
 	procID actuator.ProcessID,
 	_ *ir.Program,
 ) {
-	log.Debugf("rcscrape: attached to process %v", procID)
+	log.Tracef("rcscrape: attached to process %v", procID)
 }
 
 // ReportAttachingFailed implements actuator.Reporter.
@@ -169,7 +169,7 @@ func (s *scraperReporter) ReportDetached(
 	procID actuator.ProcessID,
 	_ *ir.Program,
 ) {
-	log.Debugf("rcscrape: detached from process %v", procID)
+	log.Tracef("rcscrape: detached from process %v", procID)
 	s.untrack(procID)
 }
 

--- a/pkg/dyninst/uploader/batcher.go
+++ b/pkg/dyninst/uploader/batcher.go
@@ -114,12 +114,12 @@ func (b *batcher) run() {
 			}
 		case result := <-b.sendResultCh:
 			if result.err != nil {
-				log.Debugf(
+				log.Tracef(
 					"uploader %s: batch outcome id=%d: err=%v",
 					b.name, result.id, result.err,
 				)
 			} else {
-				log.Debugf(
+				log.Tracef(
 					"uploader %s: batch outcome id=%d: success",
 					b.name, result.id,
 				)

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -238,12 +238,14 @@ func TestLogsUploader(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		uploaderFactory := NewLogsUploader(
+		uploaderFactory := NewLogsUploaderFactory(
 			WithURL(ts.serverURL),
 			WithMaxBatchItems(2),
 		)
 		defer uploaderFactory.Stop()
-		uploader := uploaderFactory.GetUploader("service:test")
+		uploader := uploaderFactory.GetUploader(LogsUploaderMetadata{
+			Tags: "service:test",
+		})
 
 		msg1 := json.RawMessage(`{"key":"value1"}`)
 		msg2 := json.RawMessage(`{"key":"value2"}`)
@@ -273,12 +275,14 @@ func TestLogsUploader(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		uploaderFactory := NewLogsUploader(
+		uploaderFactory := NewLogsUploaderFactory(
 			WithURL(ts.serverURL),
 			WithMaxBatchItems(1),
 		)
 		defer uploaderFactory.Stop()
-		uploader := uploaderFactory.GetUploader("service:test")
+		uploader := uploaderFactory.GetUploader(LogsUploaderMetadata{
+			Tags: "service:test",
+		})
 
 		msg1 := json.RawMessage(`{"key":"value1"}`)
 		uploader.Enqueue(msg1)


### PR DESCRIPTION
### What does this PR do?

This scapes and uploads container IDs with logs for processes. This leads to the trace-agent applying lots of useful tags to the log.

Relates to [DEBUG-4139](https://datadoghq.atlassian.net/browse/DEBUG-4139). 


[DEBUG-4139]: https://datadoghq.atlassian.net/browse/DEBUG-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ