### PR TITLE
fix(installer): Fix preinst removal of custom integrations

### DIFF
--- a/pkg/fleet/installer/packages/integrations/integrations_test.go
+++ b/pkg/fleet/installer/packages/integrations/integrations_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package integrations contains packaging logic for python integrations
+package integrations
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveCustomIntegrations(t *testing.T) {
+	dir := t.TempDir()
+
+	paths := []string{
+		// Installed by customer outside of the agent
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/direct_url.json",
+		// Installed by agent integration command
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json",
+		// Not installed by agent integration command
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/direct_url.json",
+		// Previous version .pyc files
+		"embedded/lib/python3.8/site-packages/datadog_checks/__pycache__/__init__.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/__pycache__/errors.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/__init__.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/agent.cpython-312.pyc",
+	}
+
+	for _, relPath := range paths {
+		fullPath := filepath.Join(dir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", fullPath, err)
+		}
+		f, err := os.Create(fullPath)
+		if err != nil {
+			t.Fatalf("failed to create file %s: %v", fullPath, err)
+		}
+		f.Close()
+	}
+
+	installedByPkgPath := filepath.Join(dir, "embedded", ".installed_by_pkg.txt")
+	content := `# DO NOT REMOVE/MODIFY - used by package removal tasks
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt
+./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json
+`
+	if err := os.WriteFile(installedByPkgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create .installed_by_pkg.txt: %v", err)
+	}
+
+	if err := RemoveCustomIntegrations(context.TODO(), dir); err != nil {
+		t.Fatalf("RemoveCustomIntegrations failed: %v", err)
+	}
+
+	remaining := []string{
+		// Installed by customer outside of the agent
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/direct_url.json",
+		// In the .installed_by_pkg.txt
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json",
+	}
+
+	removed := []string{
+		// Not in the .installed_by_pkg.txt
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/direct_url.json",
+		"embedded/lib/python3.8/site-packages/datadog_checks/__pycache__/__init__.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/__pycache__/errors.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/__init__.cpython-312.pyc",
+		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/agent.cpython-312.pyc",
+	}
+
+	for _, relPath := range removed {
+		fullPath := filepath.Join(dir, relPath)
+		if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, but it exists", fullPath)
+		}
+	}
+
+	for _, relPath := range remaining {
+		fullPath := filepath.Join(dir, relPath)
+		if _, err := os.Stat(fullPath); err != nil {
+			t.Errorf("expected %s to exist, but got error: %v", fullPath, err)
+		}
+	}
+}

--- a/pkg/fleet/installer/packages/integrations/integrations_test.go
+++ b/pkg/fleet/installer/packages/integrations/integrations_test.go
@@ -27,7 +27,7 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/WHEEL",
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/entry_points.txt",
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/direct_url.json",
-		// Installed by agent integration command
+		// Installed by agent binary
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER",
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA",
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD",
@@ -35,7 +35,7 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL",
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt",
 		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json",
-		// Not installed by agent integration command
+		// Installed by agent integration command
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/INSTALLER",
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/METADATA",
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/RECORD",

--- a/releasenotes/notes/fix_custom_integrations_removal-2b44991a06d9757f.yaml
+++ b/releasenotes/notes/fix_custom_integrations_removal-2b44991a06d9757f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue with the agent pre-install script that caused integrations shipped with the agent
+    to be removed during an agent upgrade.

--- a/releasenotes/notes/fix_custom_integrations_removal-2b44991a06d9757f.yaml
+++ b/releasenotes/notes/fix_custom_integrations_removal-2b44991a06d9757f.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Fix an issue with the agent pre-install script that caused integrations shipped with the agent
-    to be removed during an agent upgrade.
+    Fix an issue with the Agent pre-install script that caused integrations shipped with the Agent
+    to be removed during an Agent upgrade.


### PR DESCRIPTION
### What does this PR do?
There were two issues with the preinst migration to the installer regarding the removal of custom integrations:
- `filepath.Glob` returns absolute paths instead of relative ones in bash; leading to a comparison mismatch
- `.installed_by_pkg.txt` list files; not directories. Most entries were not matching.

This PR fixes it by:
- Walking the dir instead using filepath.Glob; mimicking the previous behaviour obtained with `find . -depth -path './embedded/lib/python*/site-packages/datadog_*'`
- We make sure to compare apples to apples by resolving all paths to be absolute.

### Motivation

### Describe how you validated your changes
Added a bunch of unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
