### PR TITLE
terminate pending states

### DIFF
--- a/pkg/fleet/installer/packages/service/windows/impl_test.go
+++ b/pkg/fleet/installer/packages/service/windows/impl_test.go
@@ -326,7 +326,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 				api.On("GetServiceState", "datadog-trace-agent").Return(svc.Running, nil).Once()
 				// Mock the GetServiceProcessID calls within TerminateServiceProcess
 				api.On("GetServiceProcessID", "datadog-trace-agent").Return(uint32(1234), errors.New("access denied"))
-				// after failed termiantion, the service ended up being stopped
+				// after failed termination, the service ended up being stopped
 				api.On("GetServiceState", "datadog-trace-agent").Return(svc.Stopped, nil).Once()
 
 				// Other services are not running

--- a/pkg/fleet/installer/packages/service/windows/system_api.go
+++ b/pkg/fleet/installer/packages/service/windows/system_api.go
@@ -18,7 +18,7 @@ import (
 // systemAPI abstracts system-level API calls
 type systemAPI interface {
 	GetServiceProcessID(serviceName string) (uint32, error)
-	IsServiceRunning(serviceName string) (bool, error)
+	GetServiceState(serviceName string) (svc.State, error)
 	StopService(serviceName string) error
 	StartService(serviceName string) error
 	OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (windows.Handle, error)
@@ -62,14 +62,14 @@ func (api *winSystemAPI) GetServiceProcessID(serviceName string) (uint32, error)
 	return status.ProcessId, nil
 }
 
-// IsServiceRunning returns false if the service is stopped, true otherwise.
-func (api *winSystemAPI) IsServiceRunning(serviceName string) (bool, error) {
+// GetServiceState returns the current state of the service.
+func (api *winSystemAPI) GetServiceState(serviceName string) (svc.State, error) {
 	status, err := api.queryServiceStatus(serviceName)
 	if err != nil {
-		return false, err
+		return svc.Stopped, err
 	}
-	// return true for all non-stopped states (start_pending, stop_pending, etc.)
-	return status.State != svc.Stopped, nil
+
+	return status.State, nil
 }
 
 func (api *winSystemAPI) StopService(serviceName string) error {

--- a/pkg/fleet/installer/packages/service/windows/system_api_test.go
+++ b/pkg/fleet/installer/packages/service/windows/system_api_test.go
@@ -10,6 +10,7 @@ package windows
 import (
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
 )
 
 // Mock implementations
@@ -23,9 +24,9 @@ func (m *mockSystemAPI) GetServiceProcessID(serviceName string) (uint32, error) 
 	return args.Get(0).(uint32), args.Error(1)
 }
 
-func (m *mockSystemAPI) IsServiceRunning(serviceName string) (bool, error) {
+func (m *mockSystemAPI) GetServiceState(serviceName string) (svc.State, error) {
 	args := m.Called(serviceName)
-	return args.Bool(0), args.Error(1)
+	return args.Get(0).(svc.State), args.Error(1)
 }
 
 func (m *mockSystemAPI) StopService(serviceName string) error {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
extends https://github.com/DataDog/datadog-agent/pull/38408 to include services stuck in pending states

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1552
the `winutil.IsServiceRunning` helper we used only returned true if state was `SERVICE_RUNNING`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
new/existing unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
prior PR is unreleased so no changelog is needed