### PR TITLE
dyninst: do not fail hard on decoding issues, report them

### DIFF
--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -1,0 +1,188 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2025 Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+)
+
+// TestDecoderErrorHandling tests that decoder errors do not cause the
+// entire subsystem to fail and shut down.
+func TestDecoderErrorHandling(t *testing.T) {
+	dyninsttest.SkipIfKernelNotSupported(t)
+	tmpDir, cleanup := dyninsttest.PrepTmpDir(t, "decoder-error-handling-test")
+	defer cleanup()
+
+	diagCh := make(chan []byte, 10)
+	backend := &mockBackend{diagPayloadCh: diagCh}
+	backendServer := httptest.NewServer(backend)
+	t.Cleanup(backendServer.Close)
+
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
+		return c.GOARCH == runtime.GOARCH
+	})
+	require.NotEqual(t, -1, idx)
+	cfg := cfgs[idx]
+
+	sampleServicePath := testprogs.MustGetBinary(t, "rc_tester", cfg)
+	sampleServiceCmd, serverPort, err := startSampleService(t, sampleServiceConfig{
+		binaryPath: sampleServicePath,
+		tmpDir:     tmpDir,
+	})
+	require.NoError(t, err)
+	probes := testprogs.MustGetProbeDefinitions(t, "rc_tester")
+
+	loader, err := loader.NewLoader()
+	require.NoError(t, err)
+	actuator := actuator.NewActuator(loader)
+	scraper := &mockScraper{}
+	logsURL, err := url.Parse(backendServer.URL + "/logs")
+	require.NoError(t, err)
+	diagURL, err := url.Parse(backendServer.URL + "/diags")
+	require.NoError(t, err)
+
+	c := module.NewController(
+		actuator,
+		uploader.NewLogsUploaderFactory(uploader.WithURL(logsURL)),
+		uploader.NewDiagnosticsUploader(uploader.WithURL(diagURL)),
+		scraper,
+		&failOnceDecoderFactory{
+			underlying: module.DefaultDecoderFactory{},
+		},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	for _, probe := range probes {
+		setSnapshotsPerSecond(t, probe, 100)
+	}
+
+	scraper.setUpdates([]rcscrape.ProcessUpdate{
+		{
+			ProcessUpdate: procmon.ProcessUpdate{
+				ProcessID: procmon.ProcessID{PID: int32(sampleServiceCmd.Process.Pid)},
+				Executable: procmon.Executable{
+					Path: sampleServicePath,
+				},
+				Service: "rc_tester",
+			},
+			RuntimeID: "foo",
+			Probes:    probes,
+		},
+	})
+
+	// This will result in one decoding failure and then the probes will
+	// continue to emit and so we'll eventually go to the expected number
+	// of logs.
+	expectedProbeIDs := []string{"look_at_the_request", "http_handler"}
+	waitForProbeStatus(t, diagCh, uploader.StatusInstalled, expectedProbeIDs)
+	t.Log("Sending requests to trigger probes...")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				sendTestRequests(t, serverPort, 1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	waitForLogMessages(t, backend, 10, "")
+}
+
+type mockScraper struct {
+	mu struct {
+		sync.Mutex
+		updates []rcscrape.ProcessUpdate
+	}
+}
+
+func (s *mockScraper) GetUpdates() []rcscrape.ProcessUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.mu.updates)
+}
+
+func (s *mockScraper) setUpdates(updates []rcscrape.ProcessUpdate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.updates = updates
+}
+
+type failOnceDecoderFactory struct {
+	underlying module.DecoderFactory
+	failed     atomic.Bool
+}
+
+func (f *failOnceDecoderFactory) NewDecoder(
+	program *ir.Program,
+) (module.Decoder, error) {
+	decoder, err := f.underlying.NewDecoder(program)
+	if err != nil {
+		return nil, err
+	}
+	if !f.failed.CompareAndSwap(false, true) {
+		return decoder, nil
+	}
+	return &failOnceDecoder{
+		underlying: decoder,
+	}, nil
+}
+
+type failOnceDecoder struct {
+	underlying module.Decoder
+	failed     atomic.Bool
+}
+
+func (d *failOnceDecoder) Decode(
+	event decode.Event, symbolicator symbol.Symbolicator, out io.Writer,
+) (ir.ProbeDefinition, error) {
+	if !d.failed.CompareAndSwap(false, true) {
+		return d.underlying.Decode(event, symbolicator, out)
+	}
+	return nil, errors.New("boom")
+}

