### PR TITLE
[CWS] allow secl errors to unwrap themselves into underlying errors

### DIFF
--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -117,6 +117,10 @@ func (e ErrRuleLoad) Error() string {
 	return fmt.Sprintf("rule `%s` error: %s", e.Rule.Def.ID, e.Err)
 }
 
+func (e ErrRuleLoad) Unwrap() error {
+	return e.Err
+}
+
 // RuleLoadErrType defines an rule error type
 type RuleLoadErrType string
 
@@ -161,6 +165,10 @@ func (e *ErrRuleSyntax) Error() string {
 	return fmt.Sprintf("syntax error `%v`", e.Err)
 }
 
+func (e *ErrRuleSyntax) Unwrap() error {
+	return e.Err
+}
+
 // ErrActionFilter is on filter definition error
 type ErrActionFilter struct {
 	Expression string
@@ -171,6 +179,10 @@ func (e ErrActionFilter) Error() string {
 	return fmt.Sprintf("filter `%s` error: %s", e.Expression, e.Err)
 }
 
+func (e ErrActionFilter) Unwrap() error {
+	return e.Err
+}
+
 // ErrScopeField is return on scope field definition error
 type ErrScopeField struct {
 	Expression string
@@ -179,6 +191,10 @@ type ErrScopeField struct {
 
 func (e ErrScopeField) Error() string {
 	return fmt.Sprintf("scope_field `%s` error: %s", e.Expression, e.Err)
+}
+
+func (e ErrScopeField) Unwrap() error {
+	return e.Err
 }
 
 // ErrFieldNotAvailable is returned when a field is not available


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds some `Unwrap() error` functions to errors in the SECL package. This will allow to use `errors.As` and `errors.Is` to check the underlying error, especially in the cws-rule-checker.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->