### PR TITLE
dyninst/procmon: quiet some logs

### DIFF
--- a/pkg/dyninst/rcscrape/scraper.go
+++ b/pkg/dyninst/rcscrape/scraper.go
@@ -151,7 +151,7 @@ func (s *scraperReporter) ReportAttached(
 	procID actuator.ProcessID,
 	_ *ir.Program,
 ) {
-	log.Tracef("rcscrape: attached to process %v", procID)
+	log.Debugf("rcscrape: attached to process %v", procID)
 }
 
 // ReportAttachingFailed implements actuator.Reporter.


### PR DESCRIPTION
We get ESRCH on some attempts to interact with procfs, so we should silence those. Also, on some hosts we're seeing EPERM interacting with procfs and with container filesystems. We don't want to spam those, but we do want to see them sometimes. Also, I do want to see on staging when we attach the rc scraping probes.
