### PR TITLE
Remove beta-only option

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -38,9 +38,6 @@ spec:
             value: ___value___
           - name: DD_DOGSTATSD_SOCKET
             value: "/socket/statsd.socket"
-          - name: DD_SEND_HOST_METADATA
-            # Legacy option name, keep as `false` when running alongside another Agent
-            value: "false"
           - name: DD_ENABLE_METADATA_COLLECTION
             value: "false"
           - name: DD_HOSTNAME
@@ -84,9 +81,6 @@ spec:
         env:
           - name: DD_API_KEY
             value: ___value___
-          - name: DD_SEND_HOST_METADATA
-            # Legacy option name, keep as `false` when running alongside another Agent
-            value: "false"
           - name: DD_ENABLE_METADATA_COLLECTION
             value: "false"
           - name: DD_HOSTNAME


### PR DESCRIPTION
### What does this PR do?

Remove `DD_SEND_HOST_METADATA` which only applied to the dogstatsd:beta build. (Ref: https://github.com/DataDog/datadog-agent/pull/465); stable builds use `DD_ENABLE_METADATA_COLLECTION` instead.
This transitioned out of beta phase in 2018. (Ref: https://github.com/DataDog/datadog-agent/pull/1369)


### Motivation

Caused some confusion as to what `DD_SEND_HOST_METADATA` with no mention that this only applied to beta builds that is no longer used.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->