### PR TITLE
[CNM] add plaintext protocol in classifier

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -68,6 +68,7 @@ typedef enum {
     __LAYER_ENCRYPTION_MIN = LAYER_ENCRYPTION_BIT,
     //  Add encryption protocols below (eg. TLS)
     PROTOCOL_TLS,
+    PROTOCOL_PLAINTEXT,
     __LAYER_ENCRYPTION_MAX = LAYER_ENCRYPTION_MAX,
 } __attribute__ ((packed)) protocol_t;
 

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -193,6 +193,13 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
             }
         }
         return;
+    } else {
+        // Add a plaintext encryption layer tag if TLS classification returns false
+        protocol_stack = get_or_create_protocol_stack(&classification_ctx->tuple);
+        if (!protocol_stack) {
+            return;
+        }
+        update_protocol_information(classification_ctx, protocol_stack, PROTOCOL_PLAINTEXT);
     }
 
     // If we have already classified the encryption layer, we can skip the rest of the classification

--- a/pkg/network/protocols/ebpf.go
+++ b/pkg/network/protocols/ebpf.go
@@ -43,6 +43,8 @@ func toProtocolType(protoNum uint8, layerBit uint16) ProtocolType {
 		return Kafka
 	case ebpfTLS:
 		return TLS
+	case ebpfPlaintext:
+		return Plaintext
 	case ebpfMongo:
 		return Mongo
 	case ebpfPostgres:
@@ -71,6 +73,8 @@ func FromProtocolType(protocolType ProtocolType) uint8 {
 		return uint8((uint16(ebpfKafka) ^ uint16(layerApplicationBit)) & uint16(0xff))
 	case TLS:
 		return uint8((uint16(ebpfTLS) ^ uint16(layerEncryptionBit)) & uint16(0xff))
+	case Plaintext:
+		return uint8((uint16(ebpfPlaintext) ^ uint16(layerEncryptionBit)) & uint16(0xff))
 	case Mongo:
 		return uint8((uint16(ebpfMongo) ^ uint16(layerApplicationBit)) & uint16(0xff))
 	case Postgres:

--- a/pkg/network/protocols/ebpf_types.go
+++ b/pkg/network/protocols/ebpf_types.go
@@ -94,6 +94,8 @@ const (
 	ebpfKafka ebpfProtocolType = C.PROTOCOL_KAFKA
 	// TLS protocol
 	ebpfTLS ebpfProtocolType = C.PROTOCOL_TLS
+	// Plaintext protocol
+	ebpfPlaintext ebpfProtocolType = C.PROTOCOL_PLAINTEXT
 	// Mongo protocol
 	ebpfMongo ebpfProtocolType = C.PROTOCOL_MONGO
 	// Postgres protocol

--- a/pkg/network/protocols/ebpf_types_linux.go
+++ b/pkg/network/protocols/ebpf_types_linux.go
@@ -80,6 +80,8 @@ const (
 
 	ebpfTLS ebpfProtocolType = 0x8001
 
+	ebpfPlaintext ebpfProtocolType = 0x8002
+
 	ebpfMongo ebpfProtocolType = 0x4004
 
 	ebpfPostgres ebpfProtocolType = 0x4005

--- a/pkg/network/protocols/types.go
+++ b/pkg/network/protocols/types.go
@@ -19,6 +19,8 @@ const (
 	Kafka
 	// TLS protocol
 	TLS
+	// Plaintext protocol (encryption layer)
+	Plaintext
 	// Mongo protocol
 	Mongo
 	// Postgres protocol
@@ -46,6 +48,8 @@ func (p ProtocolType) String() string {
 		return "Kafka"
 	case TLS:
 		return "TLS"
+	case Plaintext:
+		return "Plaintext"
 	case Mongo:
 		return "Mongo"
 	case Postgres:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Explicitly adds an encryption layer protocol tag for plaintext traffic if TLS classification fails. This will allow the CNM backend to be certain that traffic is not TLS.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->