### PR TITLE
Do not try to run SMP commenter service on documentation changes

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -296,6 +296,19 @@ single-machine-performance-regression_detector-pr-comment:
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a duplicate, specialized artifact that is not useful to run through SMP on every PR
     - !reference [.on_dev_branches]
+    - changes:
+        - "**/*.md"
+        - "**/*_test.go"
+        - "docs/**/*"
+        - "README*"
+        - ".vscode/**/*"
+        - "examples/**/*"
+        - "LICENSE*"
+        - "NOTICE*"
+        - "CHANGELOG*"
+        - "releasenotes/**/*"
+        - "releasenotes-dca/**/*"
+      when: never
     - when: always
   image:
     name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"


### PR DESCRIPTION
### What does this PR do?

Adds same rules to `single-machine-performance-regression_detector-pr-comment` as `single-machine-performance-regression_detector` so that both jobs are skipped on documentation changes. 

### Motivation

Fix failures in `test_gitlab_compare_to`

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
