### PR TITLE
[CWS] introduce network filter action

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1633,6 +1633,9 @@ Workload Protection events for Linux systems have the following JSON schema:
                 },
                 "tls": {
                     "$ref": "#/$defs/TLSContext"
+                },
+                "dropped": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false,
@@ -4599,6 +4602,9 @@ Workload Protection events for Linux systems have the following JSON schema:
         },
         "tls": {
             "$ref": "#/$defs/TLSContext"
+        },
+        "dropped": {
+            "type": "boolean"
         }
     },
     "additionalProperties": false,

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1622,6 +1622,9 @@
         },
         "tls": {
           "$ref": "#/$defs/TLSContext"
+        },
+        "dropped": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -66,12 +66,12 @@ enum TC_TAIL_CALL_KEYS {
 };
 
 // see probes/rawpacket/pcap.go
-#define RAW_PACKET_FILTER_MAX_TAIL_CALL 5
+#define RAW_PACKET_MAX_TAIL_CALL 5
 
 enum TC_RAWPACKET_KEYS {
     RAW_PACKET_FILTER,
     // reserved keys for raw packet filter tail calls
-    RAW_PACKET_SHOOTER = RAW_PACKET_FILTER + RAW_PACKET_FILTER_MAX_TAIL_CALL,
+    RAW_PACKET_DROP_ACTION = RAW_PACKET_FILTER + RAW_PACKET_MAX_TAIL_CALL + 1, // + 1 for the sender program
 };
 
 #define DNS_MAX_LENGTH 256

--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -65,9 +65,13 @@ enum TC_TAIL_CALL_KEYS {
     DNS_RESPONSE
 };
 
+// see probes/rawpacket/pcap.go
+#define RAW_PACKET_FILTER_MAX_TAIL_CALL 5
+
 enum TC_RAWPACKET_KEYS {
     RAW_PACKET_FILTER,
     // reserved keys for raw packet filter tail calls
+    RAW_PACKET_SHOOTER = RAW_PACKET_FILTER + RAW_PACKET_FILTER_MAX_TAIL_CALL,
 };
 
 #define DNS_MAX_LENGTH 256

--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -263,7 +263,8 @@ enum link_target_dentry_origin {
 };
 
 enum global_rate_limiter_type {
-    RAW_PACKET_LIMITER = 0,
+    RAW_PACKET_FILTER_LIMITER = 0,
+    RAW_PACKET_ACTION_LIMITER,
 };
 
 #define TAIL_CALL_FNC_NAME(name, ...) tail_call_##name(__VA_ARGS__)

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -54,7 +54,7 @@ enum event_type
     EVENT_ON_DEMAND,
     EVENT_LOGIN_UID_WRITE,
     EVENT_CGROUP_WRITE,
-    EVENT_RAW_PACKET,
+    EVENT_RAW_PACKET_FILTER,
     EVENT_NETWORK_FLOW_MONITOR,
     EVENT_STAT,
     EVENT_SYSCTL,
@@ -62,6 +62,7 @@ enum event_type
     EVENT_SETSOCKOPT,
     EVENT_FSMOUNT,
     EVENT_OPEN_TREE,
+    EVENT_RAW_PACKET_ACTION,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffff // used as a mask for all the events

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -492,7 +492,7 @@ struct raw_packet_event_t {
     struct cgroup_context_t cgroup;
     struct network_device_context_t device;
 
-    int len;
+    u32 len;
     char data[256];
 };
 

--- a/pkg/security/ebpf/c/include/helpers/network/raw.h
+++ b/pkg/security/ebpf/c/include/helpers/network/raw.h
@@ -8,4 +8,18 @@ __attribute__((always_inline)) struct raw_packet_event_t *get_raw_packet_event()
     return bpf_map_lookup_elem(&raw_packet_event, &key);
 }
 
+__attribute__((always_inline)) int is_raw_packet_allowed(struct packet_t *pkt) {
+    u64 filter = 0;
+    LOAD_CONSTANT("raw_packet_filter", filter);
+    if (!filter) {
+        return 1;
+    }
+
+    // do not handle tcp packet outside of SYN without process context
+    if (pkt->ns_flow.flow.l4_protocol == IPPROTO_TCP && !pkt->tcp.syn && pkt->pid <= 0) {
+        return 0;
+    }
+    return 1;
+}
+
 #endif

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -169,4 +169,9 @@ static void __attribute__((always_inline)) fill_cgroup_context(struct proc_cache
     }
 }
 
