### PR TITLE
dyninst/symdb: add snapshot testing

### DIFF
--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -8,12 +8,17 @@
 package symdb_test
 
 import (
+	"flag"
 	"github.com/stretchr/testify/require"
 	_ "net/http/pprof"
+	"os"
+	"path"
+	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/symdbutil"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
 
@@ -25,9 +30,7 @@ func TestSymDB(t *testing.T) {
 			binaryPath, err := testprogs.GetBinary("simple", cfg)
 			require.NoError(t, err)
 			t.Logf("exploring binary: %s", binaryPath)
-			file, err := object.OpenElfFile(binaryPath)
-			require.NoError(t, err)
-			symBuilder, err := symdb.NewSymDBBuilder(file)
+			symBuilder, err := symdb.NewSymDBBuilder(binaryPath)
 			require.NoError(t, err)
 			symbols, err := symBuilder.ExtractSymbols()
 			require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
@@ -46,6 +49,67 @@ func TestSymDB(t *testing.T) {
 			require.True(t, v.FunctionArgument)
 			require.NotZero(t, v.DeclLine)
 			require.NotEmpty(t, v.AvailableLineRanges)
+		})
+	}
+}
+
+var rewriteFromEnv = func() bool {
+	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
+	return rewrite
+}()
+var rewrite = flag.Bool("rewrite", rewriteFromEnv, "rewrite the snapshot files")
+
+const snapshotDir = "testdata/snapshot"
+
+var cases = []string{"sample"}
+
+func TestSymDBSnapshot(t *testing.T) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	for _, caseName := range cases {
+		t.Run(caseName, func(t *testing.T) {
+			for _, cfg := range cfgs {
+				t.Run(cfg.String(), func(t *testing.T) {
+					binaryPath := testprogs.MustGetBinary(t, caseName, cfg)
+					t.Logf("exploring binary: %s", binaryPath)
+					symBuilder, err := symdb.NewSymDBBuilder(binaryPath)
+					require.NoError(t, err)
+					symbols, err := symBuilder.ExtractSymbols()
+					require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
+					require.NotEmpty(t, symbols.Packages)
+
+					var sb strings.Builder
+					symbols.Serialize(symdbutil.MakePanickingWriter(&sb),
+						symdb.SerializationOptions{
+							// Keep the size of the snapshot small by only
+							// including the main module.
+							OnlyMainModule: true,
+							PackageSerializationOptions: symdb.PackageSerializationOptions{
+								// Make the snapshot machine-independent by
+								// removing local file paths (given that the
+								// inspected binaries are built locally).
+								StripLocalFilePrefix: true,
+							},
+						},
+					)
+					out := sb.String()
+
+					outputFile := path.Join(snapshotDir, caseName+"."+cfg.String()+".out")
+					if *rewrite {
+						tmpFile, err := os.CreateTemp(snapshotDir, ".out")
+						require.NoError(t, err)
+						name := tmpFile.Name()
+						defer func() { _ = os.Remove(name) }()
+						_, err = tmpFile.WriteString(out)
+						require.NoError(t, err)
+						require.NoError(t, tmpFile.Close())
+						require.NoError(t, os.Rename(name, outputFile))
+					} else {
+						expected, err := os.ReadFile(outputFile)
+						require.NoError(t, err)
+						require.Equal(t, string(expected), out)
+					}
+				})
+			}
 		})
 	}
 }

