### PR TITLE
[ AGNTLOG-99 ] Extend logs_dd_url to support path prefixes

### DIFF
--- a/comp/core/agenttelemetry/impl/sender.go
+++ b/comp/core/agenttelemetry/impl/sender.go
@@ -20,6 +20,8 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/DataDog/zstd"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -27,7 +29,6 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/zstd"
 )
 
 const (
@@ -177,10 +178,11 @@ func buildURL(endpoint logconfig.Endpoint) string {
 	} else {
 		address = endpoint.Host
 	}
+
 	url := url.URL{
 		Scheme: "https",
 		Host:   address,
-		Path:   telemetryPath,
+		Path:   endpoint.PathPrefix + telemetryPath,
 	}
 
 	return url.String()
@@ -465,9 +467,9 @@ func (s *senderImpl) flushSession(ss *senderSession) error {
 
 		// Log return status (and URL if unsuccessful)
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			s.logComp.Debugf("Telemetery enpoint response status:%s, request type:%s, status code:%d", resp.Status, reqType, resp.StatusCode)
+			s.logComp.Debugf("Telemetery endpoint response status:%s, request type:%s, status code:%d", resp.Status, reqType, resp.StatusCode)
 		} else {
-			s.logComp.Debugf("Telemetery enpoint response status:%s, request type:%s, status code:%d, url:%s", resp.Status, reqType, resp.StatusCode, url)
+			s.logComp.Debugf("Telemetery endpoint response status:%s, request type:%s, status code:%d, url:%s", resp.Status, reqType, resp.StatusCode, url)
 		}
 	}
 

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -210,7 +210,7 @@ func (suite *AgentTestSuite) TestAgentHttp() {
 }
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
-	endpoint := config.NewEndpoint("", "", "fake:", 0, false)
+	endpoint := config.NewEndpoint("", "", "fake:", 0, config.EmptyPathPrefix, false)
 	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{}, true, false)
 
 	env.SetFeatures(suite.T(), env.Docker, env.Kubernetes)

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,12 @@ const (
 	httpEndpointPrefix           = "agent-http-intake.logs."
 	serverlessHTTPEndpointPrefix = "http-intake.logs."
 )
+
+// legacyPathPrefixes are the path prefixes that match existing log intake endpoints present
+// at the time that logs_dd_url was extended to support the ability to specify a path prefix.
+// Users with these set are assumed to be relying on legacy logs_dd_url behavior and will
+// have these path prefixes dropped accordingly.
+var legacyPathPrefixes = []string{"/v1/input", "/api/v2/logs"}
 
 // AgentJSONIntakeProtocol agent json protocol
 const AgentJSONIntakeProtocol = "agent-json"
@@ -230,7 +237,7 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 	}
 
 	if vectorURL, vectorURLDefined := logsConfig.getObsPipelineURL(); logsConfig.obsPipelineWorkerEnabled() && vectorURLDefined {
-		host, port, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
+		host, port, _, useSSL, err := parseAddressWithScheme(vectorURL, defaultNoSSL, parseAddress)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", vectorURL, err)
 		}
@@ -238,16 +245,17 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		main.Port = port
 		main.useSSL = useSSL
 	} else if logsDDURL, logsDDURLDefined := logsConfig.logsDDURL(); logsDDURLDefined {
-		host, port, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
+		host, port, pathPrefix, useSSL, err := parseAddressWithScheme(logsDDURL, defaultNoSSL, parseAddress)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
 		}
 		main.Host = host
 		main.Port = port
+		main.PathPrefix = pathPrefix
 		main.useSSL = useSSL
 	} else {
 		addr := pkgconfigutils.GetMainEndpoint(coreConfig, endpointPrefix, logsConfig.getConfigKey("dd_url"))
-		host, port, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
+		host, port, _, useSSL, err := parseAddressWithScheme(addr, logsConfig.devModeNoSSL(), parseAddressAsHost)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", logsDDURL, err)
 		}
@@ -266,12 +274,12 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 			return nil, fmt.Errorf("cannot construct MRF endpoint: %s", err)
 		}
 
-		mrfHost, mrfPort, mrfUseSSL, err := parseAddressWithScheme(mrfURL, defaultNoSSL, parseAddressAsHost)
+		mrfHost, mrfPort, mrfPathPrefix, mrfUseSSL, err := parseAddressWithScheme(mrfURL, defaultNoSSL, parseAddressAsHost)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %s: %v", mrfURL, err)
 		}
 
