### PR TITLE
fix(windows e2e): Force ami to a fixed version to prevent test failures

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/network/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/network/common.go
@@ -33,7 +33,7 @@ func (v *networkCheckSuite) getSuiteOptions() []e2e.SuiteOption {
 	suiteOptions := []e2e.SuiteOption{}
 	suiteOptions = append(suiteOptions, e2e.WithProvisioner(
 		awshost.Provisioner(
-			awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor), ec2.WithAMI("ami-0345f44fe05216fc4", v.descriptor, v.descriptor.Architecture)),
+			awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
 		),
 	))
 

--- a/test/new-e2e/tests/agent-runtimes/checks/network/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/network/common.go
@@ -33,7 +33,7 @@ func (v *networkCheckSuite) getSuiteOptions() []e2e.SuiteOption {
 	suiteOptions := []e2e.SuiteOption{}
 	suiteOptions = append(suiteOptions, e2e.WithProvisioner(
 		awshost.Provisioner(
-			awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor)),
+			awshost.WithEC2InstanceOptions(ec2.WithOS(v.descriptor), ec2.WithAMI("ami-0345f44fe05216fc4", v.descriptor, v.descriptor.Architecture)),
 		),
 	))
 

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"testing"
 
@@ -403,6 +405,9 @@ func run[Env any](t *testing.T, s e2e.Suite[Env], systemProbeConfig string, agen
 		),
 		awsHostWindows.WithAgentClientOptions(
 			agentclientparams.WithSkipWaitForAgentReady(),
+		),
+		awsHostWindows.WithEC2InstanceOptions(
+			ec2.WithAMI("ami-0345f44fe05216fc4", e2eos.WindowsServer2022, e2eos.AMD64Arch),
 		),
 	))}
 	e2e.Run(t, s, opts...)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force the windows ami to a fix version

### Motivation
Prevent failure when [cleaning files](https://github.com/DataDog/datadog-agent/blob/nschweitzer/force_ami/test/new-e2e/tests/windows/service-test/startstop_test.go#L575):
```
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/service-test/startstop_test.go:570
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:195
        	Error:      	Received unexpected error:
        	            	sftp: "Bad message" (SSH_FX_BAD_MESSAGE)
        	Test:       	TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe/TestAgentStartsAllServices
        	Messages:   	should remove agent.log
    host.go:378: Removing C:\ProgramData\Datadog\logs/process-agent.log
    host.go:378: Removing C:\ProgramData\Datadog\logs/trace-agent.log
    startstop_test.go:570: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/service-test/startstop_test.go:570
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:195
        	Error:      	Received unexpected error:
        	            	sftp: "Bad message" (SSH_FX_BAD_MESSAGE)
        	Test:       	TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe/TestAgentStartsAllServices
        	Messages:   	should remove trace-agent.log
    host.go:378: Removing C:\ProgramData\Datadog\logs/updater.log
```
#incident-40730

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->