### PR TITLE
[SBOM] Only consider layers with digest when checking number of layers

### DIFF
--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy/walker"
+	"github.com/samber/lo"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	local "github.com/aquasecurity/trivy/pkg/fanal/artifact/container"
@@ -32,8 +33,11 @@ type fakeContainer struct {
 }
 
 func newFakeContainer(layerIDs []string, imgMeta *workloadmeta.ContainerImageMetadata, layerPaths []string) (*fakeContainer, error) {
-	if len(layerIDs) != len(layerPaths) || len(layerIDs) != len(imgMeta.Layers) {
-		return nil, fmt.Errorf("mismatch count for layer IDs and paths (%v, %v, %v)", layerIDs, layerPaths, imgMeta.Layers)
+	imageLayers := lo.Filter(imgMeta.Layers, func(layer workloadmeta.ContainerImageLayer, _ int) bool {
+		return layer.Digest != ""
+	})
+	if len(layerIDs) != len(layerPaths) || len(layerIDs) != len(imageLayers) {
+		return nil, fmt.Errorf("mismatch count for layer IDs and paths (%v, %v, %v)", layerIDs, layerPaths, imgMeta)
 	}
 
 	return &fakeContainer{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Only consider the layers with a digest (thus ignoring the one that are empty)

### Motivation

If there are comments in the Dockerfile, we end up having layers without any digest,
making the checks on the number of layers fail.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->