### PR TITLE
USM: Add invalid HTTP status code check and telemetry

### DIFF
--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -160,6 +160,16 @@ func (h *StatKeeper) add(tx Transaction) {
 		return
 	}
 
+	// Validate HTTP status code
+	statusCode := tx.StatusCode()
+	if statusCode < 100 || statusCode > 599 {
+		h.telemetry.invalidStatusCode.Add(1)
+		if h.oversizedLogLimit.ShouldLog() {
+			log.Warnf("invalid status code: %s", tx.String())
+		}
+		return
+	}
+
 	key := NewKeyWithConnection(tx.ConnTuple(), path, fullPath, tx.Method())
 	if h.connectionAggregator != nil {
 		key.ConnectionKey = h.connectionAggregator.RollupKey(key.ConnectionKey)

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -162,7 +162,7 @@ func (h *StatKeeper) add(tx Transaction) {
 
 	// Validate HTTP status code
 	statusCode := tx.StatusCode()
-	if statusCode < 100 || statusCode > 599 {
+	if !isValidStatusCode(statusCode) {
 		h.telemetry.invalidStatusCode.Add(1)
 		if h.oversizedLogLimit.ShouldLog() {
 			log.Warnf("invalid status code: %s", tx.String())

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -154,11 +154,6 @@ func NewRequestStats() *RequestStats {
 	}
 }
 
-// isValid checks is the status code is in the range of valid HTTP responses.
-func (r *RequestStats) isValid(status uint16) bool {
-	return status >= 100 && status < 600
-}
-
 // CombineWith merges the data in 2 RequestStats objects
 // newStats is kept as it is, while the method receiver gets mutated
 func (r *RequestStats) CombineWith(newStats *RequestStats) {
@@ -205,7 +200,7 @@ func (r *RequestStats) CombineWith(newStats *RequestStats) {
 
 // AddRequest takes information about a HTTP transaction and adds it to the request stats
 func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags uint64, dynamicTags []string) {
-	if !r.isValid(statusCode) {
+	if !isValidStatusCode(statusCode) {
 		return
 	}
 
@@ -261,4 +256,9 @@ func (r *RequestStats) Close() {
 			stats.close()
 		}
 	}
+}
+
+// isValidStatusCode checks if the status code is in the range of valid HTTP responses.
+func isValidStatusCode(statusCode uint16) bool {
+	return statusCode >= 100 && statusCode < 600
 }

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -258,7 +258,7 @@ func (r *RequestStats) Close() {
 	}
 }
 
-// isValidStatusCode checks if the status code is in the range of valid HTTP responses.
+// isValidStatusCode checks if the status code is in the range of valid HTTP responses
 func isValidStatusCode(statusCode uint16) bool {
 	return statusCode >= 100 && statusCode < 600
 }

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -37,10 +37,10 @@ type Telemetry struct {
 
 	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *TLSCounter
 
-	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
-	rejected                                                         *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
-	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters *libtelemetry.Counter // this happens when the request doesn't have the expected format
-	aggregations                                                     *libtelemetry.Counter
+	dropped                                                                             *libtelemetry.Counter // this happens when statKeeper reaches capacity
+	rejected                                                                            *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
+	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters, invalidStatusCode *libtelemetry.Counter // this happens when the request doesn't have the expected format
+	aggregations                                                                        *libtelemetry.Counter
 
 	joiner telemetryJoiner
 }
@@ -67,6 +67,7 @@ func NewTelemetry(protocol string) *Telemetry {
 		unknownMethod:          metricGroup.NewCounter("malformed", "type:unknown-method", libtelemetry.OptStatsd),
 		invalidLatency:         metricGroup.NewCounter("malformed", "type:invalid-latency", libtelemetry.OptStatsd),
 		nonPrintableCharacters: metricGroup.NewCounter("malformed", "type:non-printable-char", libtelemetry.OptStatsd),
+		invalidStatusCode:      metricGroup.NewCounter("malformed", "type:invalid-status-code", libtelemetry.OptStatsd),
 
 		joiner: telemetryJoiner{
 			requests:         metricGroupJoiner.NewCounter("requests", libtelemetry.OptPrometheus),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Introduces validation for HTTP status codes and adds telemetry within USM HTTP monitoring.

### Motivation
Ensure early failure on invalid status codes and improve observability around such occurrences.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->