### PR TITLE
Skip debian 10 on ddot install tests

### DIFF
--- a/.gitlab/e2e_install_packages/debian.yml
+++ b/.gitlab/e2e_install_packages/debian.yml
@@ -150,6 +150,9 @@ new-e2e-agent-platform-ddot-debian-a7-x86_64:
     - .new-e2e_os_debian
     - .new-e2e_debian_a7_x86_64
   rules: !reference [.on_default_new_e2e_tests]
+  variables:
+    # TODO(@alopezz): Avoids debian 10 on purpose, revert when #incident-40625 is fixed
+    E2E_OSVERS: "debian-9,debian-11,debian-12"
 
 new-e2e-agent-platform-ddot-debian-a7-arm64:
   extends:
@@ -158,3 +161,7 @@ new-e2e-agent-platform-ddot-debian-a7-arm64:
     - .new-e2e_os_debian
     - .new-e2e_debian_a7_arm64
   rules: !reference [.on_default_new_e2e_tests]
+  variables:
+    # TODO(@alopezz): Avoids debian 10 on purpose, revert when #incident-40625 is fixed
+    E2E_OSVERS: "debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"


### PR DESCRIPTION
### What does this PR do?

It skips the Debian 10 platform on tests for ddot installation.

### Motivation

#incident-40625.

Debian Buster repositories stopped being available in the default mirrors last Saturday, breaking every test that tries to `apt update` or similar on Debian 10 (buster).

This remediation will minimize disruption for contributors while we fix the underlying cause (the mirror setup).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->