### PR TITLE
[CWS] migrate SBOM resolver to use common cgroupfs

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -294,7 +294,7 @@ func (r *Resolver) doScan(sbom *SBOM) (*trivy.Report, error) {
 		report  *trivy.Report
 	)
 
-	cfs := utils.NewCGroupFS()
+	cfs := utils.DefaultCGroupFS()
 
 	for _, rootCandidatePID := range sbom.cgroup.GetPIDs() {
 		// check if this pid still exists and is in the expected container ID (if we loose an exit and need to wait for

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -246,7 +246,7 @@ func TestCGroupSnapshot(t *testing.T) {
 
 	SkipIfNotAvailable(t)
 
-	cfs := utils.NewCGroupFS()
+	cfs := utils.DefaultCGroupFS()
 
 	_, cgroupContext, _, err := cfs.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
 	if err != nil {
@@ -343,7 +343,7 @@ func TestCGroupSnapshot(t *testing.T) {
 		assert.Equal(t, testsuiteEntry.CGroup.CGroupFile, syscallTesterEntry.CGroup.CGroupFile)
 
 		// Check that we have the right cgroup inode
-		cgroupFS := utils.NewCGroupFS()
+		cgroupFS := utils.DefaultCGroupFS()
 		_, _, cgroupSysFSPath, err := cgroupFS.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
 		if err != nil {
 			t.Error(err)

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -178,13 +178,13 @@ var once sync.Once
 // DefaultCGroupFS returns a singleton instance of CGroupFS
 func DefaultCGroupFS() *CGroupFS {
 	once.Do(func() {
-		defaultCGroupFS = NewCGroupFS()
+		defaultCGroupFS = newCGroupFS()
 	})
 	return defaultCGroupFS
 }
 
-// NewCGroupFS creates a new CGroupFS instance
-func NewCGroupFS() *CGroupFS {
+// newCGroupFS creates a new CGroupFS instance
+func newCGroupFS() *CGroupFS {
 	cfs := &CGroupFS{}
 
 	for _, mountpoint := range defaultCGroupMountpoints {

--- a/pkg/security/utils/cgroup_test.go
+++ b/pkg/security/utils/cgroup_test.go
@@ -344,7 +344,7 @@ func TestCGroupFS(t *testing.T) {
 
 		untar(t, "testdata/cgroupv2.tar.xz", tempDir)
 
-		cfs := NewCGroupFS()
+		cfs := newCGroupFS()
 		cfs.cGroupMountPoints = []string{
 			filepath.Join(tempDir, "sys/fs/cgroup"),
 		}
@@ -376,7 +376,7 @@ func TestCGroupFS(t *testing.T) {
 
 		untar(t, "testdata/cgroupv1.tar.xz", tempDir)
 
-		cfs := NewCGroupFS()
+		cfs := newCGroupFS()
 		cfs.cGroupMountPoints = []string{
 			filepath.Join(tempDir, "sys/fs/cgroup"),
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR migrates the SBOM resolver to use the common cgroup fs (it was the last user) and migrates all the tests to use the common/shared cgroup fs as well. Once this is done, the `NewCGroupFS` function is made private.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->