### PR TITLE
Add registry key for termination

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -22,6 +22,8 @@ import (
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
 	"os"
+
+	"github.com/stretchr/testify/suite"
 )
 
 // BaseSuite the base suite for all installer tests on Windows (install script, MSI, exe etc...).
@@ -237,6 +239,8 @@ func (s *BaseSuite) getAgentVersionVars(prefix string) (string, string) {
 func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
 
+	host := s.Env().RemoteHost
+
 	// Create a new subdir per test since these suites often have multiple tests
 	testPart := common.SanitizeDirectoryName(testName)
 	outputDir := filepath.Join(s.SessionOutputDir(), testPart)
@@ -244,6 +248,73 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 
 	s.installer = NewDatadogInstaller(s.Env(), s.CurrentAgentVersion().MSIPackage().URL, outputDir)
 	s.installScriptImpl = NewDatadogInstallScript(s.Env())
+
+	// clear the event logs before each test
+	for _, logName := range []string{"System", "Application"} {
+		s.T().Logf("Clearing %s event log", logName)
+		err := windowscommon.ClearEventLog(s.Env().RemoteHost, logName)
+		s.Require().NoError(err, "should clear %s event log", logName)
+	}
+
+	// Clear agent logs
+	s.T().Logf("Clearing agent logs")
+	logsFolder, err := host.GetLogsFolder()
+	s.Require().NoError(err, "should get logs folder")
+	entries, err := host.ReadDir(logsFolder)
+	if s.Assert().NoError(err, "should read log folder") {
+		for _, entry := range entries {
+			err = host.Remove(filepath.Join(logsFolder, entry.Name()))
+			s.Assert().NoError(err, "should remove %s", entry.Name())
+		}
+	}
+}
+
+// NOTE: AfterTest is not called after subtests
+func (s *BaseSuite) AfterTest(suiteName, testName string) {
+	if afterTest, ok := any(&s.BaseSuite).(suite.AfterTest); ok {
+		afterTest.AfterTest(suiteName, testName)
+	}
+
+	if s.T().Failed() {
+		// If the test failed, export the event logs for debugging
+		vm := s.Env().RemoteHost
+		for _, logName := range []string{"System", "Application"} {
+			// collect the full event log as an evtx file
+			s.T().Logf("Exporting %s event log", logName)
+			outputPath := filepath.Join(s.SessionOutputDir(), fmt.Sprintf("%s.evtx", logName))
+			err := windowscommon.ExportEventLog(vm, logName, outputPath)
+			s.Assert().NoError(err, "should export %s event log", logName)
+			// Log errors and warnings to the screen for easy access
+			out, err := windowscommon.GetEventLogErrorsAndWarnings(vm, logName)
+			if s.Assert().NoError(err, "should get errors and warnings from %s event log", logName) && out != "" {
+				s.T().Logf("Errors and warnings from %s event log:\n%s", logName, out)
+			}
+		}
+		// collect agent logs
+		s.collectAgentLogs()
+	}
+}
+
+func (s *BaseSuite) collectAgentLogs() {
+	host := s.Env().RemoteHost
+
+	s.T().Logf("Collecting agent logs")
+	logsFolder, err := host.GetLogsFolder()
+	if !s.Assert().NoError(err, "should get logs folder") {
+		return
+	}
+	entries, err := host.ReadDir(logsFolder)
+	if !s.Assert().NoError(err, "should read log folder") {
+		return
+	}
+	for _, entry := range entries {
+		s.T().Logf("Found log file: %s", entry.Name())
+		err = host.GetFile(
+			filepath.Join(logsFolder, entry.Name()),
+			filepath.Join(s.SessionOutputDir(), entry.Name()),
+		)
+		s.Assert().NoError(err, "should download %s", entry.Name())
+	}
 }
 
 // SetCatalogWithCustomPackage sets the catalog with a custom package

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -249,13 +249,6 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.installer = NewDatadogInstaller(s.Env(), s.CurrentAgentVersion().MSIPackage().URL, outputDir)
 	s.installScriptImpl = NewDatadogInstallScript(s.Env())
 
-	// clear the event logs before each test
-	for _, logName := range []string{"System", "Application"} {
-		s.T().Logf("Clearing %s event log", logName)
-		err := windowscommon.ClearEventLog(s.Env().RemoteHost, logName)
-		s.Require().NoError(err, "should clear %s event log", logName)
-	}
-
 	// Clear agent logs
 	s.T().Logf("Clearing agent logs")
 	logsFolder, err := host.GetLogsFolder()

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -269,6 +269,7 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	}
 }
 
