### PR TITLE
[CWS] fix ebpf-manager data race

### DIFF
--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -9,10 +9,17 @@
 package ebpf
 
 import (
+	"sync"
+
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 )
+
+type Manager struct {
+	sync.Mutex
+	Manager *manager.Manager
+}
 
 // NewDefaultOptions returns a new instance of the default runtime security manager options
 func NewDefaultOptions(kretprobeMaxActive int) manager.Options {

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 )
 
+// Manager handle the safeness of the ebpf manager
 type Manager struct {
 	sync.Mutex
 	Manager *manager.Manager

--- a/pkg/security/probe/discarders_linux.go
+++ b/pkg/security/probe/discarders_linux.go
@@ -579,7 +579,7 @@ func dnsResponseCodeDiscarderHandler(_ *rules.RuleSet, event *model.Event, probe
 	mask <<= dnsResponse.Response.ResponseCode
 	dnsMask |= mask
 
-	bufferSelector, err := managerhelper.Map(probe.Manager, "filtered_dns_rcodes")
+	bufferSelector, err := managerhelper.Map(probe.EM.Manager, "filtered_dns_rcodes")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -50,7 +50,7 @@ func (m *EBPFMonitors) Init() error {
 	p := m.ebpfProbe
 
 	// instantiate a new event statistics monitor
-	m.eventStreamMonitor, err = eventstream.NewEventStreamMonitor(p.config.Probe, p.Erpc, p.Manager, p.statsdClient, p.onEventLost, p.useRingBuffers)
+	m.eventStreamMonitor, err = eventstream.NewEventStreamMonitor(p.config.Probe, p.Erpc, p.EM.Manager, p.statsdClient, p.onEventLost, p.useRingBuffers)
 	if err != nil {
 		return fmt.Errorf("couldn't create the events statistics monitor: %w", err)
 	}
@@ -59,17 +59,17 @@ func (m *EBPFMonitors) Init() error {
 		m.runtimeMonitor = runtime.NewRuntimeMonitor(p.statsdClient)
 	}
 
-	m.discarderMonitor, err = discarder.NewDiscarderMonitor(p.Manager, p.statsdClient)
+	m.discarderMonitor, err = discarder.NewDiscarderMonitor(p.EM.Manager, p.statsdClient)
 	if err != nil {
 		return fmt.Errorf("couldn't create the discarder monitor: %w", err)
 	}
-	m.approverMonitor, err = approver.NewApproverMonitor(p.Manager, p.statsdClient)
+	m.approverMonitor, err = approver.NewApproverMonitor(p.EM.Manager, p.statsdClient)
 	if err != nil {
 		return fmt.Errorf("couldn't create the approver monitor: %w", err)
 	}
 
 	if p.opts.SyscallsMonitorEnabled {
-		m.syscallsMonitor, err = syscalls.NewSyscallsMonitor(p.Manager, p.statsdClient)
+		m.syscallsMonitor, err = syscalls.NewSyscallsMonitor(p.EM.Manager, p.statsdClient)
 		if err != nil {
 			return fmt.Errorf("couldn't create the approver monitor: %w", err)
 		}
@@ -78,7 +78,7 @@ func (m *EBPFMonitors) Init() error {
 	m.cgroupsMonitor = cgroups.NewCgroupsMonitor(p.statsdClient, p.Resolvers.CGroupResolver)
 
 	if p.config.Probe.DNSResolutionEnabled {
-		m.dnsMonitor, err = dns.NewDNSMonitor(p.Manager, p.statsdClient)
+		m.dnsMonitor, err = dns.NewDNSMonitor(p.EM.Manager, p.statsdClient)
 		if err != nil {
 			return fmt.Errorf("couldn't create the DNS monitor: %w", err)
 		}

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -262,7 +262,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(p.Manager); err != nil {
+	if err := resolver.Start(p.EM.Manager); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromERPC(pathKey, true)
@@ -331,7 +331,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(p.Manager); err != nil {
+	if err := resolver.Start(p.EM.Manager); err != nil {
 		b.Fatal(err)
 	}
 	name, err := resolver.ResolveNameFromMap(pathKey)
@@ -399,7 +399,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	if err := resolver.Start(p.Manager); err != nil {
+	if err := resolver.Start(p.EM.Manager); err != nil {
 		b.Fatal(err)
 	}
 	f, err := resolver.ResolveFromMap(pathKey, true)

--- a/pkg/security/tests/flow_pid_bind_test.go
+++ b/pkg/security/tests/flow_pid_bind_test.go
@@ -138,7 +138,7 @@ func checkBindFlowPidEntry(t *testing.T, testModule *testModule, key FlowPid, ex
 		return
 	}
 
-	m, _, err := p.Manager.GetMap("flow_pid")
+	m, _, err := p.EM.Manager.GetMap("flow_pid")
 	if err != nil {
 		close(closeClientSocket)
 		t.Errorf("failed to get map flow_pid: %v", err)

--- a/pkg/security/tests/flow_pid_security_sk_classify_flow_test.go
+++ b/pkg/security/tests/flow_pid_security_sk_classify_flow_test.go
@@ -350,7 +350,7 @@ func getFlowPidMap(t *testing.T, testModule *testModule) *ebpf.Map {
 		return nil
 	}
 
-	m, _, err := p.Manager.GetMap("flow_pid")
+	m, _, err := p.EM.Manager.GetMap("flow_pid")
 	if err != nil {
 		t.Errorf("failed to get map flow_pid: %v", err)
 		return nil

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -227,7 +227,7 @@ func TestTCFilters(t *testing.T) {
 			t.Fatal("not supported")
 		}
 
-		if err := p.Manager.CleanupNetworkNamespace(nsid); err != nil {
+		if err := p.EM.Manager.CleanupNetworkNamespace(nsid); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
### What does this PR do?

It fixes this data race:

```
==================
WARNING: DATA RACE
Read at 0x00c0002a4bc8 by goroutine 8960:
  github.com/DataDog/datadog-agent/pkg/ebpf.AddProbeFDMappings()
      /go/src/github.com/DataDog/datadog-agent/pkg/ebpf/mappings.go:299 +0xab
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).updateEBPFCheckMapping()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1834 +0x76
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).updateProbes()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1827 +0x1f2d
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).ApplyRuleSet()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2172 +0xc64
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).ApplyRuleSet()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:211 +0x821
  github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).LoadPolicies()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:361 +0x7dc
  github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).reloadPolicies()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:125 +0x2d7
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:700 +0x18dd
  github.com/DataDog/datadog-agent/pkg/security/tests.TestFilterRenameFileDiscarder()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/filters_test.go:679 +0x1a7
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1851 +0x44
Previous write at 0x00c0002a4bc8 by goroutine 8860:
  github.com/DataDog/ebpf-manager.(*Manager).CloneProgramWithSpecEditor()
      /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.12/manager.go:1251 +0x162f
  github.com/DataDog/ebpf-manager.(*Manager).CloneProgram()
      /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.12/manager.go:1164 +0xa3b
  github.com/DataDog/datadog-agent/pkg/security/resolvers/tc.(*Resolver).SetupNewTCClassifierWithNetNSHandle()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/tc/resolver.go:134 +0xa40
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).snapshotNetworkDevices()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:352 +0x644
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).preventNetworkNamespaceDrift()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:511 +0x4fc
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).manualFlushNamespaces()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:434 +0xa4
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).flushNamespaces()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:446 +0xda
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).Start.gowrap1()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:422 +0x4f
Goroutine 8960 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1851 +0x8f2
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2279 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1792 +0x225
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2277 +0x96c
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2142 +0xeea
  github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:24 +0xb3
  main.main()
      _testmain.go:431 +0x171
Goroutine 8860 (running) created at:
  github.com/DataDog/datadog-agent/pkg/security/resolvers/netns.(*Resolver).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/netns/resolver.go:422 +0x10d
  github.com/DataDog/datadog-agent/pkg/security/resolvers.(*EBPFResolvers).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/resolvers/resolvers_ebpf.go:249 +0x2b8
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Init()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:527 +0xa19
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Init()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:136 +0xb6
  github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Init()
      /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:94 +0x55
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:797 +0x3018
  github.com/DataDog/datadog-agent/pkg/security/probe.NewEBPFProbe()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2563 +0xa04
  github.com/DataDog/datadog-agent/pkg/security/probe.NewProbe()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_linux.go:45 +0x4f2
  github.com/DataDog/datadog-agent/pkg/eventmonitor.NewEventMonitor()
      /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:230 +0xea
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:759 +0x242e
  github.com/DataDog/datadog-agent/pkg/security/tests.testFilterOpenParentDiscarder()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/filters_test.go:279 +0x1a7
  github.com/DataDog/datadog-agent/pkg/security/tests.TestFilterOpenParentDiscarder()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/filters_test.go:338 +0x64
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1851 +0x44
==================
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

The manager is used on other parts without locks, I'm not sure it's needed everywhere but that's a start.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->