### PR TITLE
[EBPF] gpu: support GKE device plugin IDs

### DIFF
--- a/pkg/gpu/containers.go
+++ b/pkg/gpu/containers.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// this file contains utilities to work with GPU assignment to containers
+
+//go:build linux_bpf && nvml
+
+package gpu
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
+)
+
+var errCannotMatchDevice = errors.New("cannot find matching device")
+var numberedResourceRegex = regexp.MustCompile(`^nvidia([0-9]+)$`)
+
+func matchContainerDevices(container *workloadmeta.Container, devices []ddnvml.Device) ([]ddnvml.Device, error) {
+	var filteredDevices []ddnvml.Device
+
+	var multiErr error
+	for _, resource := range container.ResolvedAllocatedResources {
+		// Only consider NVIDIA GPUs
+		if !gpuutil.IsNvidiaKubernetesResource(resource.Name) {
+			continue
+		}
+
+		matchingDevice, err := findDeviceForResourceName(devices, resource.ID)
+		if err != nil {
+			multiErr = errors.Join(multiErr, err)
+			continue
+		}
+
+		filteredDevices = append(filteredDevices, matchingDevice)
+	}
+
+	return filteredDevices, multiErr
+}
+
+func findDeviceForResourceName(devices []ddnvml.Device, resourceID string) (ddnvml.Device, error) {
+	// The NVIDIA device plugin resource ID is the GPU UUID, while GKE
+	// device plugin sets the ID as nvidiaX, where X is the GPU index.
+	match := numberedResourceRegex.FindStringSubmatch(resourceID)
+	if len(match) == 0 {
+		// No match -> NVIDIA device plugin
+		return findDeviceByUUID(devices, resourceID)
+	}
+
+	// Match -> GKE device plugin
+	deviceIndex, err := strconv.Atoi(match[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse device index from resource name %s: %w", resourceID, err)
+	}
+	return findDeviceByIndex(devices, deviceIndex)
+}
+
+func findDeviceByUUID(devices []ddnvml.Device, uuid string) (ddnvml.Device, error) {
+	for _, device := range devices {
+		if device.GetDeviceInfo().UUID == uuid {
+			return device, nil
+		}
+
+		// If the device has MIG children, check if any of them matches the resource ID
+		physicalDevice, ok := device.(*ddnvml.PhysicalDevice)
+		if ok {
+			for _, migChild := range physicalDevice.MIGChildren {
+				if uuid == migChild.UUID {
+					return migChild, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("%w with uuid %s", errCannotMatchDevice, uuid)
+}
+
+func findDeviceByIndex(devices []ddnvml.Device, index int) (ddnvml.Device, error) {
+	for _, device := range devices {
+		if device.GetDeviceInfo().Index == index {
+			return device, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w with index %d", errCannotMatchDevice, index)
+}

--- a/pkg/gpu/containers.go
+++ b/pkg/gpu/containers.go
@@ -54,6 +54,15 @@ func findDeviceForResourceName(devices []ddnvml.Device, resourceID string) (ddnv
 		return findDeviceByUUID(devices, resourceID)
 	}
 
+	// Check if any of the devices are MIG devices
+	for _, device := range devices {
+		physicalDevice, isPhysicalDevice := device.(*ddnvml.PhysicalDevice)
+		_, isMigDevice := device.(*ddnvml.MIGDevice)
+		if isMigDevice || (isPhysicalDevice && len(physicalDevice.MIGChildren) > 0) {
+			return nil, fmt.Errorf("MIG devices are not supported for GKE device plugin")
+		}
+	}
+
 	// Match -> GKE device plugin
 	deviceIndex, err := strconv.Atoi(match[1])
 	if err != nil {

--- a/pkg/gpu/containers_test.go
+++ b/pkg/gpu/containers_test.go
@@ -160,6 +160,21 @@ func TestFindDeviceForResourceName(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, errCannotMatchDevice)
 	})
+
+	t.Run("UUIDBasedMIGDevice", func(t *testing.T) {
+		// Test with MIG device
+		devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, testutil.DevicesWithMIGChildren...)
+		device, err := findDeviceForResourceName(devices, testutil.MIGChildrenUUIDs[5][0])
+		require.NoError(t, err)
+		require.Equal(t, device.GetDeviceInfo().UUID, testutil.MIGChildrenUUIDs[5][0])
+	})
+
+	t.Run("GKEWithMIGDevice", func(t *testing.T) {
+		// Test with MIG device
+		devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, testutil.DevicesWithMIGChildren...)
+		_, err := findDeviceForResourceName(devices, "nvidia3")
+		require.Error(t, err)
+	})
 }
 
 func TestFindDeviceByUUID(t *testing.T) {

--- a/pkg/gpu/containers_test.go
+++ b/pkg/gpu/containers_test.go
@@ -1,0 +1,330 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf && nvml
+
+package gpu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
+)
+
+func TestMatchContainerDevices(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("ContainerWithNvidiaGPU", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container",
+			},
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   testutil.GPUUUIDs[1], // Use device index 1
+				},
+			},
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 1)
+		assert.Equal(t, devices[1], filteredDevices[0])
+	})
+
+	t.Run("ContainerWithMultipleNvidiaGPUs", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container-multi",
+			},
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   testutil.GPUUUIDs[0],
+				},
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   "nvidia2",
+				},
+			},
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 2)
+		assert.Equal(t, devices[0], filteredDevices[0])
+		assert.Equal(t, devices[2], filteredDevices[1])
+	})
+
+	t.Run("ContainerWithNonNvidiaResource", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container-non-nvidia",
+			},
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: "cpu",
+					ID:   "cpu-0",
+				},
+			},
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 0)
+	})
+
+	t.Run("ContainerWithNoResources", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container-empty",
+			},
+			ResolvedAllocatedResources: nil,
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 0)
+	})
+
+	t.Run("ContainerWithInvalidGPU", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container-invalid",
+			},
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   "invalid-uuid",
+				},
+			},
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.Error(t, err)
+		require.Len(t, filteredDevices, 0)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+}
+
+func TestFindDeviceForResourceName(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("NvidiaDevicePluginUUID", func(t *testing.T) {
+		// Test with NVIDIA device plugin format (UUID)
+		device, err := findDeviceForResourceName(devices, testutil.GPUUUIDs[1])
+		require.NoError(t, err)
+		assert.Equal(t, devices[1], device)
+	})
+
+	t.Run("GKEDevicePluginIndex", func(t *testing.T) {
+		// Test with GKE device plugin format (nvidiaX)
+		device, err := findDeviceForResourceName(devices, "nvidia1")
+		require.NoError(t, err)
+		assert.Equal(t, devices[1], device)
+	})
+
+	t.Run("InvalidUUID", func(t *testing.T) {
+		// Test with invalid UUID
+		_, err := findDeviceForResourceName(devices, "invalid-uuid")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+
+	t.Run("EmptyResourceID", func(t *testing.T) {
+		// Test with empty resource ID
+		_, err := findDeviceForResourceName(devices, "")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+}
+
+func TestFindDeviceByUUID(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("ValidUUID", func(t *testing.T) {
+		device, err := findDeviceByUUID(devices, testutil.GPUUUIDs[1])
+		require.NoError(t, err)
+		assert.Equal(t, devices[1], device)
+	})
+
+	t.Run("ValidUUIDFirstDevice", func(t *testing.T) {
+		device, err := findDeviceByUUID(devices, testutil.GPUUUIDs[0])
+		require.NoError(t, err)
+		assert.Equal(t, devices[0], device)
+	})
+
+	t.Run("ValidUUIDLastDevice", func(t *testing.T) {
+		device, err := findDeviceByUUID(devices, testutil.GPUUUIDs[2])
+		require.NoError(t, err)
+		assert.Equal(t, devices[2], device)
+	})
+
+	t.Run("InvalidUUID", func(t *testing.T) {
+		_, err := findDeviceByUUID(devices, "invalid-uuid")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+		assert.Contains(t, err.Error(), "invalid-uuid")
+	})
+
+	t.Run("EmptyUUID", func(t *testing.T) {
+		_, err := findDeviceByUUID(devices, "")
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+		assert.Contains(t, err.Error(), "")
+	})
+
+	t.Run("EmptyDeviceList", func(t *testing.T) {
+		_, err := findDeviceByUUID([]ddnvml.Device{}, testutil.GPUUUIDs[0])
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+}
+
+func TestFindDeviceByUUIDWithMIG(t *testing.T) {
+	// Setup mock NVML with MIG enabled for some devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+
+	// Get test devices including MIG children
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2, 3, 4, 5, 6)
+
+	t.Run("PhysicalDeviceUUID", func(t *testing.T) {
+		device, err := findDeviceByUUID(devices, testutil.GPUUUIDs[0])
+		require.NoError(t, err)
+		assert.Equal(t, devices[0], device)
+	})
+
+	t.Run("MIGChildUUID", func(t *testing.T) {
+		// Test finding a MIG child device by UUID
+		migUUID := testutil.MIGChildrenUUIDs[5][0] // First MIG child of device 5
+		device, err := findDeviceByUUID(devices, migUUID)
+		require.NoError(t, err)
+
+		// Verify it's a MIG device
+		require.IsType(t, &ddnvml.MIGDevice{}, device)
+		deviceInfo := device.GetDeviceInfo()
+		assert.Equal(t, migUUID, deviceInfo.UUID)
+	})
+
+	t.Run("MIGChildUUIDSecondDevice", func(t *testing.T) {
+		// Test finding a MIG child device by UUID from second device
+		migUUID := testutil.MIGChildrenUUIDs[6][1] // Second MIG child of device 6
+		device, err := findDeviceByUUID(devices, migUUID)
+		require.NoError(t, err)
+
+		// Verify it's a MIG device
+		deviceInfo := device.GetDeviceInfo()
+		assert.Equal(t, migUUID, deviceInfo.UUID)
+	})
+}
+
+func TestFindDeviceByIndex(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("ValidIndex", func(t *testing.T) {
+		device, err := findDeviceByIndex(devices, 1)
+		require.NoError(t, err)
+		assert.Equal(t, devices[1], device)
+	})
+
+	t.Run("ValidIndexZero", func(t *testing.T) {
+		device, err := findDeviceByIndex(devices, 0)
+		require.NoError(t, err)
+		assert.Equal(t, devices[0], device)
+	})
+
+	t.Run("ValidIndexLast", func(t *testing.T) {
+		device, err := findDeviceByIndex(devices, 2)
+		require.NoError(t, err)
+		assert.Equal(t, devices[2], device)
+	})
+
+	t.Run("InvalidIndex", func(t *testing.T) {
+		_, err := findDeviceByIndex(devices, 999)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+		assert.Contains(t, err.Error(), "999")
+	})
+
+	t.Run("NegativeIndex", func(t *testing.T) {
+		_, err := findDeviceByIndex(devices, -1)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+		assert.Contains(t, err.Error(), "-1")
+	})
+
+	t.Run("EmptyDeviceList", func(t *testing.T) {
+		_, err := findDeviceByIndex([]ddnvml.Device{}, 0)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+}
+
+func TestMatchContainerDevicesWithErrors(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("ContainerWithValidAndInvalidGPUs", func(t *testing.T) {
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-container-mixed-validity",
+			},
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   testutil.GPUUUIDs[1], // Valid GPU
+				},
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   "invalid-uuid", // Invalid GPU
+				},
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   testutil.GPUUUIDs[2], // Valid GPU
+				},
+			},
+		}
+
+		filteredDevices, err := matchContainerDevices(container, devices)
+		require.Error(t, err)              // Should have error due to invalid UUID
+		require.Len(t, filteredDevices, 2) // Should still return valid devices
+		assert.Equal(t, devices[1], filteredDevices[0])
+		assert.Equal(t, devices[2], filteredDevices[1])
+		require.ErrorIs(t, err, errCannotMatchDevice)
+	})
+}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -86,6 +86,9 @@ var DefaultTotalMemory = uint64(1024 * 1024 * 1024)
 // DefaultMaxClockRates is an array of Max SM clock and Max Mem Clock rates for the default device
 var DefaultMaxClockRates = [2]uint32{1000, 2000}
 
+// DevicesWithMIGChildren is a list of device indexes that have MIG children.
+var DevicesWithMIGChildren = []int{5, 6}
+
 // MIGChildrenPerDevice is a map of device index to the number of MIG children for that device.
 var MIGChildrenPerDevice = map[int]int{
 	5: 2,

--- a/releasenotes/notes/gpu-system-probe-gke-0c444e01966d6913.yaml
+++ b/releasenotes/notes/gpu-system-probe-gke-0c444e01966d6913.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    GPUM: fix kubernetes device allocation detection in Google Kubernetes Engine
+    GPUM: fix Kubernetes device allocation detection in Google Kubernetes Engine

--- a/releasenotes/notes/gpu-system-probe-gke-0c444e01966d6913.yaml
+++ b/releasenotes/notes/gpu-system-probe-gke-0c444e01966d6913.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    GPUM: fix kubernetes device allocation detection in Google Kubernetes Engine


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support for GKE device plugin way of reporting GPU device IDs, which returns `nvidiaX` instead of the device UUID.

### Motivation

Support GKE. https://datadoghq.atlassian.net/browse/NWL-1334

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added unit tests to cover these cases.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


In order to make the code more easily testable, and also in preparation for Docker support where this logic might need to be changed, the functions have been moved to standalone functions in a `pkg/gpu/containers.go` file.

MIG will not be supported in this PR, if the GKE cluster has MIG devices there might be wrong assignments or errors when matching devices to containers.