+// AfterTest collects the event logs and agent logs after each test
 // NOTE: AfterTest is not called after subtests
 func (s *BaseSuite) AfterTest(suiteName, testName string) {
 	if afterTest, ok := any(&s.BaseSuite).(suite.AfterTest); ok {

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -45,9 +45,6 @@ func TestAgentUpgrades(t *testing.T) {
 // The expectation is that the MSI becomes the new stable package
 func (s *testAgentUpgradeSuite) TestUpgradeMSI() {
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 
 	s.installPreviousAgentVersion()
 	s.AssertSuccessfulAgentPromoteExperiment(s.StableAgentVersion().PackageVersion())
@@ -61,9 +58,6 @@ func (s *testAgentUpgradeSuite) TestUpgradeMSI() {
 func (s *testAgentUpgradeSuite) TestUpgradeAgentPackage() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -88,9 +82,6 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageWithAltDir() {
 		installerwindows.WithMSIArg("PROJECTLOCATION="+altInstallPath),
 		installerwindows.WithMSIArg("APPLICATIONDATADIRECTORY="+altConfigRoot),
 	)
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 
 	// Act
 	s.MustStartExperimentCurrentVersion()
@@ -119,9 +110,6 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageAfterRollback() {
 	flake.Mark(s.T())
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -154,9 +142,6 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageAfterRollback() {
 func (s *testAgentUpgradeSuite) TestRunAgentMSIAfterExperiment() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 	s.MustStartExperimentPreviousVersion()
 	s.AssertSuccessfulAgentStartExperiment(s.StableAgentVersion().PackageVersion())
@@ -176,9 +161,6 @@ func (s *testAgentUpgradeSuite) TestRunAgentMSIAfterExperiment() {
 func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -196,9 +178,6 @@ func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 func (s *testAgentUpgradeSuite) TestStopExperiment() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -223,9 +202,6 @@ func (s *testAgentUpgradeSuite) TestStopExperiment() {
 func (s *testAgentUpgradeSuite) TestExperimentForNonExistingPackageFails() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -250,9 +226,6 @@ func (s *testAgentUpgradeSuite) TestExperimentForNonExistingPackageFails() {
 func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -275,9 +248,6 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 func (s *testAgentUpgradeSuite) TestStopWithoutExperiment() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -300,9 +270,6 @@ func (s *testAgentUpgradeSuite) TestStopWithoutExperiment() {
 func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDies() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -332,9 +299,6 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDies() {
 func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenTimeout() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 	// lower timeout to 2 minute
 	s.setWatchdogTimeout(2)
@@ -372,9 +336,6 @@ func (s *testAgentUpgradeSuite) TestExperimentMSIRollbackMaintainsCustomUserAndA
 	altConfigRoot := `C:\ddconfig`
 	altInstallPath := `C:\ddinstall`
 	agentUser := "customuser"
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
 	s.setAgentConfigWithAltDir(altConfigRoot)
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
@@ -450,9 +411,6 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDiesMaintainsCus
 	altConfigRoot := `C:\ddconfig`
 	altInstallPath := `C:\ddinstall`
 	agentUser := "customuser"
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
 	s.setAgentConfigWithAltDir(altConfigRoot)
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
@@ -504,9 +462,6 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDiesMaintainsCus
 func (s *testAgentUpgradeSuite) TestUpgradeWithAgentUser() {
 	// Arrange
 	s.setAgentConfig()
-	// set terminate policy to false to prevent the service from being forcefully terminated
-	// this is to alert us to issues with agent termination that might be hidden by the default policy
-	s.setTerminatePolicy(false)
 	agentUser := "customuser"
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
 	s.installPreviousAgentVersion(
@@ -680,6 +635,10 @@ func TestAgentUpgradesFromGA(t *testing.T) {
 // BeforeTest wraps the installer in the DatadogInstallerGA type to handle the special cases for 7.65.x
 func (s *testAgentUpgradeFromGASuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
+
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 
 	// Wrap the installer in the InstallerGA type to handle the special cases for 7.65.x
 	s.SetInstaller(&installerwindows.DatadogInstallerGA{

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -614,7 +614,6 @@ func (s *testAgentUpgradeSuite) setAgentConfigWithAltDir(path string) {
 api_key: `+apiKey+`
 site: datadoghq.com
 remote_updates: true
-log_level: DEBUG
 `))
 }
 

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -45,6 +45,9 @@ func TestAgentUpgrades(t *testing.T) {
 // The expectation is that the MSI becomes the new stable package
 func (s *testAgentUpgradeSuite) TestUpgradeMSI() {
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 
 	s.installPreviousAgentVersion()
 	s.AssertSuccessfulAgentPromoteExperiment(s.StableAgentVersion().PackageVersion())
@@ -56,7 +59,6 @@ func (s *testAgentUpgradeSuite) TestUpgradeMSI() {
 // TestUpgradeAgentPackage tests that the daemon can upgrade the Agent
 // through the experiment (start/promote) workflow.
 func (s *testAgentUpgradeSuite) TestUpgradeAgentPackage() {
-
 	// Arrange
 	s.setAgentConfig()
 	// set terminate policy to false to prevent the service from being forcefully terminated
@@ -86,6 +88,9 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageWithAltDir() {
 		installerwindows.WithMSIArg("PROJECTLOCATION="+altInstallPath),
 		installerwindows.WithMSIArg("APPLICATIONDATADIRECTORY="+altConfigRoot),
 	)
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 
 	// Act
 	s.MustStartExperimentCurrentVersion()
@@ -114,6 +119,9 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageAfterRollback() {
 	flake.Mark(s.T())
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -146,6 +154,9 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageAfterRollback() {
 func (s *testAgentUpgradeSuite) TestRunAgentMSIAfterExperiment() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 	s.MustStartExperimentPreviousVersion()
 	s.AssertSuccessfulAgentStartExperiment(s.StableAgentVersion().PackageVersion())
@@ -165,6 +176,9 @@ func (s *testAgentUpgradeSuite) TestRunAgentMSIAfterExperiment() {
 func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -182,6 +196,9 @@ func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 func (s *testAgentUpgradeSuite) TestStopExperiment() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -206,6 +223,9 @@ func (s *testAgentUpgradeSuite) TestStopExperiment() {
 func (s *testAgentUpgradeSuite) TestExperimentForNonExistingPackageFails() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -230,6 +250,9 @@ func (s *testAgentUpgradeSuite) TestExperimentForNonExistingPackageFails() {
 func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -252,6 +275,9 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 func (s *testAgentUpgradeSuite) TestStopWithoutExperiment() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installCurrentAgentVersion()
 
 	// Act
@@ -274,6 +300,9 @@ func (s *testAgentUpgradeSuite) TestStopWithoutExperiment() {
 func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDies() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 
 	// Act
@@ -303,6 +332,9 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDies() {
 func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenTimeout() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.installPreviousAgentVersion()
 	// lower timeout to 2 minute
 	s.setWatchdogTimeout(2)
@@ -340,6 +372,9 @@ func (s *testAgentUpgradeSuite) TestExperimentMSIRollbackMaintainsCustomUserAndA
 	altConfigRoot := `C:\ddconfig`
 	altInstallPath := `C:\ddinstall`
 	agentUser := "customuser"
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
 	s.setAgentConfigWithAltDir(altConfigRoot)
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
@@ -415,6 +450,9 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDiesMaintainsCus
 	altConfigRoot := `C:\ddconfig`
 	altInstallPath := `C:\ddinstall`
 	agentUser := "customuser"
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	s.Installer().SetBinaryPath(altInstallPath + `\bin\` + consts.BinaryName)
 	s.setAgentConfigWithAltDir(altConfigRoot)
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
@@ -466,6 +504,9 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenServiceDiesMaintainsCus
 func (s *testAgentUpgradeSuite) TestUpgradeWithAgentUser() {
 	// Arrange
 	s.setAgentConfig()
+	// set terminate policy to false to prevent the service from being forcefully terminated
+	// this is to alert us to issues with agent termination that might be hidden by the default policy
+	s.setTerminatePolicy(false)
 	agentUser := "customuser"
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUser, "the custom user should be different from the default user")
 	s.installPreviousAgentVersion(
@@ -573,6 +614,7 @@ func (s *testAgentUpgradeSuite) setAgentConfigWithAltDir(path string) {
 api_key: `+apiKey+`
 site: datadoghq.com
 remote_updates: true
+log_level: DEBUG
 `))
 }
 
@@ -648,8 +690,8 @@ func (s *testAgentUpgradeFromGASuite) BeforeTest(suiteName, testName string) {
 
 // createStableAgent provides AgentVersionManager for the 7.65.0 Agent release to the suite
 func (s *testAgentUpgradeFromGASuite) createStableAgent() (*installerwindows.AgentVersionManager, error) {
-	previousVersion := "7.65.0-rc.10"
-	previousVersionPackage := "7.65.0-rc.10-1"
+	previousVersion := "7.65.2"
+	previousVersionPackage := "7.65.2-1"
 
 	// Get previous version OCI package
 	previousOCI, err := installerwindows.NewPackageConfig(
@@ -661,7 +703,7 @@ func (s *testAgentUpgradeFromGASuite) createStableAgent() (*installerwindows.Age
 	s.Require().NoError(err, "Failed to lookup OCI package for previous agent version")
 
 	// Get previous version MSI package
-	url, err := windowsagent.GetChannelURL("beta")
+	url, err := windowsagent.GetChannelURL("stable")
 	s.Require().NoError(err)
 	previousMSI, err := windowsagent.NewPackage(
 		windowsagent.WithVersion(previousVersionPackage),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a registry key for not force shutting down the `datadog agent` windows services. This is to verify that our services are correctly shutdown during e2e tests and that it is not using the force shutdown fallback that is enabled by default. It also updates our base testing version to `7.65.2`, this is where the agent service will shutdown the installer service, which also allows us to remove the flake flag. This is a follow up to `incident-40537`. 

This PR also grabs agent, and event logs to aid in debugging of future issues involving the incorrect shutdown of the `datadog agent` services. 

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1666

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Adds e2e tests that enable the registry key.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->