### PR TITLE
go.work: add one more module

### DIFF
--- a/go.work
+++ b/go.work
@@ -89,6 +89,7 @@ use (
 	pkg/config/teeconfig
 	pkg/config/utils
 	pkg/config/viperconfig
+	pkg/dyninst/testprogs/progs
 	pkg/errors
 	pkg/fips
 	pkg/fleet/installer


### PR DESCRIPTION
List the module we use for dynamic instrumentation test binaries to make GoLand happy.
