### PR TITLE
[SBOM] convert to cyclonedx sooner in the pipeline

### DIFF
--- a/cmd/sbomgen/scanners.go
+++ b/cmd/sbomgen/scanners.go
@@ -126,11 +126,7 @@ func runScanCrio(imageMeta *workloadmeta.ContainerImageMetadata, analyzers []str
 }
 
 func outputReport(report sbom.Report) error {
-	bom, err := report.ToCycloneDX()
-	if err != nil {
-		return err
-	}
-
+	bom := report.ToCycloneDX()
 	bomJSON, err := json.MarshalIndent(bom, "", "  ")
 	if err != nil {
 		return err

--- a/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -11,8 +11,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/CycloneDX/cyclonedx-go"
-
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
@@ -145,18 +144,14 @@ func (c *collector) processScanResult(ctx context.Context, result sbom.ScanResul
 func convertScanResultToSBOM(result sbom.ScanResult) *workloadmeta.SBOM {
 	status := workloadmeta.Success
 	reportedError := ""
-	var report *cyclonedx.BOM
+	var report *cyclonedx_v1_4.Bom
 
 	if result.Error != nil {
 		log.Debugf("Failed to generate SBOM for containerd image: %s", result.Error)
 		status = workloadmeta.Failed
 		reportedError = result.Error.Error()
-	} else if bom, err := result.Report.ToCycloneDX(); err != nil {
-		log.Debugf("Failed to extract SBOM from report")
-		status = workloadmeta.Failed
-		reportedError = err.Error()
 	} else {
-		report = bom
+		report = result.Report.ToCycloneDX()
 	}
 
 	return &workloadmeta.SBOM{

--- a/comp/core/workloadmeta/collectors/internal/crio/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image_sbom_trivy.go
@@ -12,8 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/CycloneDX/cyclonedx-go"
-
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
@@ -136,18 +135,14 @@ func (c *collector) processScanResult(result sbom.ScanResult) {
 func convertScanResultToSBOM(result sbom.ScanResult) *workloadmeta.SBOM {
 	status := workloadmeta.Success
 	reportedError := ""
-	var report *cyclonedx.BOM
+	var report *cyclonedx_v1_4.Bom
 
 	if result.Error != nil {
 		log.Errorf("SBOM generation failed for image: %v", result.Error)
 		status = workloadmeta.Failed
 		reportedError = result.Error.Error()
-	} else if bom, err := result.Report.ToCycloneDX(); err != nil {
-		log.Errorf("Failed to convert report to CycloneDX BOM.")
-		status = workloadmeta.Failed
-		reportedError = err.Error()
 	} else {
-		report = bom
+		report = result.Report.ToCycloneDX()
 	}
 
 	return &workloadmeta.SBOM{

--- a/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -12,8 +12,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/CycloneDX/cyclonedx-go"
-
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
@@ -114,20 +113,14 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 				}
 				status := workloadmeta.Success
 				reportedError := ""
-				var report *cyclonedx.BOM
+				var report *cyclonedx_v1_4.Bom
 				if result.Error != nil {
 					// TODO: add a retry mechanism for retryable errors
 					log.Errorf("Failed to generate SBOM for docker: %s", result.Error)
 					status = workloadmeta.Failed
 					reportedError = result.Error.Error()
 				} else {
-					bom, err := result.Report.ToCycloneDX()
-					if err != nil {
-						log.Errorf("Failed to extract SBOM from report")
-						status = workloadmeta.Failed
-						reportedError = result.Error.Error()
-					}
-					report = bom
+					report = result.Report.ToCycloneDX()
 				}
 
 				sbom := &workloadmeta.SBOM{

--- a/comp/core/workloadmeta/collectors/util/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/image_util_test.go
@@ -12,11 +12,12 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/CycloneDX/cyclonedx-go"
 	trivycore "github.com/aquasecurity/trivy/pkg/sbom/core"
 	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func Test_UpdateSBOMRepoMetadata(t *testing.T) {
@@ -48,9 +49,9 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
-					CycloneDXBOM: &cyclonedx.BOM{
-						Metadata: &cyclonedx.Metadata{
-							Component: &cyclonedx.Component{Properties: nil},
+					CycloneDXBOM: &cyclonedx_v1_4.Bom{
+						Metadata: &cyclonedx_v1_4.Metadata{
+							Component: &cyclonedx_v1_4.Component{Properties: nil},
 						},
 					},
 				},
@@ -59,9 +60,9 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 			want: &workloadmeta.SBOM{
 				Status: workloadmeta.Success,
-				CycloneDXBOM: &cyclonedx.BOM{
-					Metadata: &cyclonedx.Metadata{
-						Component: &cyclonedx.Component{Properties: nil},
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					Metadata: &cyclonedx_v1_4.Metadata{
+						Component: &cyclonedx_v1_4.Component{Properties: nil},
 					},
 				},
 			},
@@ -71,12 +72,12 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
-					CycloneDXBOM: &cyclonedx.BOM{
-						Metadata: &cyclonedx.Metadata{
-							Component: &cyclonedx.Component{
-								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest2"},
-									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag2"},
+					CycloneDXBOM: &cyclonedx_v1_4.Bom{
+						Metadata: &cyclonedx_v1_4.Metadata{
+							Component: &cyclonedx_v1_4.Component{
+								Properties: []*cyclonedx_v1_4.Property{
+									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest2")},
+									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag2")},
 								},
 							},
 						},
@@ -87,14 +88,14 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 			want: &workloadmeta.SBOM{
 				Status: workloadmeta.Success,
-				CycloneDXBOM: &cyclonedx.BOM{
-					Metadata: &cyclonedx.Metadata{
-						Component: &cyclonedx.Component{
-							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
-								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest2"},
-								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag1"},
-								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag2"},
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					Metadata: &cyclonedx_v1_4.Metadata{
+						Component: &cyclonedx_v1_4.Component{
+							Properties: []*cyclonedx_v1_4.Property{
+								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
+								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest2")},
+								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
+								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag2")},
 							},
 						},
 					},
@@ -106,12 +107,12 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
-					CycloneDXBOM: &cyclonedx.BOM{
-						Metadata: &cyclonedx.Metadata{
-							Component: &cyclonedx.Component{
-								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag1"},
-									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
+					CycloneDXBOM: &cyclonedx_v1_4.Bom{
+						Metadata: &cyclonedx_v1_4.Metadata{
+							Component: &cyclonedx_v1_4.Component{
+								Properties: []*cyclonedx_v1_4.Property{
+									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
+									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
 								},
 							},
 						},
@@ -122,12 +123,12 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 			want: &workloadmeta.SBOM{
 				Status: workloadmeta.Success,
-				CycloneDXBOM: &cyclonedx.BOM{
-					Metadata: &cyclonedx.Metadata{
-						Component: &cyclonedx.Component{
-							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
-								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag1"},
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					Metadata: &cyclonedx_v1_4.Metadata{
+						Component: &cyclonedx_v1_4.Component{
+							Properties: []*cyclonedx_v1_4.Property{
+								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
+								{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
 							},
 						},
 					},
@@ -139,12 +140,12 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
-					CycloneDXBOM: &cyclonedx.BOM{
-						Metadata: &cyclonedx.Metadata{
-							Component: &cyclonedx.Component{
-								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag1"},
-									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
+					CycloneDXBOM: &cyclonedx_v1_4.Bom{
+						Metadata: &cyclonedx_v1_4.Metadata{
+							Component: &cyclonedx_v1_4.Component{
+								Properties: []*cyclonedx_v1_4.Property{
+									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
+									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
 								},
 							},
 						},
@@ -154,11 +155,11 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 			want: &workloadmeta.SBOM{
 				Status: workloadmeta.Success,
-				CycloneDXBOM: &cyclonedx.BOM{
-					Metadata: &cyclonedx.Metadata{
-						Component: &cyclonedx.Component{
-							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					Metadata: &cyclonedx_v1_4.Metadata{
+						Component: &cyclonedx_v1_4.Component{
+							Properties: []*cyclonedx_v1_4.Property{
+								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
 							},
 						},
 					},
@@ -170,13 +171,13 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			args: args{
 				sbom: &workloadmeta.SBOM{
 					Status: workloadmeta.Success,
-					CycloneDXBOM: &cyclonedx.BOM{
-						Metadata: &cyclonedx.Metadata{
-							Component: &cyclonedx.Component{
-								Properties: &[]cyclonedx.Property{
-									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: "tag1"},
-									{Name: "prop1", Value: "tag1"},
-									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
+					CycloneDXBOM: &cyclonedx_v1_4.Bom{
+						Metadata: &cyclonedx_v1_4.Metadata{
+							Component: &cyclonedx_v1_4.Component{
+								Properties: []*cyclonedx_v1_4.Property{
+									{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
+									{Name: "prop1", Value: pointer.Ptr("tag1")},
+									{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
 								},
 							},
 						},
@@ -186,12 +187,12 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 			},
 			want: &workloadmeta.SBOM{
 				Status: workloadmeta.Success,
-				CycloneDXBOM: &cyclonedx.BOM{
-					Metadata: &cyclonedx.Metadata{
-						Component: &cyclonedx.Component{
-							Properties: &[]cyclonedx.Property{
-								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: "digest1"},
-								{Name: "prop1", Value: "tag1"},
+				CycloneDXBOM: &cyclonedx_v1_4.Bom{
+					Metadata: &cyclonedx_v1_4.Metadata{
+						Component: &cyclonedx_v1_4.Component{
+							Properties: []*cyclonedx_v1_4.Property{
+								{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
+								{Name: "prop1", Value: pointer.Ptr("tag1")},
 							},
 						},
 					},
@@ -209,10 +210,10 @@ func Test_UpdateSBOMRepoMetadata(t *testing.T) {
 				got.CycloneDXBOM.Metadata.Component != nil &&
 				got.CycloneDXBOM.Metadata.Component.Properties != nil {
 				// Sort properties to ensure consistent ordering for tests
-				props := *got.CycloneDXBOM.Metadata.Component.Properties
+				props := got.CycloneDXBOM.Metadata.Component.Properties
 				sort.Slice(props, func(i, j int) bool {
 					if props[i].Name == props[j].Name {
-						return props[i].Value < props[j].Value
+						return *props[i].Value < *props[j].Value
 					}
 					return props[i].Name < props[j].Name
 				})

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -12,11 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/mohae/deepcopy"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
@@ -1341,7 +1341,7 @@ type ContainerImageLayer struct {
 
 // SBOM represents the Software Bill Of Materials (SBOM) of a container
 type SBOM struct {
-	CycloneDXBOM       *cyclonedx.BOM
+	CycloneDXBOM       *cyclonedx_v1_4.Bom
 	GenerationTime     time.Time
 	GenerationDuration time.Duration
 	Status             SBOMStatus

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -254,17 +254,9 @@ func (p *processor) processHostScanResult(result sbom.ScanResult) {
 		if p.hostCache != "" && p.hostCache == result.Report.ID() && result.CreatedAt.Sub(p.hostLastFullSBOM) < p.hostHeartbeatValidity {
 			sbom.Heartbeat = true
 		} else {
-			report, err := result.Report.ToCycloneDX()
-			if err != nil {
-				log.Errorf("Failed to extract SBOM from report: %s", err)
-				sbom.Sbom = &model.SBOMEntity_Error{
-					Error: err.Error(),
-				}
-				sbom.Status = model.SBOMStatus_FAILED
-			} else {
-				sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-					Cyclonedx: bomconvert.ConvertBOM(report),
-				}
+			report := result.Report.ToCycloneDX()
+			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: report,
 			}
 
 			sbom.Hash = result.Report.ID()
@@ -325,17 +317,9 @@ func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 		if p.hostCache != "" && p.hostCache == result.Report.ID() && result.CreatedAt.Sub(p.hostLastFullSBOM) < p.hostHeartbeatValidity {
 			sbom.Heartbeat = true
 		} else {
-			report, err := result.Report.ToCycloneDX()
-			if err != nil {
-				log.Errorf("Failed to extract SBOM from report: %s", err)
-				sbom.Sbom = &model.SBOMEntity_Error{
-					Error: err.Error(),
-				}
-				sbom.Status = model.SBOMStatus_FAILED
-			} else {
-				sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-					Cyclonedx: bomconvert.ConvertBOM(report),
-				}
+			report := result.Report.ToCycloneDX()
+			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
+				Cyclonedx: report,
 			}
 		}
 	}
@@ -456,7 +440,7 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 			sbom.GeneratedAt = timestamppb.New(img.SBOM.GenerationTime)
 			sbom.GenerationDuration = bomconvert.ConvertDuration(img.SBOM.GenerationDuration)
 			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: bomconvert.ConvertBOM(img.SBOM.CycloneDXBOM),
+				Cyclonedx: img.SBOM.CycloneDXBOM,
 			}
 		}
 		p.queue <- sbom

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -75,10 +75,10 @@ func TestProcessEvents(t *testing.T) {
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
 						SBOM: &workloadmeta.SBOM{
-							CycloneDXBOM: &cyclonedx.BOM{
-								SpecVersion: cyclonedx.SpecVersion1_4,
-								Version:     42,
-								Components: &[]cyclonedx.Component{
+							CycloneDXBOM: &cyclonedx_v1_4.Bom{
+								SpecVersion: cyclonedx.SpecVersion1_4.String(),
+								Version:     pointer.Ptr(int32(42)),
+								Components: []*cyclonedx_v1_4.Component{
 									{
 										Name: "Foo",
 									},
@@ -243,10 +243,10 @@ func TestProcessEvents(t *testing.T) {
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
 						SBOM: &workloadmeta.SBOM{
-							CycloneDXBOM: &cyclonedx.BOM{
-								SpecVersion: cyclonedx.SpecVersion1_4,
-								Version:     42,
-								Components: &[]cyclonedx.Component{
+							CycloneDXBOM: &cyclonedx_v1_4.Bom{
+								SpecVersion: cyclonedx.SpecVersion1_4.String(),
+								Version:     pointer.Ptr(int32(42)),
+								Components: []*cyclonedx_v1_4.Component{
 									{
 										Name: "Foo",
 									},
@@ -322,10 +322,10 @@ func TestProcessEvents(t *testing.T) {
 							"my-image:latest",
 						},
 						SBOM: &workloadmeta.SBOM{
-							CycloneDXBOM: &cyclonedx.BOM{
-								SpecVersion: cyclonedx.SpecVersion1_4,
-								Version:     42,
-								Components: &[]cyclonedx.Component{
+							CycloneDXBOM: &cyclonedx_v1_4.Bom{
+								SpecVersion: cyclonedx.SpecVersion1_4.String(),
+								Version:     pointer.Ptr(int32(42)),
+								Components: []*cyclonedx_v1_4.Component{
 									{
 										Name: "Foo",
 									},
@@ -394,9 +394,9 @@ func TestProcessEvents(t *testing.T) {
 						RepoTags:    []string{"datadog/agent:7-rc"},
 						RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
 						SBOM: &workloadmeta.SBOM{
-							CycloneDXBOM: &cyclonedx.BOM{
-								SpecVersion: cyclonedx.SpecVersion1_4,
-								Version:     42,
+							CycloneDXBOM: &cyclonedx_v1_4.Bom{
+								SpecVersion: cyclonedx.SpecVersion1_4.String(),
+								Version:     pointer.Ptr(int32(42)),
 							},
 							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,

--- a/pkg/sbom/collectors/host/flare_provider.go
+++ b/pkg/sbom/collectors/host/flare_provider.go
@@ -31,11 +31,7 @@ func FlareProvider(fb flaretypes.FlareBuilder) error {
 		return scanResult.Error
 	}
 
-	cycloneDX, err := scanResult.Report.ToCycloneDX()
-	if err != nil {
-		return err
-	}
-
+	cycloneDX := scanResult.Report.ToCycloneDX()
 	jsonContent, err := json.MarshalIndent(cycloneDX, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
+	"github.com/aquasecurity/trivy/pkg/types"
 )
 
 // Collector defines a host collector
@@ -62,6 +63,15 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 // DirectScan performs a scan on a specific path
 func (c *Collector) DirectScan(ctx context.Context, path string) (sbom.Report, error) {
 	return c.trivyCollector.ScanFilesystem(ctx, path, c.opts, true)
+}
+
+// DirectScanForTrivyReport performs a scan on a specific path
+func (c *Collector) DirectScanForTrivyReport(ctx context.Context, path string) (*types.Report, error) {
+	report, err := c.trivyCollector.ScanFSTrivyReport(ctx, path, c.opts, true)
+	if err != nil {
+		return nil, err
+	}
+	return report, nil
 }
 
 // NewCollectorForCWS creates a new host collector, specifically for CWS

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -9,11 +9,10 @@ package sbom
 import (
 	"time"
 
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom/types"
-
-	cyclonedxgo "github.com/CycloneDX/cyclonedx-go"
 )
 
 const (
@@ -23,7 +22,7 @@ const (
 
 // Report defines the report interface
 type Report interface {
-	ToCycloneDX() (*cyclonedxgo.BOM, error)
+	ToCycloneDX() *cyclonedx_v1_4.Bom
 	ID() string
 }
 

--- a/pkg/sbom/scanner/scanner_test.go
+++ b/pkg/sbom/scanner/scanner_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	compConfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
@@ -27,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 
-	cyclonedxgo "github.com/CycloneDX/cyclonedx-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/fx"
@@ -61,8 +61,8 @@ type mockReport struct {
 }
 
 // ToCycloneDX returns a mock BOM
-func (m mockReport) ToCycloneDX() (*cyclonedxgo.BOM, error) {
-	return &cyclonedxgo.BOM{}, nil
+func (m mockReport) ToCycloneDX() *cyclonedx_v1_4.Bom {
+	return &cyclonedx_v1_4.Bom{}
 }
 
 // ID returns the report ID

--- a/pkg/security/resolvers/sbom/file_querier.go
+++ b/pkg/security/resolvers/sbom/file_querier.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	"github.com/DataDog/datadog-agent/pkg/util/trivy"
+	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/twmb/murmur3"
 )
 
@@ -34,7 +34,7 @@ and each part group is at the index of the given package
 for example here hash5 would match pkgs[2]
 */
 
-func newFileQuerier(report *trivy.Report) fileQuerier {
+func newFileQuerier(report *types.Report) fileQuerier {
 	fileCount := 0
 	pkgCount := 0
 	for _, result := range report.Results {

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/avast/retry-go/v4"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/skydive-project/go-debouncer"
@@ -34,7 +35,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 )
 
 const (
@@ -84,7 +84,7 @@ func (s *SBOM) IsComputed() bool {
 }
 
 // SetReport sets the SBOM report
-func (s *SBOM) setReport(report *trivy.Report) {
+func (s *SBOM) setReport(report *types.Report) {
 	// build file cache
 	s.data.files = newFileQuerier(report)
 }
@@ -267,11 +267,11 @@ func (r *Resolver) RefreshSBOM(containerID containerutils.ContainerID) error {
 }
 
 // generateSBOM calls Trivy to generate the SBOM of a sbom
-func (r *Resolver) generateSBOM(root string) (*trivy.Report, error) {
+func (r *Resolver) generateSBOM(root string) (*types.Report, error) {
 	seclog.Infof("Generating SBOM for %s", root)
 	r.sbomGenerations.Inc()
 
-	report, err := r.sbomCollector.DirectScan(context.Background(), root)
+	report, err := r.sbomCollector.DirectScanForTrivyReport(context.Background(), root)
 	if err != nil {
 		r.failedSBOMGenerations.Inc()
 		return nil, fmt.Errorf("failed to generate SBOM for %s: %w", root, err)
@@ -279,19 +279,14 @@ func (r *Resolver) generateSBOM(root string) (*trivy.Report, error) {
 
 	seclog.Infof("SBOM successfully generated from %s", root)
 
-	trivyReport, ok := report.(*trivy.Report)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert report for %s", root)
-	}
-
-	return trivyReport, nil
+	return report, nil
 }
 
-func (r *Resolver) doScan(sbom *SBOM) (*trivy.Report, error) {
+func (r *Resolver) doScan(sbom *SBOM) (*types.Report, error) {
 	var (
 		lastErr error
 		scanned bool
-		report  *trivy.Report
+		report  *types.Report
 	)
 
 	cfs := utils.DefaultCGroupFS()

--- a/pkg/util/trivy/overlayfs.go
+++ b/pkg/util/trivy/overlayfs.go
@@ -122,5 +122,5 @@ func (c *Collector) scanOverlayFS(ctx context.Context, layers []string, ctr ftyp
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
 
-	return c.buildReport(trivyReport, imgMeta.ID), nil
+	return c.buildReport(trivyReport, imgMeta.ID)
 }

--- a/pkg/util/trivy/scan_image.go
+++ b/pkg/util/trivy/scan_image.go
@@ -53,5 +53,5 @@ func (c *Collector) scanImage(ctx context.Context, fanalImage ftypes.Image, imgM
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
 
-	return c.buildReport(trivyReport, trivyReport.Metadata.ImageID), nil
+	return c.buildReport(trivyReport, trivyReport.Metadata.ImageID)
 }

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -316,8 +316,8 @@ func (fa *artifactWithType) Clean(ref artifact.Reference) error {
 	return fa.inner.Clean(ref)
 }
 
-// ScanFilesystem scans the specified directory and logs detailed scan steps.
-func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions sbom.ScanOptions, removeLayers bool) (sbom.Report, error) {
+// ScanFSTrivyReport scans the specified directory and logs detailed scan steps.
+func (c *Collector) ScanFSTrivyReport(ctx context.Context, path string, scanOptions sbom.ScanOptions, removeLayers bool) (*types.Report, error) {
 	// For filesystem scans, it is required to walk the filesystem to get the persistentCache key so caching does not add any value.
 	// TODO: Cache directly the trivy report for container images
 	cache := newMemoryCache()
@@ -335,7 +335,12 @@ func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions
 		wrapper.forceType = artifact.TypeFilesystem
 	}
 
-	trivyReport, err := c.scan(ctx, wrapper, applier.NewApplier(cache))
+	return c.scan(ctx, wrapper, applier.NewApplier(cache))
+}
+
+// ScanFilesystem scans the specified directory and logs detailed scan steps.
+func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions sbom.ScanOptions, removeLayers bool) (sbom.Report, error) {
+	trivyReport, err := c.ScanFSTrivyReport(ctx, path, scanOptions, removeLayers)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
@@ -347,7 +352,7 @@ func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions
 	}
 
 	hash := "sha256:" + base64.StdEncoding.EncodeToString(hasher.Sum(nil))
-	return c.buildReport(trivyReport, hash), nil
+	return c.buildReport(trivyReport, hash)
 }
 
 func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applier applier.Applier) (*types.Report, error) {
@@ -367,7 +372,7 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applie
 	return &trivyReport, nil
 }
 
-func (c *Collector) buildReport(trivyReport *types.Report, id string) *Report {
+func (c *Collector) buildReport(trivyReport *types.Report, id string) (*Report, error) {
 	log.Debugf("Found OS: %+v", trivyReport.Metadata.OS)
 	pkgCount := 0
 	for _, results := range trivyReport.Results {
@@ -375,11 +380,7 @@ func (c *Collector) buildReport(trivyReport *types.Report, id string) *Report {
 	}
 	log.Debugf("Found %d packages", pkgCount)
 
-	return &Report{
-		Report:    trivyReport,
-		id:        id,
-		marshaler: c.marshaler,
-	}
+	return newReport(id, trivyReport, c.marshaler)
 }
 
 func looselyCompareAnalyzers(given []string, against []string) bool {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When doing a SBOM we currently juggle multiple formats:
- the scanner outputs a `trivy.Report`
- that is then marshaled into a `cyclonedx-go.BOM`
- then converted into a `cyclonedx_v1_4.Bom`

Those steps are done at different steps in the pipeline. This PR moves around the code to do the conversion at the very beginning, just after the scanner.

The end goal of this, that will come in a follow up PR, is to be able to also do some proto serialization + compression to not store the full SBOM in memory for all container image at a given time. This will reduce considerably the used memory on hosts with a lot of containers running.

**Immediate win:**
Currently when we refresh container images in the processor (to keep them alive) we convert from 1.6 to 1.4, every time. This means that the same SBOM is converted multiple times. This PR fixes this completely since we now store the 1.4 SBOM in the workloadmeta store.


**One functional change:**
The content of the flare is now in the cyclonedx_v1_4 format, not in the intermediate v1.6 one. This is closer to what is sent to the backend, so arguably better.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->