### PR TITLE
[Backport 7.69.x] Fix race condition on http client

### DIFF
--- a/pkg/diagnose/connectivity/inventoryendpoint.go
+++ b/pkg/diagnose/connectivity/inventoryendpoint.go
@@ -214,14 +214,15 @@ func DiagnoseInventory(ctx context.Context, cfg config.Component, log log.Compon
 		allEndpoints = append(allEndpoints, endpoints...)
 	}
 
-	// Create HTTP client for workers
-	client := getClient(cfg, min(maxParallelWorkers, len(allEndpoints)), log, withTimeout(httpClientTimeout))
+	// Create HTTP clients for workers
+	clientNormal := getClient(cfg, min(maxParallelWorkers, len(allEndpoints)), log, withTimeout(httpClientTimeout))                      // unlimited redirects
+	clientRedirect := getClient(cfg, min(maxParallelWorkers, len(allEndpoints)), log, withTimeout(httpClientTimeout), withOneRedirect()) // limited redirects
 
-	return checkEndpoints(ctx, allEndpoints, client)
+	return checkEndpoints(ctx, allEndpoints, clientNormal, clientRedirect)
 }
 
 // checkEndpoints checks the connectivity of the provided endpoints in parallel
-func checkEndpoints(ctx context.Context, endpoints []resolvedEndpoint, client *http.Client) ([]diagnose.Diagnosis, error) {
+func checkEndpoints(ctx context.Context, endpoints []resolvedEndpoint, clientNormal, clientRedirect *http.Client) ([]diagnose.Diagnosis, error) {
 	workerCount := min(maxParallelWorkers, len(endpoints))
 
 	// Create channels for work distribution and results collection
@@ -245,6 +246,15 @@ func checkEndpoints(ctx context.Context, endpoints []resolvedEndpoint, client *h
 				if endpoint.isFailover {
 					description += " - failover"
 				}
+
+				// Select the appropriate client based on redirect configuration
+				var client *http.Client
+				if endpoint.limitRedirect {
+					client = clientRedirect
+				} else {
+					client = clientNormal
+				}
+
 				diagnosis, err := endpoint.checkServiceConnectivity(ctx, client)
 
 				var result diagnose.Diagnosis
@@ -321,13 +331,7 @@ func (e resolvedEndpoint) checkServiceConnectivity(ctx context.Context, client *
 }
 
 func (e resolvedEndpoint) checkHead(ctx context.Context, client *http.Client) (string, error) {
-	if e.limitRedirect {
-		withOneRedirect()(client)
-	}
 	statusCode, _, err := sendHead(ctx, client, e.url)
-	if e.limitRedirect {
-		client.CheckRedirect = nil
-	}
 	if err != nil {
 		return "Failed to connect", err
 	}

--- a/pkg/diagnose/connectivity/inventoryendpoint_test.go
+++ b/pkg/diagnose/connectivity/inventoryendpoint_test.go
@@ -457,9 +457,10 @@ func TestRun(t *testing.T) {
 		},
 	}
 
-	client := getClient(cfg, 2, logmock.New(t))
+	clientNormal := getClient(cfg, 2, logmock.New(t))
+	clientRedirect := getClient(cfg, 2, logmock.New(t), withOneRedirect())
 
-	diagnoses, err := checkEndpoints(context.Background(), testEndpoints, client)
+	diagnoses, err := checkEndpoints(context.Background(), testEndpoints, clientNormal, clientRedirect)
 	assert.NoError(t, err)
 	assert.Len(t, diagnoses, len(testEndpoints))
 	successCount := 0


### PR DESCRIPTION
Backport 72e5c4f65f7f4f3c41d07a33f9dad4956f327546 from #38728.

___

### What does this PR do?
Fix race condition on http client 

### Motivation
Failure of ["TestCommandPidFile" ](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3A%22TestCommandPidfile%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fcmd%2Fagent%2Fsubcommands%2Frun%22%20%40test.service%3Adatadog-agent%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1751642937084&end=1752247737084&paused=false)

### Describe how you validated your changes
Manual QA/Test 🟢 in CI 
