### PR TITLE
Ignore some networkv2 e2e comparisons with the python version

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/network/common.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/network/common.go
@@ -65,16 +65,17 @@ instances:
 			``,
 			true, // this setting is not only for Linux but the windows python check is missing some metrics
 		},
-		{
-			"collect connection queues",
-			`init_config:
-instances:
-  - collect_connection_state: true
-    collect_connection_queues: true
-`,
-			``,
-			true,
-		},
+		// XXX: unfortunately the python version does not initialize all of the queue metrics so we cannot reliably compare them without them being "new"
+		//{
+		//	"collect connection queues",
+		//	`init_config:
+		//instances:
+		//  - collect_connection_state: true
+		//    collect_connection_queues: true
+		//`,
+		//	``,
+		//	true,
+		//},
 	}
 
 	for _, testCase := range testCases {

--- a/test/new-e2e/tests/agent-runtimes/checks/network/network_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/network/network_win_test.go
@@ -22,9 +22,16 @@ func TestWindowsNetworkSuite(t *testing.T) {
 	t.Parallel()
 	suite := &windowsNetworkCheckSuite{
 		networkCheckSuite{
-			descriptor:                  e2eos.WindowsDefault,
-			metricCompareDistance:       3,
-			excludedFromValueComparison: []string{},
+			descriptor:            e2eos.WindowsDefault,
+			metricCompareDistance: 3,
+			excludedFromValueComparison: []string{
+				"system.net.tcp.connections",
+				"system.net.tcp.current_established",
+				"system.net.tcp4.connections",
+				"system.net.tcp4.current_established",
+				"system.net.tcp6.connections",
+				"system.net.tcp6.current_established",
+			},
 		},
 	}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

CI has seen flakey failures with these tests:
* windows os appears to be doing some security updates in the background and the tcp connection counts fluctuate by +/- 40 ([link](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1029667109#L2304))
* the python integration queue metrics do not initialize for all connection states so when there are some missing it causes a failure ([link](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1027112888#L2436))

### Motivation
#incident-40730

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->