### PR TITLE
dyninst/object: keep dwarf sections off the heap

### DIFF
--- a/pkg/dyninst/dwarf/loclist/reader.go
+++ b/pkg/dyninst/dwarf/loclist/reader.go
@@ -26,6 +26,23 @@ type Reader struct {
 	unitVersions map[dwarf.Offset]uint8
 }
 
+// MakeReader creates a new Reader.
+func MakeReader(
+	dataLoc []byte,
+	dataLocLists []byte,
+	debugAddr []byte,
+	ptrSize uint8,
+	unitVersions map[dwarf.Offset]uint8,
+) Reader {
+	return Reader{
+		dataLoc:      dataLoc,
+		dataLocLists: dataLocLists,
+		debugAddr:    debugAddr,
+		ptrSize:      ptrSize,
+		unitVersions: unitVersions,
+	}
+}
+
 // NewReader creates a new Reader.
 func NewReader(
 	dataLoc []byte,
@@ -34,13 +51,8 @@ func NewReader(
 	ptrSize uint8,
 	unitVersions map[dwarf.Offset]uint8,
 ) *Reader {
-	return &Reader{
-		dataLoc:      dataLoc,
-		dataLocLists: dataLocLists,
-		debugAddr:    debugAddr,
-		ptrSize:      ptrSize,
-		unitVersions: unitVersions,
-	}
+	r := MakeReader(dataLoc, dataLocLists, debugAddr, ptrSize, unitVersions)
+	return &r
 }
 
 // Loclist represents a DWARF loclist.

--- a/pkg/dyninst/object/debug_sections.go
+++ b/pkg/dyninst/object/debug_sections.go
@@ -16,56 +16,102 @@ import (
 // data section.
 type DebugSections struct {
 	// The .debug_abbrev section.
-	Abbrev []byte `elf:"abbrev"`
+	abbrev *MMappedData `elf:"abbrev"`
 	// The .debug_addr section.
-	Addr []byte `elf:"addr"`
+	addr *MMappedData `elf:"addr"`
 	// The .debug_aranges section.
-	Aranges []byte `elf:"aranges"`
+	aranges *MMappedData `elf:"aranges"`
 	// The .debug_info section.
-	Info []byte `elf:"info"`
+	info *MMappedData `elf:"info"`
 	// The .debug_line section.
-	Line []byte `elf:"line"`
+	line *MMappedData `elf:"line"`
 	// The .debug_line_str section.
-	LineStr []byte `elf:"line_str"`
+	lineStr *MMappedData `elf:"line_str"`
 	// The .debug_str section.
-	Str []byte `elf:"str"`
+	str *MMappedData `elf:"str"`
 	// The .debug_str_offsets section.
-	StrOffsets []byte `elf:"str_offsets"`
+	strOffsets *MMappedData `elf:"str_offsets"`
 	// The .debug_types section.
-	Types []byte `elf:"types"`
+	types *MMappedData `elf:"types"`
 	// The .debug_loc section.
-	Loc []byte `elf:"loc"`
+	loc *MMappedData `elf:"loc"`
 	// The .debug_loclists section.
-	LocLists []byte `elf:"loclists"`
+	locLists *MMappedData `elf:"loclists"`
 	// The .debug_ranges section.
-	Ranges []byte `elf:"ranges"`
+	ranges *MMappedData `elf:"ranges"`
 	// The .debug_rnglists section.
-	RngLists []byte `elf:"rnglists"`
+	rngLists *MMappedData `elf:"rnglists"`
 
 	// NB: We're intentionally not loading the .debug_frame or .eh_frame
 	// sections.
 }
 
-var sections = []struct {
-	name   string
-	getter func(*DebugSections) *[]byte
-}{
-	{"abbrev", func(d *DebugSections) *[]byte { return &d.Abbrev }},
-	{"addr", func(d *DebugSections) *[]byte { return &d.Addr }},
-	{"aranges", func(d *DebugSections) *[]byte { return &d.Aranges }},
-	{"info", func(d *DebugSections) *[]byte { return &d.Info }},
-	{"line", func(d *DebugSections) *[]byte { return &d.Line }},
-	{"line_str", func(d *DebugSections) *[]byte { return &d.LineStr }},
-	{"str", func(d *DebugSections) *[]byte { return &d.Str }},
-	{"str_offsets", func(d *DebugSections) *[]byte { return &d.StrOffsets }},
-	{"types", func(d *DebugSections) *[]byte { return &d.Types }},
-	{"loc", func(d *DebugSections) *[]byte { return &d.Loc }},
-	{"loclists", func(d *DebugSections) *[]byte { return &d.LocLists }},
-	{"ranges", func(d *DebugSections) *[]byte { return &d.Ranges }},
-	{"rnglists", func(d *DebugSections) *[]byte { return &d.RngLists }},
+func getData(m *MMappedData) []byte {
+	if m == nil {
+		return nil
+	}
+	return m.Data
 }
 
-func (ds *DebugSections) getSection(name string) *[]byte {
+// Abbrev returns the .debug_abbrev section.
+func (ds *DebugSections) Abbrev() []byte { return getData(ds.abbrev) }
+
+// Addr returns the .debug_addr section.
+func (ds *DebugSections) Addr() []byte { return getData(ds.addr) }
+
+// Aranges returns the .debug_aranges section.
+func (ds *DebugSections) Aranges() []byte { return getData(ds.aranges) }
+
+// Info returns the .debug_info section.
+func (ds *DebugSections) Info() []byte { return getData(ds.info) }
+
+// Line returns the .debug_line section.
+func (ds *DebugSections) Line() []byte { return getData(ds.line) }
+
+// LineStr returns the .debug_line_str section.
+func (ds *DebugSections) LineStr() []byte { return getData(ds.lineStr) }
+
+// Str returns the .debug_str section.
+func (ds *DebugSections) Str() []byte { return getData(ds.str) }
+
+// StrOffsets returns the .debug_str_offsets section.
+func (ds *DebugSections) StrOffsets() []byte { return getData(ds.strOffsets) }
+
+// Types returns the .debug_types section.
+func (ds *DebugSections) Types() []byte { return getData(ds.types) }
+
+// Loc returns the .debug_loc section.
+func (ds *DebugSections) Loc() []byte { return getData(ds.loc) }
+
+// LocLists returns the .debug_loclists section.
+func (ds *DebugSections) LocLists() []byte { return getData(ds.locLists) }
+
+// Ranges returns the .debug_ranges section.
+func (ds *DebugSections) Ranges() []byte { return getData(ds.ranges) }
+
+// RngLists returns the .debug_rnglists section.
+func (ds *DebugSections) RngLists() []byte { return getData(ds.rngLists) }
+
+var sections = []struct {
+	name   string
+	getter func(*DebugSections) **MMappedData
+}{
+	{"abbrev", func(d *DebugSections) **MMappedData { return &d.abbrev }},
+	{"addr", func(d *DebugSections) **MMappedData { return &d.addr }},
+	{"aranges", func(d *DebugSections) **MMappedData { return &d.aranges }},
+	{"info", func(d *DebugSections) **MMappedData { return &d.info }},
+	{"line", func(d *DebugSections) **MMappedData { return &d.line }},
+	{"line_str", func(d *DebugSections) **MMappedData { return &d.lineStr }},
+	{"str", func(d *DebugSections) **MMappedData { return &d.str }},
+	{"str_offsets", func(d *DebugSections) **MMappedData { return &d.strOffsets }},
+	{"types", func(d *DebugSections) **MMappedData { return &d.types }},
+	{"loc", func(d *DebugSections) **MMappedData { return &d.loc }},
+	{"loclists", func(d *DebugSections) **MMappedData { return &d.locLists }},
+	{"ranges", func(d *DebugSections) **MMappedData { return &d.ranges }},
+	{"rnglists", func(d *DebugSections) **MMappedData { return &d.rngLists }},
+}
+
+func (ds *DebugSections) getSection(name string) **MMappedData {
 	for _, s := range sections {
 		if s.name == name {
 			return s.getter(ds)
@@ -74,11 +120,8 @@ func (ds *DebugSections) getSection(name string) *[]byte {
 	return nil
 }
 
-// Sections returns an iterator over all the debug sections with their names and
-// contents. Note that this is not the sections in the file, but rather all the
-// sections that DebugSections supports.
-func (ds *DebugSections) Sections() iter.Seq2[string, []byte] {
-	return func(yield func(string, []byte) bool) {
+func (ds *DebugSections) sections() iter.Seq2[string, *MMappedData] {
+	return func(yield func(string, *MMappedData) bool) {
 		for _, s := range sections {
 			if !yield(s.name, *s.getter(ds)) {
 				return
@@ -87,16 +130,29 @@ func (ds *DebugSections) Sections() iter.Seq2[string, []byte] {
 	}
 }
 
+// Sections returns an iterator over all the debug sections with their names and
+// contents. Note that this is not the sections in the file, but rather all the
+// sections that DebugSections supports.
+func (ds *DebugSections) Sections() iter.Seq2[string, []byte] {
+	return func(yield func(string, []byte) bool) {
+		for name, mmap := range ds.sections() {
+			if !yield(name, getData(mmap)) {
+				return
+			}
+		}
+	}
+}
+
 func (ds *DebugSections) loadDwarfData() (*dwarf.Data, error) {
 	d, err := dwarf.New(
-		ds.Abbrev,
-		ds.Aranges,
+		ds.Abbrev(),
+		ds.Aranges(),
 		nil, // frame
-		ds.Info,
-		ds.Line,
+		ds.Info(),
+		ds.Line(),
 		nil, // pubnames
-		ds.Ranges,
-		ds.Str,
+		ds.Ranges(),
+		ds.Str(),
 	)
 	if err != nil {
 		return nil, err
@@ -105,10 +161,10 @@ func (ds *DebugSections) loadDwarfData() (*dwarf.Data, error) {
 		name     string
 		contents []byte
 	}{
-		{name: ".debug_addr", contents: ds.Addr},
-		{name: ".debug_line_str", contents: ds.LineStr},
-		{name: ".debug_str_offsets", contents: ds.StrOffsets},
-		{name: ".debug_rnglists", contents: ds.RngLists},
+		{name: ".debug_addr", contents: ds.Addr()},
+		{name: ".debug_line_str", contents: ds.LineStr()},
+		{name: ".debug_str_offsets", contents: ds.StrOffsets()},
+		{name: ".debug_rnglists", contents: ds.RngLists()},
 	} {
 		if len(s.contents) == 0 {
 			continue

--- a/pkg/dyninst/object/elf.go
+++ b/pkg/dyninst/object/elf.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"syscall"
 	"unsafe"
 
 	dlvdwarf "github.com/go-delve/delve/pkg/dwarf"
@@ -43,12 +44,9 @@ type ElfFile struct {
 	Underlying *MMappingElfFile
 
 	dwarfSections *DebugSections
-	dwarfData     *dwarf.Data
+	dwarfData     dwarf.Data
 	architecture  bininspect.GoArch
-
-	// Maps the compile unit entry offset to the version of the DWARF spec
-	// that was used to parse it.
-	unitVersions map[dwarf.Offset]uint8
+	reader        loclist.Reader
 }
 
 // TextSectionHeader implements File.
@@ -67,28 +65,40 @@ func (e *ElfFile) Architecture() Architecture {
 }
 
 // DwarfData implements File.
+//
+// Note that the returned dwarf.Data is not usable after the ElfFile is closed.
 func (e *ElfFile) DwarfData() *dwarf.Data {
-	return e.dwarfData
+	// By making the dwarf.Data part of the ElfFile struct, we can ensure
+	// that the ElfFile is not finalized while the dwarf.Data is in use.
+	return &e.dwarfData
 }
 
 // DwarfSections implements File.
+//
+// Note that the returned DebugSections are not usable after the ElfFile is
+// closed.
 func (e *ElfFile) DwarfSections() *DebugSections {
 	return e.dwarfSections
 }
 
 // LoclistReader implements File.
+//
+// Note that the returned loclist.Reader is not usable after the ElfFile is
+// closed.
 func (e *ElfFile) LoclistReader() *loclist.Reader {
-	return loclist.NewReader(
-		e.dwarfSections.Loc,
-		e.dwarfSections.LocLists,
-		e.dwarfSections.Addr,
-		uint8(e.architecture.PointerSize()),
-		e.unitVersions,
-	)
+	return &e.reader
 }
 
 // Close implements File.
+//
+// Note that various items returned from methods on the ElfFile are not usable
+// after the ElfFile is closed.
 func (e *ElfFile) Close() error {
+	for _, s := range e.dwarfSections.sections() {
+		if s != nil {
+			s.Close()
+		}
+	}
 	return e.Underlying.Close()
 }
 
@@ -146,18 +156,19 @@ func newElfObject(mmf *MMappingElfFile) (_ *ElfFile, retErr error) {
 	if err != nil {
 		return nil, err
 	}
-	if ds.Info == nil {
+	info := ds.Info()
+	if info == nil {
 		return nil, fmt.Errorf("no .debug_info section found")
 	}
 	d, err := ds.loadDwarfData()
 	if err != nil {
 		return nil, err
 	}
-	_, _, dwarfVersion, byteOrder := dlvdwarf.ReadDwarfLengthVersion(ds.Info)
+	_, _, dwarfVersion, byteOrder := dlvdwarf.ReadDwarfLengthVersion(info)
 	if byteOrder != binary.LittleEndian {
 		return nil, fmt.Errorf("unexpected DWARF byte order: %v", byteOrder)
 	}
-	unitVersions := dlvdwarf.ReadUnitVersions(ds.Info)
+	unitVersions := dlvdwarf.ReadUnitVersions(ds.Info())
 	if dwarfVersion >= 5 {
 		// Delve unit offset calculations are 1 byte off.
 		// If tests fail, and following code now handles DWARF5, just remove this adjustment:
@@ -168,12 +179,19 @@ func newElfObject(mmf *MMappingElfFile) (_ *ElfFile, retErr error) {
 		}
 		unitVersions = uv
 	}
+	reader := loclist.MakeReader(
+		ds.Loc(),
+		ds.LocLists(),
+		ds.Addr(),
+		uint8(arch.PointerSize()),
+		unitVersions,
+	)
 	return &ElfFile{
 		Underlying:    mmf,
 		dwarfSections: ds,
-		dwarfData:     d,
+		dwarfData:     *d,
 		architecture:  arch,
-		unitVersions:  unitVersions,
+		reader:        reader,
 	}, nil
 }
 
@@ -184,7 +202,7 @@ func newElfObject(mmf *MMappingElfFile) (_ *ElfFile, retErr error) {
 // which could be used to load the section into a file we then mmap or something
 // like that.
 
-func loadDebugSections(mef *MMappingElfFile) (*DebugSections, error) {
+func loadDebugSections(mef *MMappingElfFile) (_ *DebugSections, retErr error) {
 	dwarfSuffix := func(s *safeelf.Section) string {
 		const debug = ".debug_"
 		const zdebug = ".zdebug_"
@@ -200,6 +218,16 @@ func loadDebugSections(mef *MMappingElfFile) (*DebugSections, error) {
 	// There are many DWARf sections, but these are the ones
 	// the debug/dwarf package started with.
 	var ds DebugSections
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		for _, s := range ds.sections() {
+			if s != nil {
+				_ = s.Close()
+			}
+		}
+	}()
 	for _, s := range mef.Elf.Sections {
 		suffix := dwarfSuffix(s)
 		if suffix == "" {
@@ -255,7 +283,7 @@ type compressedFileRange struct {
 	uncompressedLength int64
 }
 
-func (r compressedFileRange) data(mef *MMappingElfFile) ([]byte, error) {
+func (r compressedFileRange) data(mef *MMappingElfFile) (_ *MMappedData, retErr error) {
 	// We don't want to let an invalid section header cause us to load
 	// too much data into memory.
 	const maxSectionSize = 512 << 20 // 512MiB
@@ -269,12 +297,11 @@ func (r compressedFileRange) data(mef *MMappingElfFile) ([]byte, error) {
 		)
 	}
 
-	var reader io.Reader
 	switch r.format {
 	case compressionFormatUnknown:
 		return nil, fmt.Errorf("unknown compression format")
 	case compressionFormatNone:
-		reader = io.NewSectionReader(mef.f, int64(r.offset), int64(r.compressedLength))
+		return mef.mmap(uint64(r.offset), uint64(r.uncompressedLength))
 	case compressionFormatZlib:
 		md, err := mef.mmap(uint64(r.offset), uint64(r.compressedLength))
 		if err != nil {
@@ -285,15 +312,30 @@ func (r compressedFileRange) data(mef *MMappingElfFile) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create zlib reader: %w", err)
 		}
-		reader = zrd
-	}
+		mapped, err := syscall.Mmap(
+			0, // fd
+			0, // offset
+			int(r.uncompressedLength),
+			syscall.PROT_READ|syscall.PROT_WRITE|syscall.PROT_GROWSUP,
+			syscall.MAP_PRIVATE|syscall.MAP_ANONYMOUS,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to mmap section: %w", err)
+		}
+		defer func() {
+			if retErr != nil {
+				_ = syscall.Munmap(mapped)
+			}
+		}()
+		if _, err := io.ReadFull(zrd, mapped); err != nil {
+			return nil, fmt.Errorf("failed to read section data: %w", err)
+		}
 
-	data := make([]byte, r.uncompressedLength)
-	_, err := io.ReadFull(reader, data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read section data: %w", err)
+		return newMMappedData(mapped, mapped), nil
+
+	default:
+		return nil, fmt.Errorf("unknown compression format: %d", r.format)
 	}
-	return data, nil
 }
 
 func sectionData(

--- a/pkg/dyninst/object/elf_test.go
+++ b/pkg/dyninst/object/elf_test.go
@@ -34,6 +34,7 @@ func TestElfObject(t *testing.T) {
 		require.NoError(t, err)
 		// Assert that some symbol we expect to exist is in there.
 		const targetFunction = "main.main"
+		defer func() { require.NoError(t, obj.Close()) }()
 		findTargetSubprogram(t, obj.DwarfData(), targetFunction)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This keeps the data off the heap. For uncompressed sections it also keeps
them file backed. This has a somewhat negative impact on decoding throughput
that is a bit surprising. I imagine that it has to do with the faults when
writing the data out, but I'm not certain. The benchmarks definitely are
noisy.

```
name                      old time/op    new time/op    delta
LoadElfFile/cockroach-10     904ms ± 6%     918ms ± 2%     ~     (p=0.067 n=20+18)
LoadElfFile/dd-agent-10      241ms ± 3%     254ms ± 3%   +5.17%  (p=0.000 n=19+19)

name                      old speed      new speed      delta
LoadElfFile/cockroach-10   290MB/s ± 6%   285MB/s ± 3%   -1.69%  (p=0.041 n=20+19)
LoadElfFile/dd-agent-10    297MB/s ± 3%   283MB/s ± 3%   -4.92%  (p=0.000 n=19+19)

name                      old alloc/op   new alloc/op   delta
LoadElfFile/cockroach-10     276MB ± 0%      14MB ± 0%  -95.02%  (p=0.000 n=20+17)
LoadElfFile/dd-agent-10     75.3MB ± 0%     3.6MB ± 0%  -95.27%  (p=0.000 n=19+19)

name                      old allocs/op  new allocs/op  delta
LoadElfFile/cockroach-10      121k ± 0%      121k ± 0%   +0.00%  (p=0.000 n=20+17)
LoadElfFile/dd-agent-10      32.1k ± 0%     32.1k ± 0%     ~     (all equal)
```

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4026