### PR TITLE
[Backport 7.69.x][DEBUG-4190] dyninst/module: do not fail on decoding errors (#38864)

### DIFF
--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -1,0 +1,188 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2025 Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+)
+
+// TestDecoderErrorHandling tests that decoder errors do not cause the
+// entire subsystem to fail and shut down.
+func TestDecoderErrorHandling(t *testing.T) {
+	dyninsttest.SkipIfKernelNotSupported(t)
+	tmpDir, cleanup := dyninsttest.PrepTmpDir(t, "decoder-error-handling-test")
+	defer cleanup()
+
+	diagCh := make(chan []byte, 10)
+	backend := &mockBackend{diagPayloadCh: diagCh}
+	backendServer := httptest.NewServer(backend)
+	t.Cleanup(backendServer.Close)
+
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
+		return c.GOARCH == runtime.GOARCH
+	})
+	require.NotEqual(t, -1, idx)
+	cfg := cfgs[idx]
+
+	sampleServicePath := testprogs.MustGetBinary(t, "rc_tester", cfg)
+	sampleServiceCmd, serverPort, err := startSampleService(t, sampleServiceConfig{
+		binaryPath: sampleServicePath,
+		tmpDir:     tmpDir,
+	})
+	require.NoError(t, err)
+	probes := testprogs.MustGetProbeDefinitions(t, "rc_tester")
+
+	loader, err := loader.NewLoader()
+	require.NoError(t, err)
+	actuator := actuator.NewActuator(loader)
+	scraper := &mockScraper{}
+	logsURL, err := url.Parse(backendServer.URL + "/logs")
+	require.NoError(t, err)
+	diagURL, err := url.Parse(backendServer.URL + "/diags")
+	require.NoError(t, err)
+
+	c := module.NewController(
+		actuator,
+		uploader.NewLogsUploader(uploader.WithURL(logsURL)),
+		uploader.NewDiagnosticsUploader(uploader.WithURL(diagURL)),
+		scraper,
+		&failOnceDecoderFactory{
+			underlying: module.DefaultDecoderFactory{},
+		},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	for _, probe := range probes {
+		setSnapshotsPerSecond(t, probe, 100)
+	}
+
+	scraper.setUpdates([]rcscrape.ProcessUpdate{
+		{
+			ProcessUpdate: procmon.ProcessUpdate{
+				ProcessID: procmon.ProcessID{PID: int32(sampleServiceCmd.Process.Pid)},
+				Executable: procmon.Executable{
+					Path: sampleServicePath,
+				},
+				Service: "rc_tester",
+			},
+			RuntimeID: "foo",
+			Probes:    probes,
+		},
+	})
+
+	// This will result in one decoding failure and then the probes will
+	// continue to emit and so we'll eventually go to the expected number
+	// of logs.
+	expectedProbeIDs := []string{"look_at_the_request", "http_handler"}
+	waitForProbeStatus(t, diagCh, uploader.StatusInstalled, expectedProbeIDs)
+	t.Log("Sending requests to trigger probes...")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				sendTestRequests(t, serverPort, 1)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	waitForLogMessages(t, backend, 10, "")
+}
+
+type mockScraper struct {
+	mu struct {
+		sync.Mutex
+		updates []rcscrape.ProcessUpdate
+	}
+}
+
+func (s *mockScraper) GetUpdates() []rcscrape.ProcessUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.mu.updates)
+}
+
+func (s *mockScraper) setUpdates(updates []rcscrape.ProcessUpdate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.updates = updates
+}
+
+type failOnceDecoderFactory struct {
+	underlying module.DecoderFactory
+	failed     atomic.Bool
+}
+
+func (f *failOnceDecoderFactory) NewDecoder(
+	program *ir.Program,
+) (module.Decoder, error) {
+	decoder, err := f.underlying.NewDecoder(program)
+	if err != nil {
+		return nil, err
+	}
+	if !f.failed.CompareAndSwap(false, true) {
+		return decoder, nil
+	}
+	return &failOnceDecoder{
+		underlying: decoder,
+	}, nil
+}
+
+type failOnceDecoder struct {
+	underlying module.Decoder
+	failed     atomic.Bool
+}
+
+func (d *failOnceDecoder) Decode(
+	event decode.Event, symbolicator symbol.Symbolicator, out io.Writer,
+) (ir.ProbeDefinition, error) {
+	if !d.failed.CompareAndSwap(false, true) {
+		return d.underlying.Decode(event, symbolicator, out)
+	}
+	return nil, errors.New("boom")
+}

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 )
 
@@ -28,29 +27,34 @@ type procRuntimeID struct {
 	gitInfo   *procmon.GitInfo
 }
 
