### PR TITLE
Remove PNGs from files to `codesign` (ABLD-94 follow-up)

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -188,14 +188,6 @@ build do
                         awk -F: '$0 ~ /[^)]:[[:space:]]*application\\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
                         xargs -0 -n10 -P#{workers} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
                 SH
-                # Also sequentially codesign PNGs (`Contents/MacOS/agent.png` out of ~20 files under 'Datadog Agent.app')
-                command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
-                    set -euo pipefail
-                    find '#{install_dir}/Datadog Agent.app' -type f -print0 |
-                        xargs -0 file --mime-type |
-                        awk -F: '$2 ~ /image\\/png/ { printf "%s%c", $1, 0 }' |
-                        xargs -0 #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
-                SH
             end
         end
     end


### PR DESCRIPTION
### What does this PR do?
Following review comment https://github.com/DataDog/datadog-agent/pull/38582#discussion_r2205224484, this is to stop `codesign`ing PNG files.

This practically applies to `/opt/datadog-agent/Datadog Agent.app/Contents/MacOS/agent.png` for which we can safely remove a special case leading to a second `codesign`ing pass.

### Motivation
PNG files are just data, not executable content. macOS Gatekeeper, notarization, and app launch services **don't validate them** via code signing.

### Additional Notes
Note that PNGs may still appear in the `ticketContents` section of the [notarization log response](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1028797632#L1036) (esp. when using `--deep` or in `.app` bundles):
```json
    {
      "path": "datadog-agent-7.70.0-devel.git.48.4d7d589.pipeline.70558906-1.dmg/datadog-agent-7.70.0-devel.git.48.4d7d589.pipeline.70558906-1.pkg/datadog-agent-core.pkg Contents/Payload/opt/datadog-agent/Datadog Agent.app/Contents/MacOS/agent.png",
      "digestAlgorithm": "SHA-256",
      "cdhash": "c386e91d0deae3a69ac248b32c0a95e457038348",
      "arch": null
    },
```
According to a famous chatbot:
> ❓ **Why Do PNGs Sometimes Appear in the Notarization Log?**
>
> Even though you **didn’t explicitly codesign PNGs**, they may still show up in the notarization log (`ticketContents`). Here's why:
> 🧠 Because of `--deep`
> If you run:
> ```bash
> codesign --deep --force -s "…" path/to/MyApp.app
> ```
> Then:
> - `codesign` recursively signs **every file in the bundle**
> - It attaches hashes of _all files_ into the CMS signature
> - These files then show up in notarization logs, especially if:
>     - They were touched during signing
>     - They had a known file type (e.g. `image/png`)
>
> 🎯 **But Apple doesn’t validate the signature of the PNG itself** — it’s just part of the overall notarized seal of the bundle.
>>>

The (now) single `codesign`ing snippet takes less than 14s.