### PR TITLE
[USMON-1448] go-tls: Introduce map cleaners for dead-processes in go_tls_read_args and go_tls_write_args maps

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
@@ -11,11 +11,11 @@ BPF_HASH_MAP(offsets_data, go_tls_offsets_data_key_t, tls_offsets_data_t, 1024)
 
 /* go_tls_read_args is used to get the read function info when running in the read-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_HASH_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
+BPF_HASH_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 10240)
 
 /* go_tls_write_args is used to get the read function info when running in the write-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_HASH_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
+BPF_HASH_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 10240)
 
 /* This map associates crypto/tls.(*Conn) values to the corresponding conn_tuple_t* value.
    It is used to implement a simplified version of tup_from_ssl_ctx from usm.c

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-types.h
@@ -81,8 +81,8 @@ typedef struct {
 } tls_offsets_data_t;
 
 typedef struct {
-    __u32 pid;
     __s64 goroutine_id;
+    __u32 pid;
 } go_tls_function_args_key_t;
 
 typedef struct {

--- a/pkg/network/protocols/http/gotls/go_tls_types.go
+++ b/pkg/network/protocols/http/gotls/go_tls_types.go
@@ -18,3 +18,6 @@ type GoroutineIDMetadata C.goroutine_id_metadata_t
 type TlsBinaryId C.go_tls_offsets_data_key_t
 type TlsConnLayout C.tls_conn_layout_t
 type TlsOffsetsData C.tls_offsets_data_t
+type TlsFunctionsArgsKey C.go_tls_function_args_key_t
+type TlsReadArgsData C.go_tls_read_args_data_t
+type TlsWriteArgsData C.go_tls_write_args_data_t

--- a/pkg/network/protocols/http/gotls/go_tls_types_linux.go
+++ b/pkg/network/protocols/http/gotls/go_tls_types_linux.go
@@ -50,3 +50,16 @@ type TlsOffsetsData struct {
 	Write_return_error Location
 	Close_conn_pointer Location
 }
+type TlsFunctionsArgsKey struct {
+	Pid uint32
+	Id  int64
+}
+type TlsReadArgsData struct {
+	Conn_pointer uint64
+	B_data       uint64
+}
+type TlsWriteArgsData struct {
+	Conn_pointer uint64
+	B_data       uint64
+	B_len        uint64
+}

--- a/pkg/network/protocols/http/gotls/go_tls_types_linux.go
+++ b/pkg/network/protocols/http/gotls/go_tls_types_linux.go
@@ -51,8 +51,9 @@ type TlsOffsetsData struct {
 	Close_conn_pointer Location
 }
 type TlsFunctionsArgsKey struct {
-	Pid uint32
-	Id  int64
+	Id        int64
+	Pid       uint32
+	Pad_cgo_0 [4]byte
 }
 type TlsReadArgsData struct {
 	Conn_pointer uint64

--- a/pkg/network/protocols/http/gotls/go_tls_types_linux_test.go
+++ b/pkg/network/protocols/http/gotls/go_tls_types_linux_test.go
@@ -31,3 +31,15 @@ func TestCgoAlignment_TlsConnLayout(t *testing.T) {
 func TestCgoAlignment_TlsOffsetsData(t *testing.T) {
 	ebpftest.TestCgoAlignment[TlsOffsetsData](t)
 }
+
+func TestCgoAlignment_TlsFunctionsArgsKey(t *testing.T) {
+	ebpftest.TestCgoAlignment[TlsFunctionsArgsKey](t)
+}
+
+func TestCgoAlignment_TlsReadArgsData(t *testing.T) {
+	ebpftest.TestCgoAlignment[TlsReadArgsData](t)
+}
+
+func TestCgoAlignment_TlsWriteArgsData(t *testing.T) {
+	ebpftest.TestCgoAlignment[TlsWriteArgsData](t)
+}

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -200,7 +200,7 @@ func (p *goTLSProgram) ConfigureOptions(options *manager.Options) {
 	}
 }
 
-// initMapCleaner creates and assigns a MapCleaner for the given eBPF map.
+// initAllMapCleaners creates map cleaner for `go_tls_read_args` and `go_tls_write_args` maps.
 func (p *goTLSProgram) initAllMapCleaners() error {
 	var err error
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -32,16 +32,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+var (
+	// The interval of the periodic scan for terminated processes. Increasing the interval, might cause larger spikes in cpu
+	// and lowering it might cause constant cpu usage.
+	// Defined as a var to allow tests to override it.
+	scanTerminatedProcessesInterval = 30 * time.Second
+)
+
 const (
 	offsetsDataMap            = "offsets_data"
 	goTLSReadArgsMap          = "go_tls_read_args"
 	goTLSWriteArgsMap         = "go_tls_write_args"
 	connectionTupleByGoTLSMap = "conn_tup_by_go_tls_conn"
 	goTLSConnByTupleMap       = "go_tls_conn_by_tuple"
-
-	// The interval of the periodic scan for terminated processes. Increasing the interval, might cause larger spikes in cpu
-	// and lowering it might cause constant cpu usage.
-	scanTerminatedProcessesInterval = 30 * time.Second
 
 	connReadProbe     = "uprobe__crypto_tls_Conn_Read"
 	connReadRetProbe  = "uprobe__crypto_tls_Conn_Read__return"

--- a/pkg/network/usm/ebpf_gotls_testutils.go
+++ b/pkg/network/usm/ebpf_gotls_testutils.go
@@ -9,6 +9,8 @@ package usm
 
 import (
 	"errors"
+	"testing"
+	"time"
 )
 
 // SetGoTLSExcludeSelf sets the GoTLSExcludeSelf configuration.
@@ -19,4 +21,13 @@ func SetGoTLSExcludeSelf(value bool) error {
 
 	goTLSSpec.Instance.(*goTLSProgram).cfg.GoTLSExcludeSelf = value
 	return nil
+}
+
+// SetGoTLSPeriodicTerminatedProcessesScanInterval sets the interval for the periodic scan of terminated processes in GoTLS.
+func SetGoTLSPeriodicTerminatedProcessesScanInterval(tb testing.TB, interval time.Duration) {
+	originalValue := scanTerminatedProcessesInterval
+	tb.Cleanup(func() {
+		scanTerminatedProcessesInterval = originalValue
+	})
+	scanTerminatedProcessesInterval = interval
 }

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -537,13 +537,13 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 }
 
 // initMapCleaner creates and assigns a MapCleaner for the given eBPF map.
-func initMapCleaner[K, V interface{}](mgr *manager.Manager, mapName string) (*ddebpf.MapCleaner[K, V], error) {
+func initMapCleaner[K, V interface{}](mgr *manager.Manager, mapName, attacherName string) (*ddebpf.MapCleaner[K, V], error) {
 	mapObj, _, err := mgr.GetMap(mapName)
 	if err != nil {
 		return nil, fmt.Errorf("dead process ssl cleaner failed to get map: %q error: %w", mapName, err)
 	}
 
-	cleaner, err := ddebpf.NewMapCleaner[K, V](mapObj, protocols.DefaultMapCleanerBatchSize, mapName, UsmTLSAttacherName)
+	cleaner, err := ddebpf.NewMapCleaner[K, V](mapObj, protocols.DefaultMapCleanerBatchSize, mapName, attacherName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create %s cleaner: %w", mapName, err)
 	}
@@ -553,17 +553,17 @@ func initMapCleaner[K, V interface{}](mgr *manager.Manager, mapName string) (*dd
 func (o *sslProgram) initAllMapCleaners() error {
 	var err error
 
-	o.sslCtxByPIDTGIDMapCleaner, err = initMapCleaner[uint64, uint64](o.ebpfManager, sslCtxByPIDTGIDMap)
+	o.sslCtxByPIDTGIDMapCleaner, err = initMapCleaner[uint64, uint64](o.ebpfManager, sslCtxByPIDTGIDMap, UsmTLSAttacherName)
 	if err != nil {
 		return err
 	}
 
-	o.sslSockByCtxMapCleaner, err = initMapCleaner[uint64, http.SslSock](o.ebpfManager, sslSockByCtxMap)
+	o.sslSockByCtxMapCleaner, err = initMapCleaner[uint64, http.SslSock](o.ebpfManager, sslSockByCtxMap, UsmTLSAttacherName)
 	if err != nil {
 		return err
 	}
 
-	o.sslCtxByTupleMapCleaner, err = initMapCleaner[http.ConnTuple, uint64](o.ebpfManager, sslCtxByTupleMap)
+	o.sslCtxByTupleMapCleaner, err = initMapCleaner[http.ConnTuple, uint64](o.ebpfManager, sslCtxByTupleMap, UsmTLSAttacherName)
 	if err != nil {
 		return err
 	}

--- a/pkg/network/usm/usm_http_monitor_test.go
+++ b/pkg/network/usm/usm_http_monitor_test.go
@@ -241,6 +241,7 @@ func TestGoTLSMapCleanup(t *testing.T) {
 		t.Skip("GoTLS not supported on this platform")
 	}
 
+	SetGoTLSPeriodicTerminatedProcessesScanInterval(t, time.Second)
 	cfg := utils.NewUSMEmptyConfig()
 	cfg.EnableHTTPMonitoring = true
 	cfg.EnableGoTLSSupport = true
@@ -257,6 +258,8 @@ func TestGoTLSMapCleanup(t *testing.T) {
 	mapsName := []string{
 		connectionTupleByGoTLSMap,
 		goTLSConnByTupleMap,
+		goTLSReadArgsMap,
+		goTLSWriteArgsMap,
 	}
 	mapsInstances := make([]*ebpf.Map, len(mapsName))
 	for i, name := range mapsName {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Introduces user-mode cleaners for the maps
* Increases the default size of the maps from 2048 entries to 10240 (x5)

### Motivation

* We noticed we're reaching to maps' capacity in staging/load test, and hence suffering from inaccuracy.
* Reproduced via terminating processes unexpectadly

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

#### RSS Impact
Maps current size - 0.21 MB
Maps new size - 1MB

Total impact - 1.6MB (2 * 0.8MB)

#### Load Test

[Link](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=usmon-1448-http-base&tpl_var_client-service%5B0%5D=golang-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=usmon-1448-http-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm4&tpl_var_server-service%5B0%5D=golang-httpbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1752580658280&to_ts=1752584485451&live=false)

<img width="1818" height="94" alt="image" src="https://github.com/user-attachments/assets/76a2ce00-8eab-44b8-bb23-ee02322d2156" />

<img width="1774" height="921" alt="image" src="https://github.com/user-attachments/assets/c81ded16-cb93-4c44-a7f2-da92ec6d854b" />