--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -86,7 +86,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		c.Run(ctx)
+		c.Run(ctx, 10*time.Millisecond)
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -114,9 +114,25 @@ func TestDecoderErrorHandling(t *testing.T) {
 	// This will result in one decoding failure and then the probes will
 	// continue to emit and so we'll eventually go to the expected number
 	// of logs.
-	expectedProbeIDs := []string{"look_at_the_request", "http_handler"}
-	waitForProbeStatus(t, diagCh, uploader.StatusInstalled, expectedProbeIDs)
-	t.Log("Sending requests to trigger probes...")
+	const (
+		httpHandlerProbeID      = "http_handler"
+		lookAtTheRequestProbeID = "look_at_the_request"
+	)
+	waitForProbeStatus(
+		t, diagCh,
+		makeTargetStatus(
+			uploader.StatusInstalled,
+			lookAtTheRequestProbeID,
+			httpHandlerProbeID,
+		),
+	)
+	sendTestRequests(t, serverPort, 1)
+	// The http_handler comes first because it's called first so it'll fail
+	// and then the look_at_the_request probe will emit.
+	waitForProbeStatus(t, diagCh, map[string]uploader.Status{
+		httpHandlerProbeID:      uploader.StatusError,
+		lookAtTheRequestProbeID: uploader.StatusEmitting,
+	})
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -131,6 +147,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 			}
 		}
 	}()
+	// They'll both still emit.
 	waitForLogMessages(t, backend, 10, "")
 }
 
