### PR TITLE
dyninst: test docker in e2e test

### DIFF
--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -55,7 +55,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 	cfg := cfgs[idx]
 
 	sampleServicePath := testprogs.MustGetBinary(t, "rc_tester", cfg)
-	sampleServiceCmd, serverPort, err := startSampleService(t, sampleServiceConfig{
+	_, sampleServicePID, serverPort, err := startSampleService(t, sampleServiceConfig{
 		binaryPath: sampleServicePath,
 		tmpDir:     tmpDir,
 	})
@@ -100,7 +100,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 	scraper.setUpdates([]rcscrape.ProcessUpdate{
 		{
 			ProcessUpdate: procmon.ProcessUpdate{
-				ProcessID: procmon.ProcessID{PID: int32(sampleServiceCmd.Process.Pid)},
+				ProcessID: procmon.ProcessID{PID: int32(sampleServicePID)},
 				Executable: procmon.Executable{
 					Path: sampleServicePath,
 				},
@@ -148,7 +148,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 		}
 	}()
 	// They'll both still emit.
-	waitForLogMessages(t, backend, 10, "")
+	waitForLogMessages(t, backend, 10, "", false /* rewrite */)
 }
 
 type mockScraper struct {

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -8,6 +8,7 @@
 package dyninst_test
 
 import (
+	"archive/tar"
 	"bufio"
 	"bytes"
 	"crypto/sha256"
@@ -22,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -55,9 +57,28 @@ type testState struct {
 	module     *di_module.Module
 	subscriber *mockSubscriber
 	serviceCmd *exec.Cmd
+	servicePID uint32
+
+	useDocker bool
+}
+
+func dockerIsEnabled(t *testing.T) bool {
+	_, err := exec.LookPath("docker")
+	if err != nil {
+		return false
+	}
+	cmd := exec.Command("docker", "system", "info")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("docker system info: %s", string(out))
+		return false
+	}
+	return true
 }
 
 const expectationsPath = "testdata/e2e/rc_tester.json"
+
+const e2eTmpDirEnv = "E2E_TMP_DIR"
 
 //go:embed testdata/e2e/rc_tester.json
 var expectations embed.FS
@@ -65,10 +86,34 @@ var expectations embed.FS
 func TestEndToEnd(t *testing.T) {
 	dyninsttest.SkipIfKernelNotSupported(t)
 	cfgs := testprogs.MustGetCommonConfigs(t)
+	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
+		return c.GOARCH == runtime.GOARCH
+	})
+	require.NotEqual(t, -1, idx)
+	cfg := cfgs[idx]
 
-	tmpDir, cleanup := dyninsttest.PrepTmpDir(t, t.Name())
+	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
+	useDocker := dockerIsEnabled(t)
+	t.Run("docker", func(t *testing.T) {
+		if rewrite {
+			t.Skip("rewrite is enabled, skipping docker test")
+		}
+		if !useDocker {
+			t.Skip("docker is not enabled")
+		}
+		t.Parallel()
+		runE2ETest(t, useDocker, cfg, rewrite)
+	})
+	t.Run("direct", func(t *testing.T) {
+		t.Parallel()
+		runE2ETest(t, false /* useDocker */, cfg, rewrite)
+	})
+}
+
+func runE2ETest(t *testing.T, useDocker bool, cfg testprogs.Config, rewrite bool) {
+	tmpDir, cleanup := dyninsttest.PrepTmpDir(t, strings.ReplaceAll(t.Name(), "/", "_"))
 	defer cleanup()
-	ts := &testState{tmpDir: tmpDir}
+	ts := &testState{tmpDir: tmpDir, useDocker: useDocker}
 
 	diagCh := make(chan []byte, 10)
 	ts.backend = &mockBackend{diagPayloadCh: diagCh}
@@ -80,19 +125,13 @@ func TestEndToEnd(t *testing.T) {
 	t.Cleanup(ts.rcServer.Close)
 	t.Cleanup(ts.rc.Close)
 
-	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
-		return c.GOARCH == runtime.GOARCH
-	})
-	require.NotEqual(t, -1, idx)
-	cfg := cfgs[idx]
-
 	sampleServicePath := testprogs.MustGetBinary(t, "rc_tester", cfg)
 	ts.setupRemoteConfig(t)
 	serverPort := ts.startSampleService(t, sampleServicePath)
 
 	ts.initializeModule(t)
 
-	ts.subscriber.NotifyExec(uint32(ts.serviceCmd.Process.Pid))
+	ts.subscriber.NotifyExec(ts.servicePID)
 
 	expectedProbeIDs := []string{"look_at_the_request", "http_handler"}
 	waitForProbeStatus(
@@ -102,7 +141,7 @@ func TestEndToEnd(t *testing.T) {
 
 	const numRequests = 3
 	sendTestRequests(t, serverPort, numRequests)
-	waitForLogMessages(t, ts.backend, numRequests*len(expectedProbeIDs), expectationsPath)
+	waitForLogMessages(t, ts.backend, numRequests*len(expectedProbeIDs), expectationsPath, rewrite)
 	waitForProbeStatus(
 		t, ts.backend.diagPayloadCh,
 		makeTargetStatus(uploader.StatusEmitting, expectedProbeIDs...),
@@ -146,7 +185,7 @@ func createProbeEntry(t *testing.T, probe rcjson.Probe) (string, []byte) {
 	return path, encoded
 }
 
-func getRcTesterEnv(rcHost string, rcPort int) []string {
+func getRcTesterEnv(rcHost string, rcPort int, tmpDir string) []string {
 	return []string{
 		fmt.Sprintf("DD_AGENT_HOST=%s", rcHost),
 		fmt.Sprintf("DD_AGENT_PORT=%d", rcPort),
@@ -155,6 +194,7 @@ func getRcTesterEnv(rcHost string, rcPort int) []string {
 		"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=.01",
 		"DD_SERVICE=rc_tester",
 		"DD_REMOTE_CONFIG_TUF_NO_VERIFICATION=true",
+		fmt.Sprintf("%s=%s", e2eTmpDirEnv, tmpDir),
 	}
 }
 
@@ -166,10 +206,12 @@ func (ts *testState) startSampleService(t *testing.T, sampleServicePath string) 
 		rcPort:     rcPort,
 		binaryPath: sampleServicePath,
 		tmpDir:     ts.tmpDir,
+		useDocker:  ts.useDocker,
 	}
-	cmd, serverPort, err := startSampleService(t, cfg)
+	cmd, sampleServicePID, serverPort, err := startSampleService(t, cfg)
 	require.NoError(t, err)
 	ts.serviceCmd = cmd
+	ts.servicePID = sampleServicePID
 	return serverPort
 }
 
@@ -178,6 +220,7 @@ type sampleServiceConfig struct {
 	rcPort     int
 	binaryPath string
 	tmpDir     string
+	useDocker  bool
 }
 
 func hostPortFromURL(urlStr string) (host string, port int, err error) {
@@ -196,9 +239,69 @@ func hostPortFromURL(urlStr string) (host string, port int, err error) {
 	return host, port, nil
 }
 
-func startSampleService(t *testing.T, cfg sampleServiceConfig) (sampleServiceCmd *exec.Cmd, serverPort int, err error) {
+func startSampleServiceWithDocker(
+	t *testing.T,
+	cfg sampleServiceConfig,
+) (sampleServiceCmd *exec.Cmd) {
+	// Copy the binary to a tar file in the tmp dir.
+	tarPath := filepath.Join(cfg.tmpDir, "rc_tester.tar")
+	tarFile, err := os.Create(tarPath)
+	require.NoError(t, err)
+	defer tarFile.Close()
+	binaryFile, err := os.Open(cfg.binaryPath)
+	require.NoError(t, err)
+	defer binaryFile.Close()
+	stat, err := binaryFile.Stat()
+	require.NoError(t, err)
+	tarWriter := tar.NewWriter(tarFile)
+	binName := filepath.Base(cfg.binaryPath)
+	tarWriter.WriteHeader(&tar.Header{
+		Name: binName,
+		Mode: 0755, //rwxr-xr-x
+		Size: stat.Size(),
+	})
+	_, err = io.Copy(tarWriter, binaryFile)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, tarFile.Close())
+
+	containerTag := strings.ReplaceAll(strings.ReplaceAll(cfg.tmpDir, "/", "_"), ":", "_")
+	containerName := fmt.Sprintf("dyninst-e2e:%s", containerTag)
+	// Build the docker image.
+	dockerBuildCmd := exec.Command("docker", "image", "import", tarPath, containerName)
+	out, err := dockerBuildCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build docker image: %s", string(out))
+	}
+	t.Logf("built docker image %s", containerName)
+	t.Cleanup(func() {
+		if err := exec.Command("docker", "image", "rm", containerName).Run(); err != nil {
+			t.Logf("failed to remove docker image %s: %v", containerName, err)
+		}
+	})
+
+	args := []string{"run", "--rm", "--network", "host"}
+	for _, env := range getRcTesterEnv(cfg.rcHost, cfg.rcPort, cfg.tmpDir) {
+		args = append(args, "--env", env)
+	}
+	args = append(args, containerName, "/"+binName)
+	dockerCmd := exec.Command("docker", args...)
+	return dockerCmd
+}
+
+func newDirectCommand(cfg sampleServiceConfig) *exec.Cmd {
 	cmd := exec.Command(cfg.binaryPath)
-	cmd.Env = getRcTesterEnv(cfg.rcHost, cfg.rcPort)
+	cmd.Env = getRcTesterEnv(cfg.rcHost, cfg.rcPort, cfg.tmpDir)
+	return cmd
+}
+
+func startSampleService(t *testing.T, cfg sampleServiceConfig) (sampleServiceCmd *exec.Cmd, sampleServicePID uint32, serverPort int, err error) {
+	var cmd *exec.Cmd
+	if cfg.useDocker {
+		cmd = startSampleServiceWithDocker(t, cfg)
+	} else {
+		cmd = newDirectCommand(cfg)
+	}
 
 	stderrFile, err := os.Create(filepath.Join(cfg.tmpDir, "rc_tester.stderr"))
 	require.NoError(t, err)
@@ -223,14 +326,64 @@ func startSampleService(t *testing.T, cfg sampleServiceConfig) (sampleServiceCmd
 	t.Log("Starting sample service...")
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
+		_ = cmd.Process.Signal(os.Interrupt)
 		_ = cmd.Wait()
 	})
-
 	serverPort = waitForServicePort(t, stdoutPath)
 	t.Logf("rc_tester listening on port %d", serverPort)
+	// Now we want to find the relevant process ID because we might be
+	// underneath docker.
+	sampleServicePID = findProcessID(t, processPredicate{
+		exeContains:     path.Base(cfg.binaryPath),
+		environContains: fmt.Sprintf("%s=%s", e2eTmpDirEnv, cfg.tmpDir),
+	})
+	t.Logf("found sample service PID %d", sampleServicePID)
 
-	return cmd, serverPort, nil
+	return cmd, sampleServicePID, serverPort, nil
+}
+
+type processPredicate struct {
+	exeContains     string
+	environContains string
+}
+
+func findProcessID(t *testing.T, p processPredicate) uint32 {
+	procs, err := os.ReadDir("/proc")
+	if err != nil {
+		t.Fatalf("failed to read /proc: %v", err)
+	}
+	for _, proc := range procs {
+		if !proc.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(proc.Name())
+		if err != nil {
+			continue
+		}
+		exePath := filepath.Join("/proc", proc.Name(), "exe")
+		exe, err := os.Readlink(exePath)
+		if err != nil {
+			continue
+		}
+		if !strings.Contains(exe, p.exeContains) {
+			continue
+		}
+		environPath := filepath.Join("/proc", proc.Name(), "environ")
+		environ, err := os.ReadFile(environPath)
+		if err != nil {
+			continue
+		}
+		if !strings.Contains(string(environ), p.environContains) {
+			continue
+		}
+		return uint32(pid)
+	}
+	t.Fatalf(
+		"no process found with exe %s and environ %s",
+		p.exeContains,
+		p.environContains,
+	)
+	return 0
 }
 
 func waitForServicePort(t *testing.T, stdoutPath string) int {
@@ -364,6 +517,7 @@ func waitForLogMessages(
 	backend *mockBackend,
 	expectedLogs int,
 	expectationsPath string,
+	rewrite bool,
 ) {
 	t.Log("Waiting for log messages...")
 
@@ -443,7 +597,6 @@ func waitForLogMessages(
 		return
 	}
 
-	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
 	if rewrite {
 		saveExpectations(t, content, expectationsPath)
 		return


### PR DESCRIPTION
We ran into an issue recently whereby we broke the flow for docker containers. This is tragically bad given most users are using Datadog with docker containers. This adds e2e testing to ensure that the whole flow works with docker.

Relates to [DEBUG-4198](https://datadoghq.atlassian.net/issues/DEBUG-4198)

[DEBUG-4198]: https://datadoghq.atlassian.net/browse/DEBUG-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