### PR TITLE
Use archive source for maven on windows builds

### DIFF
--- a/Dockerfiles/agent/install-fips.ps1
+++ b/Dockerfiles/agent/install-fips.ps1
@@ -15,7 +15,7 @@ $maven_sha512 = '2e24dbea0407489d45b4d8214afff96fb57b54a5ef2bb6878f65fbce9b41416
 
 if ("$env:WITH_JMX" -ne "false") {
     cd \fips-build
-    Invoke-WebRequest -Outfile maven.zip https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip
+    Invoke-WebRequest -Outfile maven.zip https://archive.apache.org/dist/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip
     if ((Get-FileHash -Algorithm SHA512 maven.zip).Hash -eq $maven_sha512) {
         Write-Host "Maven checksum match"
     } else {


### PR DESCRIPTION
### What does this PR do?

~~Updates maven on windows fips build script from 3.9.10 to 3.9.11.~~ _Update was postponed for release-related reasons._

It ~~also~~ changes the mirror in use to an "archive" one where artifacts are not expected to be yanked.

### Motivation

#incident-40742. The docker_build_fips_agent7_windows2022_core_jmx job is broken ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1030724071)) due to the previously used version of maven being removed from our upstream source in favor of this new update.

### Describe how you validated your changes

Green pipeline.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->