### PR TITLE
fix(installer): Move deb symlink to /opt/datadog-packages/run

### DIFF
--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -11,11 +11,12 @@ build do
     if linux_target? and install_dir == '/opt/datadog-agent'
       version = project.build_version
       mkdir '/opt/datadog-packages/datadog-agent'
-      link "/opt/datadog-agent", "/opt/datadog-packages/datadog-agent/#{version}"
-      link "/opt/datadog-packages/datadog-agent/#{version}", "/opt/datadog-packages/datadog-agent/stable"
+      mkdir '/opt/datadog-packages/run/datadog-agent'
+      link "/opt/datadog-agent", "/opt/datadog-packages/run/datadog-agent/#{version}"
+      link "/opt/datadog-packages/run/datadog-agent/#{version}", "/opt/datadog-packages/datadog-agent/stable"
       link "/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent/experiment"
       project.extra_package_file "/opt/datadog-packages/datadog-agent"
+      project.extra_package_file "/opt/datadog-packages/run"
     end
   end
 end
-


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/datadog-agent/pull/37257 introduced the capability to use Remote Agent Management from the Deb & RPM packages of the agent. It does so by artificially creating symlinks to `/opt/datadog-packages/datadog-agent` from `/opt/datadog-agent` in a way the installer understands. 

The problem is that older versions of the agent don't recognize these symlinks as valid packages and _clean them up_ when they're installed; leaving the agent without a stable to fallback on during an upgrade. Effectively, **this leads to the agent disconnecting ~15min after the first upgrade**. This PR fixes it by moving the symlink that gets cleaned up to another directory (`/opt/datadog-packages/run`) that is not affected by the cleanups.

### Motivation
RAM working without killing agents 🥲 

### Describe how you validated your changes
Manual downgrade QA

### Possible Drawbacks / Trade-offs

### Additional Notes
Will need a 7.69.x backport
