### PR TITLE
Add invalid status code metric to http telemetry

### DIFF
--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -160,6 +160,16 @@ func (h *StatKeeper) add(tx Transaction) {
 		return
 	}
 
+	// Validate HTTP status code
+	statusCode := tx.StatusCode()
+	if statusCode < 100 || statusCode > 599 {
+		h.telemetry.invalidStatus.Add(1)
+		if h.oversizedLogLimit.ShouldLog() {
+			log.Warnf("invalid status code: %s", tx.String())
+		}
+		return
+	}
+
 	key := NewKeyWithConnection(tx.ConnTuple(), path, fullPath, tx.Method())
 	if h.connectionAggregator != nil {
 		key.ConnectionKey = h.connectionAggregator.RollupKey(key.ConnectionKey)

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -298,6 +298,30 @@ func TestHTTPCorrectness(t *testing.T) {
 		require.Len(t, stats, 0)
 	})
 
+	t.Run("invalid status code", func(t *testing.T) {
+		cfg := config.New()
+		cfg.MaxHTTPStatsBuffered = 1000
+		libtelemetry.Clear()
+		tel := NewTelemetry("http")
+		sk := NewStatkeeper(cfg, tel, NewIncompleteBuffer(cfg, tel))
+		tx := generateIPv4HTTPTransaction(
+			util.AddressFromString("1.1.1.1"),
+			util.AddressFromString("2.2.2.2"),
+			1234,
+			8080,
+			"/get",
+			700,
+			30*time.Millisecond,
+		)
+
+		sk.Process(tx)
+		tel.Log()
+		require.Equal(t, int64(1), tel.invalidStatus.Get())
+
+		stats := sk.GetAndResetAllStats()
+		require.Len(t, stats, 0)
+	})
+
 	t.Run("Empty path", func(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -37,10 +37,10 @@ type Telemetry struct {
 
 	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *TLSCounter
 
-	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
-	rejected                                                         *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
-	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters *libtelemetry.Counter // this happens when the request doesn't have the expected format
-	aggregations                                                     *libtelemetry.Counter
+	dropped                                                                         *libtelemetry.Counter // this happens when statKeeper reaches capacity
+	rejected                                                                        *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
+	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters, invalidStatus *libtelemetry.Counter // this happens when the request doesn't have the expected format
+	aggregations                                                                    *libtelemetry.Counter
 
 	joiner telemetryJoiner
 }
@@ -67,6 +67,7 @@ func NewTelemetry(protocol string) *Telemetry {
 		unknownMethod:          metricGroup.NewCounter("malformed", "type:unknown-method", libtelemetry.OptStatsd),
 		invalidLatency:         metricGroup.NewCounter("malformed", "type:invalid-latency", libtelemetry.OptStatsd),
 		nonPrintableCharacters: metricGroup.NewCounter("malformed", "type:non-printable-char", libtelemetry.OptStatsd),
+		invalidStatus:          metricGroup.NewCounter("malformed", "type:invalid-status", libtelemetry.OptStatsd),
 
 		joiner: telemetryJoiner{
 			requests:         metricGroupJoiner.NewCounter("requests", libtelemetry.OptPrometheus),


### PR DESCRIPTION
### What does this PR do?
- Add a new telemetry counter for invalid HTTP status codes
- Report invalid status codes in statkeeper
- Test invalid status metric

### Motivation
Fail fast on invalid HTTP status code and have observability for it

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
[OpenAI Codex session](https://chatgpt.com/codex/tasks/task_b_6873c98b60648322b738ed8af746531e)