### PR TITLE
Use OriginDetection in trace-agent RC flow

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -43,7 +43,7 @@ func putBuffer(buffer *bytes.Buffer) {
 
 // ConfigHandler is the HTTP handler for configs
 func ConfigHandler(r *api.HTTPReceiver, cf rcclient.ConfigFetcher, cfg *config.AgentConfig, statsd statsd.ClientInterface, timing timing.Reporter) http.Handler {
-	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot, config.NoopContainerIDFromOriginInfoFunc)
+	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())
 		tags := r.TagStats(api.V07, req.Header, "").AsTags()


### PR DESCRIPTION
### What does this PR do?

Change the function used in RC flow to actually do tagging resolution instead with origin detection instead of skipping.

### Motivation

Fix bug observed with cgroupv2 flows where tags could be missing as container id was not sent.

### Describe how you validated your changes

See IR 40598

### Possible Drawbacks / Trade-offs

### Additional Notes