-		e := NewEndpoint(coreConfig.GetString("multi_region_failover.api_key"), "multi_region_failover.api_key", mrfHost, mrfPort, mrfUseSSL)
+		e := NewEndpoint(coreConfig.GetString("multi_region_failover.api_key"), "multi_region_failover.api_key", mrfHost, mrfPort, mrfPathPrefix, mrfUseSSL)
 		e.IsMRF = true
 		e.UseCompression = main.UseCompression
 		e.CompressionKind = main.CompressionKind
@@ -300,12 +308,12 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 
 type defaultParseAddressFunc func(string) (host string, port int, err error)
 
-func parseAddressWithScheme(address string, defaultNoSSL bool, defaultParser defaultParseAddressFunc) (host string, port int, useSSL bool, err error) {
+func parseAddressWithScheme(address string, defaultNoSSL bool, defaultParser defaultParseAddressFunc) (host string, port int, pathPrefix string, useSSL bool, err error) {
 	if strings.HasPrefix(address, "https://") || strings.HasPrefix(address, "http://") {
 		if strings.HasPrefix(address, "https://") && !defaultNoSSL {
 			log.Warn("dd_url set to a URL with an HTTPS prefix and logs_no_ssl set to true. These are conflicting options. In a future release logs_no_ssl will override the dd_url prefix.")
 		}
-		host, port, useSSL, err = parseURL(address)
+		host, port, pathPrefix, useSSL, err = parseURL(address)
 	} else {
 		host, port, err = defaultParser(address)
 		if err != nil {
@@ -317,7 +325,7 @@ func parseAddressWithScheme(address string, defaultNoSSL bool, defaultParser def
 	return
 }
 
-func parseURL(address string) (host string, port int, useSSL bool, err error) {
+func parseURL(address string) (host string, port int, pathPrefix string, useSSL bool, err error) {
 	u, errParse := url.Parse(address)
 	if errParse != nil {
 		err = errParse
@@ -335,6 +343,11 @@ func parseURL(address string) (host string, port int, useSSL bool, err error) {
 		if err != nil {
 			return
 		}
+	}
+	pathPrefix = u.EscapedPath()
+	if slices.Contains(legacyPathPrefixes, pathPrefix) {
+		log.Warnf("Using legacy path %s, it will be automatically updated to the current intake path if necessary.", pathPrefix)
+		pathPrefix = EmptyPathPrefix
 	}
 
 	return

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -689,7 +689,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 }
 
 func getTestEndpoint(host string, port int, ssl bool) Endpoint {
-	e := NewEndpoint("123", "", host, port, ssl)
+	e := NewEndpoint("123", "", host, port, EmptyPathPrefix, ssl)
 	e.UseCompression = true
 	e.CompressionLevel = ZstdCompressionLevel // by default endpoints uses zstd
 	e.BackoffFactor = pkgconfigsetup.DefaultLogsSenderBackoffFactor
@@ -931,12 +931,13 @@ func Test_parseAddressWithScheme(t *testing.T) {
 		defaultParser defaultParseAddressFunc
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantHost   string
-		wantPort   int
-		wantUseSSL bool
-		wantErr    bool
+		name           string
+		args           args
+		wantHost       string
+		wantPort       int
+		wantPathPrefix string
+		wantUseSSL     bool
+		wantErr        bool
 	}{
 		{
 			name: "url without scheme and port",
@@ -945,10 +946,11 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				defaultNoSSL:  true,
 				defaultParser: parseAddress,
 			},
-			wantHost:   "localhost",
-			wantPort:   8080,
-			wantUseSSL: false,
-			wantErr:    false,
+			wantHost:       "localhost",
+			wantPort:       8080,
+			wantPathPrefix: "",
+			wantUseSSL:     false,
+			wantErr:        false,
 		},
 		{
 			name: "url with https prefix",
@@ -957,10 +959,11 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				defaultNoSSL:  true,
 				defaultParser: parseAddress,
 			},
-			wantHost:   "localhost",
-			wantPort:   0,
-			wantUseSSL: true,
-			wantErr:    false,
+			wantHost:       "localhost",
+			wantPort:       0,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
+			wantErr:        false,
 		},
 		{
 			name: "url with https prefix and port",
@@ -968,10 +971,11 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				address:       "https://localhost:443",
 				defaultParser: parseAddress,
 			},
-			wantHost:   "localhost",
-			wantPort:   443,
-			wantUseSSL: true,
-			wantErr:    false,
+			wantHost:       "localhost",
+			wantPort:       443,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
+			wantErr:        false,
 		},
 		{
 			name: "invalid url",
@@ -980,10 +984,11 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				defaultNoSSL:  true,
 				defaultParser: parseAddressAsHost,
 			},
-			wantHost:   "",
-			wantPort:   0,
-			wantUseSSL: false,
-			wantErr:    true,
+			wantHost:       "",
+			wantPort:       0,
+			wantPathPrefix: "",
+			wantUseSSL:     false,
+			wantErr:        true,
 		},
 		{
 			name: "allow emptyPort",
@@ -992,10 +997,11 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				defaultNoSSL:  true,
 				defaultParser: parseAddressAsHost,
 			},
-			wantHost:   "localhost",
-			wantPort:   0,
-			wantUseSSL: true,
-			wantErr:    false,
+			wantHost:       "localhost",
+			wantPort:       0,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
+			wantErr:        false,
 		},
 		{
 			name: "no schema, not port emptyPort",
@@ -1004,15 +1010,54 @@ func Test_parseAddressWithScheme(t *testing.T) {
 				defaultNoSSL:  false,
 				defaultParser: parseAddressAsHost,
 			},
-			wantHost:   "localhost",
-			wantPort:   0,
-			wantUseSSL: true,
-			wantErr:    false,
+			wantHost:       "localhost",
+			wantPort:       0,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
+			wantErr:        false,
+		},
+		{
+			name: "path prefix",
+			args: args{
+				address:       "https://localhost:8080/path/prefix",
+				defaultNoSSL:  true,
+				defaultParser: parseAddress,
+			},
+			wantHost:       "localhost",
+			wantPort:       8080,
+			wantPathPrefix: "/path/prefix",
+			wantUseSSL:     true,
+			wantErr:        false,
+		},
+		{
+			name: "legacy path v1 prefix",
+			args: args{
+				address:       "https://localhost:8080/v1/input",
+				defaultNoSSL:  true,
+				defaultParser: parseAddress,
+			},
+			wantHost:       "localhost",
+			wantPort:       8080,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
+			wantErr:        false,
+		},
+		{
+			name: "legacy path v2 prefix",
+			args: args{
+				address:       "https://localhost:8080/api/v2/logs",
+				defaultNoSSL:  true,
+				defaultParser: parseAddress,
+			},
+			wantHost:       "localhost",
+			wantPort:       8080,
+			wantPathPrefix: "",
+			wantUseSSL:     true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotHost, gotPort, gotUseSSL, err := parseAddressWithScheme(tt.args.address, tt.args.defaultNoSSL, tt.args.defaultParser)
+			gotHost, gotPort, gotPathPrefix, gotUseSSL, err := parseAddressWithScheme(tt.args.address, tt.args.defaultNoSSL, tt.args.defaultParser)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseAddressWithScheme() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1022,6 +1067,9 @@ func Test_parseAddressWithScheme(t *testing.T) {
 			}
 			if gotPort != tt.wantPort {
 				t.Errorf("parseAddressWithScheme() gotPort = %v, want %v", gotPort, tt.wantPort)
+			}
+			if gotPathPrefix != tt.wantPathPrefix {
+				t.Errorf("parseAddressWithScheme() gotPathPrefix = %v, want %v", gotPathPrefix, tt.wantPathPrefix)
 			}
 			if gotUseSSL != tt.wantUseSSL {
 				t.Errorf("parseAddressWithScheme() gotUseSSL = %v, want %v", gotUseSSL, tt.wantUseSSL)

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
@@ -138,7 +138,7 @@ func (suite *AgentTestSuite) TestAgentHttp() {
 }
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
-	endpoint := config.NewEndpoint("", "", "fake:", 0, false)
+	endpoint := config.NewEndpoint("", "", "fake:", 0, config.EmptyPathPrefix, false)
 	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{}, true, false)
 
 	agent := createAgent(suite, endpoints)

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -479,9 +479,9 @@ func buildURL(endpoint config.Endpoint) string {
 		Host:   address,
 	}
 	if endpoint.Version == config.EPIntakeVersion2 && endpoint.TrackType != "" {
-		url.Path = fmt.Sprintf("/api/v2/%s", endpoint.TrackType)
+		url.Path = fmt.Sprintf("%s/api/v2/%s", endpoint.PathPrefix, endpoint.TrackType)
 	} else {
-		url.Path = "/v1/input"
+		url.Path = fmt.Sprintf("%s/v1/input", endpoint.PathPrefix)
 	}
 	return url.String()
 }

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -27,26 +27,50 @@ import (
 )
 
 func TestBuildURLShouldReturnHTTPSWithUseSSL(t *testing.T) {
-	url := buildURL(config.NewEndpoint("bar", "", "foo", 0, true))
+	url := buildURL(config.NewEndpoint("bar", "", "foo", 0, config.EmptyPathPrefix, true))
 	assert.Equal(t, "https://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnHTTPWithoutUseSSL(t *testing.T) {
-	url := buildURL(config.NewEndpoint("bar", "", "foo", 0, false))
+	url := buildURL(config.NewEndpoint("bar", "", "foo", 0, config.EmptyPathPrefix, false))
 	assert.Equal(t, "http://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnAddressWithPortWhenDefined(t *testing.T) {
-	url := buildURL(config.NewEndpoint("bar", "", "foo", 1234, false))
+	url := buildURL(config.NewEndpoint("bar", "", "foo", 1234, config.EmptyPathPrefix, false))
 	assert.Equal(t, "http://foo:1234/v1/input", url)
 }
 
 func TestBuildURLShouldReturnAddressForVersion2(t *testing.T) {
-	e := config.NewEndpoint("bar", "", "foo", 0, false)
+	e := config.NewEndpoint("bar", "", "foo", 0, config.EmptyPathPrefix, false)
 	e.Version = config.EPIntakeVersion2
 	e.TrackType = "test-track"
 	url := buildURL(e)
 	assert.Equal(t, "http://foo/api/v2/test-track", url)
+}
+
+func TestBuildURLPathPrefix(t *testing.T) {
+	e := config.NewEndpoint("bar", "", "foo", 0, "/prefix/url", false)
+	e.Version = config.EPIntakeVersion2
+	e.TrackType = "test-track"
+	url := buildURL(e)
+	assert.Equal(t, "http://foo/prefix/url/api/v2/test-track", url)
+}
+
+func TestBuildURLPathPrefixSSLPort(t *testing.T) {
+	e := config.NewEndpoint("bar", "", "foo", 8080, "/prefix/url", true)
+	e.Version = config.EPIntakeVersion2
+	e.TrackType = "test-track"
+	url := buildURL(e)
+	assert.Equal(t, "https://foo:8080/prefix/url/api/v2/test-track", url)
+}
+
+func TestBuildURLPathPrefixV1(t *testing.T) {
+	e := config.NewEndpoint("bar", "", "foo", 8080, "/prefix/url", true)
+	e.Version = config.EPIntakeVersion1
+	e.TrackType = "test-track"
+	url := buildURL(e)
+	assert.Equal(t, "https://foo:8080/prefix/url/v1/input", url)
 }
 
 //nolint:revive // TODO(AML) Fix revive linter

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -78,7 +78,7 @@ func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestinat
 	destCtx := client.NewDestinationsContext()
 	destCtx.Start()
 
-	endpoint := config.NewEndpoint("test", "", strings.ReplaceAll(url[1], "/", ""), port, false)
+	endpoint := config.NewEndpoint("test", "", strings.ReplaceAll(url[1], "/", ""), port, config.EmptyPathPrefix, false)
 	endpoint.BackoffFactor = 1
 	endpoint.BackoffBase = 0.01
 	endpoint.BackoffMax = 10

--- a/pkg/logs/client/tcp/connection_manager_test.go
+++ b/pkg/logs/client/tcp/connection_manager_test.go
@@ -27,7 +27,7 @@ func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
 }
 
 func newConnectionManagerForHostPort(host string, port int) *ConnectionManager {
-	endpoint := config.NewEndpoint("", "", host, port, false)
+	endpoint := config.NewEndpoint("", "", host, port, config.EmptyPathPrefix, false)
 	return NewConnectionManager(endpoint, statusinterface.NewStatusProviderMock())
 }
 

--- a/pkg/logs/client/tcp/destination_test.go
+++ b/pkg/logs/client/tcp/destination_test.go
@@ -42,7 +42,7 @@ func TestDestinationHA(t *testing.T) {
 // TestConnecitivityDiagnoseNoBlock ensures the connectivity diagnose doesn't
 // block
 func TestConnecitivityDiagnoseNoBlock(t *testing.T) {
-	endpoint := config.NewEndpoint("00000000", "", "host", 0, true)
+	endpoint := config.NewEndpoint("00000000", "", "host", 0, config.EmptyPathPrefix, true)
 	done := make(chan struct{})
 
 	go func() {
@@ -76,7 +76,7 @@ func TestConnectivityDiagnoseOperationSuccess(t *testing.T) {
 	portInt, err := strconv.Atoi(port)
 	assert.Nil(t, err)
 
-	testSuccessEndpoint := config.NewEndpoint("api-key", "", host, portInt, false)
+	testSuccessEndpoint := config.NewEndpoint("api-key", "", host, portInt, config.EmptyPathPrefix, false)
 	connManager := NewConnectionManager(testSuccessEndpoint, statusinterface.NewNoopStatusProvider())
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -104,7 +104,7 @@ func TestConnectivityDiagnoseOperationFail(t *testing.T) {
 	portInt, err := strconv.Atoi(port)
 	assert.Nil(t, err)
 
-	testFailEndpointWrongAddress := config.NewEndpoint("api-key", "", "failhost", portInt, false)
+	testFailEndpointWrongAddress := config.NewEndpoint("api-key", "", "failhost", portInt, config.EmptyPathPrefix, false)
 	connManager := NewConnectionManager(testFailEndpointWrongAddress, statusinterface.NewNoopStatusProvider())
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -112,7 +112,7 @@ func TestConnectivityDiagnoseOperationFail(t *testing.T) {
 	_, err = connManager.NewConnection(ctx)
 	assert.NotNil(t, err)
 
-	testFailEndpointWrongPort := config.NewEndpoint("api-key", "", host, portInt+1, false)
+	testFailEndpointWrongPort := config.NewEndpoint("api-key", "", host, portInt+1, config.EmptyPathPrefix, false)
 	connManager = NewConnectionManager(testFailEndpointWrongPort, statusinterface.NewNoopStatusProvider())
 	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -136,7 +136,7 @@ func (c *mockConn) Close() (err error) {
 // TestNoRetryAndWriteError ensures that a write error successfully exits the send loop when
 // retry is disabled.
 func TestNoRetryAndWriteError(t *testing.T) {
-	endpoint := config.NewEndpoint("api-key", "", "localhost", 0, false)
+	endpoint := config.NewEndpoint("api-key", "", "localhost", 0, config.EmptyPathPrefix, false)
 
 	dest := NewDestination(endpoint, false, client.NewDestinationsContext(), false, statusinterface.NewStatusProviderMock())
 	output := make(chan *message.Payload, 1)

--- a/pkg/logs/client/tcp/test_utils.go
+++ b/pkg/logs/client/tcp/test_utils.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package tcp
 
 import (
@@ -27,7 +29,7 @@ func AddrToHostPort(remoteAddr net.Addr) (string, int) {
 // AddrToEndPoint creates an EndPoint from an Addr.
 func AddrToEndPoint(addr net.Addr) config.Endpoint {
 	host, port := AddrToHostPort(addr)
-	return config.NewEndpoint("", "", host, port, false)
+	return config.NewEndpoint("", "", host, port, config.EmptyPathPrefix, false)
 }
 
 // AddrToDestination creates a Destination from an Addr

--- a/pkg/security/utils/endpoint.go
+++ b/pkg/security/utils/endpoint.go
@@ -27,5 +27,5 @@ func GetEndpointURL(endpoint logsconfig.Endpoint, uri string) string {
 			port = 80 // use default port
 		}
 	}
-	return fmt.Sprintf("%s://%s:%v/%s", protocol, endpoint.Host, port, uri)
+	return fmt.Sprintf("%s://%s:%v%s/%s", protocol, endpoint.Host, port, endpoint.PathPrefix, uri)
 }

--- a/pkg/security/utils/endpoint_test.go
+++ b/pkg/security/utils/endpoint_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+)
+
+func TestGetEndpointURL(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "localhost", 8080, "/prefix/url", false)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "http://localhost:8080/prefix/url/test", url)
+}
+
+func TestGetEndpointURLSSL(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "localhost", 8080, "/prefix/url", true)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "https://localhost:8080/prefix/url/test", url)
+}
+
+func TestGetEndpointURLHostPort(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "localhost", 8080, config.EmptyPathPrefix, false)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "http://localhost:8080/test", url)
+}
+
+func TestGetEndpointURLHostOnlySSL(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "localhost", 0, config.EmptyPathPrefix, true)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "https://localhost:443/test", url)
+}
+
+func TestGetEndpointURLHostOnlyNoSSL(t *testing.T) {
+	endpoint := config.NewEndpoint("key", "keyPath", "localhost", 0, config.EmptyPathPrefix, false)
+	url := GetEndpointURL(endpoint, "test")
+	assert.Equal(t, "http://localhost:80/test", url)
+}

--- a/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
+++ b/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    If a path is specified in the URL in `logs_config.logs_dd_url` use it as a prefix.
+    If a path is specified in the URL in `logs_config.logs_dd_url`, use it as a prefix.

--- a/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
+++ b/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added support for a path prefix in the `logs_config.logs_dd_url` configuration.

--- a/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
+++ b/releasenotes/notes/logs-dd-url-path-prefix-53ce657fcf55a6e9.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Added support for a path prefix in the `logs_config.logs_dd_url` configuration.
+    If a path is specified in the URL in `logs_config.logs_dd_url` use it as a prefix.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The configuration option `dd_url` allows the specification of a url path prefix, which in turn allows support for a layer 7 proxy setup. This support is missing for the Logs Agent equivalent, `logs_config.logs_dd_url`, which instead only recognizes a host:port paradigm. This PR extends `logs_config.logs_dd_url` to support prefix paths. 
Note that the logs_dd_url expects an absolute URL, including schema, in order to correctly process the path value. 

This change impacts the following services:
Logs Agent
Epforwarder integrations
Security + Compliance
Agent Telemetry

All of the above entites make use of the Log Agent's endpoint definition, which now has path support. User configuration for the following settings were examined:
`logs_config.logs_dd_url`
`database_monitoring.samples.logs_dd_url`
`database_monitoring.metrics.logs_dd_url`
`database_monitoring.activity.logs_dd_url`
`network_devices.metadata.logs_dd_url`
`network_devices.snmp_traps.forwarder.logs_dd_url`
`network_devices.netflow.forwarder.logs_dd_url`
`network_path.forwarder.logs_dd_url`
`container_lifecycle.logs_dd_url`
`container_image.logs_dd_url`
`sbom.logs_dd_url`
`service_discovery.forwarder.logs_dd_url`
`runtime_security_config.activity_dump.remote_storage.endpoints.logs_dd_url`
`agent_telemetry.logs_dd_url`
`multi_region_failover.logs_dd_url`
`compliance_config.endpoints.logs_dd_url`

All settings located were strictly in a host:port format, with the exception of a few instances of `logs_config.logs_dd_url`. These exceptions consisted of the  `/v1/input` and `/api/v2/logs` path values, which are identical to the intake endpoints the Logs Agent will append when transferring logs. In order to not break these use cases, specifying either of the valid datadog endpoints will not be considered a path prefix in the new logic but will instead cause the path component of the logs_dd_url setting to be ignored (as it is today). 

Additionally, an alteration has been made to the agent status page. When no path prefix is detected, the status displays as normal:
```
==========
Logs Agent
==========

    Reliable: Sending compressed logs in HTTPS to datadogtest.com on port 443
    BytesSent: 0
    EncodedBytesSent: 2
    LogsProcessed: 0
    LogsSent: 0
    LogsTruncated: 0
    RetryCount: 0
    RetryTimeSpent: 0s
```

When a path prefix is set, the output now looks like:
```
==========
Logs Agent
==========

    Reliable: Sending compressed logs in HTTPS to datadogtest.com on port 443 and path prefix "/proxied/path"
    BytesSent: 0
    EncodedBytesSent: 2
    LogsProcessed: 0
    LogsSent: 0
    LogsTruncated: 0
    RetryCount: 0
    RetryTimeSpent: 0s
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Behavior changes:
Specifying a `logs_config.logs_dd_url` value of `https://datadogtest.com:8443/this/is/a/path/prefix` will cause the expected endpoints hit by the logs agent to be of the form:
`https://datadogtest.com:8443/this/is/a/path/prefix/api/v2/logs`,
`https://datadogtest.com:8443/this/is/a/path/prefix/probe`,
etc

Automated testing was added to confirm formatting is as expected for a number of services, and that the exceptions are in place for 'v1/input' and 'api/v2/logs'. Manual tests were run with a level 7 proxy to confirm appropriate redirection for the logs agent. 


### Possible Drawbacks / Trade-offs


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->