### PR TITLE
upgrade to go-tuf version with the 5.3.11 TUF spec fix and fix transa…

### DIFF
--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -299,7 +299,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.43.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.6.0 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.31.0 // indirect

--- a/comp/otelcol/ddflareextension/impl/go.sum
+++ b/comp/otelcol/ddflareextension/impl/go.sum
@@ -44,8 +44,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 h1:jYkbxbh063O15NYxhUY3wedUURNrYpaLI8ra1GCsuk0=

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/DataDog/go-libddwaf/v3 v3.5.4 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 // indirect

--- a/comp/otelcol/ddprofilingextension/impl/go.sum
+++ b/comp/otelcol/ddprofilingextension/impl/go.sum
@@ -15,8 +15,8 @@ github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633/go.mod h1:YFoTl1xsMzdSRFIu33oCSPS/3+HZAPGpO3oOM96wXCM=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee/go.mod h1:nTot/Iy0kW16bXgXr6blEc8gFeAS7vTqYlhAxh+dbc0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.67.0 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.43.0 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.31.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
@@ -9,8 +9,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 h1:jYkbxbh063O15NYxhUY3wedUURNrYpaLI8ra1GCsuk0=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.67.0 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.43.0 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.31.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.31.0 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -9,8 +9,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 h1:jYkbxbh063O15NYxhUY3wedUURNrYpaLI8ra1GCsuk0=

--- a/comp/otelcol/otlp/components/statsprocessor/go.mod
+++ b/comp/otelcol/otlp/components/statsprocessor/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/comp/otelcol/otlp/components/statsprocessor/go.sum
+++ b/comp/otelcol/otlp/components/statsprocessor/go.sum
@@ -2,8 +2,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 h1:GAjMnaFCUT2Q+4jVFJ+r3SYIupqCc66NkU1Gm6AvHIg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0/go.mod h1:A3oj/VbBPuJ0ssrZS3B7hv0IuF7hy854TQ2XMjHwPnw=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=