--- a/pkg/dyninst/symdb/symdbutil/util.go
+++ b/pkg/dyninst/symdb/symdbutil/util.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package symdbutil provides utility functions and types for the symdb package.
+package symdbutil
+
+import (
+	"io"
+)
+
+// PanickingWriter wraps an io.StringWriter, but writes panic instead of
+// returning errors.
+//
+// PanickingWriter implements symdb.StringWriter.
+type PanickingWriter struct {
+	inner io.StringWriter
+}
+
+// MakePanickingWriter creates a PanickingWriter that will write to the provided
+// writer.
+func MakePanickingWriter(w io.StringWriter) PanickingWriter {
+	return PanickingWriter{inner: w}
+}
+
+// WriteString implements symdb.StringWriter.
+func (w PanickingWriter) WriteString(s string) {
+	_, err := w.inner.WriteString(s)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,561 @@
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: )
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: )
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: )
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: )
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: )
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: )
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: )
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: )
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: )
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: )
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: )
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: )
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: )
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: )
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: )
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: )
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: )
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: )
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: )
+		Arg: b: [3]uint32 (declared at line 88, available: )
+		Arg: c: [3]uint32 (declared at line 88, available: )
+		Arg: d: [3]uint32 (declared at line 88, available: )
+		Arg: e: [3]uint32 (declared at line 88, available: )
+		Arg: f: [3]uint32 (declared at line 88, available: )
+		Arg: g: [3]uint32 (declared at line 88, available: )
+		Arg: h: [3]uint32 (declared at line 89, available: )
+		Arg: i: [3]uint32 (declared at line 89, available: )
+		Arg: j: [3]uint32 (declared at line 89, available: )
+		Arg: k: [3]uint32 (declared at line 89, available: )
+		Arg: l: [3]uint32 (declared at line 89, available: )
+		Arg: m: [3]uint32 (declared at line 89, available: )
+		Arg: n: [3]uint32 (declared at line 89, available: )
+		Arg: o: [3]uint32 (declared at line 90, available: )
+		Arg: p: [3]uint32 (declared at line 90, available: )
+		Arg: q: [3]uint32 (declared at line 90, available: )
+		Arg: r: [3]uint32 (declared at line 90, available: )
+		Arg: s: [3]uint32 (declared at line 90, available: )
+		Arg: t: [3]uint32 (declared at line 90, available: )
+		Arg: u: [3]uint32 (declared at line 90, available: )
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: )
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: )
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: )
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: )
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: )
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: )
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: )
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: )
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: )
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: )
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: )
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: )
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: )
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: )
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: )
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: )
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: )
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: )
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: )
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: )
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: )
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: )
+		Arg: b: error (declared at line 93, available: )
+		Arg: c: uint (declared at line 93, available: )
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: )
+		Var: circ: main.circularReferenceType (declared at line 129, available: )
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-49])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [52-55])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [62-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: )
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [51-52])
+		Var: inter: string (declared at line 52, available: [52-53])
+		Var: iType: string (declared at line 53, available: [53-54])
+		Var: iFun: string (declared at line 54, available: [54-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [18:43]
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/!data!dog/dd-trace-go/v2@v2.0.1/ddtrace/tracer/option.go [975:978]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 975, available: [975-977])
+		Var: name: string (declared at line 976, available: [976-978])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [14:14]
+		Arg: s: main.structWithMap (declared at line 14, available: )
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: m: map[string]main.nestedStruct (declared at line 18, available: )
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]int (declared at line 22, available: )
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: [2]map[string]int (declared at line 26, available: )
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: *map[string]int (declared at line 30, available: )
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [33:41]
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: )
+		Arg: b: uint8 (declared at line 15, available: )
+		Arg: c: uint8 (declared at line 15, available: )
+		Arg: d: uint8 (declared at line 15, available: )
+		Arg: e: uint8 (declared at line 15, available: )
+		Arg: f: uint8 (declared at line 15, available: )
+		Arg: g: uint8 (declared at line 15, available: )
+		Arg: h: uint8 (declared at line 16, available: )
+		Arg: i: uint8 (declared at line 16, available: )
+		Arg: j: uint8 (declared at line 16, available: )
+		Arg: k: uint8 (declared at line 16, available: )
+		Arg: l: uint8 (declared at line 16, available: )
+		Arg: m: uint8 (declared at line 16, available: )
+		Arg: n: uint8 (declared at line 16, available: )
+		Arg: o: uint8 (declared at line 17, available: )
+		Arg: p: uint8 (declared at line 17, available: )
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: )
+		Arg: x: uint8 (declared at line 22, available: )
+		Arg: y: float32 (declared at line 22, available: )
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: )
+		Arg: x: int32 (declared at line 26, available: )
+		Arg: y: float32 (declared at line 26, available: )
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: )
+		Arg: x: string (declared at line 30, available: )
+		Arg: y: float32 (declared at line 30, available: )
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: )
+		Arg: x: bool (declared at line 34, available: )
+		Arg: y: float32 (declared at line 34, available: )
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: )
+		Arg: x: int (declared at line 38, available: )
+		Arg: y: float32 (declared at line 38, available: )
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: )
+		Arg: x: int8 (declared at line 42, available: )
+		Arg: y: float32 (declared at line 42, available: )
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: )
+		Arg: x: int16 (declared at line 46, available: )
+		Arg: y: float32 (declared at line 46, available: )
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: )
+		Arg: x: int32 (declared at line 50, available: )
+		Arg: y: float32 (declared at line 50, available: )
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: )
+		Arg: x: int64 (declared at line 54, available: )
+		Arg: y: float32 (declared at line 54, available: )
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: )
+		Arg: x: uint (declared at line 58, available: )
+		Arg: y: float32 (declared at line 58, available: )
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: )
+		Arg: x: uint8 (declared at line 62, available: )
+		Arg: y: float32 (declared at line 62, available: )
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: )
+		Arg: x: uint16 (declared at line 66, available: )
+		Arg: y: float32 (declared at line 66, available: )
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: )
+		Arg: x: uint32 (declared at line 70, available: )
+		Arg: y: float32 (declared at line 70, available: )
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: )
+		Arg: x: uint64 (declared at line 74, available: )
+		Arg: y: float32 (declared at line 74, available: )
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: )
+		Arg: b: uint8 (declared at line 78, available: )
+		Arg: c: int32 (declared at line 78, available: )
+		Arg: d: uint (declared at line 78, available: )
+		Arg: e: string (declared at line 78, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: )
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: )
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: )
+		Var: b: []uint8 (declared at line 29, available: [31-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: )
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: )
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: )
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: )
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: )
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: )
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: )
+		Arg: x: *main.nStruct (declared at line 71, available: )
+		Arg: a: int (declared at line 71, available: )
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: )
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: )
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: )
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: )
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: )
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: )
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: )
+		Arg: a: uint (declared at line 99, available: )
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: )
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [106:171]
+		Var: self: *main.node (declared at line 166, available: [167-171])
+		Var: z: main.spws (declared at line 112, available: )
+		Var: r: string (declared at line 111, available: )
+		Var: ssaw: main.swsp (declared at line 120, available: )
+		Var: rct: main.reallyComplexType (declared at line 131, available: )
+		Var: b: main.node (declared at line 139, available: )
+		Var: stringSlice: []string (declared at line 156, available: )
+		Var: up: *int (declared at line 162, available: )
+		Var: aruint: [2]uint (declared at line 153, available: )
+		Var: n: main.nStruct (declared at line 117, available: )
+		Var: u: int (declared at line 161, available: )
+		Var: u64F: uint64 (declared at line 107, available: )
+		Var: uintToPointTo: uint (declared at line 114, available: )
+		Var: x: main.structWithTwoValues (declared at line 128, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-24])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: )
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: )
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: )
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: )
+		Arg: a: int (declared at line 41, available: )
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: )
+		Arg: a: int (declared at line 45, available: )
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: )
+		Arg: a: int (declared at line 49, available: )
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: )
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: )
+		Arg: s: []bool (declared at line 57, available: )
+		Arg: x: uint (declared at line 57, available: )
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: )
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: )
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:88]
+		Var: originalSlice: []int (declared at line 69, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: callInlinedFuncChain (main.callInlinedFuncChain) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [30:32]
+	Function: notInlined (main.notInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [51:52]
+		Arg: ~r0: string (declared at line 51, available: )
+	Function: executeStackAndInlining (main.executeStackAndInlining) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [56:59]
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [10:10]
+		Arg: x: string (declared at line 10, available: )
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [14:14]
+		Arg: x: string (declared at line 14, available: )
+		Arg: y: string (declared at line 14, available: )
+		Arg: z: string (declared at line 14, available: )
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [28:28]
+		Arg: a: main.threeStringStruct (declared at line 28, available: )
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [32:32]
+		Arg: a: *main.threeStringStruct (declared at line 32, available: )
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [36:36]
+		Arg: a: *main.oneStringStruct (declared at line 36, available: )
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:45]
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: )
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: )
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: )
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: )
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: )
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: )
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: )
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: )
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: )
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: )
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: )
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: )
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: )
+		Arg: x: main.aStruct (declared at line 76, available: )
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: )
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: )
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: )
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: )
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: )
+		Var: s: main.aStruct (declared at line 110, available: )
+		Var: b: main.bStruct (declared at line 113, available: )
+		Var: tenStr: main.tenStrings (declared at line 130, available: )
+		Var: deep: main.deepStruct1 (declared at line 144, available: )
+		Var: fields: main.lotsOfFields (declared at line 161, available: )
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: )
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: )
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: )
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: )
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: )
+			Arg: a: int (declared at line 24, available: )
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: )
+			Arg: a: int (declared at line 28, available: )
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,561 @@
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: )
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: )
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: )
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: )
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: )
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: )
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: )
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: )
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: )
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: )
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: )
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: )
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: )
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: )
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: )
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: )
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: )
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: )
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: )
+		Arg: b: [3]uint32 (declared at line 88, available: )
+		Arg: c: [3]uint32 (declared at line 88, available: )
+		Arg: d: [3]uint32 (declared at line 88, available: )
+		Arg: e: [3]uint32 (declared at line 88, available: )
+		Arg: f: [3]uint32 (declared at line 88, available: )
+		Arg: g: [3]uint32 (declared at line 88, available: )
+		Arg: h: [3]uint32 (declared at line 89, available: )
+		Arg: i: [3]uint32 (declared at line 89, available: )
+		Arg: j: [3]uint32 (declared at line 89, available: )
+		Arg: k: [3]uint32 (declared at line 89, available: )
+		Arg: l: [3]uint32 (declared at line 89, available: )
+		Arg: m: [3]uint32 (declared at line 89, available: )
+		Arg: n: [3]uint32 (declared at line 89, available: )
+		Arg: o: [3]uint32 (declared at line 90, available: )
+		Arg: p: [3]uint32 (declared at line 90, available: )
+		Arg: q: [3]uint32 (declared at line 90, available: )
+		Arg: r: [3]uint32 (declared at line 90, available: )
+		Arg: s: [3]uint32 (declared at line 90, available: )
+		Arg: t: [3]uint32 (declared at line 90, available: )
+		Arg: u: [3]uint32 (declared at line 90, available: )
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: )
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: )
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: )
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: )
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: )
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: )
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: )
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: )
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: )
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: )
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: )
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: )
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: )
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: )
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: )
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: )
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: )
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: )
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: )
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: )
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: )
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: )
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: )
+		Arg: b: error (declared at line 93, available: )
+		Arg: c: uint (declared at line 93, available: )
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: )
+		Var: circ: main.circularReferenceType (declared at line 129, available: )
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-49])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [52-55])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [62-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: )
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [51-52])
+		Var: inter: string (declared at line 52, available: [52-53])
+		Var: iType: string (declared at line 53, available: [53-54])
+		Var: iFun: string (declared at line 54, available: [54-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: )
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [18:43]
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/!data!dog/dd-trace-go/v2@v2.0.1/ddtrace/tracer/option.go [975:978]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 975, available: [975-977])
+		Var: name: string (declared at line 976, available: [976-978])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [14:14]
+		Arg: s: main.structWithMap (declared at line 14, available: )
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: m: map[string]main.nestedStruct (declared at line 18, available: )
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]int (declared at line 22, available: )
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: [2]map[string]int (declared at line 26, available: )
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: *map[string]int (declared at line 30, available: )
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [33:41]
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: )
+		Arg: b: uint8 (declared at line 15, available: )
+		Arg: c: uint8 (declared at line 15, available: )
+		Arg: d: uint8 (declared at line 15, available: )
+		Arg: e: uint8 (declared at line 15, available: )
+		Arg: f: uint8 (declared at line 15, available: )
+		Arg: g: uint8 (declared at line 15, available: )
+		Arg: h: uint8 (declared at line 16, available: )
+		Arg: i: uint8 (declared at line 16, available: )
+		Arg: j: uint8 (declared at line 16, available: )
+		Arg: k: uint8 (declared at line 16, available: )
+		Arg: l: uint8 (declared at line 16, available: )
+		Arg: m: uint8 (declared at line 16, available: )
+		Arg: n: uint8 (declared at line 16, available: )
+		Arg: o: uint8 (declared at line 17, available: )
+		Arg: p: uint8 (declared at line 17, available: )
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: )
+		Arg: x: uint8 (declared at line 22, available: )
+		Arg: y: float32 (declared at line 22, available: )
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: )
+		Arg: x: int32 (declared at line 26, available: )
+		Arg: y: float32 (declared at line 26, available: )
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: )
+		Arg: x: string (declared at line 30, available: )
+		Arg: y: float32 (declared at line 30, available: )
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: )
+		Arg: x: bool (declared at line 34, available: )
+		Arg: y: float32 (declared at line 34, available: )
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: )
+		Arg: x: int (declared at line 38, available: )
+		Arg: y: float32 (declared at line 38, available: )
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: )
+		Arg: x: int8 (declared at line 42, available: )
+		Arg: y: float32 (declared at line 42, available: )
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: )
+		Arg: x: int16 (declared at line 46, available: )
+		Arg: y: float32 (declared at line 46, available: )
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: )
+		Arg: x: int32 (declared at line 50, available: )
+		Arg: y: float32 (declared at line 50, available: )
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: )
+		Arg: x: int64 (declared at line 54, available: )
+		Arg: y: float32 (declared at line 54, available: )
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: )
+		Arg: x: uint (declared at line 58, available: )
+		Arg: y: float32 (declared at line 58, available: )
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: )
+		Arg: x: uint8 (declared at line 62, available: )
+		Arg: y: float32 (declared at line 62, available: )
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: )
+		Arg: x: uint16 (declared at line 66, available: )
+		Arg: y: float32 (declared at line 66, available: )
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: )
+		Arg: x: uint32 (declared at line 70, available: )
+		Arg: y: float32 (declared at line 70, available: )
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: )
+		Arg: x: uint64 (declared at line 74, available: )
+		Arg: y: float32 (declared at line 74, available: )
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: )
+		Arg: b: uint8 (declared at line 78, available: )
+		Arg: c: int32 (declared at line 78, available: )
+		Arg: d: uint (declared at line 78, available: )
+		Arg: e: string (declared at line 78, available: )
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: )
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: )
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: )
+		Var: b: []uint8 (declared at line 29, available: [31-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: )
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: )
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: )
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: )
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: )
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: )
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: )
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: )
+		Arg: x: *main.nStruct (declared at line 71, available: )
+		Arg: a: int (declared at line 71, available: )
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: )
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: )
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: )
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: )
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: )
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: )
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: )
+		Arg: a: uint (declared at line 99, available: )
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: )
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [106:171]
+		Var: self: *main.node (declared at line 166, available: [167-171])
+		Var: z: main.spws (declared at line 112, available: )
+		Var: r: string (declared at line 111, available: )
+		Var: ssaw: main.swsp (declared at line 120, available: )
+		Var: rct: main.reallyComplexType (declared at line 131, available: )
+		Var: b: main.node (declared at line 139, available: )
+		Var: stringSlice: []string (declared at line 156, available: )
+		Var: up: *int (declared at line 162, available: )
+		Var: aruint: [2]uint (declared at line 153, available: )
+		Var: n: main.nStruct (declared at line 117, available: )
+		Var: u: int (declared at line 161, available: )
+		Var: u64F: uint64 (declared at line 107, available: )
+		Var: uintToPointTo: uint (declared at line 114, available: )
+		Var: x: main.structWithTwoValues (declared at line 128, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: )
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-24])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: )
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: )
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: )
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: )
+		Arg: a: int (declared at line 41, available: )
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: )
+		Arg: a: int (declared at line 45, available: )
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: )
+		Arg: a: int (declared at line 49, available: )
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: )
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: )
+		Arg: s: []bool (declared at line 57, available: )
+		Arg: x: uint (declared at line 57, available: )
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: )
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: )
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:88]
+		Var: originalSlice: []int (declared at line 69, available: )
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: callInlinedFuncChain (main.callInlinedFuncChain) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [30:32]
+	Function: notInlined (main.notInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [51:52]
+		Arg: ~r0: string (declared at line 51, available: )
+	Function: executeStackAndInlining (main.executeStackAndInlining) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [56:59]
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [10:10]
+		Arg: x: string (declared at line 10, available: )
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [14:14]
+		Arg: x: string (declared at line 14, available: )
+		Arg: y: string (declared at line 14, available: )
+		Arg: z: string (declared at line 14, available: )
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [28:28]
+		Arg: a: main.threeStringStruct (declared at line 28, available: )
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [32:32]
+		Arg: a: *main.threeStringStruct (declared at line 32, available: )
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [36:36]
+		Arg: a: *main.oneStringStruct (declared at line 36, available: )
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [39:45]
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: )
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: )
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: )
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: )
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: )
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: )
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: )
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: )
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: )
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: )
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: )
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: )
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: )
+		Arg: x: main.aStruct (declared at line 76, available: )
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: )
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: )
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: )
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: )
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: )
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: )
+		Var: s: main.aStruct (declared at line 110, available: )
+		Var: b: main.bStruct (declared at line 113, available: )
+		Var: tenStr: main.tenStrings (declared at line 130, available: )
+		Var: deep: main.deepStruct1 (declared at line 144, available: )
+		Var: fields: main.lotsOfFields (declared at line 161, available: )
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: )
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: )
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: )
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: )
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: )
+			Arg: a: int (declared at line 24, available: )
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: )
+			Arg: a: int (declared at line 28, available: )
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]

--- a/pkg/dyninst/testprogs/progs/sample/lib/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib/lib.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package lib
+
+var dummy int
+
+//go:noinline
+func Foo() {
+	dummy++
+}

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -11,6 +11,8 @@ import (
 	"os"
 
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib"
 )
 
 func main() {
@@ -30,6 +32,7 @@ func main() {
 	executeStackAndInlining()
 	executePointerFuncs()
 	executeComplexFuncs()
+	lib.Foo()
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()


### PR DESCRIPTION
This patch adds a simple text serialization format for symbols and
creates golden files for one of the test programs.

The symdb cli tool now outputs the data.