### PR TITLE
chore: add metrics for integration status

### DIFF
--- a/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
@@ -49,7 +49,8 @@ func TestExternalHostTags(t *testing.T) {
 			Overrides: map[string]interface{}{"check_cancel_timeout": 500 * time.Millisecond},
 		})))
 
-	pl, _ := c.GetPayload(context.Background())
+	agentChecks := c.getAgentChecks()
+	pl := c.GetPayload(context.Background(), agentChecks)
 	hpl := pl.ExternalhostTags
 	assert.Len(t, hpl, 2)
 	for _, elem := range hpl {

--- a/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
@@ -49,7 +49,7 @@ func TestExternalHostTags(t *testing.T) {
 			Overrides: map[string]interface{}{"check_cancel_timeout": 500 * time.Millisecond},
 		})))
 
-	pl := c.GetPayload(context.Background())
+	pl, _ := c.GetPayload(context.Background())
 	hpl := pl.ExternalhostTags
 	assert.Len(t, hpl, 2)
 	for _, elem := range hpl {

--- a/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metadata_test.go
@@ -49,8 +49,7 @@ func TestExternalHostTags(t *testing.T) {
 			Overrides: map[string]interface{}{"check_cancel_timeout": 500 * time.Millisecond},
 		})))
 
-	agentChecks := c.getAgentChecks()
-	pl := c.GetPayload(context.Background(), agentChecks)
+	pl := c.GetPayload(context.Background(), c.getAgentCheckResults())
 	hpl := pl.ExternalhostTags
 	assert.Len(t, hpl, 2)
 	for _, elem := range hpl {

--- a/comp/collector/collector/collectorimpl/agent_check_metrics.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metrics.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package collectorimpl
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	metricsInterval = 15 * time.Second
+)
+
+// sendAgentCheckMetrics creates and sends metrics series for agent checks
+func (c *collectorImpl) sendAgentCheckMetrics(ctx context.Context, timestamp time.Time, agentCheckResults []agentCheckResult) error {
+	hostname, _ := c.hostname.Get(ctx)
+	ts := float64(timestamp.Unix())
+
+	if len(agentCheckResults) == 0 {
+		log.Debugf("No agent checks found")
+		return nil
+	}
+
+	for _, check := range agentCheckResults {
+		status := "unknown"
+		switch check.status {
+		case "OK":
+			status = "healthy"
+		case "WARNING":
+			status = "warning"
+		case "ERROR":
+			status = "broken"
+		}
+
+		// Create tags for the check
+		tags := []string{
+			fmt.Sprintf("integration_type:%v", check.instanceType),
+			fmt.Sprintf("integration_name:%v", check.instanceName),
+			fmt.Sprintf("status:%s", status),
+		}
+
+		log.Debugf("Sending agent check metric: %s = %+v", "datadog.agent.integration.status", tags)
+
+		// Create individual check status metric
+		aggregator.AddRecurrentSeries(&metrics.Serie{
+			Name:   "datadog.agent.integration.status",
+			Points: []metrics.Point{{Value: 1.0, Ts: ts}},
+			Tags:   tagset.CompositeTagsFromSlice(tags),
+			Host:   hostname,
+			MType:  metrics.APIGaugeType,
+		})
+	}
+
+	return nil
+}
+
+func (c *collectorImpl) collectCheckMetrics(ctx context.Context) {
+	agentChecks := c.getAgentCheckResults()
+
+	if err := c.sendAgentCheckMetrics(ctx, time.Now(), agentChecks); err != nil {
+		c.log.Errorf("unable to send agent check metrics: %s", err)
+	}
+}
+
+// startMetricsRunner starts the metrics collection runner
+func (c *collectorImpl) startMetricsRunner() {
+	if !c.config.GetBool("integration_status_metrics_enabled") {
+		return
+	}
+
+	if c.metricsRunnerStop != nil {
+		return
+	}
+
+	c.metricsRunnerStop = make(chan struct{})
+	c.metricsRunnerWg.Add(1)
+
+	go func() {
+		defer c.metricsRunnerWg.Done()
+		ticker := time.NewTicker(metricsInterval)
+		defer ticker.Stop()
+
+		c.log.Debug("Agent check metrics runner started")
+
+		for {
+			select {
+			case <-ticker.C:
+				// Collect and send agent check metrics
+				c.collectCheckMetrics(context.Background())
+			case <-c.metricsRunnerStop:
+				c.log.Debug("Agent check metrics runner stopped")
+				return
+			}
+		}
+	}()
+}
+
+// stopMetricsRunner stops the metrics collection runner
+func (c *collectorImpl) stopMetricsRunner() {
+	if c.metricsRunnerStop == nil {
+		return // not running
+	}
+
+	close(c.metricsRunnerStop)
+	c.metricsRunnerWg.Wait()
+	c.metricsRunnerStop = nil
+	c.log.Debug("Agent check metrics runner shutdown complete")
+}

