### PR TITLE
pkg/dyninst: Fix unsafe.Pointer capture/decoding

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -290,6 +290,9 @@ func (g *generator) addTypeHandler(t ir.Type) (FunctionID, bool, error) {
 
 	// Pointer or fat pointer types.
 
+	case *ir.VoidPointerType:
+		// Nothing to process. We don't know what the pointee is.
+
 	case *ir.PointerType:
 		g.typeQueue = append(g.typeQueue, t.Pointee)
 		needed = true
@@ -405,7 +408,7 @@ func (g *generator) typeMemoryLayout(t ir.Type) ([]memoryLayoutPiece, error) {
 				PaddedOffset: offset,
 				Size:         uint32(t.GetByteSize()),
 			})
-		case *ir.PointerType:
+		case *ir.PointerType, *ir.VoidPointerType:
 			pieces = append(pieces, memoryLayoutPiece{
 				PaddedOffset: offset,
 				Size:         uint32(t.GetByteSize()),

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -201,7 +201,8 @@ func (d *Decoder) encodeValue(
 	); err != nil {
 		return err
 	}
-	if err := d.encodeValueFields(enc,
+	if err := d.encodeValueFields(
+		enc,
 		dataItems,
 		currentlyEncoding,
 		irType,
@@ -233,6 +234,14 @@ func (d *Decoder) encodeValueFields(
 			return err
 		}
 		return encodeBaseTypeValue(enc, v, data)
+	case *ir.VoidPointerType:
+		if len(data) != 8 {
+			return errors.New("passed data not long enough for void pointer")
+		}
+		return writeTokens(enc,
+			jsontext.String("address"),
+			jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)),
+		)
 	case *ir.PointerType:
 		if len(data) < int(v.GetByteSize()) {
 			return errors.New("passed data not long enough for pointer")

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -58,6 +58,7 @@ var (
 	_ Type = (*StructureType)(nil)
 	_ Type = (*ArrayType)(nil)
 
+	_ Type = (*VoidPointerType)(nil)
 	_ Type = (*GoSliceHeaderType)(nil)
 	_ Type = (*GoSliceDataType)(nil)
 	_ Type = (*GoStringHeaderType)(nil)
@@ -107,6 +108,15 @@ type BaseType struct {
 }
 
 func (t *BaseType) irType() {}
+
+// VoidPointerType is a type that represents a pointer to a value of an unknown type.
+// unsafe.Pointer is such a type.
+type VoidPointerType struct {
+	TypeCommon
+	GoTypeAttributes
+}
+
+func (t *VoidPointerType) irType() {}
 
 // PointerType is a pointer type in the target program.
 type PointerType struct {

--- a/pkg/dyninst/irgen/type_catalog.go
+++ b/pkg/dyninst/irgen/type_catalog.go
@@ -253,7 +253,10 @@ func (c *typeCatalog) buildType(
 				Pointee:          pointee,
 			}, nil
 		}
-		return &ir.BaseType{
+		// unsafe.Pointer is a special case where the type is represented
+		// in DWARF as a PointerType, but without a pointee or specified Go kind.
+		goAttrs.GoKind = reflect.UnsafePointer
+		return &ir.VoidPointerType{
 			TypeCommon:       common,
 			GoTypeAttributes: goAttrs,
 		}, nil

--- a/pkg/dyninst/irgen/visit_type_references.go
+++ b/pkg/dyninst/irgen/visit_type_references.go
@@ -66,6 +66,7 @@ func visitTypeReferences(tc *typeCatalog, f func(t *ir.Type)) {
 		case *ir.GoSubroutineType:
 		case *ir.GoSwissMapGroupsType:
 		case *ir.GoSwissMapHeaderType:
+		case *ir.VoidPointerType:
 		default:
 			panic(fmt.Sprintf("unexpected ir.Type: %#v", t))
 		}

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -258,6 +258,7 @@ var allTypes = []reflect.Type{
 	reflect.TypeOf((*ir.GoSwissMapHeaderType)(nil)),
 	reflect.TypeOf((*ir.PointerType)(nil)),
 	reflect.TypeOf((*ir.StructureType)(nil)),
+	reflect.TypeOf((*ir.VoidPointerType)(nil)),
 }
 
 var typeMarshalers map[reflect.Type]*typeMarshaler

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -1,0 +1,38 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testUnsafePointer",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testUnsafePointer",
+          "location": {
+            "method": "main.testUnsafePointer"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "unsafe.Pointer",
+                "address": "[addr]"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -133,6 +133,13 @@ probes:
   where:
     methodName: main.testThreeStringsInStruct
   captureSnapshot: true
+- id: testUnsafePointer
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testUnsafePointer
+  captureSnapshot: true
 - id: testThreeStringsInStructPointer
   type: LOG_PROBE
   tags:


### PR DESCRIPTION
### What does this PR do?

- Defines a new `ir.VoidPointerType` which handles the case of unsafe.Pointers for Go
- Adds a test case for unsafe.Pointer

### Motivation

unsafe.Pointer arguments were breaking decoding because they lacked a reflect.Kind.

### Describe how you validated your changes

Added a test case in integration testing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->