### PR TITLE
Small fix for error messages for the mount attribute resolution

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -568,9 +568,7 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "object",
             "required": [
                 "uid",
-                "gid",
-                "mount_visible",
-                "mount_detached"
+                "gid"
             ],
             "description": "FileSerializer serializes a file to JSON"
         },
@@ -717,9 +715,7 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "object",
             "required": [
                 "uid",
-                "gid",
-                "mount_visible",
-                "mount_detached"
+                "gid"
             ],
             "description": "FileEventSerializer serializes a file event to JSON"
         },
@@ -3054,9 +3050,7 @@ Workload Protection events for Linux systems have the following JSON schema:
     "type": "object",
     "required": [
         "uid",
-        "gid",
-        "mount_visible",
-        "mount_detached"
+        "gid"
     ],
     "description": "FileSerializer serializes a file to JSON"
 }
@@ -3244,9 +3238,7 @@ Workload Protection events for Linux systems have the following JSON schema:
     "type": "object",
     "required": [
         "uid",
-        "gid",
-        "mount_visible",
-        "mount_detached"
+        "gid"
     ],
     "description": "FileEventSerializer serializes a file event to JSON"
 }

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -557,9 +557,7 @@
       "type": "object",
       "required": [
         "uid",
-        "gid",
-        "mount_visible",
-        "mount_detached"
+        "gid"
       ],
       "description": "FileSerializer serializes a file to JSON"
     },
@@ -706,9 +704,7 @@
       "type": "object",
       "required": [
         "uid",
-        "gid",
-        "mount_visible",
-        "mount_detached"
+        "gid"
       ],
       "description": "FileEventSerializer serializes a file event to JSON"
     },

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -87,9 +87,10 @@ func (fh *EBPFFieldHandlers) ResolveFilePath(ev *model.Event, f *model.FileEvent
 		f.MountPath = mountPath
 		f.MountSource = source
 		f.MountOrigin = origin
-		f.MountVisible, f.MountDetached, err = fh.resolvers.PathResolver.ResolveMountAttributes(&f.FileFields, &ev.PIDContext, ev.ContainerContext)
-		if err != nil {
-			seclog.Errorf("failed to resolve mount attributes: %s", err)
+		err = fh.resolvers.PathResolver.ResolveMountAttributes(f, &ev.PIDContext, ev.ContainerContext)
+		if err != nil && f.PathResolutionError == nil {
+			seclog.Warnf("error while resolving the attributes for mountid %d: %s", f.MountID, err)
+			ev.SetPathResolutionError(f, err)
 		}
 	}
 

--- a/pkg/security/resolvers/path/interface.go
+++ b/pkg/security/resolvers/path/interface.go
@@ -21,5 +21,5 @@ type ResolverInterface interface {
 	ResolveMountRoot(ev *model.Event, e *model.Mount) (string, error)
 	SetMountPoint(ev *model.Event, e *model.Mount) error
 	ResolveMountPoint(ev *model.Event, e *model.Mount) (string, error)
-	ResolveMountAttributes(e *model.FileFields, pidCtx *model.PIDContext, ctrCtx *model.ContainerContext) (bool, bool, error)
+	ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDContext, ctrCtx *model.ContainerContext) error
 }

--- a/pkg/security/resolvers/path/no_op_resolver.go
+++ b/pkg/security/resolvers/path/no_op_resolver.go
@@ -52,6 +52,6 @@ func (n *NoOpResolver) ResolveMountPoint(_ *model.Event, _ *model.Mount) (string
 }
 
 // ResolveMountAttributes resolves the mount attributes of the mountpoint of a file
