### PR TITLE
[ACIX-928]: Fix JUnit file handling logic for e2e tests with retries

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -400,13 +400,11 @@ def run(
         partial_result_json = f"{result_json}.{attempt}.part"
         result_jsons.append(partial_result_json)
 
-        # TODO(agent-devx): Check if this is the right flavor, we are not using the flavor passed in argument
         partial_result_junit = f"junit-out-{str(AgentFlavor.base)}-{attempt}.xml"
         result_junits.append(partial_result_junit)
 
         test_res = test_flavor(
             ctx,
-            # TODO(agent-devx): Same comment about flavor as above
             flavor=AgentFlavor.base,
             build_tags=tags,
             modules=[e2e_module],

--- a/tasks/test_core.py
+++ b/tasks/test_core.py
@@ -63,10 +63,7 @@ class TestResult(ExecResult):
         super().__init__(path)
         self.result_type = "Tests"
         # Path to the result.json file output by gotestsum (should always be present)
-        self.result_json_path = None
-        # List of paths to the junit files output by gotestsum (only present if specified in dda inv test)
-        # We have multiple because each retry will produce a new junit file
-        self.junit_file_paths = []
+        self.result_json_path: str | None = None
 
     def get_failing_tests(self) -> tuple[set[str], dict[str, set[str]]]:
         obj: ResultJson = ResultJson.from_file(self.result_json_path)

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -111,6 +111,9 @@ func TestPackages(t *testing.T) {
 			suite := test.t(flavor, flavor.Architecture, method)
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
+				if suite.Name() == "agent_ubuntu_24_04_arm64_install_script" {
+					t.Fail()
+				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -111,9 +111,6 @@ func TestPackages(t *testing.T) {
 			suite := test.t(flavor, flavor.Architecture, method)
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
-				if suite.Name() == "agent_ubuntu_24_04_arm64_install_script" {
-					t.Fail()
-				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This brings the handling of JUnit files more in line with the handling of ResultJson files.
This also fixes some erroneous behavior with how those files are handled with e2e tests running with retried: since the `test_res` object was overwritten on each rerun the final JUnit tarball only included the last-produced file, even though the others had been correctly motivated.

### Motivation

Make sure https://github.com/DataDog/datadog-agent/pull/37862 works properly !

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually forcing failure on an e2e test locally and verifying the tarball gets created with the right files + same idea in CI with a to-be-reverted commit (d4dd7bfa24)

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A