### PR TITLE
Updating Windows Certificate e2e Test

### DIFF
--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -118,8 +118,10 @@ func (v *multiVMSuite) SetupSuite() {
 	v.Require().NoError(err)
 
 	// Start the LanmanServer to ensure that the Agent can connect to the IPC$ share
-	err = windowsCommon.StartService(certificateHost, "LanmanServer")
-	v.Require().NoError(err)
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		err = windowsCommon.StartService(certificateHost, "LanmanServer")
+		assert.NoError(c, err)
+	}, 10*time.Minute, 10*time.Second)
 
 	// Wait for the LanmanServer service to be running
 	v.EventuallyWithT(func(c *assert.CollectT) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the windows certificate e2e so that the test retries starting the lanmanserver service after a restart. This is to ensure that the lanmanserver is running before carrying on with testing the integration

### Motivation
Flaky tests: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1031095368

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run the windows certificate e2e test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->