### PR TITLE
[DEBUG-3883] dyninst/object: handle binaries with mixed dwarf

### DIFF
--- a/pkg/dyninst/dwarf/loclist/reader.go
+++ b/pkg/dyninst/dwarf/loclist/reader.go
@@ -19,24 +19,27 @@ import (
 
 // Reader reads DWARF loclists.
 type Reader struct {
-	data              []byte
-	debugAddr         []byte
-	ptrSize           uint8
-	unitVersionGetter func(unit *dwarf.Entry) (uint8, bool)
+	dataLoc      []byte
+	dataLocLists []byte
+	debugAddr    []byte
+	ptrSize      uint8
+	unitVersions map[dwarf.Offset]uint8
 }
 
 // NewReader creates a new Reader.
 func NewReader(
-	data []byte,
+	dataLoc []byte,
+	dataLocLists []byte,
 	debugAddr []byte,
 	ptrSize uint8,
-	unitVersionGetter func(unit *dwarf.Entry) (uint8, bool),
+	unitVersions map[dwarf.Offset]uint8,
 ) *Reader {
 	return &Reader{
-		data:              data,
-		debugAddr:         debugAddr,
-		ptrSize:           ptrSize,
-		unitVersionGetter: unitVersionGetter,
+		dataLoc:      dataLoc,
+		dataLocLists: dataLocLists,
+		debugAddr:    debugAddr,
+		ptrSize:      ptrSize,
+		unitVersions: unitVersions,
 	}
 }
 
@@ -47,18 +50,37 @@ type Loclist struct {
 }
 
 func (r *Reader) Read(unit *dwarf.Entry, offset int64, typeByteSize uint32) (Loclist, error) {
-	unitVersion, ok := r.unitVersionGetter(unit)
+	unitVersion, ok := r.unitVersions[unit.Offset]
 	if !ok {
 		return Loclist{}, fmt.Errorf("no unit version found for unit at offset 0x%x", unit.Offset)
 	}
 	if unitVersion < 2 {
 		return Loclist{}, fmt.Errorf("unsupported unit version: %d", unitVersion)
 	}
-
-	if offset > int64(len(r.data)) {
-		return Loclist{}, fmt.Errorf("loclist offset %d out of bounds for section length %d", offset, len(r.data))
+	var section []byte
+	if unitVersion < 5 {
+		if r.dataLoc == nil {
+			unitName, _ := unit.Val(dwarf.AttrName).(string)
+			return Loclist{}, fmt.Errorf(
+				"missing .debug_loc section for unit %q (offset 0x%x) with version %d",
+				unitName, unit.Offset, unitVersion,
+			)
+		}
+		section = r.dataLoc
+	} else {
+		if r.dataLocLists == nil {
+			unitName, _ := unit.Val(dwarf.AttrName).(string)
+			return Loclist{}, fmt.Errorf(
+				"missing .debug_loclists section for unit %q (offset 0x%x) with version %d",
+				unitName, unit.Offset, unitVersion,
+			)
+		}
+		section = r.dataLocLists
 	}
-	data := r.data[offset:]
+	if offset > int64(len(section)) {
+		return Loclist{}, fmt.Errorf("loclist offset %d out of bounds for section length %d", offset, len(section))
+	}
+	data := section[offset:]
 	var loclist Loclist
 	var err error
 	if unitVersion < 5 {

--- a/pkg/dyninst/gosym/cli/symbol.go
+++ b/pkg/dyninst/gosym/cli/symbol.go
@@ -33,7 +33,7 @@ func run(binary string, pc uint64) error {
 		return err
 	}
 	defer func() { err = errors.Join(err, goDebugSections.Close()) }()
-	goVersion, err := object.ParseGoVersion(mef)
+	goVersion, err := object.ReadGoVersion(mef)
 	if err != nil {
 		return err
 	}

--- a/pkg/dyninst/gosym/symtab_benchmark_test.go
+++ b/pkg/dyninst/gosym/symtab_benchmark_test.go
@@ -45,7 +45,7 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	goVersion, err := object.ParseGoVersion(mef)
+	goVersion, err := object.ReadGoVersion(mef)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/dyninst/gosym/symtab_test.go
+++ b/pkg/dyninst/gosym/symtab_test.go
@@ -64,7 +64,7 @@ func runTest(
 	moduledata, err := object.ParseModuleData(obj.Underlying)
 	require.NoError(t, err)
 
-	goVersion, err := object.ParseGoVersion(obj.Underlying)
+	goVersion, err := object.ReadGoVersion(obj.Underlying)
 	require.NoError(t, err)
 
 	goDebugSections, err := moduledata.GoDebugSections(obj.Underlying)

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -247,7 +247,7 @@ func testDyninst(
 	moduledata, err := object.ParseModuleData(obj.Underlying)
 	require.NoError(t, err)
 
-	goVersion, err := object.ParseGoVersion(obj.Underlying)
+	goVersion, err := object.ReadGoVersion(obj.Underlying)
 	require.NoError(t, err)
 
 	goDebugSections, err := moduledata.GoDebugSections(obj.Underlying)

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -30,6 +30,7 @@ import (
 	"maps"
 	"math"
 	"reflect"
+	"runtime/debug"
 	"slices"
 	"strings"
 
@@ -119,7 +120,7 @@ func generateIR(
 		case error:
 			retErr = pkgerrors.Wrap(r, "GenerateIR: panic")
 		default:
-			retErr = pkgerrors.Errorf("GenerateIR: panic: %v", r)
+			retErr = pkgerrors.Errorf("GenerateIR: panic: %v\n%s", r, debug.Stack())
 		}
 	}()
 
@@ -128,10 +129,7 @@ func generateIR(
 	ptrSize := objFile.PointerSize()
 
 	d := objFile.DwarfData()
-	loclistReader, err := objFile.LoclistReader()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get loclist reader: %w", err)
-	}
+	loclistReader := objFile.LoclistReader()
 	v := &rootVisitor{
 		interests:           interests,
 		dwarf:               d,

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -8,13 +8,19 @@
 package irgen_test
 
 import (
+	"crypto/rand"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
@@ -26,6 +32,13 @@ import (
 func TestIRGenAllProbes(t *testing.T) {
 	programs := testprogs.MustGetPrograms(t)
 	cfgs := testprogs.MustGetCommonConfigs(t)
+	var objcopy string
+	{
+		if objcopyPath, err := exec.LookPath("objcopy"); err == nil {
+			objcopy = objcopyPath
+		}
+	}
+
 	for _, pkg := range programs {
 		switch pkg {
 		case "simple", "sample":
@@ -42,10 +55,45 @@ func TestIRGenAllProbes(t *testing.T) {
 				t.Run(cfg.String(), func(t *testing.T) {
 					bin := testprogs.MustGetBinary(t, pkg, cfg)
 					testAllProbes(t, bin)
+					version, ok := object.ParseGoVersion(cfg.GOTOOLCHAIN)
+					require.True(t, ok)
+					if version.Minor >= 25 {
+						return // already uses loclists
+					}
+					t.Run("bogus loclist", func(t *testing.T) {
+						tempDir, cleanup := dyninsttest.PrepTmpDir(t, "irgen_all_symbols_test")
+						defer cleanup()
+						modified, err := addLoclistSection(bin, objcopy, tempDir)
+						if err != nil {
+							t.Skipf("failed to objcopy a loclist section for %s: %v", cfg.String(), err)
+						}
+						testAllProbes(t, modified)
+					})
 				})
 			}
 		})
 	}
+}
+
+func addLoclistSection(binPath, objcopy, tmpDir string) (modifiedBinPath string, err error) {
+	junkDataFile := path.Join(tmpDir, "junk.data")
+	junkData := make([]byte, 1024)
+	if _, err := io.ReadFull(rand.Reader, junkData); err != nil {
+		return "", fmt.Errorf("failed to generate junk data: %w", err)
+	}
+	if err := os.WriteFile(junkDataFile, junkData, 0644); err != nil {
+		return "", fmt.Errorf("failed to write junk data: %w", err)
+	}
+	modifiedBinPath = filepath.Join(tmpDir, "modified.bin")
+	if output, err := exec.Command(objcopy,
+		"--add-section", ".debug_loclists="+junkDataFile,
+		"--set-section-flags", ".debug_loclists=alloc,readonly,debug",
+		binPath,
+		modifiedBinPath,
+	).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("failed to objcopy: %w\n%s", err, string(output))
+	}
+	return modifiedBinPath, nil
 }
 
 func testAllProbes(t *testing.T, binPath string) {

--- a/pkg/dyninst/module/symbol.go
+++ b/pkg/dyninst/module/symbol.go
@@ -58,7 +58,7 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ i
 		return nil, nil, fmt.Errorf("error parsing module data: %w", err)
 	}
 
-	goVersion, err := object.ParseGoVersion(mef)
+	goVersion, err := object.ReadGoVersion(mef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing go version: %w", err)
 	}

--- a/pkg/dyninst/object/elf.go
+++ b/pkg/dyninst/object/elf.go
@@ -77,22 +77,14 @@ func (e *ElfFile) DwarfSections() *DebugSections {
 }
 
 // LoclistReader implements File.
-func (e *ElfFile) LoclistReader() (*loclist.Reader, error) {
-	// Loclists replace Loc in DWARF 5. Here we do not need to recognize the version,
-	// just pick the section that exists.
-	var data []byte
-	if e.dwarfSections.LocLists != nil {
-		data = e.dwarfSections.LocLists
-	} else if e.dwarfSections.Loc != nil {
-		data = e.dwarfSections.Loc
-	} else {
-		return nil, fmt.Errorf("no loc/loclist section found")
-	}
-
-	return loclist.NewReader(data, e.dwarfSections.Addr, uint8(e.architecture.PointerSize()), func(unit *dwarf.Entry) (uint8, bool) {
-		unitVersion, ok := e.unitVersions[unit.Offset]
-		return unitVersion, ok
-	}), nil
+func (e *ElfFile) LoclistReader() *loclist.Reader {
+	return loclist.NewReader(
+		e.dwarfSections.Loc,
+		e.dwarfSections.LocLists,
+		e.dwarfSections.Addr,
+		uint8(e.architecture.PointerSize()),
+		e.unitVersions,
+	)
 }
 
 // Close implements File.

--- a/pkg/dyninst/object/object.go
+++ b/pkg/dyninst/object/object.go
@@ -30,7 +30,7 @@ type File interface {
 	DwarfData() *dwarf.Data
 	// LoclistReader returns a reader that can be used to read
 	// loclist entries. The reader is not safe for concurrent use.
-	LoclistReader() (*loclist.Reader, error)
+	LoclistReader() *loclist.Reader
 	// PointerSize returns the size of a pointer on the architecture of the object file.
 	PointerSize() uint8
 }


### PR DESCRIPTION
### What does this PR do?

We ran into an issue in the wild where a binary had some compile units at dwarf 5 from a C compiler and the go was using dwarf 4. Our logic to decide which section to use to read locations lists was too brittle -- it just preferred the loclists section if it existed. This fixes that bug and adds testign that would have caught it.

### Describe how you validated your changes

Added testing.

### Possible Drawbacks / Trade-offs

None.

### Additional Notes

This bug makes Go DI unusable against binaries that link C libraries that have dwarf. We see this with librdkafka unforunately.