### PR TITLE
Update rules for internal RC jobs

### DIFF
--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -20,7 +20,7 @@ deploy_containers-dca:
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_deploy_internal_manual_auto_on_rc]
 
 # Fips flavor
 .deploy_containers-dca-fips-base:
@@ -39,4 +39,4 @@ deploy_containers-dca-fips:
 
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_deploy_internal_manual_auto_on_rc]

--- a/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
+++ b/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
@@ -20,4 +20,4 @@ deploy_containers-ot-standalone:
 # Jobs to publish images to our internal registries.
 deploy_containers-ot-standalone_internal:
   extends: .deploy_containers-ot-standalone-base
-  rules: !reference [.on_deploy_internal_manual_final]
+  rules: !reference [.on_deploy_internal_manual_auto_on_rc]

--- a/.gitlab/trigger_distribution/conditions.yml
+++ b/.gitlab/trigger_distribution/conditions.yml
@@ -98,11 +98,18 @@
 
 # Same as on_deploy_manual_final, except the job is used to publish images
 # to our internal registries.
-.on_deploy_internal_manual_final:
-  - <<: *if_beta_repo_branch
-    when: never
+.on_deploy_internal_manual_auto_on_rc:
   - <<: *if_not_stable_or_beta_repo_branch
     when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
+      CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
+      OTEL_AGENT_REPOSITORY: ci/datadog-agent/otel-agent-release
+      DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
+      CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
+      IMG_REGISTRIES: internal-aws-ddbuild
   - when: manual
     allow_failure: true
     variables:


### PR DESCRIPTION
### What does this PR do?

Jobs producing internal RC images were excluded from the RC pipeline and because of that the next jobs were marked as incorrect (as they needed them). This PR changes the rules for internal images to have the same pattern as public ones.

### Motivation

Fix broken image deployment jobs.

### Describe how you validated your changes
Validate with the next RC build.
