### PR TITLE
feat(github): Use Octo STS to get a github token

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
+/.github/chainguard/**                               @DataDog/agent-devx
 /.github/dependabot.yaml                             @DataDog/agent-devx
 /.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-aws
 /.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-aws

--- a/.github/chainguard/datadog-agent.backport.write.sts.yaml
+++ b/.github/chainguard/datadog-agent.backport.write.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/datadog-agent:ref_type:branch:ref:.*
+claim_pattern:
+  event_name: pull_request
+  ref_type: branch
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/.github/workflows/backport-pr.yml
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,6 +1,6 @@
 name: Backport PR
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
@@ -12,28 +12,29 @@ jobs:
     name: Backport PR
     runs-on: ubuntu-latest
     if: >
-      github.event.pull_request.merged
-      && (
         github.event.action == 'closed'
         || (
           github.event.action == 'labeled'
           && contains(github.event.label.name, 'backport')
         )
-      )
+      # github.event.pull_request.merged
+      # && (
+      # )
     permissions:
-      contents: write
-      pull-requests: write
+      id-token: write
+      # contents: write
+      # pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+          scope: DataDog/datadog-agent
+          policy: datadog-agent.backport.write.sts.yaml
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$"
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
           body_template: |
             Backport <%- mergeCommitSha %> from #<%- number %>.
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Switch to [octo sts](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4705912130/DD+Octo+STS) to generate a short-lived and fine grained token instead of using a generic github app

### Motivation
Security

### Describe how you validated your changes
Trigger the workflow manually
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->