### PR TITLE
usm: go-tls: Populate pid, netns and support IPv4 as IPv6

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -143,6 +143,10 @@ static __always_inline conn_tuple_t* conn_tup_from_tls_conn(tls_offsets_data_t* 
         .pid = GET_USER_MODE_PID(bpf_get_current_pid_tgid()),
         .metadata = CONN_TYPE_TCP,
     };
+
+    struct task_struct *task = (struct task_struct *) bpf_get_current_task();
+    tuple.netns = BPF_CORE_READ(task, nsproxy, net_ns, ns.inum);
+
     if (!__tuple_via_tcp_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
         if (!__tuple_via_limited_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
             log_debug("[go-tls-conn] failed to resolve tuple from conn at %p", conn);

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -130,7 +130,6 @@ static __always_inline bool __tuple_via_tcp_conn(tls_conn_layout_t* cl, void* tc
 static __always_inline bool __tuple_via_limited_conn(tls_conn_layout_t* cl, void* limited_conn_ptr, conn_tuple_t *output) {
     void *inner_conn_iface_ptr = resolve_interface(limited_conn_ptr + cl->limited_conn_inner_conn_offset);
     if (inner_conn_iface_ptr == NULL) {
-        log_debug("[go-tls-conn] failed to resolve inner conn interface at %p", limited_conn_ptr + cl->limited_conn_inner_conn_offset);
         return false;
     }
 
@@ -160,7 +159,6 @@ static __always_inline conn_tuple_t* conn_tup_from_tls_conn(tls_offsets_data_t* 
 
     if (!__tuple_via_tcp_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
         if (!__tuple_via_limited_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
-            log_debug("[go-tls-conn] failed to resolve tuple from conn at %p", conn);
             return NULL;
         }
     }

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -22,12 +22,6 @@ static __always_inline void* resolve_interface(void *iface_addr) {
 #define IPV6_ADDR_LEN 16
 #define IP_ADDR_LEN_MAX IPV6_ADDR_LEN
 
-#define IPV4_PREFIX (unsigned char[12]){ \
-    0x00, 0x00, 0x00, 0x00,              \
-    0x00, 0x00, 0x00, 0x00,              \
-    0x00, 0x00, 0xff, 0xff               \
-}
-
 // Reads an IP address from the provided slice_t structure.
 static __always_inline bool read_ip(slice_t *address_ptr, __u32 family, __u64 *out_address_h, __u64 *out_address_l) {
     // Taking 16 bytes as it is the maximum size for an IPv6 address (128 bits) and an IPv4 address (32 bits) can fit in this space.
@@ -40,14 +34,8 @@ static __always_inline bool read_ip(slice_t *address_ptr, __u32 family, __u64 *o
         }
     } else if (address_ptr->len == IPV6_ADDR_LEN && family == AF_INET6) {
         if (bpf_probe_read_user(ip, IPV6_ADDR_LEN, (void*)address_ptr->ptr) == 0) {
-            // IPv4 representation as IPv6. We traverse the operation and extract the last 4 bytes.
-            if (bpf_memcmp(ip, IPV4_PREFIX, sizeof(IPV4_PREFIX)) == 0) {
-                *out_address_h = 0;
-                *out_address_l = *((__u32*)(ip+sizeof(IPV4_PREFIX)));
-            } else {
-                *out_address_h = *((__u64*)ip);
-                *out_address_l = *((__u64*)(ip + 8));
-            }
+            *out_address_h = *((__u64*)ip);
+            *out_address_l = *((__u64*)(ip + 8));
             return true;
         }
     }
@@ -120,8 +108,19 @@ static __always_inline bool __tuple_via_tcp_conn(tls_conn_layout_t* cl, void* tc
         return false;
     }
 
-    if (family == AF_INET6 && output->saddr_h != 0 && output->saddr_l != 0) {
-        output->metadata |= CONN_V6;
+    // Similar behavior as in read_conn_tuple_partial
+    // See documentation of is_ipv4_mapped_ipv6 for further details.
+    if (family == AF_INET6) {
+        // Check if we can map IPv6 to IPv4
+        if (is_ipv4_mapped_ipv6(output->saddr_h, output->saddr_l, output->daddr_h, output->daddr_l)) {
+            output->metadata |= CONN_V4;
+            output->saddr_h = 0;
+            output->daddr_h = 0;
+            output->saddr_l = (__u32)(output->saddr_l >> 32);
+            output->daddr_l = (__u32)(output->daddr_l >> 32);
+        } else {
+            output->metadata |= CONN_V6;
+        }
     } else {
         output->metadata |= CONN_V4;
     }

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-conn.h
@@ -108,7 +108,6 @@ static __always_inline bool __tuple_via_tcp_conn(tls_conn_layout_t* cl, void* tc
         return false;
     }
 
-    output->metadata = CONN_TYPE_TCP;
     if (family == AF_INET6) {
         output->metadata |= CONN_V6;
     } else { // If we reached here, we already know the family is AF_INET or AF_INET6.
@@ -140,7 +139,10 @@ static __always_inline conn_tuple_t* conn_tup_from_tls_conn(tls_offsets_data_t* 
         return NULL;
     }
 
-    conn_tuple_t tuple = {0};
+    conn_tuple_t tuple = {
+        .pid = GET_USER_MODE_PID(bpf_get_current_pid_tgid()),
+        .metadata = CONN_TYPE_TCP,
+    };
     if (!__tuple_via_tcp_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
         if (!__tuple_via_limited_conn(&pd->conn_layout, inner_conn_iface_ptr, &tuple)) {
             log_debug("[go-tls-conn] failed to resolve tuple from conn at %p", conn);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Adds the missing fields (`pid` and `netns` to the `conn_tuple` generated from go-tls uprobes)
- Supports IPv4 representation as IPv6 (happens when client is IPv4 and server supports IPv6)

### Motivation

Regression found in our load test and manual release process of 7.69

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Load tests - 
[HTTP go tls](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=v769-http-go-tls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=v769-http-go-tls-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm2&tpl_var_server-service%5B0%5D=golang-httpbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1752487388797&to_ts=1752548262000&live=false)
<img width="1123" height="291" alt="image" src="https://github.com/user-attachments/assets/99f621f5-1604-4962-9e49-a1ec7bfaa276" />

[HTTP2 go tls](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=v769-http2-go-tls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http2-tls&tpl_var_compare_agent-env%5B0%5D=v769-http2-go-tls-new&tpl_var_http.version%5B0%5D=http%2F2&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-httpbin-http2-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1752487279851&to_ts=1752548360000&live=false)
<img width="1126" height="286" alt="image" src="https://github.com/user-attachments/assets/b93f6349-2914-4718-9e2e-241e2818cf01" />

[grpc go tls](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=v769-2-grpc-go-tls-base&tpl_var_client-service%5B0%5D=golang-k6-client-grpc-tls&tpl_var_compare_agent-env%5B0%5D=v769-2-grpc-go-tls-new&tpl_var_kube_cluster_name%5B0%5D=usm4&tpl_var_server-service%5B0%5D=golang-grpcbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1752493611707&to_ts=1752548380000&live=false)
<img width="1126" height="585" alt="image" src="https://github.com/user-attachments/assets/2630ad7d-4f29-4a6d-b197-9ae476dd7b88" />

