### PR TITLE
[APM] Pre-pull docker image in test setup

### DIFF
--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -17,12 +17,23 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 )
 
 type DockerFakeintakeSuite struct {
 	e2e.BaseSuite[environments.DockerHost]
 	transport transport
+}
+
+// SetupSuite is called once before all tests in the suite.
+// This function is called by [testify Suite].
+func (s *DockerFakeintakeSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure() // cleanup if setup fails
+
+	// Pre-pull Docker image once for all tests to avoid network timeout issues during test execution
+	s.Env().RemoteHost.MustExecute("docker pull ghcr.io/datadog/apps-tracegen:" + apps.Version)
 }
 
 func dockerSuiteOpts(tr transport, opts ...awsdocker.ProvisionerOption) []e2e.SuiteOption {

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -29,6 +29,7 @@ import (
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-configuration/secretsutils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 )
 
 type VMFakeintakeSuite struct {
@@ -47,6 +48,16 @@ func NewVMFakeintakeSuite(tr transport) *VMFakeintakeSuite {
 		transport:    tr,
 		extraLogging: extraLogging,
 	}
+}
+
+// SetupSuite is called once before all tests in the suite.
+// This function is called by [testify Suite].
+func (s *VMFakeintakeSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure() // cleanup if setup fails
+
+	// Pre-pull Docker image once for all tests to avoid network timeout issues during test execution
+	s.Env().RemoteHost.MustExecute("docker pull ghcr.io/datadog/apps-tracegen:" + apps.Version)
 }
 
 func vmProvisionerOpts(opts ...awshost.ProvisionerOption) []awshost.ProvisionerOption {


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix flaky APM e2e tests by pre-pulling Docker images during setup.

Pre-pull the ghcr.io/datadog/apps-tracegen Docker image in SetupSuite for both VM and Docker APM test suites to prevent network timeout failures during test execution.

The TestAPIKeyRefresh test was failing due to Docker registry timeouts when it ran first alphabetically and encountered network issues pulling the tracegen image. Other tests succeeded because they benefited from the image being cached after the first successful pull.

Changes:
- Add SetupSuite override to VMFakeintakeSuite and DockerFakeintakeSuite
- Pre-pull Docker image once per test suite instead of per test
- Separates infrastructure/network issues from actual test logic

### Motivation

APM tests can be flaky due to network timeouts during Docker image pulls.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

N/A

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->