### PR TITLE
remoteconfig: add LIVE_DEBUGGING_SYMBOL_DB product

### DIFF
--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -37,6 +37,7 @@ var validProducts = map[string]struct{}{
 	ProductNDMDeviceProfilesCustom:      {},
 	ProductMetricControl:                {},
 	ProductDataStreamsLiveMessages:      {},
+	ProductLiveDebuggingSymbolDB:        {},
 }
 
 const (
@@ -84,6 +85,9 @@ const (
 	ProductSDSAgentConfig = "SDS_AGENT_CONFIG"
 	// ProductLiveDebugging is the dynamic instrumentation product
 	ProductLiveDebugging = "LIVE_DEBUGGING"
+	// ProductLiveDebuggingSymbolDB is used by the live debugging product for
+	// selecting processes to upload symbols to the symbol database.
+	ProductLiveDebuggingSymbolDB = "LIVE_DEBUGGING_SYMBOL_DB"
 	// ProductContainerAutoscalingSettings receives definition of container autoscaling
 	ProductContainerAutoscalingSettings = "CONTAINER_AUTOSCALING_SETTINGS"
 	// ProductContainerAutoscalingValues receives values for container autoscaling


### PR DESCRIPTION
### What does this PR do?

The dd-trace-go library depends on this package for its remote config repository implementation. It cannot parse updates to this product without it being listed as valid.

### Motivation

We are working on symdb integration for Go DI.

### Describe how you validated your changes

I combined this with https://github.com/DataDog/datadog-agent/pull/39174 and https://github.com/DataDog/dd-trace-go/pull/3799 with some replace directives and then it all works.

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4206