### PR TITLE
[tagger/subscription_manager] Delete incorrect comment

### DIFF
--- a/comp/core/tagger/subscriber/subscription_manager.go
+++ b/comp/core/tagger/subscriber/subscription_manager.go
@@ -77,8 +77,7 @@ func (sm *subscriptionManager) Subscribe(id string, filter *types.Filter, events
 	return subscriber, nil
 }
 
-// unsubscribe ends a subscription to entity events and closes its channel. It
-// is not thread-safe, and callers should take care of synchronization.
+// Unsubscribe ends a subscription to entity events and closes its channel.
 func (sm *subscriptionManager) Unsubscribe(subscriptionID string) {
 	sm.Lock()
 	defer sm.Unlock()


### PR DESCRIPTION
### What does this PR do?

Deletes a misleading comment in the Tagger's subscription manager.
The comment mentions that the function is not thread-safe, but it is.
