### PR TITLE
fix(rpm): Stop the agent in legacy preinst

### DIFF
--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -33,6 +33,49 @@ fi
 #                   DO NOT EDIT THIS SECTION                             #
 ##########################################################################
 
+SERVICE_NAME=datadog-agent
+
+stop_agent() {
+    # Stop an already running agent
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME-process || true
+        systemctl stop $SERVICE_NAME-sysprobe || true
+        systemctl stop $SERVICE_NAME-trace || true
+        systemctl stop $SERVICE_NAME-security || true
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME-process || true
+        initctl stop $SERVICE_NAME-sysprobe || true
+        initctl stop $SERVICE_NAME-trace || true
+        initctl stop $SERVICE_NAME-security || true
+        initctl stop $SERVICE_NAME || true
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
+    fi
+}
+
+deregister_agent() {
+    # Disable agent start on system boot
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-sysprobe || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-security || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        # Nothing to do, this is defined directly in the upstart job file
+        :
+    else
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
+    fi
+}
+
+stop_agent
+deregister_agent
+
 # RPM unpacks the new files before running prerm of the old package
 # triggering manually the prerm python script of the old package
 if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/datadog-agent/pull/37078 removed the agent stop command from the RPM `preinst` to migrate it in the installer, while https://github.com/DataDog/datadog-agent/pull/37084 preserved some `preinst` commands in bash for upgrades from older agents. The combination of these two prevents us from stopping the agent before upgrading from an older version, leaving compiled Python files on disk after the upgrade that are not removed by an uninstallation of the agent.

### Motivation

### Describe how you validated your changes
Manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