-type controller struct {
-	rcScraper    *rcscrape.Scraper
-	actuator     *actuator.Tenant
-	diagUploader *uploader.DiagnosticsUploader
-	logUploader  *uploader.LogsUploader
-	store        *processStore
-	diagnostics  *diagnosticsManager
+// Controller is the main controller for the module.
+type Controller struct {
+	rcScraper      Scraper
+	actuator       *actuator.Tenant
+	diagUploader   *uploader.DiagnosticsUploader
+	logUploader    *uploader.LogsUploader
+	store          *processStore
+	diagnostics    *diagnosticsManager
+	decoderFactory DecoderFactory
 
 	procRuntimeIDbyProgramID sync.Map // map[ir.ProgramID]procRuntimeID
 }
 
-func newController(
+// NewController creates a new Controller.
+func NewController(
 	a *actuator.Actuator,
 	logUploader *uploader.LogsUploader,
 	diagUploader *uploader.DiagnosticsUploader,
-	rcScraper *rcscrape.Scraper,
-) *controller {
-	c := &controller{
-		logUploader:  logUploader,
-		diagUploader: diagUploader,
-		rcScraper:    rcScraper,
-		store:        newProcessStore(),
-		diagnostics:  newDiagnosticsManager(diagUploader),
+	rcScraper Scraper,
+	decoderFactory DecoderFactory,
+) *Controller {
+	c := &Controller{
+		logUploader:    logUploader,
+		diagUploader:   diagUploader,
+		rcScraper:      rcScraper,
+		store:          newProcessStore(),
+		diagnostics:    newDiagnosticsManager(diagUploader),
+		decoderFactory: decoderFactory,
 	}
 	c.actuator = a.NewTenant(
 		"dyninst", (*controllerReporter)(c), irgen.NewGenerator(),
@@ -63,7 +67,8 @@ func jitter(duration time.Duration, fraction float64) time.Duration {
 	return time.Duration(float64(duration) * multiplier)
 }
 
-func (c *controller) Run(ctx context.Context) {
+// Run runs the controller.
+func (c *Controller) Run(ctx context.Context) {
 	duration := func() time.Duration {
 		return jitter(200*time.Millisecond, 0.2)
 	}
@@ -80,7 +85,7 @@ func (c *controller) Run(ctx context.Context) {
 	}
 }
 
-func (c *controller) checkForUpdates() {
+func (c *Controller) checkForUpdates() {
 	scraperUpdates := c.rcScraper.GetUpdates()
 	actuatorUpdates := make([]actuator.ProcessUpdate, 0, len(scraperUpdates))
 	for i := range scraperUpdates {
@@ -103,7 +108,7 @@ func (c *controller) checkForUpdates() {
 	}
 }
 
-func (c *controller) setProbeMaybeEmitting(progID ir.ProgramID, probe ir.ProbeDefinition) {
+func (c *Controller) setProbeMaybeEmitting(progID ir.ProgramID, probe ir.ProbeDefinition) {
 	procRuntimeIDi, ok := c.procRuntimeIDbyProgramID.Load(progID)
 	if !ok {
 		return

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"io"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
+)
+
+// Scraper is an interface that enables the Controller to get updates from the
+// scraper and to set the probe status to emitting.
+type Scraper interface {
+	// GetUpdates returns the current set of updates.
+	GetUpdates() []rcscrape.ProcessUpdate
+}
+
+// DecoderFactory is a factory for creating decoders.
+type DecoderFactory interface {
+	NewDecoder(*ir.Program) (Decoder, error)
+}
+
+// Decoder is a decoder for a program.
+type Decoder interface {
+	// Decode writes the decoded event to the output writer and returns the
+	// relevant probe definition.
+	Decode(
+		event decode.Event,
+		symbolicator symbol.Symbolicator,
+		out io.Writer,
+	) (ir.ProbeDefinition, error)
+}
+
+// DefaultDecoderFactory is the default decoder factory.
+type DefaultDecoderFactory struct{}
+
+// NewDecoder creates a new decoder using decode.NewDecoder.
+func (DefaultDecoderFactory) NewDecoder(program *ir.Program) (Decoder, error) {
+	decoder, err := decode.NewDecoder(program)
+	if err != nil {
+		return nil, err
+	}
+	return decoder, nil
+}

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -30,7 +30,7 @@ import (
 type Module struct {
 	procMon       *procmon.ProcessMonitor
 	actuator      *actuator.Actuator
-	controller    *controller
+	controller    *Controller
 	cancel        context.CancelFunc
 	logUploader   *uploader.LogsUploader
 	diagsUploader *uploader.DiagnosticsUploader
@@ -43,7 +43,10 @@ type Module struct {
 }
 
 // NewModule creates a new dynamic instrumentation module
-func NewModule(config *Config, subscriber process.Subscriber) (_ *Module, retErr error) {
+func NewModule(
+	config *Config,
+	subscriber process.Subscriber,
+) (_ *Module, retErr error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		if retErr != nil {
@@ -70,7 +73,9 @@ func NewModule(config *Config, subscriber process.Subscriber) (_ *Module, retErr
 
 	actuator := actuator.NewActuator(loader)
 	rcScraper := rcscrape.NewScraper(actuator)
-	controller := newController(actuator, logUploader, diagsUploader, rcScraper)
+	controller := NewController(
+		actuator, logUploader, diagsUploader, rcScraper, DefaultDecoderFactory{},
+	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
 		actuator:       controller.actuator,
 		scraperHandler: rcScraper.AsProcMonHandler(),

--- a/pkg/dyninst/module/prochandler.go
+++ b/pkg/dyninst/module/prochandler.go
@@ -13,7 +13,7 @@ import (
 )
 
 type processHandler struct {
-	controller     *controller
+	controller     *Controller
 	actuator       *actuator.Tenant
 	scraperHandler procmon.Handler
 }

--- a/pkg/dyninst/module/reporter.go
+++ b/pkg/dyninst/module/reporter.go
@@ -11,18 +11,17 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-type controllerReporter controller
+type controllerReporter Controller
 
 // ReportAttached implements actuator.Reporter.
 func (c *controllerReporter) ReportAttached(
 	procID actuator.ProcessID, program *ir.Program,
 ) {
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	ctrl.store.link(program.ID, procID)
 
 	runtimeID, ok := ctrl.store.getRuntimeID(procID)
@@ -40,7 +39,7 @@ func (c *controllerReporter) ReportAttachingFailed(
 	procID actuator.ProcessID, program *ir.Program, err error,
 ) {
 	log.Errorf("attaching program %v to process %v failed: %v", program.ID, procID, err)
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	runtimeID, ok := ctrl.store.getRuntimeID(procID)
 	if !ok {
 		return
@@ -56,7 +55,7 @@ func (c *controllerReporter) ReportAttachingFailed(
 func (c *controllerReporter) ReportDetached(
 	_ actuator.ProcessID, program *ir.Program,
 ) {
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	ctrl.store.unlink(program.ID)
 	ctrl.procRuntimeIDbyProgramID.Delete(program.ID)
 }
@@ -68,7 +67,7 @@ func (c *controllerReporter) ReportIRGenFailed(
 	probes []ir.ProbeDefinition,
 ) {
 	log.Errorf("IR generation for process %v failed: %v", procID, err)
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	runtimeID, ok := ctrl.store.getRuntimeID(procID)
 	if !ok {
 		return
@@ -84,7 +83,7 @@ func (c *controllerReporter) ReportLoaded(
 	executable actuator.Executable,
 	program *ir.Program,
 ) (actuator.Sink, error) {
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	// The process must have already exited.
 	runtimeID, ok := ctrl.store.updateOnLoad(procID, executable, program.ID)
 	if !ok {
@@ -92,7 +91,7 @@ func (c *controllerReporter) ReportLoaded(
 	}
 	ctrl.procRuntimeIDbyProgramID.Store(program.ID, runtimeID)
 
-	decoder, err := decode.NewDecoder(program)
+	decoder, err := ctrl.decoderFactory.NewDecoder(program)
 	if err != nil {
 		return nil, fmt.Errorf("creating decoder: %w", err)
 	}
@@ -120,7 +119,7 @@ func (c *controllerReporter) ReportLoadingFailed(
 	procID actuator.ProcessID, program *ir.Program, err error,
 ) {
 	log.Errorf("loading program %v to process %v failed: %v", program.ID, procID, err)
-	ctrl := (*controller)(c)
+	ctrl := (*Controller)(c)
 	ctrl.procRuntimeIDbyProgramID.Delete(program.ID)
 	runtimeID, ok := ctrl.store.getRuntimeID(procID)
 	if !ok {


### PR DESCRIPTION
### What does this PR do?

We must not return an error from the sink handler because it will lead to the entire subsystem shutting down. Rare issues can lead to the agent needing to be restarted. This is a major problem for the new feature. The intention is to backport this change.

### Motivation

We saw in QA that decoding errors (see https://github.com/DataDog/datadog-agent/pull/38861) can lead to the entire subsystem shutting down. We need to keep the subsystem alive despite these issues.

### Describe how you validated your changes

The change includes a test that exercises this code path.

### Possible Drawbacks / Trade-offs

For the next release we need to do more: we should unhook the probe and report the error. Those changes wouldn't be backportable, so this is pulled out separately.