### PR TITLE
Also `codesign` non Mach-O executables (ABLD-94 follow-up)

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -180,13 +180,17 @@ build do
                 # Sometimes the timestamp service is not available, so we retry
                 codesign = "../tools/ci/retry.sh codesign"
 
-                # Codesign all Mach-O binaries leveraging parallelism (~280 binaries out of ~28000 files)
+                # Codesign ~480 files (out of ~28000)
                 command <<-SH.gsub(/^ {20}/, ""), cwd: Dir.pwd
                     set -euo pipefail
-                    find #{install_dir} -type f -print0 |
-                        xargs -0 -n1000 -P#{workers} file -n --mime-type |
-                        awk -F: '$0 ~ /[^)]:[[:space:]]*application\\/x-mach-binary/ { printf "%s%c", $1, 0 }' |
-                        xargs -0 -n10 -P#{workers} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
+                    (
+                        # Gather all executables, whether binaries or scripts
+                        find #{install_dir} -type f -perm +111 -print0
+                        # Gather non executable Mach-O binaries leveraging parallelism
+                        find #{install_dir} -type f ! -perm +111 -print0 |
+                            xargs -0 -n1000 -P#{workers} file -n --mime-type |
+                            awk -F: '/[^)]:[[:space:]]*application\\/x-mach-binary/ { printf "%s%c", $1, 0 }'
+                    ) | xargs -0 -n10 -P#{workers} #{codesign} #{hardened_runtime}--force --timestamp --deep -s '#{code_signing_identity}'
                 SH
             end
         end


### PR DESCRIPTION
### What does this PR do?
Because there's no point in `codesign`ing non-executable scripts (those meant to be launched through `bash script.sh`, `python script.py`, etc.), the present change simply consists in `codesign`ing all files having some executable bits set in addition to formely considered Mach-O binaries.

### Motivation
While looking for good practices wrt what to `codesign` or not (see Datadog/datadog-agent#38755), I stumbled upon the following archived piece of [documentation](https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201):
> Store Python, Perl, shell, and other script files and other non-Mach-O executables in your app's `Contents/Resources` directory.
> [...]
> Put another way, a properly-signed app that has all of its files in the correct places will not contain any signatures stored as extended attributes.

Since we don't happen to store our non Mach-O executables under `Contents/Resources` but instead under `Contents/Payload`, we're better off `codesign`ing them.

### Additional Notes
The speedup (from ~14s down to ~11s) comes from the fact there are now less files being scanned to infer their MIME type, plus many Mach-O binaries also have some executable bits set.

Contrarily to PNGs being returned in the notarization log response despite not being explicitly `codesign`ed, non Mach-O executables may not be returned in that response despite being `codesign`ed.