### PR TITLE
[SBOM] Allow setting additional folders to scan

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -906,6 +906,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.container_image.container_include", []string{})
 	config.BindEnvAndSetDefault("sbom.container_image.exclude_pause_container", true)
 	config.BindEnvAndSetDefault("sbom.container_image.allow_missing_repodigest", false)
+	config.BindEnvAndSetDefault("sbom.container_image.additional_directories", []string{})
 
 	// Container file system SBOM configuration
 	config.BindEnvAndSetDefault("sbom.container.enabled", false)
@@ -913,6 +914,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Host SBOM configuration
 	config.BindEnvAndSetDefault("sbom.host.enabled", false)
 	config.BindEnvAndSetDefault("sbom.host.analyzers", []string{"os"})
+	config.BindEnvAndSetDefault("sbom.host.additional_directories", []string{})
 
 	// Service discovery configuration
 	bindEnvAndSetLogsConfigKeys(config, "service_discovery.forwarder.")

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -37,13 +37,15 @@ func ScanOptionsFromConfigForContainers(cfg config.Component) ScanOptions {
 		Analyzers:        cfg.GetStringSlice("sbom.container_image.analyzers"),
 		UseMount:         cfg.GetBool("sbom.container_image.use_mount"),
 		OverlayFsScan:    cfg.GetBool("sbom.container_image.overlayfs_direct_scan"),
+		AdditionalDirs:   cfg.GetStringSlice("sbom.container_image.additional_directories"),
 	}
 }
 
 // ScanOptionsFromConfigForHosts loads the scanning options from the configuration
 func ScanOptionsFromConfigForHosts(cfg config.Component) ScanOptions {
 	return ScanOptions{
-		Analyzers: cfg.GetStringSlice("sbom.host.analyzers"),
+		Analyzers:      cfg.GetStringSlice("sbom.host.analyzers"),
+		AdditionalDirs: cfg.GetStringSlice("sbom.host.additional_directories"),
 	}
 }
 

--- a/pkg/sbom/types/types.go
+++ b/pkg/sbom/types/types.go
@@ -25,6 +25,7 @@ type ScanOptions struct {
 	Fast             bool
 	UseMount         bool
 	OverlayFsScan    bool
+	AdditionalDirs   []string
 }
 
 const (

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -130,6 +130,7 @@ func getDefaultArtifactOption(opts sbom.ScanOptions) artifact.Option {
 			"/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/*",
 			"/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/*",
 		}
+		option.WalkerOption.OnlyDirs = append(option.WalkerOption.OnlyDirs, opts.AdditionalDirs...)
 	} else if looselyCompareAnalyzers(opts.Analyzers, []string{OSAnalyzers, LanguagesAnalyzers}) {
 		option.WalkerOption.SkipDirs = append(
 			option.WalkerOption.SkipDirs,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow specifying additional folders to scan to generate SBOMs.

### Motivation

RHEL Edge uses /usr/share/rpm to store the RPM database but this folder
is not part of our hardcoded list. Adding support for it required releasing a new agent
to workaround the problem. With this patch, we can easily provide workarounds for customers.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->