### PR TITLE
[APM] Increase TestStopWaits test timeout

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -180,8 +180,9 @@ func TestStopWaits(t *testing.T) {
 	case <-ctx.Done():
 		// Context cancelled before we could send
 		t.Fatal("Context cancelled before payload could be sent")
-	case <-time.After(100 * time.Millisecond):
-		// Timeout - this shouldn't happen in normal operation
+	case <-time.After(500 * time.Millisecond):
+		// Timeout - this shouldn't happen in normal operation.
+		// 500ms is used to allow worker goroutines to start and be ready
 		t.Fatal("Timeout sending payload to agent")
 	}
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This test can be flaky if the test agent has not started its goroutines, causing the timeout condition to trigger.

A simple fix is to raise the timeout to 500ms. If test remains flaky with this setting, we should consider a different approach, perhaps by checking the readiness of the agent workers.


### Motivation

https://datadoghq.atlassian.net/browse/APMSP-2149

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->