--- a/go.mod
+++ b/go.mod
@@ -234,7 +234,7 @@ require (
 	github.com/AlekSi/pointer v1.2.0 // indirect
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/DataDog/aptly v1.5.3 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DisposaBoy/JsonConfigReader v0.0.0-20201129172854-99cf318d67e7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633/go.mod h1:YFoTl1xsMzdSRFIu33oCSPS/3+HZAPGpO3oOM96wXCM=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee/go.mod h1:nTot/Iy0kW16bXgXr6blEc8gFeAS7vTqYlhAxh+dbc0=
 github.com/DataDog/gopacket v0.0.0-20250206221735-64e5a8c92d94 h1:lSpWcdWc0gQRVBiPLvnDxO1GEzr8+yBcSSpkWpYSAIo=

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.59.0
+	github.com/DataDog/go-tuf v1.1.1-0.5.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/benbjohnson/clock v1.3.5
 	github.com/coreos/go-semver v0.3.1
@@ -52,7 +53,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1
-	github.com/DataDog/go-tuf v1.1.0-0.5.2
 	github.com/DataDog/viper v1.14.1-0.20250612143030-1b15c8822ed4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect

--- a/pkg/config/remote/go.sum
+++ b/pkg/config/remote/go.sum
@@ -10,8 +10,8 @@ cloud.google.com/go/compute v1.37.0/go.mod h1:AsK4VqrSyXBo4SMbRtfAO1VfaMjUEjEwv1
 cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeOCw78U8ytSU=
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/viper v1.14.1-0.20250612143030-1b15c8822ed4 h1:PwqhnH1ln2EjGm9XZGUF4RTCwLt0Jt4cebbZBTe+BnA=
 github.com/DataDog/viper v1.14.1-0.20250612143030-1b15c8822ed4/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/config/remote/uptane/client_test.go
+++ b/pkg/config/remote/uptane/client_test.go
@@ -156,14 +156,14 @@ func TestClientVerifyTUF(t *testing.T) {
 	previousConfigTargets := testRepository1.configTargets
 	client1, err := newTestClient(db, cfg)
 	assert.NoError(t, err)
-	testRepository1.configTargets = generateTargets(generateKey(), testRepository1.configTargetsVersion, nil)
+	testRepository1.configTargets = generateTargets(generateKey(), testRepository1.configTargetsVersion, nil, nil)
 	err = client1.Update(testRepository1.toUpdate())
 	assert.Error(t, err)
 
 	testRepository1.configTargets = previousConfigTargets
 	client2, err := newTestClient(db, cfg)
 	assert.NoError(t, err)
-	testRepository1.directorTargets = generateTargets(generateKey(), testRepository1.directorTargetsVersion, nil)
+	testRepository1.directorTargets = generateTargets(generateKey(), testRepository1.directorTargetsVersion, nil, nil)
 	err = client2.Update(testRepository1.toUpdate())
 	assert.Error(t, err)
 }
@@ -317,12 +317,106 @@ func TestOrgStore(t *testing.T) {
 	assert.Equal(t, "def", uuid)
 }
 
+// TestRollbackRejected asserts that a rollback attack is rejected
+func TestRollbackRejected(t *testing.T) {
+	target1content, target1 := generateTarget()
+	_, target2 := generateTarget()
+	target3Content, target3 := generateTarget()
+
+	configTargets := data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/2": target2,
+	}
+	directorTargets := data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+	}
+	targetFiles := []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: target1content}}
+
+	testRepository1 := newTestRepository(2, 1, configTargets, directorTargets, targetFiles)
+	cfg := newTestConfig(t, testRepository1)
+	db := getTestDB(t)
+
+	client1, err := newTestClient(db, cfg)
+	assert.NoError(t, err)
+	err = client1.Update(testRepository1.toUpdate())
+	assert.NoError(t, err)
+
+	configTargets = data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/2": target2,
+		"datadog/2/APM_SAMPLING/id/3": target3,
+	}
+	directorTargets = data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/3": target3,
+	}
+	targetFiles = []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: target1content}, {Path: "datadog/2/APM_SAMPLING/id/3", Raw: target3Content}}
+
+	// Roll-forward to a high version with epoch-millis used for the versions of the targets/snapshot/timestamp versions.
+	testRepository2 := testRepository1.incrementalChange(configTargets, directorTargets, targetFiles, nil, time.Now().UnixMilli())
+	err = client1.Update(testRepository2.toUpdate())
+	assert.NoError(t, err)
+
+	// Roll-back to a lower version with epoch-seconds used for the versions of the targets/snapshot/timestamp versions.
+	testRepository3 := testRepository2.incrementalChange(configTargets, directorTargets, targetFiles, nil, time.Now().Unix())
+	err = client1.Update(testRepository3.toUpdate())
+	assert.Error(t, err) // Update() fails when validating the incoming timestamp meta's version. It is lower than the last-known-good, and is rejected.
+}
+
+// TestKeyRotationRollback asserts that we can rotate signing keys to recover from a fast-forward attack
+func TestKeyRotationRollback(t *testing.T) {
+	target1content, target1 := generateTarget()
+	_, target2 := generateTarget()
+	target3Content, target3 := generateTarget()
+
+	configTargets := data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/2": target2,
+	}
+	directorTargets := data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+	}
+	targetFiles := []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: target1content}}
+
+	testRepository1 := newTestRepository(2, 10, configTargets, directorTargets, targetFiles)
+	cfg := newTestConfig(t, testRepository1)
+	db := getTestDB(t)
+
+	client1, err := newTestClient(db, cfg)
+	assert.NoError(t, err)
+	err = client1.Update(testRepository1.toUpdate())
+	assert.NoError(t, err)
+
+	// Roll-forward attack with epoch-millis used for the versions of the targets/snapshot/timestamp versions.
+	testRepository2 := testRepository1.incrementalChange(configTargets, directorTargets, targetFiles, nil, time.Now().UnixMilli())
+	err = client1.Update(testRepository2.toUpdate())
+	assert.NoError(t, err)
+
+	configTargets = data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/2": target2,
+		"datadog/2/APM_SAMPLING/id/3": target3,
+	}
+	directorTargets = data.TargetFiles{
+		"datadog/2/APM_SAMPLING/id/1": target1,
+		"datadog/2/APM_SAMPLING/id/3": target3,
+	}
+	targetFiles = []*pbgo.File{{Path: "datadog/2/APM_SAMPLING/id/1", Raw: target1content}, {Path: "datadog/2/APM_SAMPLING/id/3", Raw: target3Content}}
+
+	// Update with revoked/rotated targets/snapshot/timestamp keys, and a downgraded version for those roles (to epoch-seconds, down from epoch-millis)
+	testRepository3 := testRepository2.incrementalChangeWithKeyRotation(configTargets, directorTargets, targetFiles, time.Now().Unix())
+	err = client1.Update(testRepository3.toUpdate())
+	assert.NoError(t, err) // Despite the downgrade of the timestamp, snapshot and targets versions, the key rotations allow the update to succeed.
+}
+
 func generateKey() keys.Signer {
 	key, _ := keys.GenerateEd25519Key()
 	return key
 }
 
 type testRepositories struct {
+	snapshotOrgID int
+
 	configTimestampKey   keys.Signer
 	configTargetsKey     keys.Signer
 	configSnapshotKey    keys.Signer
@@ -353,15 +447,76 @@ type testRepositories struct {
 	targetFiles []*pbgo.File
 }
 
+func (r testRepositories) incrementalChange(configTargetFiles data.TargetFiles, directorTargetFiles data.TargetFiles, targetFiles []*pbgo.File, expires *time.Time, version int64) testRepositories {
+	r.configTimestampVersion++
+	r.configTargetsVersion++
+	r.configSnapshotVersion++
+
+	r.directorTimestampVersion = version
+	r.directorTargetsVersion = version
+	r.directorSnapshotVersion = version
+
+	r.configTargets = generateTargets(r.configTargetsKey, r.configTargetsVersion, configTargetFiles, expires)
+	r.configSnapshot = generateSnapshot(r.snapshotOrgID, r.configSnapshotKey, r.configSnapshotVersion, r.configTargetsVersion, expires)
+	r.configTimestamp = generateTimestamp(r.configTimestampKey, r.configTimestampVersion, r.configSnapshotVersion, r.configSnapshot, expires)
+
+	r.directorTargets = generateTargets(r.directorTargetsKey, r.directorTargetsVersion, directorTargetFiles, expires)
+	r.directorSnapshot = generateSnapshot(r.snapshotOrgID, r.directorSnapshotKey, r.directorSnapshotVersion, r.directorTargetsVersion, expires)
+	r.directorTimestamp = generateTimestamp(r.directorTimestampKey, r.directorTimestampVersion, r.directorSnapshotVersion, r.directorSnapshot, expires)
+
+	r.targetFiles = targetFiles
+	return r
+}
+
+func (r testRepositories) incrementalChangeWithKeyRotation(configTargetFiles data.TargetFiles, directorTargetFiles data.TargetFiles, targetFiles []*pbgo.File, version int64) testRepositories {
+	// Increment the config versions
+	r.configTimestampVersion++
+	r.configTargetsVersion++
+	r.configSnapshotVersion++
+	r.configRootVersion++
+
+	// Update the director versions
+	r.directorTimestampVersion = version
+	r.directorSnapshotVersion = version
+	r.directorTargetsVersion = version
+	r.directorRootVersion++
+
+	prevConfigRootKey := r.configRootKey
+	r.configRootKey = generateKey()
+	r.configRoot = generateRoot(r.configRootKey, r.configRootVersion, r.configTimestampKey, r.configTargetsKey, r.configSnapshotKey, prevConfigRootKey, nil)
+	r.configTargets = generateTargets(r.configTargetsKey, r.configTargetsVersion, configTargetFiles, nil)
+	r.configSnapshot = generateSnapshot(r.snapshotOrgID, r.configSnapshotKey, r.configSnapshotVersion, r.configTargetsVersion, nil)
+	r.configTimestamp = generateTimestamp(r.configTimestampKey, r.configTimestampVersion, r.configSnapshotVersion, r.configSnapshot, nil)
+
+	// rotate director keys
+	prevDirectorRootKey := r.directorRootKey
+	r.directorRootKey = generateKey()
+
+	directorTargetSnapshotDirectorKey := generateKey()
+	r.directorTargetsKey = directorTargetSnapshotDirectorKey
+	r.directorTimestampKey = directorTargetSnapshotDirectorKey
+	r.directorSnapshotKey = directorTargetSnapshotDirectorKey
+
+	r.directorRoot = generateRoot(r.directorRootKey, r.directorRootVersion, r.directorTimestampKey, r.directorTargetsKey, r.directorSnapshotKey, prevDirectorRootKey, nil)
+	r.directorTargets = generateTargets(r.directorTargetsKey, r.directorTargetsVersion, directorTargetFiles, nil)
+	r.directorSnapshot = generateSnapshot(r.snapshotOrgID, r.directorSnapshotKey, r.directorSnapshotVersion, r.directorTargetsVersion, nil)
+	r.directorTimestamp = generateTimestamp(r.directorTimestampKey, r.directorTimestampVersion, r.directorSnapshotVersion, r.directorSnapshot, nil)
+
+	r.targetFiles = targetFiles
+	return r
+}
+
 func newTestRepository(snapshotOrgID int, version int64, configTargets data.TargetFiles, directorTargets data.TargetFiles, targetFiles []*pbgo.File) testRepositories {
+	directorTimestampSnapshotTargetKey := generateKey()
 	repos := testRepositories{
+		snapshotOrgID:        snapshotOrgID,
 		configTimestampKey:   generateKey(),
 		configTargetsKey:     generateKey(),
 		configSnapshotKey:    generateKey(),
 		configRootKey:        generateKey(),
-		directorTimestampKey: generateKey(),
-		directorTargetsKey:   generateKey(),
-		directorSnapshotKey:  generateKey(),
+		directorTimestampKey: directorTimestampSnapshotTargetKey,
+		directorTargetsKey:   directorTimestampSnapshotTargetKey,
+		directorSnapshotKey:  directorTimestampSnapshotTargetKey,
 		directorRootKey:      generateKey(),
 		targetFiles:          targetFiles,
 	}
@@ -373,14 +528,14 @@ func newTestRepository(snapshotOrgID int, version int64, configTargets data.Targ
 	repos.directorTimestampVersion = 20 + version
 	repos.directorTargetsVersion = 200 + version
 	repos.directorSnapshotVersion = 2000 + version
-	repos.configRoot = generateRoot(repos.configRootKey, version, repos.configTimestampKey, repos.configTargetsKey, repos.configSnapshotKey, nil)
-	repos.configTargets = generateTargets(repos.configTargetsKey, 100+version, configTargets)
-	repos.configSnapshot = generateSnapshot(snapshotOrgID, repos.configSnapshotKey, 1000+version, repos.configTargetsVersion)
-	repos.configTimestamp = generateTimestamp(repos.configTimestampKey, 10+version, repos.configSnapshotVersion, repos.configSnapshot)
-	repos.directorRoot = generateRoot(repos.directorRootKey, version, repos.directorTimestampKey, repos.directorTargetsKey, repos.directorSnapshotKey, nil)
-	repos.directorTargets = generateTargets(repos.directorTargetsKey, 200+version, directorTargets)
-	repos.directorSnapshot = generateSnapshot(snapshotOrgID, repos.directorSnapshotKey, 2000+version, repos.directorTargetsVersion)
-	repos.directorTimestamp = generateTimestamp(repos.directorTimestampKey, 20+version, repos.directorSnapshotVersion, repos.directorSnapshot)
+	repos.configRoot = generateRoot(repos.configRootKey, version, repos.configTimestampKey, repos.configTargetsKey, repos.configSnapshotKey, nil, nil)
+	repos.configTargets = generateTargets(repos.configTargetsKey, 100+version, configTargets, nil)
+	repos.configSnapshot = generateSnapshot(snapshotOrgID, repos.configSnapshotKey, 1000+version, repos.configTargetsVersion, nil)
+	repos.configTimestamp = generateTimestamp(repos.configTimestampKey, 10+version, repos.configSnapshotVersion, repos.configSnapshot, nil)
+	repos.directorRoot = generateRoot(repos.directorRootKey, version, repos.directorTimestampKey, repos.directorTargetsKey, repos.directorSnapshotKey, nil, nil)
+	repos.directorTargets = generateTargets(repos.directorTargetsKey, 200+version, directorTargets, nil)
+	repos.directorSnapshot = generateSnapshot(snapshotOrgID, repos.directorSnapshotKey, 2000+version, repos.directorTargetsVersion, nil)
+	repos.directorTimestamp = generateTimestamp(repos.directorTimestampKey, 20+version, repos.directorSnapshotVersion, repos.directorSnapshot, nil)
 	return repos
 }
 
@@ -402,10 +557,13 @@ func (r testRepositories) toUpdate() *pbgo.LatestConfigsResponse {
 	}
 }
 
-func generateRoot(key keys.Signer, version int64, timestampKey keys.Signer, targetsKey keys.Signer, snapshotKey keys.Signer, previousRootKey keys.Signer) []byte {
+func generateRoot(key keys.Signer, version int64, timestampKey keys.Signer, targetsKey keys.Signer, snapshotKey keys.Signer, previousRootKey keys.Signer, expires *time.Time) []byte {
 	root := data.NewRoot()
 	root.Version = version
 	root.Expires = time.Now().Add(1 * time.Hour)
+	if expires != nil {
+		root.Expires = *expires
+	}
 	root.AddKey(key.PublicData())
 	root.AddKey(timestampKey.PublicData())
 	root.AddKey(targetsKey.PublicData())
@@ -437,9 +595,12 @@ func generateRoot(key keys.Signer, version int64, timestampKey keys.Signer, targ
 	return serializedRoot
 }
 
-func generateTimestamp(key keys.Signer, version int64, snapshotVersion int64, snapshot []byte) []byte {
+func generateTimestamp(key keys.Signer, version int64, snapshotVersion int64, snapshot []byte, expires *time.Time) []byte {
 	meta := data.NewTimestamp()
 	meta.Expires = time.Now().Add(1 * time.Hour)
+	if expires != nil {
+		meta.Expires = *expires
+	}
 	meta.Version = version
 	meta.Meta["snapshot.json"] = data.TimestampFileMeta{Version: snapshotVersion, Length: int64(len(snapshot)), Hashes: data.Hashes{
 		"sha256": hashSha256(snapshot),
@@ -449,9 +610,12 @@ func generateTimestamp(key keys.Signer, version int64, snapshotVersion int64, sn
 	return serialized
 }
 
-func generateTargets(key keys.Signer, version int64, targets data.TargetFiles) []byte {
+func generateTargets(key keys.Signer, version int64, targets data.TargetFiles, expires *time.Time) []byte {
 	meta := data.NewTargets()
 	meta.Expires = time.Now().Add(1 * time.Hour)
+	if expires != nil {
+		meta.Expires = *expires
+	}
 	meta.Version = version
 	meta.Targets = targets
 	signed, _ := sign.Marshal(&meta, key)
@@ -459,9 +623,12 @@ func generateTargets(key keys.Signer, version int64, targets data.TargetFiles) [
 	return serialized
 }
 
-func generateSnapshot(orgID int, key keys.Signer, version int64, targetsVersion int64) []byte {
+func generateSnapshot(orgID int, key keys.Signer, version int64, targetsVersion int64, expires *time.Time) []byte {
 	meta := data.NewSnapshot()
 	meta.Expires = time.Now().Add(1 * time.Hour)
+	if expires != nil {
+		meta.Expires = *expires
+	}
 	meta.Version = version
 	meta.Meta["targets.json"] = data.SnapshotFileMeta{Version: targetsVersion}
 

--- a/pkg/config/remote/uptane/local_store_test.go
+++ b/pkg/config/remote/uptane/local_store_test.go
@@ -131,3 +131,81 @@ func TestLocalStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, found)
 }
+
+func TestLocalStoreDeleteAfterCommit(t *testing.T) {
+	db := getTestDB(t)
+	root := []byte(`{"signatures":[{"keyid":"b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8","sig":"ada4a7723d462eb4c1f087025f81f5eab5de48cb18b710de94ad2194ee9e0524fafe6eaddf95e894808f8254380a86f8f7219d69bf693d6e1c80db904a47830e"}],"signed":{"_type":"root","consistent_snapshot":true,"expires":"1970-01-01T00:00:17Z","keys":{"44d70fa8eae4c07f26c2767270827b6b9e11e7972926b3b419b5ea14ec32f796":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"286d6ae328365afec0f92519ceab68cd627e34072cde90b2f5d167badea970f2"},"scheme":"ed25519"},"b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"afdd68be53815d67f8fa99cf101aac4589a358c660adf7dd4e179fe96834d3c9"},"scheme":"ed25519"}},"roles":{"root":{"keyids":["44d70fa8eae4c07f26c2767270827b6b9e11e7972926b3b419b5ea14ec32f796","b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8"],"threshold":2},"snapshot":{"keyids":["44d70fa8eae4c07f26c2767270827b6b9e11e7972926b3b419b5ea14ec32f796","b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8"],"threshold":2},"targets":{"keyids":["44d70fa8eae4c07f26c2767270827b6b9e11e7972926b3b419b5ea14ec32f796","b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8"],"threshold":2},"timestamp":{"keyids":["44d70fa8eae4c07f26c2767270827b6b9e11e7972926b3b419b5ea14ec32f796","b2b93a6dccc96d053e6db39181124c85ba4156d43503d4351b5500316fa084e8"],"threshold":2}},"spec_version":"1.0","version":2}}`)
+	embeddedRoots := meta.NewEmbeddedRoot(root)
+
+	transactionalStore := newTransactionalStore(db)
+
+	store, err := newLocalStore(transactionalStore, "test", embeddedRoots)
+	assert.NoError(t, err)
+	storeRoot2 := json.RawMessage(root)
+
+	rootVersion, err := store.GetMetaVersion("root.json")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(2), rootVersion)
+
+	rootExpires, err := store.GetMetaExpires("root.json")
+	assert.NoError(t, err)
+	assert.Equal(t, time.Unix(17, 0).In(time.UTC), rootExpires)
+
+	metas, err := store.GetMeta()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]json.RawMessage{
+		"root.json": storeRoot2,
+	}, metas)
+
+	storeTimestamp5 := json.RawMessage(`{"signatures":[],"signed":{"_type":"timestamp","version":5}}`)
+	err = store.SetMeta("timestamp.json", storeTimestamp5)
+	assert.NoError(t, err)
+	metas, err = store.GetMeta()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]json.RawMessage{
+		"root.json":      storeRoot2,
+		"timestamp.json": storeTimestamp5,
+	}, metas)
+
+	storeSnapshot6 := json.RawMessage(`{"signatures":[],"signed":{"_type":"snapshot","version":6}}`)
+	err = store.SetMeta("snapshot.json", storeSnapshot6)
+	assert.NoError(t, err)
+	metas, err = store.GetMeta()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]json.RawMessage{
+		"root.json":      storeRoot2,
+		"timestamp.json": storeTimestamp5,
+		"snapshot.json":  storeSnapshot6,
+	}, metas)
+
+	storeTargets7 := json.RawMessage(`{"signatures":[],"signed":{"_type":"targets","version":7}}`)
+	err = store.SetMeta("targets.json", storeTargets7)
+	assert.NoError(t, err)
+	metas, err = store.GetMeta()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]json.RawMessage{
+		"root.json":      storeRoot2,
+		"timestamp.json": storeTimestamp5,
+		"snapshot.json":  storeSnapshot6,
+		"targets.json":   storeTargets7,
+	}, metas)
+
+	// Commit the changes to the local store
+	err = transactionalStore.commit()
+	assert.NoError(t, err)
+
+	// Now delete the timestamp. This will delete it in memory, but not on disk, until another commit is made.
+	err = store.DeleteMeta("timestamp.json")
+	assert.NoError(t, err)
+
+	// Load meta from a combination of memory and disk
+	metas, err = store.GetMeta()
+	assert.NoError(t, err)
+
+	// Assert that timestamp is deleted, and not returned from disk (since it has been deleted from memory)
+	assert.Equal(t, map[string]json.RawMessage{
+		"root.json":     storeRoot2,
+		"snapshot.json": storeSnapshot6,
+		"targets.json":  storeTargets7,
+	}, metas)
+}

