### PR TITLE
[ABLD-18] Fix effective architecture detection in macOS install script

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -62,7 +62,7 @@ if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   fi
 fi
 
-arch=$(/usr/bin/arch)
+arch=$(/usr/bin/uname -m)
 
 # Cleanup tmp files used for installation
 rm -f /tmp/install-ddagent/system-wide


### PR DESCRIPTION
### What does this PR do?
The present change aims at fixing the way the macOS installation script determines the _effective_ architecture (not necessarily the _real_ one) being used.

### Motivation
It turns out `/usr/bin/arch` doesn't work as expected:
1. for AArch64/ARM64, it prints the correct architecture: `arm64` :green_circle: **unless the calling process[^1] runs under Rosetta 2**, in which case it prints `i386` :red_circle: as for x86_86/AMD64,
2. for x86_86/AMD64, it prints `i386` :red_circle:, which is annoying because the macOS installation script **won't resolve DMGs with an explicit `x86_64` qualifier** and thus will default to the "universal" DMG.
  This is what the present change aims at fixing by replacing `/usr/bin/arch` with `/usr/bin/uname -m`, which prints the [_effective_ architecture](https://github.com/YoshitakaMo/localcolabfold/blob/930cbcd724d3a68bc66622605dccdf7be6456210/update_M1mac.sh#L4):
   1. for AArch64/ARM64: `arm64` :green_circle: **unless the calling process[^1] runs under Rosetta 2**, in which case it prints `x86_64` :yellow_circle:,
   2. for x86_86/AMD64: `x86_64` :green_circle:.

[^1]: theoretically a `bash` interpreter as per https://app.datadoghq.eu/fleet/install-agent/latest?platform=macos

### Possible Drawbacks / Trade-offs
This trivial change is worth taking as such, buying us time to decide whether efforts should be invested on bypassing Rosetta 2 (🟡 ➡ 🟢) to run the script under the [_real_ architecture](https://github.com/YoshitakaMo/localcolabfold/blob/930cbcd724d3a68bc66622605dccdf7be6456210/update_M1mac.sh#L5-L10), for instance with something _like_:
```sh
if [ "$arch" = x86_64 ] && [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = 1 ]; then
  # restart under native AArch64/ARM64
  exec /usr/bin/arch -arm64 "$(ps -p $$ -o comm=)" "$0" "$@"
fi
```

### Additional Notes
A few references:
- https://apple.stackexchange.com/questions/458124/after-moving-to-apple-silicon-terminal-arch-is-still-i386
- https://stackoverflow.com/questions/12763296/os-x-arch-command-incorrect
- https://unix.stackexchange.com/questions/518318/what-does-i386-mean-on-macos-mojave
- https://www.metasimple.org/2025/01/11/dual-brew-setup.html