### PR TITLE
[EBPF] gpu: use common container mapping in core check

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -9,6 +9,7 @@ package gpu
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -42,6 +43,9 @@ const (
 	metricNameMemoryUsage = gpuMetricsNs + "memory.usage"
 	metricNameMemoryLimit = gpuMetricsNs + "memory.limit"
 )
+
+// logLimitCheck is used to limit the number of times we log messages about streams and cuda events, as that can be very verbose
+var logLimitCheck = log.NewLogLimit(20, 10*time.Minute)
 
 // Check represents the GPU check that will be periodically executed via the Run() function
 type Check struct {
@@ -335,7 +339,7 @@ func (c *Check) getGPUToContainersMap() map[string][]*workloadmeta.Container {
 
 	for _, container := range wmetaContainers {
 		containerDevices, err := containers.MatchContainerDevices(container, c.deviceCache.All())
-		if err != nil {
+		if err != nil && logLimitCheck.ShouldLog() {
 			log.Warnf("error matching container devices: %s. Will continue with the available devices", err)
 		}
 

--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -3,11 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-// this file contains utilities to work with GPU assignment to containers
+//go:build nvml
 
-//go:build linux_bpf && nvml
-
-package gpu
+// Package containers has utilities to work with GPU assignment to containers
+package containers
 
 import (
 	"errors"
@@ -20,10 +19,13 @@ import (
 	gpuutil "github.com/DataDog/datadog-agent/pkg/util/gpu"
 )
 
-var errCannotMatchDevice = errors.New("cannot find matching device")
+// ErrCannotMatchDevice is returned when a device cannot be matched to a container
+var ErrCannotMatchDevice = errors.New("cannot find matching device")
 var numberedResourceRegex = regexp.MustCompile(`^nvidia([0-9]+)$`)
 
-func matchContainerDevices(container *workloadmeta.Container, devices []ddnvml.Device) ([]ddnvml.Device, error) {
+// MatchContainerDevices matches the devices assigned to a container to the list of available devices
+// It returns a list of devices that are assigned to the container, and an error if any of the devices cannot be matched
+func MatchContainerDevices(container *workloadmeta.Container, devices []ddnvml.Device) ([]ddnvml.Device, error) {
 	var filteredDevices []ddnvml.Device
 
 	var multiErr error
@@ -88,7 +90,7 @@ func findDeviceByUUID(devices []ddnvml.Device, uuid string) (ddnvml.Device, erro
 		}
 	}
 
-	return nil, fmt.Errorf("%w with uuid %s", errCannotMatchDevice, uuid)
+	return nil, fmt.Errorf("%w with uuid %s", ErrCannotMatchDevice, uuid)
 }
 
 func findDeviceByIndex(devices []ddnvml.Device, index int) (ddnvml.Device, error) {
@@ -98,5 +100,5 @@ func findDeviceByIndex(devices []ddnvml.Device, index int) (ddnvml.Device, error
 		}
 	}
 
-	return nil, fmt.Errorf("%w with index %d", errCannotMatchDevice, index)
+	return nil, fmt.Errorf("%w with index %d", ErrCannotMatchDevice, index)
 }

--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build nvml
+//go:build linux && nvml
 
 // Package containers has utilities to work with GPU assignment to containers
 package containers

--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux_bpf && nvml
+//go:build nvml
 
-package gpu
+package containers
 
 import (
 	"testing"
@@ -41,7 +41,7 @@ func TestMatchContainerDevices(t *testing.T) {
 			},
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 1)
 		assert.Equal(t, devices[1], filteredDevices[0])
@@ -65,7 +65,7 @@ func TestMatchContainerDevices(t *testing.T) {
 			},
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 2)
 		assert.Equal(t, devices[0], filteredDevices[0])
@@ -86,7 +86,7 @@ func TestMatchContainerDevices(t *testing.T) {
 			},
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 0)
 	})
@@ -100,7 +100,7 @@ func TestMatchContainerDevices(t *testing.T) {
 			ResolvedAllocatedResources: nil,
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 0)
 	})
@@ -119,10 +119,10 @@ func TestMatchContainerDevices(t *testing.T) {
 			},
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.Error(t, err)
 		require.Len(t, filteredDevices, 0)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 }
 
@@ -151,14 +151,14 @@ func TestFindDeviceForResourceName(t *testing.T) {
 		// Test with invalid UUID
 		_, err := findDeviceForResourceName(devices, "invalid-uuid")
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 
 	t.Run("EmptyResourceID", func(t *testing.T) {
 		// Test with empty resource ID
 		_, err := findDeviceForResourceName(devices, "")
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 
 	t.Run("UUIDBasedMIGDevice", func(t *testing.T) {
@@ -205,21 +205,21 @@ func TestFindDeviceByUUID(t *testing.T) {
 	t.Run("InvalidUUID", func(t *testing.T) {
 		_, err := findDeviceByUUID(devices, "invalid-uuid")
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 		assert.Contains(t, err.Error(), "invalid-uuid")
 	})
 
 	t.Run("EmptyUUID", func(t *testing.T) {
 		_, err := findDeviceByUUID(devices, "")
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 		assert.Contains(t, err.Error(), "")
 	})
 
 	t.Run("EmptyDeviceList", func(t *testing.T) {
 		_, err := findDeviceByUUID([]ddnvml.Device{}, testutil.GPUUUIDs[0])
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 }
 
@@ -288,21 +288,21 @@ func TestFindDeviceByIndex(t *testing.T) {
 	t.Run("InvalidIndex", func(t *testing.T) {
 		_, err := findDeviceByIndex(devices, 999)
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 		assert.Contains(t, err.Error(), "999")
 	})
 
 	t.Run("NegativeIndex", func(t *testing.T) {
 		_, err := findDeviceByIndex(devices, -1)
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 		assert.Contains(t, err.Error(), "-1")
 	})
 
 	t.Run("EmptyDeviceList", func(t *testing.T) {
 		_, err := findDeviceByIndex([]ddnvml.Device{}, 0)
 		require.Error(t, err)
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 }
 
@@ -335,11 +335,11 @@ func TestMatchContainerDevicesWithErrors(t *testing.T) {
 			},
 		}
 
-		filteredDevices, err := matchContainerDevices(container, devices)
+		filteredDevices, err := MatchContainerDevices(container, devices)
 		require.Error(t, err)              // Should have error due to invalid UUID
 		require.Len(t, filteredDevices, 2) // Should still return valid devices
 		assert.Equal(t, devices[1], filteredDevices[0])
 		assert.Equal(t, devices[2], filteredDevices[1])
-		require.ErrorIs(t, err, errCannotMatchDevice)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
 	})
 }

--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build nvml
+//go:build linux && nvml
 
 package containers
 

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -14,6 +14,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
+	"github.com/DataDog/datadog-agent/pkg/gpu/containers"
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -182,7 +183,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []ddnvml.Device, con
 		return nil, fmt.Errorf("cannot retrieve data for container %s: %s", containerID, err)
 	}
 
-	filteredDevices, err := matchContainerDevices(container, devices)
+	filteredDevices, err := containers.MatchContainerDevices(container, devices)
 
 	// Found matching devices, return them
 	if len(filteredDevices) > 0 {

--- a/pkg/gpu/safenvml/testutil/nvml.go
+++ b/pkg/gpu/safenvml/testutil/nvml.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build linux_bpf && test && nvml
+//go:build test && nvml
 
 // Package testutil provides utilities for testing the NVML package.
 package testutil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Uses the container mapping implemented in #38799 in the GPU core-check too, supporting GKE device ids.

### Motivation

Fix support in GKE.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests and manual validation.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->