--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -66,10 +66,12 @@ func (ts *transactionalStore) getAll(bucketName string) ([]pathData, error) {
 	blobs := []pathData{}
 
 	for path, data := range ts.getMemBucket(bucketName) {
+		seenBlobs[path] = struct{}{}
 		if len(data) == 0 {
+			// if the path is seen but the data is empty in the in-memory state, it means we've "deleted" it
+			// so we should not include in the result, and also not try to read it from the db.
 			continue
 		}
-		seenBlobs[path] = struct{}{}
 		blobs = append(blobs, pathData{path, data})
 	}
 

--- a/pkg/dyninst/testprogs/progs/go.mod
+++ b/pkg/dyninst/testprogs/progs/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/DataDog/go-libddwaf/v4 v4.3.0 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.0 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect

--- a/pkg/dyninst/testprogs/progs/go.sum
+++ b/pkg/dyninst/testprogs/progs/go.sum
@@ -28,8 +28,8 @@ github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633/go.mod h1:YFoTl1xsMzdSRFIu33oCSPS/3+HZAPGpO3oOM96wXCM=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.0 h1:5US5SqqhfkZkg/E64uvn7YmeTwnudJHtlPEH/LOT99w=

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/remoteconfig/state
 go 1.23.0
 
 require (
-	github.com/DataDog/go-tuf v1.1.0-0.5.2
+	github.com/DataDog/go-tuf v1.1.1-0.5.2
 	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.9.0
 	github.com/stretchr/testify v1.10.0

--- a/pkg/remoteconfig/state/go.sum
+++ b/pkg/remoteconfig/state/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -72,7 +72,7 @@ require (
 require (
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -2,8 +2,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 h1:GAjMnaFCUT2Q+4jVFJ+r3SYIupqCc66NkU1Gm6AvHIg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0/go.mod h1:A3oj/VbBPuJ0ssrZS3B7hv0IuF7hy854TQ2XMjHwPnw=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/pkg/trace/stats/oteltest/go.sum
+++ b/pkg/trace/stats/oteltest/go.sum
@@ -2,8 +2,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 h1:GAjMnaFCUT2Q+4jVFJ+r3SYIupqCc66NkU1Gm6AvHIg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0/go.mod h1:A3oj/VbBPuJ0ssrZS3B7hv0IuF7hy854TQ2XMjHwPnw=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -261,7 +261,7 @@ require (
 	github.com/DataDog/go-libddwaf/v4 v4.3.0 // indirect
 	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -22,8 +22,8 @@ github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b
 github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633/go.mod h1:YFoTl1xsMzdSRFIu33oCSPS/3+HZAPGpO3oOM96wXCM=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
 github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.43.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.6.0 // indirect
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
-	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.31.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.31.0 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect

--- a/test/otel/go.sum
+++ b/test/otel/go.sum
@@ -9,8 +9,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
 github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
-github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
-github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2 h1:YWvghV4ZvrQsPcUw8IOUMSDpqc3W5ruOIC+KJxPknv0=
+github.com/DataDog/go-tuf v1.1.1-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0 h1:jYkbxbh063O15NYxhUY3wedUURNrYpaLI8ra1GCsuk0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.31.0/go.mod h1:KzMc/SWTFReO6WTkKucJ3qxHUSzLYuz7GrRfXjRFMDo=
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.31.0 h1:45au8YNruaT0MmkgeFcKraPRPnraQYDTpJRrt1Ucjh0=


### PR DESCRIPTION
### What does this PR do?

Fixes an issue when handling a threshold number of TUF meta keys being revoked.

The intended behaviors is that when the threshold number of signing keys for a given TUF meta are revoked (rotated), the TUF client will delete the corresponding locally stored meta, so that said meta's last-known-good version is not used to validate against the version of the same meta in the incoming remote Update we're processing. This enforces 5.3.11 in the TUF spec.

There were two issues causing this behavior to not work as intended:
1. A `go-tuf` bug regarding how the last-known-good version of a meta isn't updated, specifically when the meta is deleted from localStorage. This is fixed in [this `go-tuf` PR](https://github.com/DataDog/go-tuf/pull/70), which is being pulled into this `datadog-agent` PR through the [pkg/config/remote/go.mod submodule](https://github.com/DataDog/datadog-agent/pull/38897/files). 
2. Our `transactional_store` implementation of the `localStore` still returns a given meta even after it has been deleted during a given transaction. Specifically, the `delete()` function deletes the meta from _memory but not disk_, and the `getAll()` function was [reading-through memory](https://github.com/DataDog/datadog-agent/pull/38897/files#diff-624bc118439a3d844b6705a5abdd0ae74c38019a91eca254c665114668fdf634R68-R76) and loading the meta from disk.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Thorough unit tests regarding this sequence of interactions have been added both in datadog-agent in this PR as well as in the go-tuf repo to ensure both components are exhibiting the correct behavior.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->