### PR TITLE
[CONTP-791] Add cluster check runner count to cluster agent metadata

### DIFF
--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -118,6 +118,7 @@ func (c *ClusterChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, err
 
 	status := types.NodeStatus{
 		LastChange: c.lastChange,
+		NodeType:   "clc-runner",
 	}
 
 	reply, err := c.dcaClient.PostClusterCheckStatus(ctx, c.identifier, status)
@@ -216,6 +217,7 @@ func (c *ClusterChecksConfigProvider) postHeartbeat(ctx context.Context) error {
 
 	status := types.NodeStatus{
 		LastChange: types.ExtraHeartbeatLastChangeValue,
+		NodeType:   "clc-runner",
 	}
 
 	_, err := c.dcaClient.PostClusterCheckStatus(ctx, c.identifier, status)

--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -54,7 +54,7 @@ func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.Configuration
 		graceDuration:    defaultGraceDuration,
 		degradedDuration: defaultDegradedDeadline,
 		heartbeat:        atomic.NewTime(time.Now()),
-		nodeType:         types.NodeTypeUnknown,
+		nodeType:         types.NodeTypeCLCRunner,
 	}
 
 	c.identifier = pkgconfigsetup.Datadog().GetString("clc_runner_id")
@@ -71,7 +71,7 @@ func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.Configuration
 	}
 
 	// Set nodeType based on config
-	if pkgconfigsetup.Datadog().GetBool("clc_runner_enabled") {
+	if pkgconfigsetup.IsCLCRunner(pkgconfigsetup.Datadog()) {
 		c.nodeType = types.NodeTypeCLCRunner
 	} else {
 		c.nodeType = types.NodeTypeNodeAgent

--- a/comp/core/autodiscovery/providers/clusterchecks.go
+++ b/comp/core/autodiscovery/providers/clusterchecks.go
@@ -39,6 +39,7 @@ type ClusterChecksConfigProvider struct {
 	lastChange       int64
 	identifier       string
 	flushedConfigs   bool
+	nodeType         types.NodeType
 }
 
 // NewClusterChecksConfigProvider returns a new ConfigProvider collecting
@@ -53,6 +54,7 @@ func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.Configuration
 		graceDuration:    defaultGraceDuration,
 		degradedDuration: defaultDegradedDeadline,
 		heartbeat:        atomic.NewTime(time.Now()),
+		nodeType:         types.NodeTypeUnknown,
 	}
 
 	c.identifier = pkgconfigsetup.Datadog().GetString("clc_runner_id")
@@ -66,6 +68,13 @@ func NewClusterChecksConfigProvider(providerConfig *pkgconfigsetup.Configuration
 				c.identifier = boshID
 			}
 		}
