### PR TITLE
[kubernetes/leaderelection] Fix race condition

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -106,10 +106,12 @@ func (le *LeaderEngine) createLeaderTokenIfNotExists() error {
 					Namespace: le.LeaderNamespace,
 				},
 			}, metav1.CreateOptions{})
-			if err != nil && !errors.IsConflict(err) {
+			if err != nil && !errors.IsConflict(err) && !errors.IsAlreadyExists(err) {
 				return err
 			}
 		}
+
+		return nil
 	}
 	_, err := le.coreClient.ConfigMaps(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
 	if err != nil {
@@ -125,11 +127,11 @@ func (le *LeaderEngine) createLeaderTokenIfNotExists() error {
 				Name: le.LeaseName,
 			},
 		}, metav1.CreateOptions{})
-		if err != nil && !errors.IsConflict(err) {
+		if err != nil && !errors.IsConflict(err) && !errors.IsAlreadyExists(err) {
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 // newElection creates an election.

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine_test.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package leaderelection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	cmLock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
+)
+
+func TestCreateLeaderTokenIfNotExists(t *testing.T) {
+	tokenNamespace := "default"
+	tokenName := "test-lease"
+
+	tests := []struct {
+		name         string
+		lockType     string
+		setupFunc    func(*fake.Clientset) error
+		expectsError bool
+		verifyFunc   func(*testing.T, *fake.Clientset)
+	}{
+		{
+			name:         "Leases - lease does not exist",
+			lockType:     rl.LeasesResourceLock,
+			expectsError: false,
+			verifyFunc: func(t *testing.T, client *fake.Clientset) {
+				_, err := client.CoordinationV1().Leases(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.NoError(t, err)
+
+				// Regression test: check that it does not create a ConfigMap too
+				_, err = client.CoreV1().ConfigMaps(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.True(t, errors.IsNotFound(err))
+			},
+		},
+		{
+			name:         "ConfigMap - configmap does not exist",
+			lockType:     cmLock.ConfigMapsResourceLock,
+			expectsError: false,
+			verifyFunc: func(t *testing.T, client *fake.Clientset) {
+				_, err := client.CoreV1().ConfigMaps(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.NoError(t, err)
+
+				_, err = client.CoordinationV1().Leases(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.True(t, errors.IsNotFound(err))
+			},
+		},
+		{
+			name:     "Leases - lease already exists",
+			lockType: rl.LeasesResourceLock,
+			setupFunc: func(client *fake.Clientset) error {
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tokenName,
+						Namespace: tokenNamespace,
+					},
+					Spec: coordinationv1.LeaseSpec{},
+				}
+				_, err := client.CoordinationV1().Leases(tokenNamespace).Create(context.TODO(), lease, metav1.CreateOptions{})
+				return err
+			},
+			expectsError: false,
+			verifyFunc: func(t *testing.T, client *fake.Clientset) {
+				_, err := client.CoordinationV1().Leases(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:     "ConfigMap - configmap already exists",
+			lockType: cmLock.ConfigMapsResourceLock,
+			setupFunc: func(client *fake.Clientset) error {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tokenName,
+						Namespace: tokenNamespace,
+					},
+				}
+				_, err := client.CoreV1().ConfigMaps(tokenNamespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+				return err
+			},
+			expectsError: false,
+			verifyFunc: func(t *testing.T, client *fake.Clientset) {
+				_, err := client.CoreV1().ConfigMaps(tokenNamespace).Get(context.TODO(), tokenName, metav1.GetOptions{})
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:     "Leases - lease created between check and create",
+			lockType: rl.LeasesResourceLock,
+			setupFunc: func(client *fake.Clientset) error {
+				// Mock the Create method to return an "AlreadyExists" error. This
+				// simulates another DCA creating the resource between the check and
+				// the creation operations.
+				client.PrependReactor("create", "leases", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.NewAlreadyExists(coordinationv1.Resource("leases"), tokenName)
+				})
+
+				return nil
+			},
+			expectsError: false, // Should handle the race condition and not return error
+		},
+		{
+			name:     "ConfigMap - configmap created between check and create",
+			lockType: cmLock.ConfigMapsResourceLock,
+			setupFunc: func(client *fake.Clientset) error {
+				// Mock the Create method to return an "AlreadyExists" error. This
+				// simulates another DCA creating the resource between the check and
+				// the creation operations.
+				client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.NewAlreadyExists(corev1.Resource("configmaps"), tokenName)
+				})
+
+				return nil
+			},
+			expectsError: false, // Should handle the race condition and not return error
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewClientset()
+
+			le := &LeaderEngine{
+				LeaseName:       tokenName,
+				LeaderNamespace: tokenNamespace,
+				coreClient:      client.CoreV1(),
+				coordClient:     client.CoordinationV1(),
+				lockType:        test.lockType,
+			}
+
+			if test.setupFunc != nil {
+				err := test.setupFunc(client)
+				require.NoError(t, err)
+			}
+
+			err := le.createLeaderTokenIfNotExists()
+
+			if test.expectsError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if test.verifyFunc != nil {
+				test.verifyFunc(t, client)
+			}
+		})
+	}
+}

--- a/releasenotes-dca/notes/contp-853-leader-election-race-condition-e72315fbc03f6a6d.yaml
+++ b/releasenotes-dca/notes/contp-853-leader-election-race-condition-e72315fbc03f6a6d.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue that caused some Datadog Cluster Agent replicas to restart
+    during the first install.
+  - |
+    When using leases for leader election with the
+    ``leader_election_default_resource`` option, the Datadog Cluster Agent no
+    longer creates an unused config map.


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 issues in the `createLeaderTokenIfNotExists` function in the leader election package:
- When `leader_election_default_resource` was set to leases, the Cluster Agent still created a configmap. This was unnecessary and is now fixed.
- There was a race condition during the first install when running multiple Cluster Agent replicas. The function checked if a lease or configmap existed, and if not, tried to create it. But another replica could create it in the middle of the two operations, which was not handled correctly.

### Describe how you validated your changes

I added unit tests. I also tested it manually by setting `leader_election_default_resource` to leases and confirmed that the configmap is no longer created.

We'll need to merge https://github.com/DataDog/test-infra-definitions/pull/1492 again. It's the PR that exposed the race condition.
