### PR TITLE
[Backport 7.68.x] remoteconfig: add LIVE_DEBUGGING_SYMBOL_DB product

### DIFF
--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -36,6 +36,7 @@ var validProducts = map[string]struct{}{
 	ProductHaAgent:                      {},
 	ProductNDMDeviceProfilesCustom:      {},
 	ProductMetricControl:                {},
+	ProductLiveDebuggingSymbolDB:        {},
 }
 
 const (
@@ -83,6 +84,9 @@ const (
 	ProductSDSAgentConfig = "SDS_AGENT_CONFIG"
 	// ProductLiveDebugging is the dynamic instrumentation product
 	ProductLiveDebugging = "LIVE_DEBUGGING"
+	// ProductLiveDebuggingSymbolDB is used by the live debugging product for
+	// selecting processes to upload symbols to the symbol database.
+	ProductLiveDebuggingSymbolDB = "LIVE_DEBUGGING_SYMBOL_DB"
 	// ProductContainerAutoscalingSettings receives definition of container autoscaling
 	ProductContainerAutoscalingSettings = "CONTAINER_AUTOSCALING_SETTINGS"
 	// ProductContainerAutoscalingValues receives values for container autoscaling


### PR DESCRIPTION
### What does this PR do?
The dd-trace-go library depends on this package for its remote config repository implementation. It cannot parse updates to this product without it being listed as valid.

### Motivation

The Live Debugger team needs dd-trace-go to be able to subscribe to this product. This library is used in `dd-trace-go`. We'd like to backport this non-functional change into datadog-agent so that dd-trace-go can adopt it without having to bump the major version of the `datadog-agent` dependency and pick up the changes to transitive dependencies.

### Additional Notes

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4206