### PR TITLE
dyninst/procmon: cache executable analysis

### DIFF
--- a/pkg/dyninst/procmon/htlhash.go
+++ b/pkg/dyninst/procmon/htlhash.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// computeHtlHash computes a hash of the first 4096 bytes of the file and the
+// last 4096 bytes of the file, and the length of the file. This is a cheap to
+// compute hash that is extremely likely to be unique for the executable.
+//
+// If the function returns an error, the file will be left in an unknown state.
+// Otherwise, the file will have been seeked to the original position.
+//
+// Derived from https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/ec6ee459/libpf/fileid.go#L122-L128
+// See also https://opentelemetry.io/docs/specs/otel/profiles/mappings/#algorithm-for-processexecutablebuild_idhtlhash
+func computeHtlHash(f io.ReadSeeker) (_ string, retErr error) {
+	maybeWrapErr := func(msg string, err error) error {
+		if errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return fmt.Errorf("computeHtlHash: %s: %w", msg, err)
+	}
+	origOffset, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return "", maybeWrapErr("failed to seek to current position", err)
+	}
+	defer func() {
+		if retErr != nil {
+			if _, err := f.Seek(origOffset, io.SeekStart); err != nil {
+				retErr = maybeWrapErr(
+					"failed to seek to original position", err,
+				)
+			}
+		}
+	}()
+	h := sha256.New()
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", maybeWrapErr("failed to seek to original position", err)
+	}
+	if _, err := io.Copy(h, io.LimitReader(f, 4096)); err != nil {
+		return "", maybeWrapErr("failed to copy file to hash", err)
+	}
+	size, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return "", maybeWrapErr("failed to seek to end of file", err)
+	}
+	tailBytes := min(size, 4096)
+	if _, err := f.Seek(-tailBytes, io.SeekEnd); err != nil {
+		return "", maybeWrapErr("failed to seek to end of file", err)
+	}
+	if _, err := io.Copy(h, io.LimitReader(f, tailBytes)); err != nil {
+		return "", maybeWrapErr("failed to copy file to hash", err)
+	}
+
+	var lengthBuf [8]byte
+	binary.BigEndian.PutUint64(lengthBuf[:], uint64(size))
+	h.Write(lengthBuf[:])
+	return hex.EncodeToString(h.Sum(nil)[:16]), nil
+}

--- a/pkg/dyninst/procmon/htlhash_test.go
+++ b/pkg/dyninst/procmon/htlhash_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package procmon
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+func TestComputeHtlHash(t *testing.T) {
+	// Just test that it doesn't fail and comes up with unique strings for every
+	// test program.
+	t.Run("programs are unique", func(t *testing.T) {
+		hashes := make(map[string]struct{})
+		programs := testprogs.MustGetPrograms(t)
+		cfgs := testprogs.MustGetCommonConfigs(t)
+		expectedNumHashes := 0
+		for _, prog := range programs {
+			for _, cfg := range cfgs {
+				expectedNumHashes++
+				t.Run(fmt.Sprintf(
+					"%s-%s-%s", prog, cfg.GOARCH, cfg.GOTOOLCHAIN,
+				), func(t *testing.T) {
+					bin := testprogs.MustGetBinary(t, prog, cfg)
+					f, err := os.Open(bin)
+					if err != nil {
+						t.Fatalf("failed to open binary: %v", err)
+					}
+					defer f.Close()
+					hash, err := computeHtlHash(f)
+					if err != nil {
+						t.Fatalf("failed to compute htl hash: %v", err)
+					}
+					hashes[hash] = struct{}{}
+				})
+			}
+		}
+		require.Equal(t, expectedNumHashes, len(hashes))
+	})
+	t.Run("small files are unique", func(t *testing.T) {
+		const maxSize = 4096 * 3
+		buf := make([]byte, maxSize)
+		hashes := make(map[string]struct{}, maxSize)
+		reader := bytes.NewReader(nil)
+		for i := 0; i < maxSize; i++ {
+			reader.Reset(buf[:i])
+			hash, err := computeHtlHash(reader)
+			if err != nil {
+				t.Fatalf("failed to compute htl hash: %v", err)
+			}
+			hashes[hash] = struct{}{}
+		}
+		require.Equal(t, maxSize, len(hashes))
+	})
+}

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -94,30 +94,27 @@ func (pm *ProcessMonitor) NotifyExit(pid uint32) {
 
 // cacheSize is the size of the cache for the executable analyzer.
 //
-// The number is somewhat arbitrary, but the logic is something like:
-//   - We want to avoid redoing work when processes are created and destroyed
-//     frequently.
-//   - We don't want to use too much memory. Maybe we're cool with allocating
-//     <100K bytes of memory for the caches.
+// This value balances performance and memory usage:
+//   - Avoids redundant analysis when processes are created/destroyed frequently
+//   - Limits memory usage to approximately 32KiB for both caches combined
 //
-// The lru entries aren't super optimized, so they are 6 words per entry. Plus
-// some constant overheads and some map overheads due to load factor.
+// Memory calculation (approximate):
 //
-// FileKey: 32 bytes (16 for FileHandle + 16 for LastModified)
-// HashCacheEntry: 32 bytes (16 for the string header + 16 for the string data)
+//	FileKey: 32 bytes (16 for FileHandle + 16 for LastModified)
+//	HashCacheEntry: 32 bytes (16 for string header + 16 for string data)
+//	LRU overhead: ~48 bytes per entry
+//	Map overhead: ~56 bytes per entry (~32 bytes for the key, ~8 bytes for
+//	 			  the value, and conservatively ~16 bytes for the map
+//	 			  overhead and load factor)
 //
-// Per entry: 2*32 bytes (Key) + 48 bytes (lru entry) + 8 bytes (bool) + 8 bytes
-// map value.
-//
-// Each cache entry in each cache works out to roughly ~128 bytes, and we have 2
-// caches, so that's ~256 bytes per entry here.
-//
-// By this math at 64 entries we're looking at <32KiB bytes of memory (16KiB
-// for the for the variable data plus some scattered overheads).
+//	Total per entry: ~144 bytes (32 + 8 + 48 + 56)
+//	At 64 entries: ~9KiB from entries + constant overheads < 16KiB per cache
 const cacheSize = 64
 
 // newProcessMonitor is injectable with a fake FS for tests.
-func newProcessMonitor(h Handler, procFS string, resolver ContainerResolver) *ProcessMonitor {
+func newProcessMonitor(
+	h Handler, procFS string, resolver ContainerResolver,
+) *ProcessMonitor {
 	pm := &ProcessMonitor{
 		handler:            h,
 		procfsRoot:         procFS,
@@ -172,7 +169,7 @@ func (pm *ProcessMonitor) analyzeProcess(pid uint32) {
 	go func() {
 		defer pm.wg.Done()
 		pa, err := analyzeProcess(
-			pid, pm.procfsRoot, pm.resolver, &pm.executableAnalyzer,
+			pid, pm.procfsRoot, pm.resolver, pm.executableAnalyzer,
 		)
 		shouldLog := err != nil &&
 			!os.IsNotExist(err) &&


### PR DESCRIPTION
### What does this PR do?
This PR adds caching to make the checking cheap in the case that we know the binary is not interesting. This code runs on every process exec, so it deserves to be optimized.

### Motivation

Analyzing an executable is not free. For a big binary it can be a few
ms. There are cases where executables fork children frequently or get
caught in loops and to incur milliseconds of CPU time per process launch
could be rather painful. 
