### PR TITLE
Introduce fuzz tests for the 'noop' parser

### DIFF
--- a/pkg/logs/internal/parsers/noop/noop_test.go
+++ b/pkg/logs/internal/parsers/noop/noop_test.go
@@ -6,6 +6,7 @@
 package noop
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -20,4 +21,45 @@ func TestNoopParserHandleMessages(t *testing.T) {
 	assert.Nil(t, err)
 	assert.False(t, logMessage.ParsingExtra.IsPartial)
 	assert.Equal(t, logMessage.GetContent(), msg.GetContent())
+}
+
+// FuzzNoopParser tests the noop parser with arbitrary input. Even though the
+// noop parser just returns its input unchanged, we still want to ensure it
+// never panics and always returns the same message object it was given.
+func FuzzNoopParser(f *testing.F) {
+	f.Add([]byte("Foo"))
+	f.Add([]byte(""))
+	f.Add([]byte(" "))
+	f.Add([]byte("\x00\x01\x02\x03"))
+	f.Add([]byte("\xFF\xFE\xFD\xFC"))
+
+	parser := New()
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		msg := message.NewMessage(data, nil, "", 0)
+		originalContent := msg.GetContent()
+
+		// Parser must not panic
+		result, err := parser.Parse(msg)
+
+		// Noop parser should never return an error
+		if err != nil {
+			t.Fatalf("Noop parser returned error: %v", err)
+		}
+
+		// Must return the same message object
+		if result != msg {
+			t.Fatal("Noop parser returned different message object")
+		}
+
+		// Content must be unchanged
+		if !bytes.Equal(result.GetContent(), originalContent) {
+			t.Fatal("Noop parser modified content")
+		}
+
+		// IsPartial should remain false (noop doesn't support partial lines)
+		if result.ParsingExtra.IsPartial {
+			t.Fatal("Noop parser set IsPartial to true")
+		}
+	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This fuzz test is introduced for completion. It is the case that the
    no-op parser is so simple we can be reasonably confident from
    examination that it won't ever crash et al but this demonstrates it.

### Motivation

Increase fuzz test coverage in the project.