### PR TITLE
[ACIX-926]: Enable retries for all end-to-end tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -73,7 +73,7 @@
     E2E_RESULT_JSON: $CI_PROJECT_DIR/e2e_test_output.json
     E2E_USE_AWS_PROFILE: "true"
     PRE_BUILT_BINARIES_FLAG: "--use-prebuilt-binaries"
-    MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
+    MAX_RETRIES_FLAG: "--max-retries=3" # Retry failed tests up to 3 times by default
   script:
     - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
@@ -578,7 +578,6 @@ new-e2e-installer-script:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
     E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -601,7 +600,6 @@ new-e2e-installer:
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
     E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template
@@ -627,7 +625,6 @@ new-e2e-installer-windows:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "windows"
     E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
   parallel:
     matrix:
       # agent-package
@@ -703,7 +700,6 @@ new-e2e-installer-ansible:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "ansible"
     E2E_USE_AWS_PROFILE: "false"
-    MAX_RETRIES_FLAG: "--max-retries=3"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enables the retry mechanism introduced in #37862 for all e2e tests. It was previously only enabled on jobs in `new-e2e-installer` and `new-e2e-installer-script` stages for verification purposes.

### Motivation

Improve reliability of CI and reduce impact of e2e test flakes.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

N/A

### Possible Drawbacks / Trade-offs

- Increased CI time when tests are "reliably" broken

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I set the `MAX_RETRIES_FLAG` variable directly in the root `.new-e2e-template` instead of setting it manually in all (~100) leaf jobs. This might not be the way we want to do it as it could make it less clear that tests have this retry functionality built-in.

Note however that it is still possible to disable/change the number of retries for an individual job by overriding `MAX_RETRIES_FLAG` (making it `""` for example) at the job level.