@@ -181,8 +198,9 @@ type failOnceDecoder struct {
 func (d *failOnceDecoder) Decode(
 	event decode.Event, symbolicator symbol.Symbolicator, out io.Writer,
 ) (ir.ProbeDefinition, error) {
-	if !d.failed.CompareAndSwap(false, true) {
-		return d.underlying.Decode(event, symbolicator, out)
+	probe, err := d.underlying.Decode(event, symbolicator, out)
+	if err == nil && d.failed.CompareAndSwap(false, true) {
+		err = errors.New("boom")
 	}
-	return nil, errors.New("boom")
+	return probe, err
 }

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -85,6 +85,15 @@ func (c *Controller) Run(ctx context.Context, interval time.Duration) {
 	}
 }
 
+func (c *Controller) handleRemovals(removals []procmon.ProcessID) {
+	c.store.remove(removals)
+	if len(removals) > 0 {
+		c.actuator.HandleUpdate(actuator.ProcessesUpdate{
+			Removals: removals,
+		})
+	}
+}
+
 func (c *Controller) checkForUpdates() {
 	scraperUpdates := c.rcScraper.GetUpdates()
 	actuatorUpdates := make([]actuator.ProcessUpdate, 0, len(scraperUpdates))

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -69,9 +69,9 @@ func jitter(duration time.Duration, fraction float64) time.Duration {
 }
 
 // Run runs the controller.
-func (c *Controller) Run(ctx context.Context) {
+func (c *Controller) Run(ctx context.Context, interval time.Duration) {
 	duration := func() time.Duration {
-		return jitter(200*time.Millisecond, 0.2)
+		return jitter(interval, 0.2)
 	}
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -116,4 +116,15 @@ func (c *Controller) setProbeMaybeEmitting(progID ir.ProgramID, probe ir.ProbeDe
 	}
 	procRuntimeID := procRuntimeIDi.(procRuntimeID)
 	c.diagnostics.reportEmitting(procRuntimeID, probe)
+}
+
+func (c *Controller) reportProbeError(
+	progID ir.ProgramID, probe ir.ProbeDefinition, err error, errType string,
+) (reported bool) {
+	procRuntimeIDi, ok := c.procRuntimeIDbyProgramID.Load(progID)
+	if !ok {
+		return false
+	}
+	procRuntimeID := procRuntimeIDi.(procRuntimeID)
+	return c.diagnostics.reportError(procRuntimeID, probe, err, errType)
 }

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 )
 
 type procRuntimeID struct {
@@ -31,26 +30,26 @@ type procRuntimeID struct {
 // Controller is the main controller for the module.
 type Controller struct {
 	rcScraper      Scraper
-	actuator       *actuator.Tenant
-	diagUploader   *uploader.DiagnosticsUploader
-	logUploader    *uploader.LogsUploaderFactory
-	store          *processStore
-	diagnostics    *diagnosticsManager
+	actuator       ActuatorTenant
 	decoderFactory DecoderFactory
+	diagUploader   DiagnosticsUploader
+	logUploader    erasedLogsUploaderFactory
 
+	store                    *processStore
+	diagnostics              *diagnosticsManager
 	procRuntimeIDbyProgramID sync.Map // map[ir.ProgramID]procRuntimeID
 }
 
 // NewController creates a new Controller.
-func NewController(
-	a *actuator.Actuator,
-	logUploader *uploader.LogsUploaderFactory,
-	diagUploader *uploader.DiagnosticsUploader,
+func NewController[AT ActuatorTenant, LU LogsUploader](
+	a Actuator[AT],
+	logUploader LogsUploaderFactory[LU],
+	diagUploader DiagnosticsUploader,
 	rcScraper Scraper,
 	decoderFactory DecoderFactory,
 ) *Controller {
 	c := &Controller{
-		logUploader:    logUploader,
+		logUploader:    logsUploaderFactoryImpl[LU]{factory: logUploader},
 		diagUploader:   diagUploader,
 		rcScraper:      rcScraper,
 		store:          newProcessStore(),

--- a/pkg/dyninst/module/controller_test.go
+++ b/pkg/dyninst/module/controller_test.go
@@ -1,0 +1,581 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+)
+
+// Stub/fake implementations for testing.
+
+type fakeScraper struct {
+	updates []rcscrape.ProcessUpdate
+}
+
+func (f *fakeScraper) GetUpdates() []rcscrape.ProcessUpdate {
+	return f.updates
+}
+
+type fakeActuatorTenant struct {
+	name        string
+	reporter    actuator.Reporter
+	irGenerator actuator.IRGenerator
+	updates     []actuator.ProcessesUpdate
+}
+
+func (f *fakeActuatorTenant) HandleUpdate(update actuator.ProcessesUpdate) {
+	f.updates = append(f.updates, update)
+}
+
+type fakeActuator struct {
+	t      *testing.T
+	tenant *fakeActuatorTenant
+}
+
+func (f *fakeActuator) NewTenant(name string, reporter actuator.Reporter, irGenerator actuator.IRGenerator) *fakeActuatorTenant {
+	assert.Nil(f.t, f.tenant)
+	f.tenant = &fakeActuatorTenant{
+		name:        name,
+		reporter:    reporter,
+		irGenerator: irGenerator,
+	}
+	return f.tenant
+}
+
+type fakeDecoderFactory struct {
+	decoder module.Decoder
+	err     error
+}
+
+func (f *fakeDecoderFactory) NewDecoder(_ *ir.Program) (module.Decoder, error) {
+	return f.decoder, f.err
+}
+
+type fakeDecoder struct {
+	probe  ir.ProbeDefinition
+	err    error
+	output string
+
+	decodeCalls []decodeCall
+}
+
+type decodeCall struct {
+	event        decode.Event
+	symbolicator symbol.Symbolicator
+	out          io.Writer
+}
+
+func (f *fakeDecoder) Decode(event decode.Event, symbolicator symbol.Symbolicator, out io.Writer) (ir.ProbeDefinition, error) {
+	f.decodeCalls = append(f.decodeCalls, decodeCall{event, symbolicator, out})
+	if f.output != "" {
+		_, err := io.WriteString(out, f.output)
+		return f.probe, err
+	}
+	return f.probe, f.err
+}
+
+type fakeDiagnosticsUploader struct {
+	messages []*uploader.DiagnosticMessage
+}
+
+func (f *fakeDiagnosticsUploader) Enqueue(diag *uploader.DiagnosticMessage) error {
+	f.messages = append(f.messages, diag)
+	return nil
+}
+
+type fakeLogsUploaderFactory struct {
+	uploaders map[uploader.LogsUploaderMetadata]*fakeLogsUploader
+}
+
+func (f *fakeLogsUploaderFactory) GetUploader(metadata uploader.LogsUploaderMetadata) module.LogsUploader {
+	if len(f.uploaders) > 0 {
+		for _, uploader := range f.uploaders {
+			return uploader
+		}
+	}
+	if f.uploaders == nil {
+		f.uploaders = make(map[uploader.LogsUploaderMetadata]*fakeLogsUploader)
+	}
+	ul, ok := f.uploaders[metadata]
+	if !ok {
+		ul = &fakeLogsUploader{}
+		f.uploaders[metadata] = ul
+	}
+	return ul
+}
+
+type fakeLogsUploader struct {
+	messages []json.RawMessage
+	closed   bool
+}
+
+func (f *fakeLogsUploader) Enqueue(data json.RawMessage) {
+	f.messages = append(f.messages, data)
+}
+
+func (f *fakeLogsUploader) Close() {
+	f.closed = true
+}
+
+// Test data helpers.
+
+func createTestProbe(id string) ir.ProbeDefinition {
+	return &rcjson.LogProbe{
+		LogProbeCommon: rcjson.LogProbeCommon{
+			ProbeCommon: rcjson.ProbeCommon{
+				ID:      id,
+				Version: 1,
+				Where:   &rcjson.Where{MethodName: "main"},
+			},
+			Template: "test log message",
+		},
+	}
+}
+
+func createTestProcessUpdate() rcscrape.ProcessUpdate {
+	return rcscrape.ProcessUpdate{
+		ProcessUpdate: procmon.ProcessUpdate{
+			ProcessID:  procmon.ProcessID{PID: 12345},
+			Executable: procmon.Executable{Path: "/usr/bin/test"},
+			Service:    "test-service",
+		},
+		Probes:    []ir.ProbeDefinition{createTestProbe("probe-1"), createTestProbe("probe-2")},
+		RuntimeID: "runtime-123",
+	}
+}
+
+func createTestProgram() *ir.Program {
+	return &ir.Program{
+		ID: ir.ProgramID(42),
+		Probes: []*ir.Probe{
+			{ProbeDefinition: createTestProbe("probe-1")},
+			{ProbeDefinition: createTestProbe("probe-2")},
+		},
+	}
+}
+
+// TestController_HappyPathEndToEnd verifies the basic end-to-end flow where
+// the controller receives process updates from the scraper, forwards them to
+// the actuator, and generates appropriate diagnostic messages for each probe.
+func TestController_HappyPathEndToEnd(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{t: t}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(
+		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+	)
+	require.NotNil(t, controller)
+
+	controller.CheckForUpdates()
+
+	require.Len(t, a.tenant.updates, 1)
+	actualUpdate := a.tenant.updates[0]
+	require.Len(t, actualUpdate.Processes, 1)
+	assert.Equal(t, processUpdate.ProcessID, actualUpdate.Processes[0].ProcessID)
+	assert.Equal(t, processUpdate.Executable, actualUpdate.Processes[0].Executable)
+	assert.Len(t, actualUpdate.Processes[0].Probes, 2)
+
+	require.Len(t, diagUploader.messages, 2)
+	for _, msg := range diagUploader.messages {
+		assert.Equal(t, uploader.StatusReceived, msg.Debugger.Diagnostic.Status)
+		assert.Contains(t, []string{"probe-1", "probe-2"}, msg.Debugger.Diagnostic.ProbeID)
+	}
+}
+
+// TestController_ProgramLifecycleFlow tests the complete program lifecycle
+// including attachment, loading with metadata (git info, container info), and
+// proper sink creation with the correct uploader metadata.
+func TestController_ProgramLifecycleFlow(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{t: t}
+	decoder := &fakeDecoder{}
+	decoderFactory := &fakeDecoderFactory{decoder: decoder}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	processUpdate.Container = procmon.ContainerInfo{
+		ContainerID: "container-123",
+		EntityID:    "entity-123",
+	}
+	processUpdate.GitInfo = procmon.GitInfo{
+		CommitSha:     "commit-123",
+		RepositoryURL: "https://github.com/test/test",
+	}
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(
+		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+	)
+	require.NotNil(t, controller)
+	require.NotNil(t, a.tenant)
+	require.NotNil(t, a.tenant.reporter)
+
+	controller.CheckForUpdates()
+
+	a.tenant.reporter.ReportAttached(procID, program)
+
+	installedCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusInstalled {
+			installedCount++
+		}
+	}
+	assert.Equal(t, 2, installedCount)
+
+	sink, err := a.tenant.reporter.ReportLoaded(procID, processUpdate.Executable, program)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+	require.Len(t, logUploaderFactory.uploaders, 1)
+	require.Equal(t,
+		slices.Collect(maps.Keys(logUploaderFactory.uploaders)),
+		[]uploader.LogsUploaderMetadata{{
+			Tags:        "git.commit.sha:commit-123,git.repository_url:https://github.com/test/test",
+			EntityID:    "entity-123",
+			ContainerID: "container-123",
+		}},
+	)
+}
+
+// TestController_IRGenerationFailure verifies that IR generation failures
+// are properly reported as error diagnostics for all affected probes.
+func TestController_IRGenerationFailure(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	procID := processUpdate.ProcessID
+	testError := errors.New("IR generation failed")
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(
+		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+	)
+	require.NotNil(t, controller)
+	require.NotNil(t, a.tenant)
+	require.NotNil(t, a.tenant.reporter)
+
+	reporter := a.tenant.reporter
+
+	controller.CheckForUpdates()
+
+	reporter.ReportIRGenFailed(procID, testError, processUpdate.Probes)
+
+	errorCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusError {
+			assert.Equal(t, "IRGenFailed", msg.Debugger.Diagnostic.DiagnosticException.Type)
+			assert.Equal(t, testError.Error(), msg.Debugger.Diagnostic.DiagnosticException.Message)
+			errorCount++
+		}
+	}
+	assert.Equal(t, 2, errorCount)
+}
+
+// TestController_AttachmentFailure verifies that program attachment failures
+// are properly reported as error diagnostics for all probes in the program.
+func TestController_AttachmentFailure(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+	testError := errors.New("attachment failed")
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(
+		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+	)
+
+	controller.CheckForUpdates()
+
+	require.Len(t, diagUploader.messages, 2)
+	for _, msg := range diagUploader.messages {
+		assert.Equal(t, uploader.StatusReceived, msg.Debugger.Diagnostic.Status)
+		assert.Contains(t, []string{"probe-1", "probe-2"}, msg.Debugger.Diagnostic.ProbeID)
+	}
+
+	a.tenant.reporter.ReportAttachingFailed(procID, program, testError)
+
+	require.Len(t, diagUploader.messages, 4)
+	errorCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusError &&
+			msg.Debugger.Diagnostic.DiagnosticException.Type == "AttachmentFailed" {
+			assert.Equal(t, testError.Error(), msg.Debugger.Diagnostic.DiagnosticException.Message)
+			assert.Contains(t, []string{"probe-1", "probe-2"}, msg.Debugger.Diagnostic.ProbeID)
+			errorCount++
+		}
+	}
+	assert.Equal(t, 2, errorCount)
+}
+
+// TestController_LoadingFailure verifies that program loading failures
+// are properly reported as error diagnostics for all probes in the program.
+func TestController_LoadingFailure(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+	testError := errors.New("loading failed")
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(a, logUploaderFactory, diagUploader, scraper, decoderFactory)
+
+	controller.CheckForUpdates()
+
+	require.Len(t, diagUploader.messages, 2)
+	for _, msg := range diagUploader.messages {
+		assert.Equal(t, uploader.StatusReceived, msg.Debugger.Diagnostic.Status)
+		assert.Contains(t, []string{"probe-1", "probe-2"}, msg.Debugger.Diagnostic.ProbeID)
+	}
+
+	a.tenant.reporter.ReportLoadingFailed(procID, program, testError)
+
+	require.Len(t, diagUploader.messages, 4)
+	errorCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusError &&
+			msg.Debugger.Diagnostic.DiagnosticException.Type == "LoadingFailed" {
+			assert.Equal(t, testError.Error(), msg.Debugger.Diagnostic.DiagnosticException.Message)
+			assert.Contains(t, []string{"probe-1", "probe-2"}, msg.Debugger.Diagnostic.ProbeID)
+			errorCount++
+		}
+	}
+	assert.Equal(t, 2, errorCount)
+}
+
+// TestController_DecoderCreationFailure verifies that decoder creation
+// failures are properly handled and reported during program loading.
+func TestController_DecoderCreationFailure(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	decoderFactory := &fakeDecoderFactory{err: errors.New("decoder creation failed")}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(a, logUploaderFactory, diagUploader, scraper, decoderFactory)
+	controller.CheckForUpdates()
+
+	sink, err := a.tenant.reporter.ReportLoaded(procID, processUpdate.Executable, program)
+	require.Error(t, err)
+	require.Nil(t, sink)
+	assert.Contains(t, err.Error(), "creating decoder")
+}
+
+// TestController_EventDecodingSuccess verifies successful event decoding,
+// log uploading, and probe emitting diagnostic generation.
+func TestController_EventDecodingSuccess(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	probe := createTestProbe("probe-1")
+	decoder := &fakeDecoder{probe: probe, output: `{"test": "data"}`}
+	decoderFactory := &fakeDecoderFactory{decoder: decoder}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(a, logUploaderFactory, diagUploader, scraper, decoderFactory)
+
+	controller.CheckForUpdates()
+
+	sink, err := a.tenant.reporter.ReportLoaded(procID, processUpdate.Executable, program)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	testEvent := decode.Event{
+		Event:       []byte("test event data"),
+		ServiceName: processUpdate.Service,
+	}
+	err = sink.HandleEvent(testEvent.Event)
+	require.NoError(t, err)
+	require.Len(t, decoder.decodeCalls, 1)
+	call := decoder.decodeCalls[0]
+	require.Equal(t, testEvent, call.event)
+	require.Len(t, logUploaderFactory.uploaders, 1)
+	logUploader, ok := logUploaderFactory.uploaders[uploader.LogsUploaderMetadata{}]
+	require.True(t, ok)
+
+	require.Len(t, logUploader.messages, 1)
+	assert.Equal(t, json.RawMessage(`{"test": "data"}`), logUploader.messages[0])
+
+	emittingCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusEmitting &&
+			msg.Debugger.Diagnostic.ProbeID == "probe-1" {
+			emittingCount++
+		}
+	}
+	assert.Equal(t, 1, emittingCount)
+}
+
+// TestController_EventDecodingFailure verifies that event decoding failures
+// are handled gracefully and reported as probe error diagnostics.
+func TestController_EventDecodingFailure(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	probe := createTestProbe("probe-1")
+	decoder := &fakeDecoder{probe: probe, err: errors.New("decode failed")}
+	decoderFactory := &fakeDecoderFactory{decoder: decoder}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	program := createTestProgram()
+	procID := processUpdate.ProcessID
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(a, logUploaderFactory, diagUploader, scraper, decoderFactory)
+
+	controller.CheckForUpdates()
+
+	sink, err := a.tenant.reporter.ReportLoaded(procID, processUpdate.Executable, program)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+
+	testEvent := decode.Event{}
+	err = sink.HandleEvent(testEvent.Event)
+	require.NoError(t, err)
+
+	errorCount := 0
+	for _, msg := range diagUploader.messages {
+		if msg.Debugger.Diagnostic.Status == uploader.StatusError &&
+			msg.Debugger.Diagnostic.DiagnosticException.Type == "DecodeFailed" &&
+			msg.Debugger.Diagnostic.ProbeID == "probe-1" {
+			errorCount++
+		}
+	}
+	assert.Equal(t, 1, errorCount)
+}
+
+// TestController_ProcessRemoval verifies that process removals are properly
+// handled by updating the internal state and notifying the actuator.
+func TestController_ProcessRemoval(t *testing.T) {
+	scraper := &fakeScraper{}
+	a := &fakeActuator{}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate := createTestProcessUpdate()
+	removals := []procmon.ProcessID{processUpdate.ProcessID}
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
+
+	controller := module.NewController(a, logUploaderFactory, diagUploader, scraper, decoderFactory)
+	at := a.tenant
+
+	controller.CheckForUpdates()
+	require.Len(t, at.updates, 1)
+
+	controller.HandleRemovals(removals)
+
+	require.Len(t, at.updates, 2)
+	require.Equal(t, at.updates[0], actuator.ProcessesUpdate{
+		Processes: []actuator.ProcessUpdate{
+			{
+				ProcessID:  processUpdate.ProcessID,
+				Executable: processUpdate.Executable,
+				Probes:     processUpdate.Probes,
+			},
+		},
+	})
+	require.Equal(t, at.updates[1], actuator.ProcessesUpdate{
+		Removals: removals,
+	})
+}
+
+// TestController_MultipleProcesses verifies that the controller can handle
+// multiple processes in a single update, generating diagnostics for all probes
+// across all processes.
+func TestController_MultipleProcesses(t *testing.T) {
+	scraper := &fakeScraper{}
+	actuator := &fakeActuator{t: t}
+	decoderFactory := &fakeDecoderFactory{}
+	diagUploader := &fakeDiagnosticsUploader{}
+	logUploaderFactory := &fakeLogsUploaderFactory{}
+
+	processUpdate1 := createTestProcessUpdate()
+	processUpdate1.ProcessID = procmon.ProcessID{PID: 12345}
+	processUpdate1.Service = "service-1"
+	processUpdate1.RuntimeID = "runtime-1"
+
+	processUpdate2 := createTestProcessUpdate()
+	processUpdate2.ProcessID = procmon.ProcessID{PID: 67890}
+	processUpdate2.Service = "service-2"
+	processUpdate2.RuntimeID = "runtime-2"
+
+	scraper.updates = []rcscrape.ProcessUpdate{processUpdate1, processUpdate2}
+
+	controller := module.NewController(actuator, logUploaderFactory, diagUploader, scraper, decoderFactory)
+
+	controller.CheckForUpdates()
+
+	require.Len(t, actuator.tenant.updates, 1)
+	actualUpdate := actuator.tenant.updates[0]
+	require.Len(t, actualUpdate.Processes, 2)
+
+	assert.Len(t, diagUploader.messages, 4)
+	for _, msg := range diagUploader.messages {
+		assert.Equal(t, uploader.StatusReceived, msg.Debugger.Diagnostic.Status)
+	}
+}

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"io"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
+)
+
+// Scraper is an interface that enables the Controller to get updates from the
+// scraper and to set the probe status to emitting.
+type Scraper interface {
+	// GetUpdates returns the current set of updates.
+	GetUpdates() []rcscrape.ProcessUpdate
+}
+
+// DecoderFactory is a factory for creating decoders.
+type DecoderFactory interface {
+	NewDecoder(*ir.Program) (Decoder, error)
+}
+
+// Decoder is a decoder for a program.
+type Decoder interface {
+	// Decode writes the decoded event to the output writer and returns the
+	// relevant probe definition.
+	Decode(
+		event decode.Event,
+		symbolicator symbol.Symbolicator,
+		out io.Writer,
+	) (ir.ProbeDefinition, error)
+}
+
+// DefaultDecoderFactory is the default decoder factory.
+type DefaultDecoderFactory struct{}
+
+// NewDecoder creates a new decoder using decode.NewDecoder.
+func (DefaultDecoderFactory) NewDecoder(program *ir.Program) (Decoder, error) {
+	decoder, err := decode.NewDecoder(program)
+	if err != nil {
+		return nil, err
+	}
+	return decoder, nil
+}

