### PR TITLE
[Backport 7.69.x] dyninst/procmon: quiet some logs (#38852)

### DIFF
--- a/pkg/dyninst/procmon/analyze_test.go
+++ b/pkg/dyninst/procmon/analyze_test.go
@@ -96,7 +96,7 @@ func TestAnalyzeProcess(t *testing.T) {
 		_, procRoot, cleanup := makeProcFS(t, 103, envTrue, false)
 		defer cleanup()
 		res, err := analyzeProcess(103, procRoot)
-		require.Regexp(t, "failed to open exe link for pid 103.*: no such file or directory", err)
+		require.NoError(t, err)
 		require.False(t, res.interesting)
 	})
 

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -126,6 +126,10 @@ func (pm *ProcessMonitor) Close() {
 // It is set to infinite in tests.
 var analysisFailureLogLimiter = rate.NewLimiter(rate.Every(1*time.Second), 10)
 
+// Limit the rate of logging permission errors, because if we see them, we'll
+// probably see a lot of them.
+var analysisFailurePermissionLogLimiter = rate.NewLimiter(rate.Every(10*time.Minute), 10)
+
 // analyzeProcess analyzes the process with the given PID and sends the result
 // to the state machine.
 func (pm *ProcessMonitor) analyzeProcess(pid uint32) {
@@ -133,11 +137,17 @@ func (pm *ProcessMonitor) analyzeProcess(pid uint32) {
 	go func() {
 		defer pm.wg.Done()
 		pa, err := analyzeProcess(pid, pm.procfsRoot)
-		shouldLog := err != nil &&
-			!os.IsNotExist(err) &&
-			analysisFailureLogLimiter.Allow()
+		shouldLog := err != nil && analysisFailureLogLimiter.Allow()
 		if shouldLog {
-			log.Infof("failed to analyze process %d: %v", pid, err)
+			pid := pid
+			// We don't want to be too noisy about permission errors, but we do
+			// want to learn about them as they are a sign of a problem. Let's
+			// only info log about them every 10 minutes.
+			if !os.IsPermission(err) || analysisFailurePermissionLogLimiter.Allow() {
+				log.Infof("failed to analyze process %d: %v", pid, err)
+			} else {
+				log.Tracef("failed to analyze process %d: %v", pid, err)
+			}
 		}
 		pm.sendEvent(&analysisResult{
 			pid:             pid,


### PR DESCRIPTION
### What does this PR do?

Backport #38852 to 7.69.x. 

### Motivation

In QA for that release, we saw lots of logging about ESRCH and permissions issues which we should not log so frequently as they are common (they were limited to 1/s per host, but still).

See [this logs page](https://ddstaging.datadoghq.com/logs?query=service%3Asystem-probe%20dyninst%20%22failed%20to%20analyze%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1752681571610&to_ts=1752695971610&live=true).
