### PR TITLE
Improve docker image size computation

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -88,6 +88,17 @@
       if [[ "$FLATTEN_IMAGE" == "true" ]]; then
         crane flatten -t ${TARGET_TAG} ${TARGET_TAG}
       fi
+    # Calculate the on disk and on wire size of the image
+    - |
+      ON_DISK_SIZE=$(crane export ${TARGET_TAG} | wc -c)
+      echo "On disk size: $ON_DISK_SIZE"
+      ON_WIRE_SIZE=$(crane pull ${TARGET_TAG} | wc -c)
+      echo "On wire size: $ON_WIRE_SIZE"
+      echo "{\"image_tag\":\"${TARGET_TAG}\",\"on_disk_size\":\"${ON_DISK_SIZE}\",\"on_wire_size\":\"${ON_WIRE_SIZE}\"}" > ${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH.json
+  artifacts:
+    paths:
+      - ${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH.json
+    expire_in: 1 week
   # Workaround for temporary network failures
   retry: 2
   timeout: 30m


### PR DESCRIPTION
Previous approach with awk was summing
all size attribute occurrences within
docker manifest. That led to a constant
overestimation of the image size as
that always included layers that
don't belong to the current platform.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->