+u64 __attribute__((always_inline)) get_cgroup_id(u32 tgid) {
+    struct proc_cache_t *entry = get_proc_cache(tgid);
+    return entry ? entry->container.cgroup_context.cgroup_file.ino : 0;
+}
+
 #endif

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -171,7 +171,7 @@ static void __attribute__((always_inline)) fill_cgroup_context(struct proc_cache
 
 u64 __attribute__((always_inline)) get_cgroup_id(u32 tgid) {
     struct proc_cache_t *entry = get_proc_cache(tgid);
-    return entry ? entry->container.cgroup_context.cgroup_file.ino : 0;
+    return entry ? entry->cgroup.cgroup_file.ino : 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -176,7 +176,6 @@ int __attribute__((always_inline)) dr_cgroup_write_callback(void *ctx) {
     return 0;
 }
 
-
 TAIL_CALL_FNC(dr_cgroup_write_callback, ctx_t *ctx) {
     return dr_cgroup_write_callback(ctx);
 }

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -39,8 +39,6 @@ __attribute__((always_inline)) int send_raw_packet_event(struct __sk_buff *skb, 
 
     send_event_with_size_ptr(skb, event_type, evt, len);
 
-    bpf_printk("raw_packet_drop_action_shot: %d", action);
-
     return action;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -45,7 +45,16 @@ TAIL_CALL_CLASSIFIER_FNC(raw_packet_sender, struct __sk_buff *skb) {
 
     send_event_with_size_ptr(skb, EVENT_RAW_PACKET, evt, len);
 
+    // tail call to the shooters
+    bpf_tail_call_compat(skb, &raw_packet_classifier_router, RAW_PACKET_SHOOTER);
+
     return TC_ACT_UNSPEC;
+}
+
+TAIL_CALL_CLASSIFIER_FNC(raw_packet_shot, struct __sk_buff *skb) {
+    bpf_printk("raw_packet_shot");
+
+    return ACT_OK;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -56,11 +56,13 @@ TAIL_CALL_CLASSIFIER_FNC(raw_packet_sender, struct __sk_buff *skb) {
 }
 
 TAIL_CALL_CLASSIFIER_FNC(raw_packet_drop_action_cb, struct __sk_buff *skb) {
+    bpf_printk("raw_packet_drop_action_cb: %d", bpf_get_current_cgroup_id());
+
     if (!global_limiter_allow(RAW_PACKET_ACTION_LIMITER, 1, 1)) {
-        return TC_ACT_SHOT;
+        return TC_ACT_UNSPEC;
     }
 
-    return send_raw_packet_event(skb, EVENT_RAW_PACKET_ACTION, TC_ACT_SHOT);
+    return send_raw_packet_event(skb, EVENT_RAW_PACKET_ACTION, TC_ACT_UNSPEC);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -45,16 +45,13 @@ TAIL_CALL_CLASSIFIER_FNC(raw_packet_sender, struct __sk_buff *skb) {
 
     send_event_with_size_ptr(skb, EVENT_RAW_PACKET, evt, len);
 
-    // tail call to the shooters
-    bpf_tail_call_compat(skb, &raw_packet_classifier_router, RAW_PACKET_SHOOTER);
-
     return TC_ACT_UNSPEC;
 }
 
-TAIL_CALL_CLASSIFIER_FNC(raw_packet_shot, struct __sk_buff *skb) {
-    bpf_printk("raw_packet_shot");
+TAIL_CALL_CLASSIFIER_FNC(raw_packet_drop_action_cb, struct __sk_buff *skb) {
+    bpf_printk("raw_packet_drop_action_shot");
 
-    return ACT_OK;
+    return TC_ACT_SHOT;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -56,13 +56,11 @@ TAIL_CALL_CLASSIFIER_FNC(raw_packet_sender, struct __sk_buff *skb) {
 }
 
 TAIL_CALL_CLASSIFIER_FNC(raw_packet_drop_action_cb, struct __sk_buff *skb) {
-    bpf_printk("raw_packet_drop_action_cb: %d", bpf_get_current_cgroup_id());
-
     if (!global_limiter_allow(RAW_PACKET_ACTION_LIMITER, 1, 1)) {
-        return TC_ACT_UNSPEC;
+        return TC_ACT_SHOT;
     }
 
-    return send_raw_packet_event(skb, EVENT_RAW_PACKET_ACTION, TC_ACT_UNSPEC);
+    return send_raw_packet_event(skb, EVENT_RAW_PACKET_ACTION, TC_ACT_SHOT);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -36,7 +36,7 @@ __attribute__((always_inline)) int prepare_raw_packet_event(struct __sk_buff *sk
     }
 
     evt->process.pid = pkt->pid;
-    evt->container.cgroup_context.cgroup_file.ino = pkt->cgroup_id;
+    evt->cgroup.cgroup_file.ino = pkt->cgroup_id;
 
     bpf_skb_pull_data(skb, 0);
 

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -100,9 +100,9 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
     }
     resolve_pid(pkt);
 
-    u64 sched_cls_has_current_pid_tgid_helper = 0;
-    LOAD_CONSTANT("sched_cls_has_current_pid_tgid_helper", sched_cls_has_current_pid_tgid_helper);
-    if (sched_cls_has_current_pid_tgid_helper) {
+    u64 sched_cls_has_current_cgroup_id_helper = 0;
+    LOAD_CONSTANT("sched_cls_has_current_cgroup_id_helper", sched_cls_has_current_cgroup_id_helper);
+    if (sched_cls_has_current_cgroup_id_helper) {
         pkt->cgroup_id = bpf_get_current_cgroup_id();
     } else {
         pkt->cgroup_id = get_cgroup_id(pkt->pid);

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -36,7 +36,7 @@ BPF_ARRAY_MAP(connect_addr_family_approvers, struct u64_flags_filter_t, 1)
 BPF_ARRAY_MAP(syscalls_stats_enabled, u32, 1)
 BPF_ARRAY_MAP(syscall_ctx_gen_id, u32, 1)
 BPF_ARRAY_MAP(syscall_ctx, char[MAX_SYSCALL_CTX_SIZE], MAX_SYSCALL_CTX_ENTRIES)
-BPF_ARRAY_MAP(global_rate_limiters, struct rate_limiter_ctx, 1)
+BPF_ARRAY_MAP(global_rate_limiters, struct rate_limiter_ctx, 2)
 BPF_ARRAY_MAP(filtered_dns_rcodes, u16, 1)
 
 BPF_HASH_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/c/include/structs/network.h
+++ b/pkg/security/ebpf/c/include/structs/network.h
@@ -111,6 +111,7 @@ struct packet_t {
     s64 pid;
     u32 payload_len;
     u32 network_direction;
+    u64 cgroup_id;
 };
 
 struct network_device_context_t {

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -31,6 +31,7 @@ SEC("test/raw_packet_drop_action")
 int raw_packet_drop_action(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();
     evt->process.pid = 123;
+    evt->container.cgroup_context.cgroup_file.ino = 456;
 
     // assert_not_null(evt, "unable to get raw packet event")
     assert_not_null(evt, "unable to get raw packet event")

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -31,7 +31,7 @@ SEC("test/raw_packet_drop_action")
 int raw_packet_drop_action(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();
     evt->process.pid = 123;
-    evt->container.cgroup_context.cgroup_file.ino = 456;
+    evt->cgroup.cgroup_file.ino = 456;
 
     // assert_not_null(evt, "unable to get raw packet event")
     assert_not_null(evt, "unable to get raw packet event")

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -27,10 +27,10 @@ int raw_packet_tail_calls(struct __sk_buff *skb) {
     return 1;
 }
 
-SEC("test/raw_packet_shooter")
-int raw_packet_tail_calls(struct __sk_buff *skb) {
+SEC("test/raw_packet_drop_action")
+int raw_packet_drop_action(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();
-    ev.process.pid = 123;
+    evt->process.pid = 123;
     
     // assert_not_null(evt, "unable to get raw packet event")
     assert_not_null(evt, "unable to get raw packet event")
@@ -48,7 +48,7 @@ int raw_packet_tail_calls(struct __sk_buff *skb) {
     };
     baloum_memcpy(evt->data, data, sizeof(data));
 
-    bpf_tail_call_compat(skb, &raw_packet_classifier_router, RAW_PACKET_SHOOTER);
+    bpf_tail_call_compat(skb, &raw_packet_classifier_router, RAW_PACKET_DROP_ACTION);
 
     return 1;
 }

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -27,6 +27,32 @@ int raw_packet_tail_calls(struct __sk_buff *skb) {
     return 1;
 }
 
+SEC("test/raw_packet_shooter")
+int raw_packet_tail_calls(struct __sk_buff *skb) {
+    struct raw_packet_event_t *evt = get_raw_packet_event();
+    ev.process.pid = 123;
+    
+    // assert_not_null(evt, "unable to get raw packet event")
+    assert_not_null(evt, "unable to get raw packet event")
+
+    // tcp dst port 5555 and tcp[tcpflags] == tcp-syn
+    unsigned char data[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x45, 0x10,
+        0x00, 0x30, 0xf4, 0xa2, 0x40, 0x00, 0x40, 0x06,
+        0x48, 0x13, 0x7f, 0x00, 0x00, 0x01, 0x7f, 0x00,
+        0x00, 0x01, 0xa2, 0x36, 0x15, 0xb3, 0x1c, 0x5b,
+        0x89, 0x33, 0x00, 0x00, 0x00, 0x00, 0x70, 0x02,
+        0xff, 0xd7, 0xfe, 0x24, 0x00, 0x00, 0x02, 0x04,
+        0xff, 0xd7, 0x01, 0x03, 0x03, 0x07
+    };
+    baloum_memcpy(evt->data, data, sizeof(data));
+
+    bpf_tail_call_compat(skb, &raw_packet_classifier_router, RAW_PACKET_SHOOTER);
+
+    return 1;
+}
+
 SEC("test/raw_packet_bpfdoor_magic_number")
 int raw_packet_bpfdoor_magic_number(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();

--- a/pkg/security/ebpf/c/include/tests/raw_packet_test.h
+++ b/pkg/security/ebpf/c/include/tests/raw_packet_test.h
@@ -31,7 +31,7 @@ SEC("test/raw_packet_drop_action")
 int raw_packet_drop_action(struct __sk_buff *skb) {
     struct raw_packet_event_t *evt = get_raw_packet_event();
     evt->process.pid = 123;
-    
+
     // assert_not_null(evt, "unable to get raw packet event")
     assert_not_null(evt, "unable to get raw packet event")
 

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -177,8 +177,8 @@ func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentPidTgid) == nil
 }
 
-// HasBpfGetCurrentCgroupIdForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// HasBpfGetCurrentCgroupIDForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
 // https://github.com/torvalds/linux/commit/c501bf55c88b834adefda870c7c092ec9052a437
-func (k *Version) HasBpfGetCurrentCgroupIdForSchedCLS() bool {
+func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentCgroupId) == nil
 }

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -180,5 +180,5 @@ func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 // HasBpfGetCurrentCgroupIdForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
 // https://github.com/torvalds/linux/commit/c501bf55c88b834adefda870c7c092ec9052a437
 func (k *Version) HasBpfGetCurrentCgroupIdForSchedCLS() bool {
-	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbCgroupId) == nil
+	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentCgroupId) == nil
 }

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -176,3 +176,9 @@ func (k *Version) SupportCORE() bool {
 func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentPidTgid) == nil
 }
+
+// HasBpfGetCurrentCgroupIdForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// https://github.com/torvalds/linux/commit/c501bf55c88b834adefda870c7c092ec9052a437
+func (k *Version) HasBpfGetCurrentCgroupIdForSchedCLS() bool {
+	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbCgroupId) == nil
+}

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -79,3 +79,9 @@ func (k *Version) HasTracingHelpersInCgroupSysctlPrograms() bool {
 func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 	return false
 }
+
+// HasBpfGetCurrentCgroupIdForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// https://github.com/torvalds/linux/commit/c501bf55c88b834adefda870c7c092ec9052a437
+func (k *Version) HasBpfGetCurrentCgroupIdForSchedCLS() bool {
+	return false
+}

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -80,8 +80,8 @@ func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 	return false
 }
 
-// HasBpfGetCurrentCgroupIdForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// HasBpfGetCurrentCgroupIDForSchedCLS returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
 // https://github.com/torvalds/linux/commit/c501bf55c88b834adefda870c7c092ec9052a437
-func (k *Version) HasBpfGetCurrentCgroupIdForSchedCLS() bool {
+func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return false
 }

--- a/pkg/security/ebpf/probes/const.go
+++ b/pkg/security/ebpf/probes/const.go
@@ -75,7 +75,7 @@ const (
 
 const (
 	// RawPacketFilterMaxTailCall defines the maximum of tail calls, see constants/custom.h
-	RawPacketFilterMaxTailCall = 5
+	RawPacketMaxTailCall = 5
 )
 
 const (
@@ -94,11 +94,11 @@ const (
 	// reserve 5 tail calls for the filtering
 	TCRawPacketFilterKey uint32 = 0
 	// TCRawPacketParserSenderKey is the key to the raw packet sender program
-	TCRawPacketSenderKey = TCRawPacketFilterKey + RawPacketFilterMaxTailCall
+	TCRawPacketSenderKey = TCRawPacketFilterKey + RawPacketMaxTailCall
 
-	// TCRawPacketShooterKey is the key to the raw packet shooter program
-	TCRawPacketShooterKey       = TCRawPacketSenderKey + 1
-	TCRawPacketShooterResultKey = TCRawPacketShooterKey + 1
+	// TCRawPacketDropActionKey is the key to the raw packet drop action program
+	TCRawPacketDropActionKey     = TCRawPacketSenderKey + 1
+	TCRawPacketDropActionShotKey = TCRawPacketDropActionKey + RawPacketMaxTailCall
 	// reserved key for filter tail calls
 )
 

--- a/pkg/security/ebpf/probes/const.go
+++ b/pkg/security/ebpf/probes/const.go
@@ -74,7 +74,7 @@ const (
 )
 
 const (
-	// RawPacketFilterMaxTailCall defines the maximum of tail calls, see constants/custom.h
+	// RawPacketMaxTailCall defines the maximum of tail calls, see constants/custom.h
 	RawPacketMaxTailCall = 5
 )
 
@@ -93,13 +93,13 @@ const (
 	// TCRawPacketFilterKey  is the key to the raw packet filter program
 	// reserve 5 tail calls for the filtering
 	TCRawPacketFilterKey uint32 = 0
-	// TCRawPacketParserSenderKey is the key to the raw packet sender program
+	// TCRawPacketSenderKey is the key to the raw packet sender program
 	TCRawPacketSenderKey = TCRawPacketFilterKey + RawPacketMaxTailCall
 
 	// TCRawPacketDropActionKey is the key to the raw packet drop action program
-	TCRawPacketDropActionKey     = TCRawPacketSenderKey + 1
+	TCRawPacketDropActionKey = TCRawPacketSenderKey + 1
+	// TCRawPacketDropActionShotKey is the key to the raw packet drop action program
 	TCRawPacketDropActionShotKey = TCRawPacketDropActionKey + RawPacketMaxTailCall
-	// reserved key for filter tail calls
 )
 
 const (

--- a/pkg/security/ebpf/probes/const.go
+++ b/pkg/security/ebpf/probes/const.go
@@ -74,7 +74,7 @@ const (
 )
 
 const (
-	// RawPacketFilterMaxTailCall defines the maximum of tail calls
+	// RawPacketFilterMaxTailCall defines the maximum of tail calls, see constants/custom.h
 	RawPacketFilterMaxTailCall = 5
 )
 
@@ -92,9 +92,14 @@ const (
 const (
 	// TCRawPacketFilterKey  is the key to the raw packet filter program
 	// reserve 5 tail calls for the filtering
-	TCRawPacketFilterKey uint32 = iota
+	TCRawPacketFilterKey uint32 = 0
 	// TCRawPacketParserSenderKey is the key to the raw packet sender program
-	TCRawPacketParserSenderKey = TCRawPacketFilterKey + RawPacketFilterMaxTailCall // reserved key for filter tail calls
+	TCRawPacketSenderKey = TCRawPacketFilterKey + RawPacketFilterMaxTailCall
+
+	// TCRawPacketShooterKey is the key to the raw packet shooter program
+	TCRawPacketShooterKey       = TCRawPacketSenderKey + 1
+	TCRawPacketShooterResultKey = TCRawPacketShooterKey + 1
+	// reserved key for filter tail calls
 )
 
 const (

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -559,7 +559,10 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 
 	// Add probes required to track network interfaces and map network flows to processes
 	// networkEventTypes: dns, imds, packet, network_monitor
+	// add packet_action as not exposed through SECL thus not repoted by GetEventTypePerCategory
 	networkEventTypes := model.GetEventTypePerCategory(model.NetworkCategory)[model.NetworkCategory]
+	networkEventTypes = append(networkEventTypes, model.RawPacketActionEventType.String())
+
 	for _, networkEventType := range networkEventTypes {
 		selectorsPerEventTypeStore[networkEventType] = []manager.ProbesSelector{
 			&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/rawpacket/bpffilter.go
+++ b/pkg/security/ebpf/probes/rawpacket/bpffilter.go
@@ -13,10 +13,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
+// TCAct is the type of the tc action
 type TCAct int
 
 const (
-	// state of tc action
 	// TCActOk will terminate the packet processing pipeline and allows the packet to proceed
 	TCActOk TCAct = 0
 	// TCActShot will terminate the packet processing pipeline and drop the packet

--- a/pkg/security/ebpf/probes/rawpacket/bpffilter.go
+++ b/pkg/security/ebpf/probes/rawpacket/bpffilter.go
@@ -12,8 +12,61 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+type TCAct int
+
+const (
+	// state of tc action
+	// TCActOk will terminate the packet processing pipeline and allows the packet to proceed
+	TCActOk TCAct = 0
+	// TCActShot will terminate the packet processing pipeline and drop the packet
+	TCActShot TCAct = 2
+	// TCActUnspec will continue packet processing
+	TCActUnspec TCAct = -1
+)
+
+// Policy defines the policy for a raw packet filter
+type Policy int
+
+const (
+	// PolicyAllow allows the packet to pass
+	PolicyAllow Policy = iota
+	// PolicyDrop drops the packet
+	PolicyDrop
+)
+
+// ToTCAct converts a policy to a TCAct
+func (p Policy) ToTCAct() TCAct {
+	switch p {
+	case PolicyDrop:
+		return TCActShot
+	default:
+		return TCActUnspec
+	}
+}
+
+// String returns the string representation of the policy
+func (p Policy) String() string {
+	switch p {
+	case PolicyDrop:
+		return "drop"
+	default:
+		return "allow"
+	}
+}
+
+// Parse parses a string and sets the policy
+func (p *Policy) Parse(str string) {
+	switch str {
+	case "drop":
+		*p = PolicyDrop
+	default:
+		*p = PolicyAllow
+	}
+}
+
 // Filter defines a raw packet filter
 type Filter struct {
 	RuleID    eval.RuleID
 	BPFFilter string
+	Policy    Policy
 }

--- a/pkg/security/ebpf/probes/rawpacket/bpffilter.go
+++ b/pkg/security/ebpf/probes/rawpacket/bpffilter.go
@@ -10,6 +10,7 @@ package rawpacket
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 type TCAct int
@@ -66,7 +67,9 @@ func (p *Policy) Parse(str string) {
 
 // Filter defines a raw packet filter
 type Filter struct {
-	RuleID    eval.RuleID
-	BPFFilter string
-	Policy    Policy
+	RuleID        eval.RuleID
+	BPFFilter     string
+	Policy        Policy
+	Pid           uint32
+	CGroupPathKey model.PathKey
 }

--- a/pkg/security/ebpf/probes/rawpacket/bpffilter.go
+++ b/pkg/security/ebpf/probes/rawpacket/bpffilter.go
@@ -9,6 +9,8 @@
 package rawpacket
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -72,4 +74,9 @@ type Filter struct {
 	Policy        Policy
 	Pid           uint32
 	CGroupPathKey model.PathKey
+}
+
+// Key returns a key representing the filter
+func (f *Filter) Key() string {
+	return fmt.Sprintf("%s:%d:%d", f.RuleID, f.Pid, f.CGroupPathKey.Inode)
 }

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -141,19 +141,21 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 
 			// check the cgroup id
 			asm.FnGetCurrentCgroupId.Call(),
+			asm.Mov.Reg(asm.R7, asm.R0),
 
 			// printk
-			/*asm.Mov.Reg(asm.R7, asm.R0),
-			asm.Mov.Reg(asm.R3, asm.R0),
-			asm.LoadImm(asm.R2, 2675202386094219606, asm.DWord),
-			asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
-			asm.Mov.Imm(asm.R2, 100),
-			asm.StoreMem(asm.RFP, -8, asm.R2, asm.Half),
-			asm.Mov.Reg(asm.R1, asm.RFP),
-			asm.Add.Imm(asm.R1, -16),
-			asm.Mov.Imm(asm.R2, 10),
-			asm.FnTracePrintk.Call(),
-			asm.Mov.Reg(asm.R0, asm.R7),*/
+			/*
+				asm.Mov.Reg(asm.R3, asm.R0),
+				asm.LoadImm(asm.R2, 2675202386094219606, asm.DWord),
+				asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
+				asm.Mov.Imm(asm.R2, 100),
+				asm.StoreMem(asm.RFP, -8, asm.R2, asm.Half),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -16),
+				asm.Mov.Imm(asm.R2, 10),
+				asm.FnTracePrintk.Call(),
+				asm.Mov.Reg(asm.R0, asm.R7),
+			*/
 
 			// check the cgroup id
 			asm.JEq.Imm(asm.R7, int32(filter.CGroupPathKey.Inode), opts.onMatchLabel),

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -25,22 +25,15 @@ import (
 
 const (
 	// progPrefix prefix used for raw packet filter programs
-	progPrefix = "raw_packet_prog_"
+	defaultProgPrefix = "raw_packet_filter_"
 
 	// packetCaptureSize see kernel definition
 	packetCaptureSize = 256
 
 	// raw packet data, see kernel definition
 	structRawPacketEventDataSize   = 256
-	structRawPacketEventDataOffset = 92
-
-	// state of tc action
-	// TCActOk will terminate the packet processing pipeline and allows the packet to proceed
-	TCActOk = 0
-	// TCActShot will terminate the packet processing pipeline and drop the packet
-	TCActShot = 2
-	// TCActUnspec will continue packet processing
-	TCActUnspec = -1
+	structRawPacketEventDataOffset = 164
+	structRawPacketEventPidOffset  = 16
 )
 
 // ProgOpts defines options
@@ -53,12 +46,16 @@ type ProgOpts struct {
 	MaxProgSize int
 	// Number of nop instruction inserted in each program
 	NopInstLen int
+	// ProgPrefix prefix used for raw packet filter programs
+	ProgPrefix string
 
 	// internals
-	sendEventLabel string
-	shotLabel      string
-	ctxSave        asm.Register
-	tailCallMapFd  int
+
+	// target register. register holding either the pid or the cgroup id/path
+	target        asm.Register
+	onMatchLabel  string
+	ctxSave       asm.Register
+	tailCallMapFd int
 }
 
 // DefaultProgOpts default options
@@ -76,14 +73,21 @@ func DefaultProgOpts() ProgOpts {
 			},
 			StackOffset: 16, // adapt using the stack size used outside of the filter itself, ex: map_lookup
 		},
-		sendEventLabel: "send_event",
-		ctxSave:        asm.R9,
-		MaxTailCalls:   probes.RawPacketFilterMaxTailCall,
-		MaxProgSize:    4000,
+		target:       asm.R8,
+		onMatchLabel: "on_match",
+		ctxSave:      asm.R9,
+		MaxTailCalls: probes.RawPacketFilterMaxTailCall,
+		MaxProgSize:  4000,
 	}
 }
 
-// BPFFilterToInsts compile a bpf filter expression
+// WithAction sets the action to take when a filter matches
+func (opts *ProgOpts) WithProgPrefix(prefix string) *ProgOpts {
+	opts.ProgPrefix = prefix
+	return opts
+}
+
+// FilterToInsts compile a bpf filter expression
 func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, error) {
 	pcapBPF, err := pcap.CompileBPFFilter(layers.LinkTypeEthernet, 256, filter.BPFFilter)
 	if err != nil {
@@ -109,40 +113,43 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 
 	resultLabel := cbpfcOpts.ResultLabel
 
-	jumpLabel := opts.sendEventLabel
-	if filter.Policy == PolicyDrop {
-		jumpLabel = opts.shotLabel
-	}
-
 	// add nop insts, used to test the max insts and artificially generate tail calls
 	for i := 0; i != opts.NopInstLen; i++ {
+		// insert a nop instruction
 		insts = append(insts,
-			asm.JEq.Imm(asm.R9, 0, jumpLabel).WithSymbol(resultLabel),
+			asm.JEq.Imm(opts.ctxSave, 0, opts.onMatchLabel).WithSymbol(resultLabel),
 		)
 		resultLabel = ""
 	}
 
-	// filter result
-	insts = append(insts,
-		asm.JNE.Imm(cbpfcOpts.Result, 0, jumpLabel).WithSymbol(resultLabel),
-	)
+	mismatchLabel := fmt.Sprintf("mismatch_%d_", index)
 
+	if filter.Pid != 0 {
+		fmt.Printf("!!!!!!!!!!!!!! filter.Pid: %d\n", filter.Pid)
+
+		insts = append(insts,
+			// == 0, no match
+			asm.JEq.Imm(cbpfcOpts.Result, 0, mismatchLabel).WithSymbol(resultLabel),
+
+			// check the pid
+			asm.JEq.Imm(opts.target, int32(filter.Pid), opts.onMatchLabel),
+			asm.Mov.Imm(asm.R4, 0).WithSymbol(mismatchLabel),
+		)
+	} else {
+		insts = append(insts,
+			asm.JNE.Imm(cbpfcOpts.Result, 0, opts.onMatchLabel).WithSymbol(resultLabel),
+		)
+	}
 	return insts, nil
 }
 
-func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, senderInsts asm.Instructions) ([]asm.Instructions, *multierror.Error) {
+func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, footerInsts asm.Instructions) ([]asm.Instructions, *multierror.Error) {
 	var (
 		progInsts []asm.Instructions
 		mErr      *multierror.Error
 		tailCalls int
 		header    bool
 	)
-
-	// prepend a return instruction in case of fail
-	footerInsts := append(asm.Instructions{
-		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
-		asm.Return(),
-	}, senderInsts...)
 
 	isMaxSizeExceeded := func(filterInsts, tailCallInsts asm.Instructions) bool {
 		return len(filterInsts)+len(tailCallInsts)+len(footerInsts) > opts.MaxProgSize
@@ -205,13 +212,8 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, senderInsts as
 	return progInsts, mErr
 }
 
-// FiltersToProgramSpecs returns list of program spec from raw packet filters definitions
-func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Filter, opts ProgOpts) ([]*ebpf.ProgramSpec, error) {
-	var mErr *multierror.Error
-
-	opts.tailCallMapFd = clsRouterMapFd
-
-	headerInsts := append(asm.Instructions{},
+func getHeaderInsts(rawPacketEventMapFd int, opts ProgOpts) asm.Instructions {
+	return append(asm.Instructions{},
 		// save ctx
 		asm.Mov.Reg(opts.ctxSave, asm.R1),
 		// load raw event
@@ -223,24 +225,51 @@ func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Fi
 		asm.JNE.Imm(asm.R0, 0, "raw-packet-event-not-null"),
 		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
 		asm.Return(),
+		// load the pid from the packet
+		asm.LoadMem(opts.target, asm.R0, structRawPacketEventPidOffset, asm.Word).WithSymbol("raw-packet-event-not-null"),
 		// place in result in the start register and end register
-		asm.Mov.Reg(opts.PacketStart, asm.R0).WithSymbol("raw-packet-event-not-null"),
+		asm.Mov.Reg(opts.PacketStart, asm.R0),
 		asm.Add.Imm(opts.PacketStart, structRawPacketEventDataOffset),
 		asm.Mov.Reg(opts.PacketEnd, opts.PacketStart),
 		asm.Add.Imm(opts.PacketEnd, structRawPacketEventDataSize),
 	)
+}
+
+// FiltersToProgramSpecs returns list of program spec from raw packet filters definitions
+func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Filter, opts ProgOpts) ([]*ebpf.ProgramSpec, error) {
+	var mErr *multierror.Error
+
+	if opts.ProgPrefix == "" {
+		opts.ProgPrefix = defaultProgPrefix
+	}
+
+	opts.tailCallMapFd = clsRouterMapFd
+
+	headerInsts := getHeaderInsts(rawPacketEventMapFd, opts)
 
 	senderInsts := asm.Instructions{
-		asm.Mov.Reg(asm.R1, opts.ctxSave).WithSymbol(opts.sendEventLabel),
+		asm.Mov.Reg(asm.R1, opts.ctxSave).WithSymbol(opts.onMatchLabel),
 		asm.LoadMapPtr(asm.R2, clsRouterMapFd),
-		asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketParserSenderKey)),
+		asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketSenderKey)),
 		asm.FnTailCall.Call(),
 		asm.Mov.Imm(asm.R0, probes.TCActUnspec),
 		asm.Return(),
 	}
 
+	// prepend a return instruction in case of fail
+	footerInsts := append(asm.Instructions{
+		// chain with shooters
+		asm.Mov.Reg(asm.R1, opts.ctxSave),
+		asm.LoadMapPtr(asm.R2, clsRouterMapFd),
+		asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketShooterKey)),
+		asm.FnTailCall.Call(),
+		// otherwise accept the packet
+		asm.Mov.Imm(asm.R0, int32(TCActUnspec)),
+		asm.Return(),
+	}, senderInsts...)
+
 	// compile and convert to eBPF progs
-	progInsts, err := filtersToProgs(filters, opts, headerInsts, senderInsts)
+	progInsts, err := filtersToProgs(filters, opts, headerInsts, footerInsts)
 	if err.ErrorOrNil() != nil {
 		mErr = multierror.Append(mErr, err)
 	}
@@ -253,7 +282,62 @@ func FiltersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Fi
 	progSpecs := make([]*ebpf.ProgramSpec, len(progInsts))
 
 	for i, insts := range progInsts {
-		name := fmt.Sprintf("%s%d", progPrefix, i)
+		name := fmt.Sprintf("%s%d", opts.ProgPrefix, i)
+
+		progSpecs[i] = &ebpf.ProgramSpec{
+			Name:         name,
+			Type:         ebpf.SchedCLS,
+			Instructions: insts,
+			License:      "GPL",
+		}
+	}
+
+	return progSpecs, mErr.ErrorOrNil()
+}
+
+// ShootersToProgramSpecs returns list of program spec from raw packet filters definitions
+func ShootersToProgramSpecs(rawPacketEventMapFd, clsRouterMapFd int, filters []Filter, opts ProgOpts) ([]*ebpf.ProgramSpec, error) {
+	var mErr *multierror.Error
+
+	if opts.ProgPrefix == "" {
+		opts.ProgPrefix = defaultProgPrefix
+	}
+
+	opts.tailCallMapFd = clsRouterMapFd
+
+	headerInsts := getHeaderInsts(rawPacketEventMapFd, opts)
+
+	resultInsts := asm.Instructions{
+		asm.Mov.Reg(asm.R1, opts.ctxSave).WithSymbol(opts.onMatchLabel),
+		asm.LoadMapPtr(asm.R2, clsRouterMapFd),
+		asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketShooterResultKey)),
+		asm.FnTailCall.Call(),
+		asm.Mov.Imm(asm.R0, int32(TCActUnspec)),
+		asm.Return(),
+	}
+
+	// prepend a return instruction in case of fail
+	footerInsts := append(asm.Instructions{
+		// otherwise accept the packet
+		asm.Mov.Imm(asm.R0, int32(TCActUnspec)),
+		asm.Return(),
+	}, resultInsts...)
+
+	// compile and convert to eBPF progs
+	progInsts, err := filtersToProgs(filters, opts, headerInsts, footerInsts)
+	if err.ErrorOrNil() != nil {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	// should be possible
+	if len(progInsts) == 0 {
+		return nil, errors.New("no program were generated")
+	}
+
+	progSpecs := make([]*ebpf.ProgramSpec, len(progInsts))
+
+	for i, insts := range progInsts {
+		name := fmt.Sprintf("%s%d", opts.ProgPrefix, i)
 
 		progSpecs[i] = &ebpf.ProgramSpec{
 			Name:         name,

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -159,17 +159,18 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 			// load the cgroup id from the packet
 			asm.LoadMem(asm.R7, opts.eventPtrReg, packetCgroupIdOffset, asm.DWord),
 
-			// printk
-
-			asm.Mov.Reg(asm.R3, asm.R7),
-			asm.LoadImm(asm.R2, 2675202386094219606, asm.DWord),
-			asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
-			asm.Mov.Imm(asm.R2, 100),
-			asm.StoreMem(asm.RFP, -8, asm.R2, asm.Half),
-			asm.Mov.Reg(asm.R1, asm.RFP),
-			asm.Add.Imm(asm.R1, -16),
-			asm.Mov.Imm(asm.R2, 10),
-			asm.FnTracePrintk.Call(),
+			// printk the cgroup id
+			/*
+				asm.Mov.Reg(asm.R3, asm.R7),
+				asm.LoadImm(asm.R2, 2675202386094219606, asm.DWord),
+				asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
+				asm.Mov.Imm(asm.R2, 100),
+				asm.StoreMem(asm.RFP, -8, asm.R2, asm.Half),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -16),
+				asm.Mov.Imm(asm.R2, 10),
+				asm.FnTracePrintk.Call(),
+			*/
 
 			// check the cgroup id
 			asm.LoadImm(asm.R8, int64(filter.CGroupPathKey.Inode), asm.DWord),

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -142,7 +142,22 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 			// check the cgroup id
 			asm.Mov.Reg(asm.R1, opts.ctxSave),
 			asm.FnSkbCgroupId.Call(),
-			asm.JEq.Imm(asm.R0, int32(filter.CGroupPathKey.Inode), opts.onMatchLabel),
+
+			// save result in r7
+			asm.Mov.Reg(asm.R7, asm.R0),
+
+			// printk
+			asm.Mov.Reg(asm.R3, asm.R0),
+			asm.LoadImm(asm.R2, 2675202386094219606, asm.DWord),
+			asm.StoreMem(asm.RFP, -16, asm.R2, asm.DWord),
+			asm.Mov.Imm(asm.R2, 100),
+			asm.StoreMem(asm.RFP, -8, asm.R2, asm.Half),
+			asm.Mov.Reg(asm.R1, asm.RFP),
+			asm.Add.Imm(asm.R1, -16),
+			asm.Mov.Imm(asm.R2, 10),
+			asm.FnTracePrintk.Call(),
+
+			asm.JNE.Imm(asm.R7, int32(filter.CGroupPathKey.Inode), opts.onMatchLabel),
 			asm.Mov.Imm(asm.R4, 0).WithSymbol(mismatchLabel),
 		)
 	} else {

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -96,8 +96,8 @@ func (opts *ProgOpts) WithProgPrefix(prefix string) *ProgOpts {
 	return opts
 }
 
-// WithGetCurrentCgroupId sets if the program should use the get_current_cgroup_id function
-func (opts *ProgOpts) WithGetCurrentCgroupId(hasGetCurrentCgroupId bool) *ProgOpts {
+// WithGetCurrentCgroupID sets if the program should use the get_current_cgroup_id function
+func (opts *ProgOpts) WithGetCurrentCgroupID(hasGetCurrentCgroupId bool) *ProgOpts {
 	opts.hasGetCurrentCgroupId = hasGetCurrentCgroupId
 	return opts
 }

--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -31,19 +31,13 @@ const (
 	packetCaptureSize = 256
 
 	// raw packet data, see kernel definition
-<<<<<<< HEAD
-	structRawPacketEventDataSize   = 256
-	structRawPacketEventDataOffset = 164
-	structRawPacketEventPidOffset  = 16
-=======
 	// pahole /opt/datadog-agent/embedded/share/system-probe/ebpf/runtime-security-syscall-wrapper.o -y raw_packet_event_t -E --structs -V
-	packetPidOffset      = 16
-	packetCgroupIdOffset = 136
-	packetDataOffset     = 164
+	structRawPacketEventPidOffset      = 16
+	structRawPacketEventCgroupIdOffset = 64
+	structRawPacketEventDataOffset     = 92
 
 	// payload size
-	packetDataSize = 256
->>>>>>> e988783e33d (fix probes selection)
+	structRawPacketEventDataSize = 256
 )
 
 // ProgOpts defines options
@@ -146,7 +140,7 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 
 			// check the pid
 			// load the pid from the packet
-			asm.LoadMem(asm.R7, opts.eventPtrReg, packetPidOffset, asm.Word),
+			asm.LoadMem(asm.R7, opts.eventPtrReg, structRawPacketEventPidOffset, asm.Word),
 			asm.JEq.Imm(asm.R7, int32(filter.Pid), opts.onMatchLabel),
 			asm.Mov.Imm(asm.R4, 0).WithSymbol(mismatchLabel), // nop instruction, just hold the symbol
 		)
@@ -157,7 +151,7 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 			asm.JEq.Imm(cbpfcOpts.Result, 0, mismatchLabel).WithSymbol(resultLabel),
 
 			// load the cgroup id from the packet
-			asm.LoadMem(asm.R7, opts.eventPtrReg, packetCgroupIdOffset, asm.DWord),
+			asm.LoadMem(asm.R7, opts.eventPtrReg, structRawPacketEventCgroupIdOffset, asm.DWord),
 
 			// printk the cgroup id
 			/*

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -30,7 +30,7 @@ func DefaultProgOpts() ProgOpts {
 	return ProgOpts{}
 }
 
-// WithAction sets the action to take when a filter matches
+// WithProgPrefix sets the prefix for the program name
 func (opts *ProgOpts) WithProgPrefix(_ string) *ProgOpts {
 	return opts
 }

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -35,6 +35,11 @@ func (opts *ProgOpts) WithProgPrefix(_ string) *ProgOpts {
 	return opts
 }
 
+// WithGetCurrentCgroupId sets if the program should use the get_current_cgroup_id function
+func (opts *ProgOpts) WithGetCurrentCgroupId(hasGetCurrentCgroupId bool) *ProgOpts {
+	return opts
+}
+
 // FilterToInsts compile a bpf filter expression
 func FilterToInsts(_ int, _ Filter, _ ProgOpts) (asm.Instructions, error) {
 	return asm.Instructions{}, errors.New("not supported")

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -30,12 +30,22 @@ func DefaultProgOpts() ProgOpts {
 	return ProgOpts{}
 }
 
-// BPFFilterToInsts compile a bpf filter expression
-func BPFFilterToInsts(_ int, _ string, _ ProgOpts) (asm.Instructions, error) {
+// WithAction sets the action to take when a filter matches
+func (opts *ProgOpts) WithProgPrefix(prefix string) *ProgOpts {
+	return opts
+}
+
+// FilterToInsts compile a bpf filter expression
+func FilterToInsts(_ int, _ Filter, _ ProgOpts) (asm.Instructions, error) {
 	return asm.Instructions{}, errors.New("not supported")
 }
 
 // FiltersToProgramSpecs returns list of program spec from raw packet filters definitions
 func FiltersToProgramSpecs(_, _ int, _ []Filter, _ ProgOpts) ([]*ebpf.ProgramSpec, error) {
+	return nil, errors.New("not supported")
+}
+
+// ShootersToProgramSpecs returns list of program spec from raw packet filters definitions
+func ShootersToProgramSpecs(_, _ int, _ []Filter, _ ProgOpts) ([]*ebpf.ProgramSpec, error) {
 	return nil, errors.New("not supported")
 }

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -35,8 +35,8 @@ func (opts *ProgOpts) WithProgPrefix(_ string) *ProgOpts {
 	return opts
 }
 
-// WithGetCurrentCgroupId sets if the program should use the get_current_cgroup_id function
-func (opts *ProgOpts) WithGetCurrentCgroupId(hasGetCurrentCgroupId bool) *ProgOpts {
+// WithGetCurrentCgroupID sets if the program should use the get_current_cgroup_id function
+func (opts *ProgOpts) WithGetCurrentCgroupID(_ bool) *ProgOpts {
 	return opts
 }
 

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -31,7 +31,7 @@ func DefaultProgOpts() ProgOpts {
 }
 
 // WithAction sets the action to take when a filter matches
-func (opts *ProgOpts) WithProgPrefix(prefix string) *ProgOpts {
+func (opts *ProgOpts) WithProgPrefix(_ string) *ProgOpts {
 	return opts
 }
 
@@ -45,7 +45,7 @@ func FiltersToProgramSpecs(_, _ int, _ []Filter, _ ProgOpts) ([]*ebpf.ProgramSpe
 	return nil, errors.New("not supported")
 }
 
-// ShootersToProgramSpecs returns list of program spec from raw packet filters definitions
-func ShootersToProgramSpecs(_, _ int, _ []Filter, _ ProgOpts) ([]*ebpf.ProgramSpec, error) {
+// DropActionsToProgramSpecs returns list of program spec from raw packet filters definitions
+func DropActionsToProgramSpecs(_, _ int, _ []Filter, _ ProgOpts) ([]*ebpf.ProgramSpec, error) {
 	return nil, errors.New("not supported")
 }

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -10,6 +10,7 @@ package probes
 
 import (
 	"fmt"
+	"slices"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
@@ -25,6 +26,16 @@ const (
 	// TCActUnspec will continue packet processing
 	TCActUnspec = -1
 )
+
+// ProgAllowedToTCActShot programs allowed to use shot tc act
+var ProgAllowedToTCActShot = []string{
+	tailCallClassifierFnc("raw_packet_drop_action_cb"),
+}
+
+// IsProgAllowedToTCActShot checks if the program is allowed to use shot tc act
+func IsProgAllowedToTCActShot(prog string) bool {
+	return slices.Contains(ProgAllowedToTCActShot, prog)
+}
 
 // GetTCProbes returns the list of TCProbes
 func GetTCProbes(withNetworkIngress bool, withRawPacket bool) []*manager.Probe {
@@ -170,6 +181,9 @@ func getTCTailCallRoutes(withRawPacket bool) []manager.TailCallRoute {
 func CheckUnspecReturnCode(progSpecs map[string]*ebpf.ProgramSpec) error {
 	for _, progSpec := range progSpecs {
 		if progSpec.Type == ebpf.SchedCLS {
+			if IsProgAllowedToTCActShot(progSpec.Name) {
+				continue
+			}
 
 			r0 := int32(255)
 

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -156,9 +156,9 @@ func getTCTailCallRoutes(withRawPacket bool) []manager.TailCallRoute {
 
 		tcr = append(tcr, manager.TailCallRoute{
 			ProgArrayName: "raw_packet_classifier_router",
-			Key:           TCRawPacketShooterResultKey,
+			Key:           TCRawPacketDropActionShotKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFFuncName: tailCallClassifierFnc("raw_packet_shot"),
+				EBPFFuncName: tailCallClassifierFnc("raw_packet_drop_action_cb"),
 			},
 		})
 	}

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -148,9 +148,17 @@ func getTCTailCallRoutes(withRawPacket bool) []manager.TailCallRoute {
 	if withRawPacket {
 		tcr = append(tcr, manager.TailCallRoute{
 			ProgArrayName: "raw_packet_classifier_router",
-			Key:           TCRawPacketParserSenderKey,
+			Key:           TCRawPacketSenderKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: tailCallClassifierFnc("raw_packet_sender"),
+			},
+		})
+
+		tcr = append(tcr, manager.TailCallRoute{
+			ProgArrayName: "raw_packet_classifier_router",
+			Key:           TCRawPacketShooterResultKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: tailCallClassifierFnc("raw_packet_shot"),
 			},
 		})
 	}

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -93,8 +93,9 @@ func GetTCProbes(withNetworkIngress bool, withRawPacket bool) []*manager.Probe {
 // GetRawPacketTCProgramFunctions returns the raw packet functions
 func GetRawPacketTCProgramFunctions() []string {
 	return []string{
-		tailCallClassifierFnc("raw_packet"),
+		//tailCallClassifierFnc("raw_packet"),
 		tailCallClassifierFnc("raw_packet_sender"),
+		tailCallClassifierFnc("raw_packet_drop_action_cb"),
 	}
 }
 

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -60,7 +60,7 @@ func testRawPacketFilter(t *testing.T, filters []rawpacket.Filter, progName stri
 	}
 	sendProgFD := vm.AddProgram(&sendProgSpec)
 
-	_, err = routerMap.Update(probes.TCRawPacketParserSenderKey, sendProgFD, baloum.BPF_ANY)
+	_, err = routerMap.Update(probes.TCRawPacketSenderKey, sendProgFD, baloum.BPF_ANY)
 	assert.Nil(t, err, "map update error")
 
 	code, err := vm.RunProgram(&ctx, progName, ebpf.SchedCLS)

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -268,7 +268,7 @@ func TestRawPacketFilters(t *testing.T) {
 }
 
 func TestRawPacketDropAction(t *testing.T) {
-	t.Run("syn-port-std-ok", func(t *testing.T) {
+	t.Run("syn-port-std-pid-ok", func(t *testing.T) {
 		filters := []rawpacket.Filter{
 			{
 				RuleID:    "ok",

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -267,7 +267,7 @@ func TestRawPacketFilters(t *testing.T) {
 	})
 }
 
-func TestRawPacketShooters(t *testing.T) {
+func TestRawPacketDropAction(t *testing.T) {
 	t.Run("syn-port-std-ok", func(t *testing.T) {
 		filters := []rawpacket.Filter{
 			{

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/rawpacket"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 const (
@@ -274,19 +275,47 @@ func TestRawPacketDropAction(t *testing.T) {
 				RuleID:    "ok",
 				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
 				Policy:    rawpacket.PolicyDrop,
-				Pid:       uint32(123),
+				Pid:       123,
 			},
 		}
 		testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", 255, 1, rawpacket.DefaultProgOpts(), true)
 	})
 
-	t.Run("syn-port-std-ko", func(t *testing.T) {
+	t.Run("syn-port-std-pid-ko", func(t *testing.T) {
 		filters := []rawpacket.Filter{
 			{
 				RuleID:    "ko",
 				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
 				Policy:    rawpacket.PolicyDrop,
-				Pid:       uint32(567),
+				Pid:       999,
+			},
+		}
+		testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", probes.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)
+	})
+
+	t.Run("syn-port-std-cgroup-ok", func(t *testing.T) {
+		filters := []rawpacket.Filter{
+			{
+				RuleID:    "ok",
+				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
+				Policy:    rawpacket.PolicyDrop,
+				CGroupPathKey: model.PathKey{
+					Inode: 456,
+				},
+			},
+		}
+		testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", 255, 1, rawpacket.DefaultProgOpts(), true)
+	})
+
+	t.Run("syn-port-std-cgroup-ko", func(t *testing.T) {
+		filters := []rawpacket.Filter{
+			{
+				RuleID:    "ko",
+				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
+				Policy:    rawpacket.PolicyDrop,
+				CGroupPathKey: model.PathKey{
+					Inode: 999,
+				},
 			},
 		}
 		testRawPacketDropAction(t, filters, "test/raw_packet_drop_action", probes.TCActUnspec, 1, rawpacket.DefaultProgOpts(), true)

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -68,6 +68,11 @@ const (
 	SysCtlSnapshotRuleID = "sysctl_snapshot"
 	// SysCtlSnapshotRuleDesc is the description of the sysctl snapshot rule
 	SysCtlSnapshotRuleDesc = "A new sysctl snapshot was generated"
+
+	// RawPacketActionRuleID is the rule ID for raw packet action events
+	RawPacketActionRuleID = "rawpacket_action"
+	// RawPacketActionRuleDesc is the rule description for raw packet action events
+	RawPacketActionRuleDesc = "RawPacket Action"
 )
 
 // AgentContainerContext is like model.ContainerContext, but without event based resolvers

--- a/pkg/security/probe/actions_linux.go
+++ b/pkg/security/probe/actions_linux.go
@@ -94,3 +94,42 @@ func (k *HashActionReport) PatchEvent(ev *serializers.EventSerializer) {
 	ev.FileEventSerializer.HashState = k.fileEvent.HashState.String()
 	ev.FileEventSerializer.Hashes = k.fileEvent.Hashes
 }
+
+// RawPacketActionReport defines a raw packet action reports
+// easyjson:json
+type RawPacketActionReport struct {
+	sync.RWMutex
+
+	Filter string `json:"filter"`
+	Policy string `json:"policy"`
+
+	// internal
+	resolved bool
+	rule     *rules.Rule
+}
+
+// IsResolved return if the action is resolved
+func (k *RawPacketActionReport) IsResolved() error {
+	return nil
+}
+
+// ToJSON marshal the action
+func (k *RawPacketActionReport) ToJSON() ([]byte, error) {
+	k.Lock()
+	defer k.Unlock()
+
+	data, err := utils.MarshalEasyJSON(k)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// IsMatchingRule returns true if this action report is targeted at the given rule ID
+func (k *RawPacketActionReport) IsMatchingRule(ruleID eval.RuleID) bool {
+	k.RLock()
+	defer k.RUnlock()
+
+	return k.rule.ID == ruleID
+}

--- a/pkg/security/probe/actions_linux.go
+++ b/pkg/security/probe/actions_linux.go
@@ -104,8 +104,7 @@ type RawPacketActionReport struct {
 	Policy string `json:"policy"`
 
 	// internal
-	resolved bool
-	rule     *rules.Rule
+	rule *rules.Rule
 }
 
 // IsResolved return if the action is resolved

--- a/pkg/security/probe/actions_linux_easyjson.go
+++ b/pkg/security/probe/actions_linux_easyjson.go
@@ -20,7 +20,66 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *HashActionReport) {
+func easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *RawPacketActionReport) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "filter":
+			out.Filter = string(in.String())
+		case "policy":
+			out.Policy = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in RawPacketActionReport) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"filter\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Filter))
+	}
+	{
+		const prefix string = ",\"policy\":"
+		out.RawString(prefix)
+		out.String(string(in.Policy))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v RawPacketActionReport) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *RawPacketActionReport) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
+}
+func easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *HashActionReport) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -57,7 +116,7 @@ func easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		in.Consumed()
 	}
 }
-func easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in HashActionReport) {
+func easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jwriter.Writer, in HashActionReport) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -86,10 +145,10 @@ func easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v HashActionReport) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
+	easyjson7cab6e30EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *HashActionReport) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
+	easyjson7cab6e30DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(l, v)
 }

--- a/pkg/security/probe/model_ebpf.go
+++ b/pkg/security/probe/model_ebpf.go
@@ -35,7 +35,13 @@ func NewEBPFModel(probe *EBPFProbe) *model.Model {
 				if probe.isRawPacketNotSupported() {
 					return fmt.Errorf("%s is not available on this kernel version", field)
 				}
-				if _, err := rawpacket.BPFFilterToInsts(0, value.Value.(string), rawpacket.DefaultProgOpts()); err != nil {
+
+				filter := rawpacket.Filter{
+					BPFFilter: value.Value.(string),
+					Policy:    rawpacket.PolicyAllow,
+				}
+
+				if _, err := rawpacket.FilterToInsts(0, filter, rawpacket.DefaultProgOpts()); err != nil {
 					return err
 				}
 			}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2485,6 +2485,10 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Name:  "sched_cls_has_current_pid_tgid_helper",
 			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentPidTgidForSchedCLS()),
 		},
+		manager.ConstantEditor{
+			Name:  "sched_cls_has_current_cgroup_id_helper",
+			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupIdForSchedCLS()),
+		},
 	)
 
 	if p.kernelVersion.HavePIDLinkStruct() {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3070,7 +3070,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				}
 
 				if action.Def.NetworkFilter.Scope == "cgroup" {
-					dropActionFilter.CGroupPathKey = ev.CGroupContext.CGroupPathKey
+					dropActionFilter.CGroupPathKey = ev.CGroupContext.CGroupFile
 				} else {
 					dropActionFilter.Pid = ev.ProcessContext.Pid
 				}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -622,7 +622,9 @@ func (p *EBPFProbe) setupRawPacketProgs(progSpecs []*lib.ProgramSpec, progKey ui
 	}
 
 	if len(progSpecs) > 0 {
-		p.enableRawPacket(true)
+		if err := p.enableRawPacket(true); err != nil {
+			return err
+		}
 	} else {
 		return nil
 	}
@@ -2267,7 +2269,9 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.FilterReport, err
 
 	if p.probe.IsNetworkRawPacketEnabled() {
 		// disable first, and let the following code enable it if needed
-		p.enableRawPacket(false)
+		if err := p.enableRawPacket(false); err != nil {
+			seclog.Errorf("unable to disable raw packet filter programs: %v", err)
+		}
 
 		if err := p.setupRawPacketFilters(rs); err != nil {
 			seclog.Errorf("unable to load raw packet filter programs: %v", err)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -685,7 +685,7 @@ func (p *EBPFProbe) setupRawPacketFilters(rs *rules.RuleSet) error {
 		opts.MaxProgSize = 1_000_000
 	}
 
-	seclog.Debugf("generate rawpacker filter programs with a limit of %d max instructions", opts.MaxProgSize)
+	seclog.Debugf("generate rawpacket filter programs with a limit of %d max instructions", opts.MaxProgSize)
 
 	rawPacketEventMap, routerMap, err := p.getRawPacketMaps()
 	if err != nil {
@@ -709,13 +709,14 @@ func (p *EBPFProbe) applyRawPacketActionFilters() error {
 
 	opts := rawpacket.DefaultProgOpts()
 	opts.WithProgPrefix("raw_packet_drop_action_")
+	opts.WithGetCurrentCgroupId(p.kernelVersion.HasBpfGetCurrentPidTgidForSchedCLS())
 
 	// adapt max instruction limits depending of the kernel version
 	if p.kernelVersion.Code >= kernel.Kernel5_2 {
 		opts.MaxProgSize = 1_000_000
 	}
 
-	seclog.Errorf("generate rawpacker filter programs with a limit of %d max instructions", opts.MaxProgSize)
+	seclog.Errorf("generate rawpacket filter programs with a limit of %d max instructions", opts.MaxProgSize)
 
 	rawPacketEventMap, routerMap, err := p.getRawPacketMaps()
 	if err != nil {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -709,7 +709,7 @@ func (p *EBPFProbe) applyRawPacketActionFilters() error {
 
 	opts := rawpacket.DefaultProgOpts()
 	opts.WithProgPrefix("raw_packet_drop_action_")
-	opts.WithGetCurrentCgroupId(p.kernelVersion.HasBpfGetCurrentPidTgidForSchedCLS())
+	opts.WithGetCurrentCgroupID(p.kernelVersion.HasBpfGetCurrentPidTgidForSchedCLS())
 
 	// adapt max instruction limits depending of the kernel version
 	if p.kernelVersion.Code >= kernel.Kernel5_2 {
@@ -2487,7 +2487,7 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 		},
 		manager.ConstantEditor{
 			Name:  "sched_cls_has_current_cgroup_id_helper",
-			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupIdForSchedCLS()),
+			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupIDForSchedCLS()),
 		},
 	)
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -739,7 +739,7 @@ func (p *EBPFProbe) addRawPacketActionFilter(actionFilter rawpacket.Filter) erro
 	seclog.Infof("add raw packet action filter: %+v\n", actionFilter)
 
 	if slices.ContainsFunc(p.rawPacketActionFilters, func(af rawpacket.Filter) bool {
-		return actionFilter.RuleID == af.RuleID
+		return actionFilter.Key() == af.Key()
 	}) {
 		return nil
 	}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -570,7 +570,9 @@ func (e *RuleEngine) getEventTypeEnabled() map[eval.EventType]bool {
 		if eventTypes, exists := categories[model.NetworkCategory]; exists {
 			for _, eventType := range eventTypes {
 				switch eventType {
-				case model.RawPacketEventType.String():
+				case model.RawPacketFilterEventType.String():
+					enabled[eventType] = e.probe.IsNetworkRawPacketEnabled()
+				case model.RawPacketActionEventType.String():
 					enabled[eventType] = e.probe.IsNetworkRawPacketEnabled()
 				case model.NetworkFlowMonitorEventType.String():
 					enabled[eventType] = e.probe.IsNetworkFlowMonitorEnabled()

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -206,12 +206,13 @@ type PolicyState struct {
 // RuleAction is used to report policy was loaded
 // easyjson:json
 type RuleAction struct {
-	Filter   *string         `json:"filter,omitempty"`
-	Set      *RuleSetAction  `json:"set,omitempty"`
-	Kill     *RuleKillAction `json:"kill,omitempty"`
-	Hash     *HashAction     `json:"hash,omitempty"`
-	CoreDump *CoreDumpAction `json:"coredump,omitempty"`
-	Log      *LogAction      `json:"log,omitempty"`
+	Filter        *string              `json:"filter,omitempty"`
+	Set           *RuleSetAction       `json:"set,omitempty"`
+	Kill          *RuleKillAction      `json:"kill,omitempty"`
+	Hash          *HashAction          `json:"hash,omitempty"`
+	CoreDump      *CoreDumpAction      `json:"coredump,omitempty"`
+	Log           *LogAction           `json:"log,omitempty"`
+	NetworkFilter *NetworkFilterAction `json:"network_filter,omitempty"`
 }
 
 // HashAction is used to report 'hash' action
@@ -257,6 +258,14 @@ type CoreDumpAction struct {
 type LogAction struct {
 	Level   string `json:"level,omitempty"`
 	Message string `json:"message,omitempty"`
+}
+
+// NetworkFilterAction is used to report the 'network_filter' action
+// easyjson:json
+type NetworkFilterAction struct {
+	Filter string `json:"filter,omitempty"`
+	Policy string `json:"policy,omitempty"`
+	Scope  string `json:"scope,omitempty"`
 }
 
 // RulesetLoadedEvent is used to report that a new ruleset was loaded
@@ -356,6 +365,12 @@ func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status 
 			ruleAction.Log = &LogAction{
 				Level:   action.Def.Log.Level,
 				Message: action.Def.Log.Message,
+			}
+		case action.Def.NetworkFilter != nil:
+			ruleAction.NetworkFilter = &NetworkFilterAction{
+				Filter: action.Def.NetworkFilter.BPFFilter,
+				Policy: action.Def.NetworkFilter.Policy,
+				Scope:  action.Def.NetworkFilter.Scope,
 			}
 		}
 		ruleState.Actions = append(ruleState.Actions, ruleAction)

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -1615,6 +1615,16 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 				}
 				(*out.Log).UnmarshalEasyJSON(in)
 			}
+		case "network_filter":
+			if in.IsNull() {
+				in.Skip()
+				out.NetworkFilter = nil
+			} else {
+				if out.NetworkFilter == nil {
+					out.NetworkFilter = new(NetworkFilterAction)
+				}
+				(*out.NetworkFilter).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -1684,6 +1694,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 			out.RawString(prefix)
 		}
 		(*in.Log).MarshalEasyJSON(out)
+	}
+	if in.NetworkFilter != nil {
+		const prefix string = ",\"network_filter\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.NetworkFilter).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1826,7 +1846,84 @@ func (v PolicyState) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *PolicyState) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor6(l, v)
 }
-func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(in *jlexer.Lexer, out *LogAction) {
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(in *jlexer.Lexer, out *NetworkFilterAction) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "filter":
+			out.Filter = string(in.String())
+		case "policy":
+			out.Policy = string(in.String())
+		case "scope":
+			out.Scope = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(out *jwriter.Writer, in NetworkFilterAction) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.Filter != "" {
+		const prefix string = ",\"filter\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.Filter))
+	}
+	if in.Policy != "" {
+		const prefix string = ",\"policy\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Policy))
+	}
+	if in.Scope != "" {
+		const prefix string = ",\"scope\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Scope))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v NetworkFilterAction) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *NetworkFilterAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(l, v)
+}
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(in *jlexer.Lexer, out *LogAction) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1859,7 +1956,7 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(
 		in.Consumed()
 	}
 }
-func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(out *jwriter.Writer, in LogAction) {
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(out *jwriter.Writer, in LogAction) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1884,14 +1981,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v LogAction) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(w, v)
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *LogAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor7(l, v)
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(l, v)
 }
-func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(in *jlexer.Lexer, out *HeartbeatEvent) {
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(in *jlexer.Lexer, out *HeartbeatEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1946,7 +2043,7 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(
 		in.Consumed()
 	}
 }
-func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(out *jwriter.Writer, in HeartbeatEvent) {
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(out *jwriter.Writer, in HeartbeatEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1983,14 +2080,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v HeartbeatEvent) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(w, v)
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *HeartbeatEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor8(l, v)
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(l, v)
 }
-func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(in *jlexer.Lexer, out *HashAction) {
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(in *jlexer.Lexer, out *HashAction) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2021,7 +2118,7 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(
 		in.Consumed()
 	}
 }
-func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(out *jwriter.Writer, in HashAction) {
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(out *jwriter.Writer, in HashAction) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2036,14 +2133,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v HashAction) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(w, v)
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *HashAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor9(l, v)
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(l, v)
 }
-func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(in *jlexer.Lexer, out *CoreDumpAction) {
+func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor11(in *jlexer.Lexer, out *CoreDumpAction) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2080,7 +2177,7 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10
 		in.Consumed()
 	}
 }
-func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(out *jwriter.Writer, in CoreDumpAction) {
+func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor11(out *jwriter.Writer, in CoreDumpAction) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2125,10 +2222,10 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CoreDumpAction) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(w, v)
+	easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor11(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CoreDumpAction) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10(l, v)
+	easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor11(l, v)
 }

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -67,7 +67,8 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 	// Network
 	case
 		IMDSEventType.String(),
-		RawPacketEventType.String(),
+		RawPacketFilterEventType.String(),
+		RawPacketActionEventType.String(),
 		DNSEventType.String(),
 		FullDNSResponseEventType.String(),
 		NetworkFlowMonitorEventType.String():

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -111,8 +111,8 @@ const (
 	LoginUIDWriteEventType
 	// CgroupWriteEventType is sent when a new cgroup was created
 	CgroupWriteEventType
-	// RawPacketEventType raw packet event
-	RawPacketEventType
+	// RawPacketEventType raw packet filter event
+	RawPacketFilterEventType
 	// NetworkFlowMonitorEventType is sent to monitor network activity
 	NetworkFlowMonitorEventType
 	// StatEventType stat event (used kernel side only)
@@ -127,6 +127,8 @@ const (
 	FileFsmountEventType
 	// FileOpenTreeEventType Open Tree event
 	FileOpenTreeEventType
+	// RawPacketActionEventType raw packet action event
+	RawPacketActionEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -257,8 +259,10 @@ func (t EventType) String() string {
 		return "imds"
 	case OnDemandEventType:
 		return "ondemand"
-	case RawPacketEventType:
+	case RawPacketFilterEventType:
 		return "packet"
+	case RawPacketActionEventType:
+		return "packet_action"
 	case NetworkFlowMonitorEventType:
 		return "network_flow_monitor"
 	case StatEventType:

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -111,7 +111,7 @@ const (
 	LoginUIDWriteEventType
 	// CgroupWriteEventType is sent when a new cgroup was created
 	CgroupWriteEventType
-	// RawPacketEventType raw packet filter event
+	// RawPacketFilterEventType raw packet filter event
 	RawPacketFilterEventType
 	// NetworkFlowMonitorEventType is sent to monitor network activity
 	NetworkFlowMonitorEventType

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -101,6 +101,8 @@ type NetworkContext struct {
 	Destination      IPPortContext `field:"destination"`       // destination of the network packet
 	NetworkDirection uint32        `field:"network_direction"` // SECLDoc[network_direction] Definition:`Network direction of the network packet` Constants:`Network directions`
 	Size             uint32        `field:"size"`              // SECLDoc[size] Definition:`Size in bytes of the network packet`
+
+	Action uint32 `field:"-"`
 }
 
 // IsZero returns if there is a network context

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -101,8 +101,6 @@ type NetworkContext struct {
 	Destination      IPPortContext `field:"destination"`       // destination of the network packet
 	NetworkDirection uint32        `field:"network_direction"` // SECLDoc[network_direction] Definition:`Network direction of the network packet` Constants:`Network directions`
 	Size             uint32        `field:"size"`              // SECLDoc[size] Definition:`Size in bytes of the network packet`
-
-	Action uint32 `field:"-"`
 }
 
 // IsZero returns if there is a network context

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -120,12 +120,13 @@ type ActionDefinitionInterface interface {
 
 // ActionDefinition describes a rule action section
 type ActionDefinition struct {
-	Filter   *string             `yaml:"filter" json:"filter,omitempty"`
-	Set      *SetDefinition      `yaml:"set" json:"set,omitempty" jsonschema:"oneof_required=SetAction"`
-	Kill     *KillDefinition     `yaml:"kill" json:"kill,omitempty" jsonschema:"oneof_required=KillAction"`
-	CoreDump *CoreDumpDefinition `yaml:"coredump" json:"coredump,omitempty" jsonschema:"oneof_required=CoreDumpAction"`
-	Hash     *HashDefinition     `yaml:"hash" json:"hash,omitempty" jsonschema:"oneof_required=HashAction"`
-	Log      *LogDefinition      `yaml:"log" json:"log,omitempty" jsonschema:"oneof_required=LogAction"`
+	Filter        *string                  `yaml:"filter" json:"filter,omitempty"`
+	Set           *SetDefinition           `yaml:"set" json:"set,omitempty" jsonschema:"oneof_required=SetAction"`
+	Kill          *KillDefinition          `yaml:"kill" json:"kill,omitempty" jsonschema:"oneof_required=KillAction"`
+	CoreDump      *CoreDumpDefinition      `yaml:"coredump" json:"coredump,omitempty" jsonschema:"oneof_required=CoreDumpAction"`
+	Hash          *HashDefinition          `yaml:"hash" json:"hash,omitempty" jsonschema:"oneof_required=HashAction"`
+	Log           *LogDefinition           `yaml:"log" json:"log,omitempty" jsonschema:"oneof_required=LogAction"`
+	NetworkFilter *NetworkFilterDefinition `yaml:"network_filter" json:"network_filter,omitempty"`
 }
 
 // Name returns the name of the action
@@ -350,6 +351,21 @@ type LogDefinition struct {
 func (l *LogDefinition) PreCheck(_ PolicyLoaderOpts) error {
 	if l.Level == "" {
 		return errors.New("a valid log level must be specified to the the 'log' action")
+	}
+
+	return nil
+}
+
+// NetworkFilterDefinition describes the 'network_filter' section of a rule action
+type NetworkFilterDefinition struct {
+	BPFFilter string `yaml:"filter" json:"filter,omitempty"`
+	Policy    string `yaml:"policy" json:"policy,omitempty"`
+}
+
+// Check returns an error if the network filter action is invalid
+func (n *NetworkFilterDefinition) Check(opts PolicyLoaderOpts) error {
+	if n.BPFFilter == "" {
+		return errors.New("a valid BPF filter must be specified to the 'network_filter' action")
 	}
 
 	return nil

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -366,7 +366,7 @@ type NetworkFilterDefinition struct {
 	DefaultActionDefinition
 	BPFFilter string `yaml:"filter" json:"filter,omitempty"`
 	Policy    string `yaml:"policy" json:"policy,omitempty"`
-	Scope     string `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container"`
+	Scope     string `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=cgroup"`
 }
 
 // PreCheck returns an error if the network filter action is invalid
@@ -376,7 +376,7 @@ func (n *NetworkFilterDefinition) PreCheck(_ PolicyLoaderOpts) error {
 	}
 
 	// default scope to process
-	if n.Scope != "" && n.Scope != "process" && n.Scope != "container" {
+	if n.Scope != "" && n.Scope != "process" && n.Scope != "cgroup" {
 		return fmt.Errorf("invalid scope '%s'", n.Scope)
 	}
 

--- a/pkg/security/secl/schemas/agent_context.schema.json
+++ b/pkg/security/secl/schemas/agent_context.schema.json
@@ -42,6 +42,9 @@
                     },
                     {
                         "$ref": "hash.schema.json"
+                    },
+                    {
+                        "$ref": "network_filter.schema.json"
                     }
                 ]
             }

--- a/pkg/security/secl/schemas/network_filter.schema.json
+++ b/pkg/security/secl/schemas/network_filter.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "kill.schema.json",
+    "type": "object",
+    "properties": {
+        "filter": {
+            "type": "string"
+        },
+        "policy": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "filter",
+        "policy"
+    ]
+}

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -53,6 +53,9 @@
         },
         "log": {
           "$ref": "#/$defs/LogDefinition"
+        },
+        "network_filter": {
+          "$ref": "#/$defs/NetworkFilterDefinition"
         }
       },
       "additionalProperties": false,
@@ -212,6 +215,26 @@
         "id"
       ],
       "description": "MacroDefinition holds the definition of a macro"
+    },
+    "NetworkFilterDefinition": {
+      "properties": {
+        "filter": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "process",
+            "container"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetworkFilterDefinition describes the 'network_filter' section of a rule action"
     },
     "OverrideOptions": {
       "properties": {

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -228,7 +228,7 @@
           "type": "string",
           "enum": [
             "process",
-            "container"
+            "cgroup"
           ]
         }
       },

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -111,8 +111,8 @@ const (
 	LoginUIDWriteEventType
 	// CgroupWriteEventType is sent when a new cgroup was created
 	CgroupWriteEventType
-	// RawPacketEventType raw packet event
-	RawPacketEventType
+	// RawPacketEventType raw packet filter event
+	RawPacketFilterEventType
 	// NetworkFlowMonitorEventType is sent to monitor network activity
 	NetworkFlowMonitorEventType
 	// StatEventType stat event (used kernel side only)
@@ -127,6 +127,8 @@ const (
 	FileFsmountEventType
 	// FileOpenTreeEventType Open Tree event
 	FileOpenTreeEventType
+	// RawPacketActionEventType raw packet action event
+	RawPacketActionEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -257,8 +259,10 @@ func (t EventType) String() string {
 		return "imds"
 	case OnDemandEventType:
 		return "ondemand"
-	case RawPacketEventType:
+	case RawPacketFilterEventType:
 		return "packet"
+	case RawPacketActionEventType:
+		return "packet_action"
 	case NetworkFlowMonitorEventType:
 		return "network_flow_monitor"
 	case StatEventType:

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -111,7 +111,7 @@ const (
 	LoginUIDWriteEventType
 	// CgroupWriteEventType is sent when a new cgroup was created
 	CgroupWriteEventType
-	// RawPacketEventType raw packet filter event
+	// RawPacketFilterEventType raw packet filter event
 	RawPacketFilterEventType
 	// NetworkFlowMonitorEventType is sent to monitor network activity
 	NetworkFlowMonitorEventType

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -101,6 +101,8 @@ type NetworkContext struct {
 	Destination      IPPortContext `field:"destination"`       // destination of the network packet
 	NetworkDirection uint32        `field:"network_direction"` // SECLDoc[network_direction] Definition:`Network direction of the network packet` Constants:`Network directions`
 	Size             uint32        `field:"size"`              // SECLDoc[size] Definition:`Size in bytes of the network packet`
+
+	Action uint32 `field:"-"`
 }
 
 // IsZero returns if there is a network context

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -101,8 +101,6 @@ type NetworkContext struct {
 	Destination      IPPortContext `field:"destination"`       // destination of the network packet
 	NetworkDirection uint32        `field:"network_direction"` // SECLDoc[network_direction] Definition:`Network direction of the network packet` Constants:`Network directions`
 	Size             uint32        `field:"size"`              // SECLDoc[size] Definition:`Size in bytes of the network packet`
-
-	Action uint32 `field:"-"`
 }
 
 // IsZero returns if there is a network context

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -264,6 +264,7 @@ type RawPacketSerializer struct {
 	*NetworkContextSerializer
 
 	TLSContext *TLSContextSerializer `json:"tls,omitempty"`
+	Dropped    *bool                 `json:"dropped,omitempty"`
 }
 
 // NetworkStatsSerializer defines a new network stats serializer

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -454,6 +454,16 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(i
 				}
 				(*out.TLSContext).UnmarshalEasyJSON(in)
 			}
+		case "dropped":
+			if in.IsNull() {
+				in.Skip()
+				out.Dropped = nil
+			} else {
+				if out.Dropped == nil {
+					out.Dropped = new(bool)
+				}
+				*out.Dropped = bool(in.Bool())
+			}
 		case "device":
 			if in.IsNull() {
 				in.Skip()
@@ -495,6 +505,16 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(o
 		first = false
 		out.RawString(prefix[1:])
 		(*in.TLSContext).MarshalEasyJSON(out)
+	}
+	if in.Dropped != nil {
+		const prefix string = ",\"dropped\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(*in.Dropped))
 	}
 	if in.Device != nil {
 		const prefix string = ",\"device\":"

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -227,7 +227,7 @@ func TestRawPacketAction(t *testing.T) {
 		assert.NoError(t, err)
 
 		// wait for the action to be performed
-		time.Sleep(3 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		cmd = cmdWrapper.Command("nslookup", []string{"google.com"}, []string{})
 		if err := cmd.Run(); err == nil {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -166,12 +166,6 @@ func TestRawPacketAction(t *testing.T) {
 
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)
 
-	if testEnvironment != DockerEnvironment && !env.IsContainerized() {
-		if out, err := loadModule("veth"); err != nil {
-			t.Fatalf("couldn't load 'veth' module: %s, %v", string(out), err)
-		}
-	}
-
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule_raw_packet_drop",
 		Expression: `exec.file.name == "free"`,

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -207,7 +207,7 @@ func TestRawPacketAction(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_raw_packet_drop")
 		})
 
-		time.Sleep(time.Second)
+		time.Sleep(5 * time.Second)
 
 		cmd = cmdWrapper.Command("nslookup", []string{"google.com"}, []string{})
 		if err := cmd.Run(); err == nil {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -229,7 +229,7 @@ func TestRawPacketAction(t *testing.T) {
 		// wait for the action to be performed
 		time.Sleep(5 * time.Second)
 
-		cmd = cmdWrapper.Command("nslookup", []string{"google.com"}, []string{})
+		cmd = cmdWrapper.Command("nslookup", []string{"microsoft.com"}, []string{})
 		if err := cmd.Run(); err == nil {
 			t.Error("should return an error")
 		}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -203,11 +203,11 @@ func TestRawPacketAction(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdWrapper.Command("free", []string{}, []string{})
 			return cmd.Run()
-		}, func(event *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_raw_packet_drop")
 		})
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 
 		cmd = cmdWrapper.Command("nslookup", []string{"google.com"}, []string{})
 		if err := cmd.Run(); err == nil {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -158,6 +158,10 @@ func TestRawPacket(t *testing.T) {
 }
 
 func TestRawPacketAction(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skipping cgroup ID test in docker")
+	}
+
 	SkipIfNotAvailable(t)
 
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The goal is to define network filter action to drop packet for a process or for a cgroup

```
    expression: exec.file.path == "/usr/bin/free"
    actions:
      - network_filter:
          filter: dst 172.67.133.176 or dst 104.21.5.178
          policy: drop
          scope: cgroup

```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->