### PR TITLE
Run automated deploy jobs immediately when trigger_distribution pipeline is created

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -17,6 +17,7 @@
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []
 
 # will push the `7.xx.y` tags
 deploy_containers-cws-instrumentation-final-versioned:

--- a/.gitlab/deploy_dca/deploy_dca.yml
+++ b/.gitlab/deploy_dca/deploy_dca.yml
@@ -17,10 +17,12 @@
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []
 
 deploy_containers-dca_internal-rc:
   extends: .deploy_containers-dca-base
   rules: !reference [.on_deploy_internal_rc]
+  needs: []
 
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
@@ -40,10 +42,12 @@ deploy_containers-dca_internal:
 deploy_containers-dca-fips:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []
 
 deploy_containers-dca-fips_internal-rc:
   extends: .deploy_containers-dca-fips-base
   rules: !reference [.on_deploy_internal_rc]
+  needs: []
 
 deploy_containers-dca-fips_internal:
   extends: .deploy_containers-dca-fips-base

--- a/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
+++ b/.gitlab/deploy_ot_standalone/deploy_ot_standalone.yml
@@ -16,12 +16,14 @@
 deploy_containers-ot-standalone:
   extends: .deploy_containers-ot-standalone-base
   rules: !reference [.on_deploy_manual_auto_on_rc]
+  needs: []
 
 # Jobs to publish images to our internal registries.
 
 deploy_containers-ot-standalone_internal-rc:
   extends: .deploy_containers-ot-standalone-base
   rules: !reference [.on_deploy_internal_rc]
+  needs: []
 
 deploy_containers-ot-standalone_internal:
   extends: .deploy_containers-ot-standalone-base


### PR DESCRIPTION
### What does this PR do?

This PR sets jobs in `deploy_containers`, `deploy_dca` and `deploy_cws_instrumentation` stages to run independently form the others and not wait/be blocked in case previous stages fail. Only jobs which can be set as automatic are affected - the only manual jobs stay the same.

### Motivation

Faster and more reliable deploy pipeline.
