### PR TITLE
[ AGNTLOG-249 ] Reduce the Logs Agent HTTP timeout back to 5 seconds on agent startup

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -39,6 +39,12 @@ const (
 	ProtobufContentType = "application/x-protobuf"
 )
 
+// NoTimeoutOverride is a special value that tells the httpClientFactory to use the logs_config.http_timeout setting.
+// This should generally be used for all HTTP destinations barring special cases like the HTTP connectivity check.
+const (
+	NoTimeoutOverride = -1
+)
+
 // HTTP errors.
 var (
 	errClient  = errors.New("client error")
@@ -112,7 +118,7 @@ func NewDestination(endpoint config.Endpoint,
 	return newDestination(endpoint,
 		contentType,
 		destinationsContext,
-		0,
+		NoTimeoutOverride,
 		shouldRetry,
 		destMeta,
 		cfg,
@@ -424,7 +430,7 @@ func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration)
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
 	timeout := timeoutOverride
-	if timeout == 0 {
+	if timeout == NoTimeoutOverride {
 		timeout = time.Second * time.Duration(cfg.GetInt("logs_config.http_timeout"))
 	}
 

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -112,7 +112,7 @@ func NewDestination(endpoint config.Endpoint,
 	return newDestination(endpoint,
 		contentType,
 		destinationsContext,
-		time.Second*10,
+		0,
 		shouldRetry,
 		destMeta,
 		cfg,
@@ -125,7 +125,7 @@ func NewDestination(endpoint config.Endpoint,
 func newDestination(endpoint config.Endpoint,
 	contentType string,
 	destinationsContext *client.DestinationsContext,
-	timeout time.Duration,
+	timeoutOverride time.Duration,
 	shouldRetry bool,
 	destMeta *client.DestinationMetadata,
 	cfg pkgconfigmodel.Reader,
@@ -157,7 +157,7 @@ func newDestination(endpoint config.Endpoint,
 		url:                 buildURL(endpoint),
 		endpoint:            endpoint,
 		contentType:         contentType,
-		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(cfg)),
+		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(cfg, timeoutOverride)),
 		destinationsContext: destinationsContext,
 		workerPool:          workerPool,
 		wg:                  sync.WaitGroup{},
@@ -419,11 +419,14 @@ func (d *Destination) updateRetryState(err error, isRetrying chan bool) bool {
 	}
 }
 
-func httpClientFactory(cfg pkgconfigmodel.Reader) func() *http.Client {
+func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration) func() *http.Client {
 	var transport *http.Transport
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
-	timeout := time.Second * time.Duration(cfg.GetInt("logs_config.http_timeout"))
+	timeout := timeoutOverride
+	if timeout == 0 {
+		timeout = time.Second * time.Duration(cfg.GetInt("logs_config.http_timeout"))
+	}
 
 	// Configure transport based on user setting
 	switch transportConfig {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -390,7 +390,7 @@ func TestTransportProtocol_HTTP1(t *testing.T) {
 	defer s.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	// Create an HTTP/1.1 request
@@ -423,7 +423,7 @@ func TestTransportProtocol_HTTP2(t *testing.T) {
 	defer s.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", s.URL, nil)
@@ -456,7 +456,7 @@ func TestTransportProtocol_InvalidProtocol(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -488,7 +488,7 @@ func TestTransportProtocol_HTTP1FallBack(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -521,7 +521,7 @@ func TestTransportProtocol_HTTP2WhenUsingProxy(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -554,7 +554,7 @@ func TestTransportProtocol_HTTP1FallBackWhenUsingProxy(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c)()
+	client := httpClientFactory(c, 0)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -390,7 +390,7 @@ func TestTransportProtocol_HTTP1(t *testing.T) {
 	defer s.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	// Create an HTTP/1.1 request
@@ -423,7 +423,7 @@ func TestTransportProtocol_HTTP2(t *testing.T) {
 	defer s.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", s.URL, nil)
@@ -456,7 +456,7 @@ func TestTransportProtocol_InvalidProtocol(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -488,7 +488,7 @@ func TestTransportProtocol_HTTP1FallBack(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -521,7 +521,7 @@ func TestTransportProtocol_HTTP2WhenUsingProxy(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -554,7 +554,7 @@ func TestTransportProtocol_HTTP1FallBackWhenUsingProxy(t *testing.T) {
 	defer server.Close()
 
 	c.SetWithoutSource("logs_config.http_timeout", 5)
-	client := httpClientFactory(c, 0)()
+	client := httpClientFactory(c, NoTimeoutOverride)()
 
 	assert.Equal(t, 5*time.Second, client.Timeout)
 	req, err := http.NewRequest("POST", server.URL, nil)
@@ -696,4 +696,11 @@ func TestDestinationCompression(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, metric, 2)
 	assert.Equal(t, "gzip", metric[0].Tags()["compression_kind"])
+}
+
+func TestHTTPTimeoutOverride(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("logs_config.http_timeout", 1)
+	client := httpClientFactory(cfg, 15*time.Second)()
+	assert.Equal(t, 15*time.Second, client.Timeout)
 }

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -38,7 +38,7 @@ func NewSyncDestination(
 	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, time.Second*10, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
+		destination:    newDestination(endpoint, contentType, destinationsContext, 0, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -38,7 +38,7 @@ func NewSyncDestination(
 	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, 0, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
+		destination:    newDestination(endpoint, contentType, destinationsContext, NoTimeoutOverride, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0"), "0"),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/releasenotes/notes/overrride-http-timeout-on-startup-78a6e7e4530da230.yaml
+++ b/releasenotes/notes/overrride-http-timeout-on-startup-78a6e7e4530da230.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Limit the HTTP timeout on startup to 5 seconds for the Logs Agent.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
HTTP timeout was intentionally set to a smaller value during agent startup to prevent delays. This functionality was overridden when the timeout was made to be configurable, and has been re-added here. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->