### PR TITLE
Don't run clone job if the upload was already made within ddci

### DIFF
--- a/.gitlab/.pre/clone.yml
+++ b/.gitlab/.pre/clone.yml
@@ -15,6 +15,9 @@ clone:
     CACHE_COMPRESSION_FORMAT: "tarzstd"
     CLONE_TO_S3: "true"
   script: "echo 'Repo is cloned from Gitaly, will upload to s3...'"
+  rules:
+    - if: '$DDCI_CLONE == "true"'
+      when: never
   retry:
     max: 2
     when:


### PR DESCRIPTION
## Context

We, the CI Platforms team, are in the process of onboarding `datadog-agent` to the [S3 Codesync Worker](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5005674110/S3+Codesync+Worker). `datadog-agent` uses the S3 strategy - uploading a commit to S3 so that CI jobs can clone from this upload. This upload currently happens in the `clone` CI job.

The S3 Codesync Worker was introduced to move this upload step out of CI and into DDCI. This allows the upload to run in parallel with DDCI, so that by the time the GitLab pipeline starts, the upload has already completed.

## Changes

If DDCI performs the upload, it will inject the `DDCI_CLONE` variable into the GitLab pipeline. If that is the case, the `clone` job can be skipped.

## Testing

Inspect this PR's [corresponding pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines?ref=marc.brede%2Fupdate-clone-job), it does not have the `clone` job. Looking at any job, f.e. [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1062253254), we can see it taking its clone from `repo-cache-ddci/...`.