### PR TITLE
Fix curl and wget retries for installer install-script

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -57,12 +57,12 @@ fi
 
 echo "Downloading the Datadog installer..."
 if command -v curl >/dev/null; then
-  if ! curl -L --retry 3 "$installer_url" | "${sudo_cmd[@]+"${sudo_cmd[@]}"}" tee "$tmp_bin" >/dev/null; then
+  if ! "${sudo_cmd[@]+"${sudo_cmd[@]}"}" curl -L --retry 3 "$installer_url" --output "$tmp_bin" >/dev/null; then
     echo "Error: Download failed with curl." >&2
     exit 1
   fi
 else
-  if ! wget --tries=3 -O - "$installer_url" | "${sudo_cmd[@]+"${sudo_cmd[@]}"}" tee "$tmp_bin" >/dev/null; then
+  if ! "${sudo_cmd[@]+"${sudo_cmd[@]}"}" wget --tries=3 -O "$tmp_bin" "$installer_url" >/dev/null; then
     echo "Error: Download failed with wget." >&2
     exit 1
   fi


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update the way we retry curl to fetch the installer, to rely on `--output` or `-O` flags, otherwise the output of the first failure is included inside the saved file, which makes it invalid and fails the integrity check.

### Motivation

Make the retry feature working

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually tested on a VM that the script was working even if upstream fails on the first run
+ E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->