--- a/pkg/dyninst/module/diagnostics.go
+++ b/pkg/dyninst/module/diagnostics.go
@@ -47,14 +47,14 @@ func (e *diagnosticTracker) mark(runtimeID string, probeID string) (first bool) 
 }
 
 type diagnosticsManager struct {
-	uploader  *uploader.DiagnosticsUploader
+	uploader  DiagnosticsUploader
 	received  *diagnosticTracker
 	installed *diagnosticTracker
 	emitted   *diagnosticTracker
 	errors    *diagnosticTracker
 }
 
-func newDiagnosticsManager(uploader *uploader.DiagnosticsUploader) *diagnosticsManager {
+func newDiagnosticsManager(uploader DiagnosticsUploader) *diagnosticsManager {
 	return &diagnosticsManager{
 		uploader:  uploader,
 		received:  newDiagnosticTracker("received"),

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -30,7 +30,7 @@ import (
 type Module struct {
 	procMon       *procmon.ProcessMonitor
 	actuator      *actuator.Actuator
-	controller    *controller
+	controller    *Controller
 	cancel        context.CancelFunc
 	logUploader   *uploader.LogsUploaderFactory
 	diagsUploader *uploader.DiagnosticsUploader
@@ -43,7 +43,10 @@ type Module struct {
 }
 
 // NewModule creates a new dynamic instrumentation module
-func NewModule(config *Config, subscriber process.Subscriber) (_ *Module, retErr error) {
+func NewModule(
+	config *Config,
+	subscriber process.Subscriber,
+) (_ *Module, retErr error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		if retErr != nil {
@@ -70,7 +73,9 @@ func NewModule(config *Config, subscriber process.Subscriber) (_ *Module, retErr
 
 	actuator := actuator.NewActuator(loader)
 	rcScraper := rcscrape.NewScraper(actuator)
-	controller := newController(actuator, logUploader, diagsUploader, rcScraper)
+	controller := NewController(
+		actuator, logUploader, diagsUploader, rcScraper, DefaultDecoderFactory{},
+	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
 		actuator:       controller.actuator,
 		scraperHandler: rcScraper.AsProcMonHandler(),

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
@@ -97,7 +98,10 @@ func NewModule(
 			log.Errorf("error syncing process monitor: %v", err)
 		}
 	}()
-	go controller.Run(ctx)
+	// This is arbitrary. It's fast enough to not be a major source of
+	// latency and slow enough to not be a problem.
+	const defaultInterval = 200 * time.Millisecond
+	go controller.Run(ctx, defaultInterval)
 	return m, nil
 }
 

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -78,7 +78,6 @@ func NewModule(
 		actuator, logUploader, diagsUploader, rcScraper, DefaultDecoderFactory{},
 	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
-		actuator:       controller.actuator,
 		scraperHandler: rcScraper.AsProcMonHandler(),
 		controller:     controller,
 	})

--- a/pkg/dyninst/module/prochandler.go
+++ b/pkg/dyninst/module/prochandler.go
@@ -13,7 +13,7 @@ import (
 )
 
 type processHandler struct {
-	controller     *controller
+	controller     *Controller
 	actuator       *actuator.Tenant
 	scraperHandler procmon.Handler
 }

--- a/pkg/dyninst/module/prochandler.go
+++ b/pkg/dyninst/module/prochandler.go
@@ -8,24 +8,17 @@
 package module
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 )
 
 type processHandler struct {
 	controller     *Controller
-	actuator       ActuatorTenant
 	scraperHandler procmon.Handler
 }
 
 var _ procmon.Handler = (*processHandler)(nil)
 
 func (c *processHandler) HandleUpdate(update procmon.ProcessesUpdate) {
-	c.controller.store.remove(update.Removals)
-	if len(update.Removals) > 0 {
-		c.actuator.HandleUpdate(actuator.ProcessesUpdate{
-			Removals: update.Removals,
-		})
-	}
+	c.controller.handleRemovals(update.Removals)
 	c.scraperHandler.HandleUpdate(update)
 }

--- a/pkg/dyninst/module/prochandler.go
+++ b/pkg/dyninst/module/prochandler.go
@@ -14,7 +14,7 @@ import (
 
 type processHandler struct {
 	controller     *Controller
-	actuator       *actuator.Tenant
+	actuator       ActuatorTenant
 	scraperHandler procmon.Handler
 }
 

--- a/pkg/dyninst/module/reporter.go
+++ b/pkg/dyninst/module/reporter.go
@@ -109,6 +109,19 @@ func (c *controllerReporter) ReportLoaded(
 		containerID = ci.ContainerID
 		entityID = ci.EntityID
 	}
+	for i := range program.Issues {
+		issue := &program.Issues[i]
+		issueErr := (*irIssueError)(&issue.Issue)
+		if ctrl.diagnostics.reportError(
+			runtimeID, issue.ProbeDefinition, issueErr, issue.Kind.String(),
+		) {
+			log.Debugf(
+				"reported issue %v for probe %v %v: %v",
+				issue.Kind, issue.ProbeDefinition.GetID(),
+				issue.ProbeDefinition.GetVersion(), issueErr,
+			)
+		}
+	}
 
 	s := &sink{
 		controller:   ctrl,
@@ -124,6 +137,10 @@ func (c *controllerReporter) ReportLoaded(
 	}
 	return s, nil
 }
+
+type irIssueError ir.Issue
+
+func (e *irIssueError) Error() string { return e.Message }
 
 // ReportLoadingFailed implements actuator.Reporter.
 func (c *controllerReporter) ReportLoadingFailed(

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -41,12 +41,21 @@ var decodingErrorLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 10)
 
 func (s *sink) HandleEvent(event output.Event) error {
 	var buf bytes.Buffer
-	// TODO: Find a way to report a partial failure of a single probe.
 	probe, err := s.decoder.Decode(decode.Event{
 		Event:       event,
 		ServiceName: s.service,
 	}, s.symbolicator, &buf)
 	if err != nil {
+		if probe != nil {
+			reported := s.controller.reportProbeError(s.programID, probe, err, "DecodeFailed")
+			if !reported {
+				log.Warnf(
+					"failed to report probe error for probe %s in service %s: %v",
+					probe.GetID(), s.service, err,
+				)
+			}
+			return nil
+		}
 		if decodingErrorLogLimiter.Allow() {
 			log.Warnf(
 				"failed to decode event in service %s: %v",

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -30,7 +29,7 @@ type sink struct {
 	symbolicator symbol.Symbolicator
 	programID    ir.ProgramID
 	service      string
-	logUploader  *uploader.LogsUploader
+	logUploader  LogsUploader
 }
 
 var _ actuator.Sink = &sink{}

--- a/pkg/dyninst/module/utils_test.go
+++ b/pkg/dyninst/module/utils_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+)
+
+// CheckForUpdates is a test helper that calls the private method
+// checkForUpdates.
+func (c *Controller) CheckForUpdates() {
+	c.checkForUpdates()
+}
+
+// HandleRemovals is a test helper that calls the private method
+// handleRemovals.
+func (c *Controller) HandleRemovals(removals []procmon.ProcessID) {
+	c.handleRemovals(removals)
+}


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that the Go DI subsystem doesn't eagerly bail out in the case
of decoding failures, and generally reports those failures to the backend.

### Motivation

When QA'ing the release we found a bug that lead to decoding failures that then, out of
an abundance of caution, led to the entire subsystem shutting down on that agent. It also
didn't report anything about those probes to the backend.

### Describe how you validated your changes

Local testing.

### Additional Notes

We need a better story to remove the probe but that won't be backportable.