+	}
+
+	// Set nodeType based on config
+	if pkgconfigsetup.Datadog().GetBool("clc_runner_enabled") {
+		c.nodeType = types.NodeTypeCLCRunner
+	} else {
+		c.nodeType = types.NodeTypeNodeAgent
 	}
 
 	if providerConfig.GraceTimeSeconds > 0 {
@@ -118,7 +127,7 @@ func (c *ClusterChecksConfigProvider) IsUpToDate(ctx context.Context) (bool, err
 
 	status := types.NodeStatus{
 		LastChange: c.lastChange,
-		NodeType:   "clc-runner",
+		NodeType:   c.nodeType,
 	}
 
 	reply, err := c.dcaClient.PostClusterCheckStatus(ctx, c.identifier, status)
@@ -217,7 +226,7 @@ func (c *ClusterChecksConfigProvider) postHeartbeat(ctx context.Context) error {
 
 	status := types.NodeStatus{
 		LastChange: types.ExtraHeartbeatLastChangeValue,
-		NodeType:   "clc-runner",
+		NodeType:   c.nodeType,
 	}
 
 	_, err := c.dcaClient.PostClusterCheckStatus(ctx, c.identifier, status)

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -213,10 +213,11 @@ func (dca *datadogclusteragent) getMetadata() map[string]interface{} {
 		}
 	}
 
-	// Add cluster check runner count
+	// Add cluster check runner and node agent counts
 	// Import "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
-	if count, err := clusterchecks.GetCLCRunnerCount(); err == nil {
-		dca.metadata["cluster_check_runner_count"] = count
+	if clcRunnerCount, nodeAgentCount, err := clusterchecks.GetNodeTypeCounts(); err == nil {
+		dca.metadata["cluster_check_runner_count"] = clcRunnerCount
+		dca.metadata["cluster_check_node_agent_count"] = nodeAgentCount
 	}
 
 	//Sending dca configuration can be disabled using `inventories_configuration_enabled`.

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -24,6 +24,7 @@ import (
 	clusteragent "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -211,6 +212,13 @@ func (dca *datadogclusteragent) getMetadata() map[string]interface{} {
 			dca.metadata["is_leader"] = leaderEngine.IsLeader()
 		}
 	}
+
+	// Add cluster check runner count
+	// Import "github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
+	if count, err := clusterchecks.GetCLCRunnerCount(); err == nil {
+		dca.metadata["cluster_check_runner_count"] = count
+	}
+
 	//Sending dca configuration can be disabled using `inventories_configuration_enabled`.
 	//By default, it is true and enabled.
 	if !dca.conf.GetBool("inventories_configuration_enabled") {

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -54,6 +54,7 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 	node.Lock()
 	defer node.Unlock()
 	node.heartbeat = timestampNow()
+	node.nodetype = status.NodeType
 	// When we receive ExtraHeartbeatLastChangeValue, we only update heartbeat
 	if status.LastChange == types.ExtraHeartbeatLastChangeValue {
 		return true

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -212,6 +212,32 @@ func TestDescheduleRescheduleSameNode(t *testing.T) {
 	requireNotLocked(t, dispatcher.store)
 }
 
+func TestProcessNodeStatus_NodeType(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	dispatcher := newDispatcher(fakeTagger)
+
+	// CLC runner
+	statusRunner := types.NodeStatus{LastChange: 1, NodeType: types.NodeTypeCLCRunner}
+	dispatcher.processNodeStatus("runner1", "10.0.0.10", statusRunner)
+	nodeRunner, found := dispatcher.store.getNodeStore("runner1")
+	assert.True(t, found)
+	assert.Equal(t, types.NodeTypeCLCRunner, nodeRunner.nodetype)
+
+	// Node agent
+	statusAgent := types.NodeStatus{LastChange: 2, NodeType: types.NodeTypeNodeAgent}
+	dispatcher.processNodeStatus("agent1", "10.0.0.20", statusAgent)
+	nodeAgent, found := dispatcher.store.getNodeStore("agent1")
+	assert.True(t, found)
+	assert.Equal(t, types.NodeTypeNodeAgent, nodeAgent.nodetype)
+
+	// Unknown
+	statusUnknown := types.NodeStatus{LastChange: 3, NodeType: types.NodeTypeUnknown}
+	dispatcher.processNodeStatus("unknown1", "10.0.0.30", statusUnknown)
+	nodeUnknown, found := dispatcher.store.getNodeStore("unknown1")
+	assert.True(t, found)
+	assert.Equal(t, types.NodeTypeUnknown, nodeUnknown.nodetype)
+}
+
 func TestProcessNodeStatus(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	dispatcher := newDispatcher(fakeTagger)

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -230,12 +230,7 @@ func TestProcessNodeStatus_NodeType(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, types.NodeTypeNodeAgent, nodeAgent.nodetype)
 
-	// Unknown
-	statusUnknown := types.NodeStatus{LastChange: 3, NodeType: types.NodeTypeUnknown}
-	dispatcher.processNodeStatus("unknown1", "10.0.0.30", statusUnknown)
-	nodeUnknown, found := dispatcher.store.getNodeStore("unknown1")
-	assert.True(t, found)
-	assert.Equal(t, types.NodeTypeUnknown, nodeUnknown.nodetype)
+	// No test for NodeTypeUnknown, as it has been removed.
 }
 
 func TestProcessNodeStatus(t *testing.T) {

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -212,25 +212,20 @@ func TestDescheduleRescheduleSameNode(t *testing.T) {
 	requireNotLocked(t, dispatcher.store)
 }
 
-func TestProcessNodeStatus_NodeType(t *testing.T) {
+func TestGetNodeTypeCounts(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	dispatcher := newDispatcher(fakeTagger)
 
-	// CLC runner
-	statusRunner := types.NodeStatus{LastChange: 1, NodeType: types.NodeTypeCLCRunner}
-	dispatcher.processNodeStatus("runner1", "10.0.0.10", statusRunner)
-	nodeRunner, found := dispatcher.store.getNodeStore("runner1")
-	assert.True(t, found)
-	assert.Equal(t, types.NodeTypeCLCRunner, nodeRunner.nodetype)
+	// Register 2 CLC runners and 3 node agents
+	dispatcher.processNodeStatus("runner1", "10.0.0.10", types.NodeStatus{LastChange: 1, NodeType: types.NodeTypeCLCRunner})
+	dispatcher.processNodeStatus("runner2", "10.0.0.11", types.NodeStatus{LastChange: 2, NodeType: types.NodeTypeCLCRunner})
+	dispatcher.processNodeStatus("agent1", "10.0.0.20", types.NodeStatus{LastChange: 3, NodeType: types.NodeTypeNodeAgent})
+	dispatcher.processNodeStatus("agent2", "10.0.0.21", types.NodeStatus{LastChange: 4, NodeType: types.NodeTypeNodeAgent})
+	dispatcher.processNodeStatus("agent3", "10.0.0.22", types.NodeStatus{LastChange: 5, NodeType: types.NodeTypeNodeAgent})
 
-	// Node agent
-	statusAgent := types.NodeStatus{LastChange: 2, NodeType: types.NodeTypeNodeAgent}
-	dispatcher.processNodeStatus("agent1", "10.0.0.20", statusAgent)
-	nodeAgent, found := dispatcher.store.getNodeStore("agent1")
-	assert.True(t, found)
-	assert.Equal(t, types.NodeTypeNodeAgent, nodeAgent.nodetype)
-
-	// No test for NodeTypeUnknown, as it has been removed.
+	clcRunnerCount, nodeAgentCount := dispatcher.store.CountNodeTypes()
+	assert.Equal(t, 2, clcRunnerCount)
+	assert.Equal(t, 3, nodeAgentCount)
 }
 
 func TestProcessNodeStatus(t *testing.T) {

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -51,13 +51,8 @@ func GetCLCRunnerCount() (int, error) {
 
 	count := 0
 	for _, node := range handler.dispatcher.store.nodes {
-		if node != nil && node.lastConfigChange != 0 && node.clcRunnerStats != nil {
-			for _, stats := range node.clcRunnerStats {
-				if stats.IsClusterCheck {
-					count++
-					break
-				}
-			}
+		if node != nil && node.nodetype == types.NodeTypeCLCRunner {
+			count++
 		}
 	}
 	return count, nil

--- a/pkg/clusteragent/clusterchecks/status.go
+++ b/pkg/clusteragent/clusterchecks/status.go
@@ -53,6 +53,9 @@ func populateStatus(stats map[string]interface{}) {
 		if cchecks, err := GetStats(); err == nil {
 			stats["clusterchecks"] = cchecks
 		}
+		if count, err := GetCLCRunnerCount(); err == nil {
+			stats["clc_runner_count"] = count
+		}
 	}
 }
 

--- a/pkg/clusteragent/clusterchecks/status.go
+++ b/pkg/clusteragent/clusterchecks/status.go
@@ -53,9 +53,6 @@ func populateStatus(stats map[string]interface{}) {
 		if cchecks, err := GetStats(); err == nil {
 			stats["clusterchecks"] = cchecks
 		}
-		if count, err := GetCLCRunnerCount(); err == nil {
-			stats["clc_runner_count"] = count
-		}
 	}
 }
 

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -93,6 +93,7 @@ type nodeStore struct {
 	clcRunnerStats   types.CLCRunnersStats
 	busyness         int
 	workers          int
+	nodetype         types.NodeType
 }
 
 func newNodeStore(name, clientIP string) *nodeStore {

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -59,6 +59,24 @@ func (s *clusterStore) getNodeStore(nodeName string) (*nodeStore, bool) {
 	return node, ok
 }
 
+// CountNodeTypes returns the number of nodes with NodeTypeCLCRunner and NodeTypeNodeAgent.
+func (s *clusterStore) CountNodeTypes() (clcRunnerCount, nodeAgentCount int) {
+	s.RLock()
+	defer s.RUnlock()
+	for _, node := range s.nodes {
+		if node == nil {
+			continue
+		}
+		switch node.nodetype {
+		case types.NodeTypeCLCRunner:
+			clcRunnerCount++
+		case types.NodeTypeNodeAgent:
+			nodeAgentCount++
+		}
+	}
+	return
+}
+
 // getOrCreateNodeStore retrieves the store struct for a given node name.
 // If the node is not yet in the store, an entry will be inserted and returned.
 func (s *clusterStore) getOrCreateNodeStore(nodeName, clientIP string) *nodeStore {

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -24,8 +24,6 @@ It is used to distinguish between CLC runners, node agents, and unknown types.
 type NodeType uint8
 
 const (
-	// NodeTypeUnknown is used when the node type is not set or cannot be determined.
-	NodeTypeUnknown NodeType = 0
 	// NodeTypeCLCRunner represents a cluster check runner.
 	NodeTypeCLCRunner NodeType = 1
 	// NodeTypeNodeAgent represents a node agent.

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -17,10 +17,25 @@ const (
 	ExtraHeartbeatLastChangeValue int64 = -1
 )
 
+/*
+NodeType represents the type of node reporting status to the cluster agent.
+It is used to distinguish between CLC runners, node agents, and unknown types.
+*/
+type NodeType uint8
+
+const (
+	// NodeTypeUnknown is used when the node type is not set or cannot be determined.
+	NodeTypeUnknown NodeType = 0
+	// NodeTypeCLCRunner represents a cluster check runner.
+	NodeTypeCLCRunner NodeType = 1
+	// NodeTypeNodeAgent represents a node agent.
+	NodeTypeNodeAgent NodeType = 2
+)
+
 // NodeStatus holds the status report from the node-agent
 type NodeStatus struct {
-	LastChange int64  `json:"last_change"`
-	NodeType   string `json:"node_type,omitempty"`
+	LastChange int64    `json:"last_change"`
+	NodeType   NodeType `json:"node_type,omitempty"`
 }
 
 // StatusResponse holds the DCA response for a status report

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -19,7 +19,8 @@ const (
 
 // NodeStatus holds the status report from the node-agent
 type NodeStatus struct {
-	LastChange int64 `json:"last_change"`
+	LastChange int64  `json:"last_change"`
+	NodeType   string `json:"node_type,omitempty"`
 }
 
 // StatusResponse holds the DCA response for a status report


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Report cluster check runner count in cluster-agent metadata payload

### Motivation

Cluster Agent Metadata: Metadata reporting has been enabled in the Cluster Agent since version 7.67. This payload enhances visibility into cluster information and aids in debugging.

Lack of Awareness in Cluster Agent: Historically, the Cluster Agent has had limited visibility into cluster check providers. As a result, both the node agent and the cluster check runner could end up executing cluster checks, depending on the user’s configuration.

Purpose of This PR: This pull request introduces reporting of the cluster check runner count. The goal is to enable better optimization of cluster check usage. For instance, the Kube State Metrics (KSM) check should not be run solely on a single node agent. If the cluster check runner count is 0 while feature_cluster_checks_enabled is true, it indicates a misconfiguration, and a cluster check runner should be enabled.

Data Visibility: The reported information can be monitored in DDSQL, pending a separate enabling PR.

Implementation:
clc runner post status with node type -> cluster agent -> node store -> metadata 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Go to leader cluster agent pod, and run
`root@datadog-agent-linux-cluster-agent-5dc58987bc-4brlv:/# agent flare
`
Download flare and find cluster-agent-metadata.json
The metadata should be like
```
    "datadog_cluster_agent_metadata": {
        "cluster_check_runner_count": 3, # number of clc runners
        .....
```

Turn off clc runner and get flare again, the count should be zero now
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->