### PR TITLE
dyninst/procmon: fix container process monitoring

### DIFF
--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -86,6 +86,10 @@ func analyzeProcess(
 		exeFile, rootErr = os.Open(exePath)
 		if rootErr != nil {
 			err = errors.Join(err, rootErr)
+		} else {
+			// If we found the exe under the proc root, we can ignore the
+			// original error.
+			err = nil
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

A previous change to improve the handling of errors in process monitoring we accidentally broke processing of executables in containers. This is a major bug, and unfortunately is challenging to test in the unit tests where we'd need containers or something like them.

### Motivation

More QA on staging.

### Describe how you validated your changes

Automated testing and now doing local testing with containers.

### Possible Drawbacks / Trade-offs

We need to do more testing with containers in the repo or in system tests.

### Additional Notes

It is hard to test containers in CI (right?)

[DEBUG-4198](https://datadoghq.atlassian.net/issues/DEBUG-4198)

[DEBUG-4198]: https://datadoghq.atlassian.net/browse/DEBUG-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