### PR TITLE
Disable Windows Docker static quality gates

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -46,30 +46,30 @@ static_quality_gate_docker_agent_jmx_amd64:
 static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 980.54 MiB
   max_on_wire_size: 324.2 MiB
-static_quality_gate_docker_agent_windows1809:
-  max_on_disk_size: 1190.61 MiB
-  max_on_wire_size: 420.48 MiB
-static_quality_gate_docker_agent_windows1809_core:
-  max_on_disk_size: 5920.75 MiB
-  max_on_wire_size: 2048.95 MiB
-static_quality_gate_docker_agent_windows1809_core_jmx:
-  max_on_disk_size: 6042.32 MiB
-  max_on_wire_size: 2048.95 MiB
-static_quality_gate_docker_agent_windows1809_jmx:
-  max_on_disk_size: 1312.42 MiB
-  max_on_wire_size: 462.77 MiB
-static_quality_gate_docker_agent_windows2022:
-  max_on_disk_size: 1209.9 MiB
-  max_on_wire_size: 433.24 MiB
-static_quality_gate_docker_agent_windows2022_core:
-  max_on_disk_size: 5893.81 MiB
-  max_on_wire_size: 2048.95 MiB
-static_quality_gate_docker_agent_windows2022_core_jmx:
-  max_on_disk_size: 6015.45 MiB
-  max_on_wire_size: 2048.95 MiB
-static_quality_gate_docker_agent_windows2022_jmx:
-  max_on_disk_size: 1331.48 MiB
-  max_on_wire_size: 475.53 MiB
+# static_quality_gate_docker_agent_windows1809:
+#   max_on_disk_size: 1190.61 MiB
+#   max_on_wire_size: 420.48 MiB
+# static_quality_gate_docker_agent_windows1809_core:
+#   max_on_disk_size: 5920.75 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows1809_core_jmx:
+#   max_on_disk_size: 6042.32 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows1809_jmx:
+#   max_on_disk_size: 1312.42 MiB
+#   max_on_wire_size: 462.77 MiB
+# static_quality_gate_docker_agent_windows2022:
+#   max_on_disk_size: 1209.9 MiB
+#   max_on_wire_size: 433.24 MiB
+# static_quality_gate_docker_agent_windows2022_core:
+#   max_on_disk_size: 5893.81 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows2022_core_jmx:
+#   max_on_disk_size: 6015.45 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows2022_jmx:
+#   max_on_disk_size: 1331.48 MiB
+#   max_on_wire_size: 475.53 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 214.5 MiB
   max_on_wire_size: 73.51 MiB


### PR DESCRIPTION
### What does this PR do?

Disables the static quality gates (size limits) for Windows Docker images, with the intention of reinstating them once the measurements are more reliable.

### Motivation

After having readjusted gate limits, we've seen the `static_quality_gate_docker_agent_windows1809_core_jmx` gate [fail on main](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1024875847), even when merging PR's that don't add any size to any other artifact.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

- [ABLD-81](https://datadoghq.atlassian.net/browse/ABLD-81) already reported problems with the way we're measuring on-disk size for Windows Docker images.
- The rest of the gates provide fairly good guarantees that the size is not generally increasing, so we don't expect significant impact from this temporary deactivation. Increasing size on Docker artifacts while not increasing size elsewhere is unlikely to happen unless for very specific work.

[ABLD-81]: https://datadoghq.atlassian.net/browse/ABLD-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