### PR TITLE
Print traceback in case of InfraError in Static Quality Gates

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -196,7 +196,7 @@ def parse_and_trigger_gates(ctx, config_path=GATE_CONFIG_PATH):
             gate_states.append({"name": gate, "state": False, "error_type": "AssertionError", "message": str(e)})
         except InfraError as e:
             print(f"Gate {gate} flaked ! (InfraError)\n Restarting the job...")
-            traceback.print_exc()
+            traceback.print_exception(e)
             ctx.run("datadog-ci tag --level job --tags static_quality_gates:\"restart\"")
             raise Exit(code=42) from e
         except Exception:

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -196,6 +196,7 @@ def parse_and_trigger_gates(ctx, config_path=GATE_CONFIG_PATH):
             gate_states.append({"name": gate, "state": False, "error_type": "AssertionError", "message": str(e)})
         except InfraError as e:
             print(f"Gate {gate} flaked ! (InfraError)\n Restarting the job...")
+            traceback.print_exc()
             ctx.run("datadog-ci tag --level job --tags static_quality_gates:\"restart\"")
             raise Exit(code=42) from e
         except Exception:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
It simply adds `traceback.print_exception(e)` in case of `InfraError` to ensure
that we see the original error message and where it occurred.
### Motivation
Sometimes static quality gates are failing, but we are unable to see
the root cause as original InfraError exception is suppressed and
the error message is replaced with something generic. This PR
improves visibility of errors that should enable developers in
debugging.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New unit test is added to ensure we see the original InfraError message.

### Possible Drawbacks / Trade-offs
None
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->