### PR TITLE
[CWS] make `DefaultStateScopes` public

### DIFF
--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -90,7 +90,7 @@ func NewRuleOpts(eventTypeEnabled map[eval.EventType]bool) *Opts {
 	var ruleOpts Opts
 	ruleOpts.
 		WithEventTypeEnabled(eventTypeEnabled).
-		WithStateScopes(getStateScopes())
+		WithStateScopes(DefaultStateScopes())
 
 	return &ruleOpts
 }

--- a/pkg/security/secl/rules/scope.go
+++ b/pkg/security/secl/rules/scope.go
@@ -18,6 +18,8 @@ const (
 	ScopeProcess = "process"
 	// ScopeContainer is the scope for container variables
 	ScopeContainer = "container"
+	// ScopeCGroup is the scope for cgroup variables
+	ScopeCGroup = "cgroup"
 )
 
 // IsScopeVariable returns true if the variable name is a scope variable

--- a/pkg/security/secl/rules/scope_linux.go
+++ b/pkg/security/secl/rules/scope_linux.go
@@ -11,11 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
-const (
-	// ScopeCGroup is the scope for cgroup variables
-	ScopeCGroup = "cgroup"
-)
-
 // VariableScopes is the list of scopes for variables
 var VariableScopes = []string{
 	ScopeCGroup,

--- a/pkg/security/secl/rules/scope_linux.go
+++ b/pkg/security/secl/rules/scope_linux.go
@@ -18,7 +18,8 @@ var VariableScopes = []string{
 	ScopeContainer,
 }
 
-func getStateScopes() map[Scope]VariableProviderFactory {
+// DefaultStateScopes returns the default state scopes for variables
+func DefaultStateScopes() map[Scope]VariableProviderFactory {
 	stateScopes := getCommonStateScopes()
 	stateScopes[ScopeCGroup] = func() VariableProvider {
 		return eval.NewScopedVariables(ScopeCGroup, func(ctx *eval.Context) eval.VariableScope {

--- a/pkg/security/secl/rules/scope_others.go
+++ b/pkg/security/secl/rules/scope_others.go
@@ -14,6 +14,7 @@ var VariableScopes = []string{
 	ScopeContainer,
 }
 
-func getStateScopes() map[Scope]VariableProviderFactory {
+// DefaultStateScopes returns the default state scopes for variables
+func DefaultStateScopes() map[Scope]VariableProviderFactory {
 	return getCommonStateScopes()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The default list of variable state scopes is pretty useful, and is currently duplicated in the `cws-rule-checker` code. This PR makes this function public so that the rule checker can make use of it directly.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->