### PR TITLE
Remove ubuntu-14 from DDOT e2e tests

### DIFF
--- a/.gitlab/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/e2e_install_packages/ubuntu.yml
@@ -151,6 +151,8 @@ new-e2e-agent-platform-ddot-ubuntu-a7-x86_64:
     - .new-e2e_os_ubuntu
     - .new-e2e_ubuntu_a7_x86_64
   rules: !reference [.on_default_new_e2e_tests]
+  variables:
+    E2E_OSVERS: "ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04,ubuntu-24-04"
 
 new-e2e-agent-platform-ddot-ubuntu-a7-arm64:
   extends:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Removes ubuntu-14 from the DDOT e2e test matrix.

### Motivation
new-e2e-agent-platform-ddot-ubuntu-a7-x86_64 is failing on main because ubuntu-14 doesn't support `systemctl` which is used by `test/new-e2e/tests/installer/host`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->