### PR TITLE
[autodiscovery/providers/kube_endpoints] Optimize by invalidating only when needed

### DIFF
--- a/comp/core/autodiscovery/providers/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_test.go
@@ -469,7 +469,63 @@ func TestGenerateConfigs(t *testing.T) {
 	}
 }
 
-func TestInvalidateIfChangedService(t *testing.T) {
+func TestInvalidateOnServiceAdd(t *testing.T) {
+	serviceWithoutEndpointAnnotations := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-no-endpoint-annotations",
+			Namespace: "default",
+			UID:       types.UID("service-no-endpoint-annotations-uid"),
+			Annotations: map[string]string{
+				"some.annotation": "some-value",
+			},
+		},
+	}
+
+	serviceWithEndpointAnnotations := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-with-endpoint-annotations",
+			Namespace: "default",
+			UID:       types.UID("service-with-endpoint-annotations-uid"),
+			Annotations: map[string]string{
+				"ad.datadoghq.com/endpoints.check_names":  "[\"http_check\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"url\": \"http://%%host%%\"}]",
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		newService       *v1.Service
+		expectedUpToDate bool
+	}{
+		{
+			name:             "Add service without endpoint annotations",
+			newService:       serviceWithoutEndpointAnnotations,
+			expectedUpToDate: true,
+		},
+		{
+			name:             "Add service with endpoint annotations",
+			newService:       serviceWithEndpointAnnotations,
+			expectedUpToDate: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &kubeEndpointsConfigProvider{upToDate: true}
+
+			provider.invalidateOnServiceAdd(test.newService)
+
+			upToDate, err := provider.IsUpToDate(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedUpToDate, upToDate)
+		})
+	}
+
+}
+
+func TestInvalidateOnServiceUpdate(t *testing.T) {
 	s88 := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "88",
@@ -553,11 +609,71 @@ func TestInvalidateIfChangedService(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			ctx := context.Background()
 			provider := &kubeEndpointsConfigProvider{upToDate: true}
-			provider.invalidateIfChangedService(tc.old, tc.obj)
+			provider.invalidateOnServiceUpdate(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, !tc.invalidate, upToDate)
+		})
+	}
+}
+
+func TestInvalidateOnServiceDelete(t *testing.T) {
+	serviceWithoutAnnotations := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-no-annotations",
+			Namespace: "default",
+			UID:       types.UID("service-no-annotations-uid"),
+		},
+	}
+
+	serviceWithAnnotations := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-with-annotations",
+			Namespace: "default",
+			UID:       types.UID("service-with-annotations-uid"),
+			Annotations: map[string]string{
+				"ad.datadoghq.com/endpoints.check_names":  "[\"http_check\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"url\": \"http://%%host%%\"}]",
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		monitoredEndpoints map[string]bool
+		deletedService     *v1.Service
+		expectedUpToDate   bool
+	}{
+		{
+			name: "Delete service that had monitored endpoints",
+			monitoredEndpoints: map[string]bool{
+				apiserver.EntityForEndpoints(serviceWithAnnotations.Namespace, serviceWithAnnotations.Name, ""): true,
+			},
+			deletedService:   serviceWithAnnotations,
+			expectedUpToDate: false,
+		},
+		{
+			name:               "Delete service that did not have monitored endpoints",
+			monitoredEndpoints: map[string]bool{},
+			deletedService:     serviceWithoutAnnotations,
+			expectedUpToDate:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &kubeEndpointsConfigProvider{
+				upToDate:           true,
+				monitoredEndpoints: test.monitoredEndpoints,
+			}
+
+			provider.invalidateOnServiceDelete(test.deletedService)
+
+			upToDate, err := provider.IsUpToDate(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedUpToDate, upToDate)
 		})
 	}
 }
@@ -879,7 +995,7 @@ func TestInvalidateIfChangedEndpoints(t *testing.T) {
 					apiserver.EntityForEndpoints("default", "myservice", ""): true,
 				},
 			}
-			provider.invalidateIfChangedEndpoints(tc.first, tc.second)
+			provider.invalidateOnEndpointsUpdate(tc.first, tc.second)
 
 			upToDate, err := provider.IsUpToDate(ctx)
 			assert.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the autodiscovery provider for Kubernetes endpoints.

The provider was marking itself as out of date every time a service was added or deleted, even when it had no annotations for endpoint checks.

There might be other possible optimizations that involve caching the configs collected, but I preferred to avoid that for now to prevent using more memory. The optimization introduced in this PR should reduce the number of unnecessary calls to Collect without storing anything extra.

### Describe how you validated your changes

Unit tests plus some manual tests creating/deleting/updating services with and without endpoint annotations.