--- a/comp/collector/collector/collectorimpl/agent_check_metrics_test.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metrics_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package collectorimpl
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	"github.com/DataDog/datadog-agent/comp/core"
+	agenttelemetry "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+func TestMetricsRunnerWithCollectorLifecycle(t *testing.T) {
+	c := newCollector(fxutil.Test[dependencies](t,
+		core.MockBundle(),
+		demultiplexerimpl.MockModule(),
+		haagentmock.Module(),
+		fx.Provide(func() option.Option[serializer.MetricSerializer] {
+			return option.None[serializer.MetricSerializer]()
+		}),
+		fx.Provide(func() option.Option[agenttelemetry.Component] {
+			return option.None[agenttelemetry.Component]()
+		}),
+		fx.Replace(config.MockParams{
+			Overrides: map[string]interface{}{"check_cancel_timeout": 500 * time.Millisecond},
+		})))
+
+	assert.Equal(t, stopped, c.state.Load(), "Collector should be stopped initially")
+	assert.Nil(t, c.metricsRunnerStop, "Metrics runner should not be started")
+
+	// Start collector collector
+	err := c.start(context.TODO())
+	assert.NoError(t, err, "Collector should start successfully")
+	assert.Equal(t, started, c.state.Load(), "Collector should be started")
+	assert.NotNil(t, c.metricsRunnerStop, "Metrics runner should be started with collector")
+
+	var gErr1, gErr2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() { // goroutine 1
+		defer wg.Done()
+		if e := c.stop(context.TODO()); e != nil {
+			gErr1 = e // write to private variable
+		}
+	}()
+
+	go func() { // goroutine 2
+		defer wg.Done()
+		if e := c.stop(context.TODO()); e != nil {
+			gErr2 = e // write to private variable
+		}
+	}()
+
+	wg.Wait()
+
+	assert.NoError(t, gErr1, "Collector should stop successfully (goroutine 1)")
+	assert.NoError(t, gErr2, "Collector should stop successfully (goroutine 2)")
+	assert.Equal(t, stopped, c.state.Load(), "Collector should be stopped")
+	assert.Nil(t, c.metricsRunnerStop, "Metrics runner should be stopped with collector")
+}
+
+func TestMetricsRunnerWithCollectorLifecycleDisabled(t *testing.T) {
+	c := newCollector(fxutil.Test[dependencies](t,
+		core.MockBundle(),
+		demultiplexerimpl.MockModule(),
+		haagentmock.Module(),
+		fx.Provide(func() option.Option[serializer.MetricSerializer] {
+			return option.None[serializer.MetricSerializer]()
+		}),
+		fx.Provide(func() option.Option[agenttelemetry.Component] {
+			return option.None[agenttelemetry.Component]()
+		}),
+		fx.Replace(config.MockParams{
+			Overrides: map[string]interface{}{
+				"check_cancel_timeout":               500 * time.Millisecond,
+				"integration_status_metrics_enabled": false,
+			},
+		})))
+
+	// Start collector collector
+	err := c.start(context.TODO())
+	assert.NoError(t, err, "Collector should start successfully")
+	assert.Equal(t, started, c.state.Load(), "Collector should be started")
+	assert.Nil(t, c.metricsRunnerStop, "Metrics runner should be started with collector")
+
+	// Stop collector
+	err = c.stop(context.TODO())
+	assert.NoError(t, err, "Collector should stop successfully")
+	assert.Equal(t, stopped, c.state.Load(), "Collector should be stopped")
+}

--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -86,10 +86,11 @@ type collectorImpl struct {
 type provides struct {
 	fx.Out
 
-	Comp             collector.Component
-	StatusProvider   status.InformationProvider
-	MetadataProvider metadata.Provider
-	APIGetPyStatus   api.AgentEndpointProvider
+	Comp                  collector.Component
+	StatusProvider        status.InformationProvider
+	MetadataProvider      metadata.Provider
+	CheckMetadataProvider metadata.Provider
+	APIGetPyStatus        api.AgentEndpointProvider
 }
 
 // Module defines the fx options for this component.
@@ -111,10 +112,11 @@ func newProvides(deps dependencies) provides {
 	}
 
 	return provides{
-		Comp:             c,
-		StatusProvider:   status.NewInformationProvider(collectorStatus.Provider{}),
-		MetadataProvider: agentCheckMetadata,
-		APIGetPyStatus:   api.NewAgentEndpointProvider(getPythonStatus, "/py/status", "GET"),
+		Comp:                  c,
+		StatusProvider:        status.NewInformationProvider(collectorStatus.Provider{}),
+		MetadataProvider:      agentCheckMetadata,
+		CheckMetadataProvider: metadata.NewProvider(c.collectCheckMetadata),
+		APIGetPyStatus:        api.NewAgentEndpointProvider(getPythonStatus, "/py/status", "GET"),
 	}
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1154,6 +1154,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("integration_profiling", false)
 	config.BindEnvAndSetDefault("integration_check_status_enabled", false)
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
+	config.BindEnvAndSetDefault("integration_status_metrics_enabled", true)
 	config.BindEnvAndSetDefault("enable_cluster_agent_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("enable_signing_metadata_collection", true)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Collect datadog.agent.integration.status metric that aggregates integration status (healthy, broken, warning) by instance name and type every 15 seconds.
Can be disabled with config `integration_status_metrics_enabled`

### Motivation
https://datadoghq.atlassian.net/browse/FA-1041

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Unit tests?manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->