### PR TITLE
Do not create invalid trace IDs in sampler fuzz test

### DIFF
--- a/pkg/trace/sampler/probabilistic_test.go
+++ b/pkg/trace/sampler/probabilistic_test.go
@@ -167,6 +167,7 @@ func FuzzConsistentWithOtel(f *testing.F) {
 	pspCfg := &probabilisticsamplerprocessor.Config{
 		SamplingPercentage: samplingPercent,
 		HashSeed:           hashSeed,
+		Mode:               "hash_seed",
 	}
 
 	conf := &config.AgentConfig{
@@ -180,7 +181,29 @@ func FuzzConsistentWithOtel(f *testing.F) {
 	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	f.Fuzz(func(t *testing.T, tid []byte) {
 		if len(tid) < 16 {
-			t.Skip("need at least 16 bytes for trace id")
+			t.Skip("need at least 16 bytes for W3C Trace Context trace id")
+		}
+		// Skip zero trace IDs as they are invalid per W3C Trace Context
+		// specification. OpenTelemetry follows the W3C Trace Context
+		// specification for trace IDs. The test uses
+		// opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
+		// which handles trace IDs according to W3C standards.
+		//
+		// Per W3C Trace Context[1] "All bytes as zero
+		// (00000000000000000000000000000000) is considered an invalid
+		// value." The behavior of these two implementations with a
+		// zero-value trace ID is undefined behavior.
+		//
+		// [1]: https://www.w3.org/TR/trace-context/#trace-id, section 3.2.2.3
+		allZero := true
+		for i := 0; i < 16 && i < len(tid); i++ {
+			if tid[i] != 0 {
+				allZero = false
+				break
+			}
+		}
+		if allZero {
+			t.Skip("zero trace IDs are invalid per OpenTelemetry / W3C spec")
 		}
 		mc := &mockConsumer{} //Do this setup in here to avoid having to clear this data between tests
 		tp, err := pspFactory.CreateTraces(context.Background(), cfg, pspCfg, mc)
@@ -194,7 +217,13 @@ func FuzzConsistentWithOtel(f *testing.F) {
 			TraceID: binary.BigEndian.Uint64(tid[8:]),
 			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
 		})
-		assert.Equal(t, len(mc.traces) == 1, sampled)
+		otelSampled := len(mc.traces) == 1
+		if otelSampled != sampled {
+			t.Logf("Trace ID: %x", tid)
+			t.Logf("OTel sampled: %v, Datadog sampled: %v", otelSampled, sampled)
+			t.Logf("Upper 8 bytes: %x, Lower 8 bytes: %x", tid[:8], tid[8:])
+		}
+		assert.Equal(t, otelSampled, sampled)
 	})
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit resolves a failure in FuzzConsistentWithOtel where we demonstrate
that the Datadog sampler and the OTel sampler have different behavior when
passed an all-zero trace ID. These are not valid trace IDs in the given
context and so we skip them in the fuzz test.

### Motivation

This will resolve https://app.datadoghq.com/error-tracking/issue/52b3f8a2-5ce7-11f0-8d0d-da7ad0900002?query=service%3Adatadog-agent-%2A-fuzzing&index=&refresh_mode=sliding&from_ts=1751912130960&to_ts=1752516930960&live=true

