### PR TITLE
[SMP] Reduce `-all-features` memory bound to account for reverted feature

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "571 MiB"
+      upper_bound: "497 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

Reduce the `quality_gate_idle_all_features` memory bound to lock in the current memory usage.

Ref https://github.com/DataDog/datadog-agent/pull/39111