### PR TITLE
Mark TestCommandPidfile as flaky

### DIFF
--- a/cmd/agent/subcommands/run/command_test.go
+++ b/cmd/agent/subcommands/run/command_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func TestCommand(t *testing.T) {
@@ -30,6 +31,8 @@ func TestCommand(t *testing.T) {
 }
 
 func TestCommandPidfile(t *testing.T) {
+	// Test is flaky since PR https://github.com/DataDog/datadog-agent/pull/38643 was merged
+	flake.Mark(t)
 	fxutil.TestOneShotSubcommand(t,
 		Commands(newGlobalParamsTest(t)),
 		[]string{"run", "--pidfile", "/pid/file"},


### PR DESCRIPTION
### What does this PR do?

Mark TestCommandPidfile as flaky for now. https://github.com/DataDog/datadog-agent/pull/38643 introduced a race, this will make the CI happy until it gets fixed.

### Motivation

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
