### PR TITLE
Revert "Create custom MacOS temporary directory"

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -16,8 +16,6 @@
       dda inv -- -e macos.remove-inactive-versions -l python -t "$PYTHON_VERSION" || true
       dda inv -- -e macos.remove-inactive-versions -l go -t "$(cat .go-version)" || true
     fi
-  # Flush temporary folder
-  - sudo rm -rf /tmp/gitlabci
 
 .select_python_env_commands:
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
@@ -107,11 +105,6 @@
     - !reference [.install_python_dependencies]
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
-    # Create custom temporary folder to isolate jobs from each other
-    - |
-      export TMPDIR="/tmp/gitlabci/$CI_JOB_ID"
-      mkdir -p "$TMPDIR"
-      echo "Temporary folder created at $TMPDIR"
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -10,9 +10,10 @@ fi
 
 # --- Setup environment ---
 unset OMNIBUS_BASE_DIR
-export INSTALL_DIR="$TMPDIR/datadog-agent-build/bin"
-export CONFIG_DIR="$TMPDIR/datadog-agent-build/config"
-export OMNIBUS_DIR="$TMPDIR/omnibus_build"
+WORKDIR="/tmp"
+export INSTALL_DIR="$WORKDIR/datadog-agent-build/bin"
+export CONFIG_DIR="$WORKDIR/datadog-agent-build/config"
+export OMNIBUS_DIR="$WORKDIR/omnibus_build"
 export OMNIBUS_PACKAGE_DIR="$PWD"/omnibus/pkg
 
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR" "$OMNIBUS_DIR"


### PR DESCRIPTION
Reverts DataDog/datadog-agent#39050

[This broke macos tests](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3A%22tests_macos_gitlab_amd64%22%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1752473517283&end=1753078317283&paused=false)