### PR TITLE
Add repository names for cws-instrumentaiton and DCA

### DIFF
--- a/.gitlab/trigger_distribution/conditions.yml
+++ b/.gitlab/trigger_distribution/conditions.yml
@@ -55,8 +55,10 @@
     when: on_success
     variables:
       AGENT_REPOSITORY: agent
+      CLUSTER_AGENT_REPOSITORY: cluster-agent
       OTEL_AGENT_REPOSITORY: ddot-collector
       DSD_REPOSITORY: dogstatsd
+      CWS_INSTRUMENTATION_REPOSITORY: cws-instrumentation
       IMG_REGISTRIES: public
 
 # Same as on_deploy_manual, except the job would not run on pipelines
@@ -76,8 +78,10 @@
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
+      CLUSTER_AGENT_REPOSITORY: cluster-agent
       OTEL_AGENT_REPOSITORY: ddot-collector
       DSD_REPOSITORY: dogstatsd
+      CWS_INSTRUMENTATION_REPOSITORY: cws-instrumentation
       IMG_REGISTRIES: public
 
 # This is used for image vulnerability scanning. Because agent 6


### PR DESCRIPTION
### What does this PR do?

Add repository names for `cws-instrumentaiton` and `DCA`. They were set only on the particular jobs level while we now have jobs relying on the in the deploy pipeline.

### Motivation

Fix publish pipeline.

### Describe how you validated your changes
Run next RC pipeline.