### PR TITLE
[DEBUG-4070]  dyninst/object: use faster zlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -311,7 +311,7 @@ require (
 	github.com/justincormack/go-memfd v0.0.0-20170219213707-6e4af0518993
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/knqyf263/go-deb-version v0.0.0-20241115132648-6f4aee6ccd23 // indirect
 	github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075 // indirect

--- a/pkg/dyninst/object/elf.go
+++ b/pkg/dyninst/object/elf.go
@@ -9,7 +9,6 @@ package object
 
 import (
 	"bytes"
-	"compress/zlib"
 	"debug/dwarf"
 	"encoding/binary"
 	"errors"
@@ -19,6 +18,7 @@ import (
 	"unsafe"
 
 	dlvdwarf "github.com/go-delve/delve/pkg/dwarf"
+	"github.com/klauspost/compress/zlib"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dwarf/loclist"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"


### PR DESCRIPTION
This commit adopts https://github.com/klauspost/compress. It's faster and much less allocation happy:

```
name                     old time/op    new time/op    delta
LoadElfFile/cockroach-4     1.13s ± 0%     0.86s ± 3%  -23.87%  (p=0.000 n=15+20)
LoadElfFile/agent-4         329ms ± 1%     258ms ± 1%  -21.76%  (p=0.000 n=18+17)

name                     old speed      new speed      delta
LoadElfFile/cockroach-4   209MB/s ± 0%   275MB/s ± 3%  +31.40%  (p=0.000 n=15+20)
LoadElfFile/agent-4       218MB/s ± 1%   278MB/s ± 1%  +27.88%  (p=0.000 n=19+17)

name                     old alloc/op   new alloc/op   delta
LoadElfFile/cockroach-4     249MB ± 0%     240MB ± 0%   -3.81%  (p=0.000 n=20+19)
LoadElfFile/agent-4        75.3MB ± 0%    72.4MB ± 0%   -3.83%  (p=0.000 n=17+16)

name                     old allocs/op  new allocs/op  delta
LoadElfFile/cockroach-4      110k ± 0%       14k ± 0%  -87.56%  (p=0.000 n=20+19)
LoadElfFile/agent-4         32.1k ± 0%      3.2k ± 0%  -89.92%  (p=0.000 n=20+18)
```
