### PR TITLE
Create custom MacOS temporary directory

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -16,6 +16,8 @@
       dda inv -- -e macos.remove-inactive-versions -l python -t "$PYTHON_VERSION" || true
       dda inv -- -e macos.remove-inactive-versions -l go -t "$(cat .go-version)" || true
     fi
+  # Flush temporary folder
+  - rm -rf /tmp/gitlabci
 
 .select_python_env_commands:
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
@@ -105,6 +107,11 @@
     - !reference [.install_python_dependencies]
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
+    # Create temporary folder
+    - |
+      export MACOS_TMPDIR="/tmp/gitlabci/$CI_JOB_ID"
+      mkdir -p "$MACOS_TMPDIR"
+      echo "Temporary folder created at $MACOS_TMPDIR"
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -107,7 +107,7 @@
     - !reference [.install_python_dependencies]
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
-    # Create temporary folder
+    # Create custom temporary folder to isolate jobs from each other
     - |
       export TMPDIR="/tmp/gitlabci/$CI_JOB_ID"
       mkdir -p "$TMPDIR"

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -17,7 +17,7 @@
       dda inv -- -e macos.remove-inactive-versions -l go -t "$(cat .go-version)" || true
     fi
   # Flush temporary folder
-  - rm -rf /tmp/gitlabci
+  - sudo rm -rf /tmp/gitlabci
 
 .select_python_env_commands:
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -109,9 +109,9 @@
     - !reference [.macos_runner_maintenance]
     # Create temporary folder
     - |
-      export MACOS_TMPDIR="/tmp/gitlabci/$CI_JOB_ID"
-      mkdir -p "$MACOS_TMPDIR"
-      echo "Temporary folder created at $MACOS_TMPDIR"
+      export TMPDIR="/tmp/gitlabci/$CI_JOB_ID"
+      mkdir -p "$TMPDIR"
+      echo "Temporary folder created at $TMPDIR"
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -10,10 +10,9 @@ fi
 
 # --- Setup environment ---
 unset OMNIBUS_BASE_DIR
-WORKDIR="/tmp"
-export INSTALL_DIR="$WORKDIR/datadog-agent-build/bin"
-export CONFIG_DIR="$WORKDIR/datadog-agent-build/config"
-export OMNIBUS_DIR="$WORKDIR/omnibus_build"
+export INSTALL_DIR="$MACOS_TMPDIR/datadog-agent-build/bin"
+export CONFIG_DIR="$MACOS_TMPDIR/datadog-agent-build/config"
+export OMNIBUS_DIR="$MACOS_TMPDIR/omnibus_build"
 export OMNIBUS_PACKAGE_DIR="$PWD"/omnibus/pkg
 
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR" "$OMNIBUS_DIR"

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -10,9 +10,9 @@ fi
 
 # --- Setup environment ---
 unset OMNIBUS_BASE_DIR
-export INSTALL_DIR="$MACOS_TMPDIR/datadog-agent-build/bin"
-export CONFIG_DIR="$MACOS_TMPDIR/datadog-agent-build/config"
-export OMNIBUS_DIR="$MACOS_TMPDIR/omnibus_build"
+export INSTALL_DIR="$TMPDIR/datadog-agent-build/bin"
+export CONFIG_DIR="$TMPDIR/datadog-agent-build/config"
+export OMNIBUS_DIR="$TMPDIR/omnibus_build"
 export OMNIBUS_PACKAGE_DIR="$PWD"/omnibus/pkg
 
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR" "$OMNIBUS_DIR"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This creates a custom temporary directory for each job. The goal is to avoid collisions within `/tmp` we can have.
Everything is exported under `$TMPDIR` and can be reused. (also applies to processes spawned from there)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->