### PR TITLE
[tagger/subscription_manager] Fix panic in Unsubscribe

### DIFF
--- a/comp/core/tagger/subscriber/subscription_manager.go
+++ b/comp/core/tagger/subscriber/subscription_manager.go
@@ -85,7 +85,7 @@ func (sm *subscriptionManager) Unsubscribe(subscriptionID string) {
 
 	sub, found := sm.subscribers[subscriptionID]
 	if !found {
-		log.Debugf("subscriber with %q is already unsubscribed", sub.id)
+		log.Debugf("subscriber with %q is already unsubscribed", subscriptionID)
 		return
 	}
 

--- a/comp/core/tagger/subscriber/subscription_manager_test.go
+++ b/comp/core/tagger/subscriber/subscription_manager_test.go
@@ -255,3 +255,11 @@ func TestSubscriptionManagerDuplicateSubscriberID(t *testing.T) {
 	_, err = sm.Subscribe(lowCardSubID, types.NewFilterBuilder().Include(types.ContainerID).Build(types.LowCardinality), nil)
 	require.Error(t, err)
 }
+
+func TestUnsubscribe(t *testing.T) {
+	tel := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+	telemetryStore := taggerTelemetry.NewStore(tel)
+	sm := NewSubscriptionManager(telemetryStore)
+
+	assert.NotPanics(t, func() { sm.Unsubscribe("non-existing-id") })
+}


### PR DESCRIPTION
### What does this PR do?
Fixes a possible panic in the `Unsubscribe` function of the Tagger's Subscription Manager.

### Describe how you validated your changes
Unit test.