-func (n *NoOpResolver) ResolveMountAttributes(_ *model.FileFields, _ *model.PIDContext, _ *model.ContainerContext) (bool, bool, error) {
-	return false, false, nil
+func (n *NoOpResolver) ResolveMountAttributes(_ *model.FileEvent, _ *model.PIDContext, _ *model.ContainerContext) error {
+	return nil
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -772,10 +772,11 @@ func (p *EBPFResolver) SetProcessPath(fileEvent *model.FileEvent, pce *model.Pro
 	fileEvent.MountPath = mountPath
 	fileEvent.MountSource = source
 	fileEvent.MountOrigin = origin
-	fileEvent.MountVisible, fileEvent.MountDetached, err = p.pathResolver.ResolveMountAttributes(&fileEvent.FileFields, &pce.PIDContext, ctrCtx)
+	err = p.pathResolver.ResolveMountAttributes(fileEvent, &pce.PIDContext, ctrCtx)
 	if err != nil {
-		seclog.Errorf("Failed to resolve mount attributes: %s", err)
+		seclog.Warnf("Failed to resolve mount attributes for mount id %d: %s", fileEvent.MountID, err)
 	}
+
 	return fileEvent.PathnameStr, nil
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -410,10 +410,15 @@ func (p *EBPFResolver) enrichEventFromProcfs(entry *model.ProcessCacheEntry, pro
 	// force mount from procfs/snapshot
 	entry.FileEvent.MountOrigin = model.MountOriginProcfs
 	entry.FileEvent.MountSource = model.MountSourceSnapshot
+	entry.FileEvent.MountVisibilityResolved = true
 
 	if entry.FileEvent.IsFileless() {
+		entry.FileEvent.MountVisible = false
+		entry.FileEvent.MountDetached = true
 		entry.FileEvent.Filesystem = model.TmpFS
 	} else {
+		entry.FileEvent.MountVisible = true
+		entry.FileEvent.MountDetached = false
 		// resolve container path with the MountEBPFResolver
 		entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.MountID, entry.Process.FileEvent.Device, entry.Process.Pid, containerID)
 		if err != nil {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -443,11 +443,12 @@ type FileEvent struct {
 	BasenameStr string `field:"name,handler:ResolveFileBasename,opts:length" op_override:"ProcessSymlinkBasename"` // SECLDoc[name] Definition:`File's basename` Example:`exec.file.name == "apt"` Description:`Matches the execution of any file named apt.`
 	Filesystem  string `field:"filesystem,handler:ResolveFileFilesystem"`                                          // SECLDoc[filesystem] Definition:`File's filesystem`
 
-	MountPath     string `field:"-"`
-	MountSource   uint32 `field:"-"`
-	MountOrigin   uint32 `field:"-"`
-	MountVisible  bool   `field:"mount_visible"`  // SECLDoc[mount_visible] Definition:`Indicates whether the file's mount is visible in the VFS`
-	MountDetached bool   `field:"mount_detached"` // SECLDoc[mount_detached] Definition:`Indicates whether the file's mount is detached from the VFS`
+	MountPath               string `field:"-"`
+	MountSource             uint32 `field:"-"`
+	MountOrigin             uint32 `field:"-"`
+	MountVisible            bool   `field:"mount_visible"`  // SECLDoc[mount_visible] Definition:`Indicates whether the file's mount is visible in the VFS`
+	MountDetached           bool   `field:"mount_detached"` // SECLDoc[mount_detached] Definition:`Indicates whether the file's mount is detached from the VFS`
+	MountVisibilityResolved bool   `field:"-"`
 
 	PathResolutionError error `field:"-"`
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -83,9 +83,9 @@ type FileSerializer struct {
 	// MountOrigin origin of the mount
 	MountOrigin string `json:"mount_origin,omitempty"`
 	// MountVisible origin of the mount
-	MountVisible bool `json:"mount_visible"`
+	MountVisible *bool `json:"mount_visible,omitempty"`
 	// MountDetached origin of the mount
-	MountDetached bool `json:"mount_detached"`
+	MountDetached *bool `json:"mount_detached,omitempty"`
 
 	FileMetadata *FileMetadataSerializer `json:"metadata,omitempty"`
 }
@@ -781,8 +781,11 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, forceInode uint64, m
 		MountPath:           fe.MountPath,
 		MountSource:         model.MountSourceToString(fe.MountSource),
 		MountOrigin:         model.MountOriginToString(fe.MountOrigin),
-		MountVisible:        fe.MountVisible,
-		MountDetached:       fe.MountDetached,
+	}
+
+	if fe.MountVisibilityResolved {
+		fs.MountVisible = &fe.MountVisible
+		fs.MountDetached = &fe.MountDetached
 	}
 
 	if metadata != nil {

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -784,8 +784,10 @@ func newFileSerializer(fe *model.FileEvent, e *model.Event, forceInode uint64, m
 	}
 
 	if fe.MountVisibilityResolved {
-		fs.MountVisible = &fe.MountVisible
-		fs.MountDetached = &fe.MountDetached
+		visible := fe.MountVisible
+		detached := fe.MountDetached
+		fs.MountVisible = &visible
+		fs.MountDetached = &detached
 	}
 
 	if metadata != nil {

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -3131,9 +3131,25 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		case "mount_origin":
 			out.MountOrigin = string(in.String())
 		case "mount_visible":
-			out.MountVisible = bool(in.Bool())
+			if in.IsNull() {
+				in.Skip()
+				out.MountVisible = nil
+			} else {
+				if out.MountVisible == nil {
+					out.MountVisible = new(bool)
+				}
+				*out.MountVisible = bool(in.Bool())
+			}
 		case "mount_detached":
-			out.MountDetached = bool(in.Bool())
+			if in.IsNull() {
+				in.Skip()
+				out.MountDetached = nil
+			} else {
+				if out.MountDetached == nil {
+					out.MountDetached = new(bool)
+				}
+				*out.MountDetached = bool(in.Bool())
+			}
 		case "metadata":
 			if in.IsNull() {
 				in.Skip()
@@ -3342,15 +3358,15 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		out.RawString(prefix)
 		out.String(string(in.MountOrigin))
 	}
-	{
+	if in.MountVisible != nil {
 		const prefix string = ",\"mount_visible\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.MountVisible))
+		out.Bool(bool(*in.MountVisible))
 	}
-	{
+	if in.MountDetached != nil {
 		const prefix string = ",\"mount_detached\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.MountDetached))
+		out.Bool(bool(*in.MountDetached))
 	}
 	if in.FileMetadata != nil {
 		const prefix string = ",\"metadata\":"
@@ -3696,9 +3712,25 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		case "mount_origin":
 			out.MountOrigin = string(in.String())
 		case "mount_visible":
-			out.MountVisible = bool(in.Bool())
+			if in.IsNull() {
+				in.Skip()
+				out.MountVisible = nil
+			} else {
+				if out.MountVisible == nil {
+					out.MountVisible = new(bool)
+				}
+				*out.MountVisible = bool(in.Bool())
+			}
 		case "mount_detached":
-			out.MountDetached = bool(in.Bool())
+			if in.IsNull() {
+				in.Skip()
+				out.MountDetached = nil
+			} else {
+				if out.MountDetached == nil {
+					out.MountDetached = new(bool)
+				}
+				*out.MountDetached = bool(in.Bool())
+			}
 		case "metadata":
 			if in.IsNull() {
 				in.Skip()
@@ -3947,15 +3979,15 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		out.RawString(prefix)
 		out.String(string(in.MountOrigin))
 	}
-	{
+	if in.MountVisible != nil {
 		const prefix string = ",\"mount_visible\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.MountVisible))
+		out.Bool(bool(*in.MountVisible))
 	}
-	{
+	if in.MountDetached != nil {
 		const prefix string = ",\"mount_detached\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.MountDetached))
+		out.Bool(bool(*in.MountDetached))
 	}
 	if in.FileMetadata != nil {
 		const prefix string = ",\"metadata\":"


### PR DESCRIPTION
### What does this PR do?

While resolving the file path and in the process resolver, we're getting plenty of error messages on the logs that shouldn't be reported as errors when trying to perform the mount attribute resolution.

The error was downgraded to a warning and it only gets reported if hasn't been previously caught while resolving the file field paths.

This PR also makes the mount visible / detached fields optional and not sent to the backend when it can't be resolved (previously both were being reported as false by default, which could lead to wrong information being sent)

### Motivation

To reduce the amount of uninteresting errors / warnings, and improve the correctness of information sent to the backend