### PR TITLE
[CWS] move non-templated code out of accessors template

### DIFF
--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -272,18 +272,6 @@ func (ev *Event) GetFields() []eval.Field {
 	}
 }
 
-func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
-	m := &Model{}
-	evaluator, err := m.GetEvaluator(field, "", 0)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx := eval.NewContext(ev)
-	value := evaluator.Eval(ctx)
-	return value, nil
-}
-
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	switch field {
 	{{range $Name, $Field := .Fields}}
@@ -297,22 +285,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	}
 
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
-}
-
-func (ev *Event) initProcess() {
-	if ev.BaseEvent.ProcessContext == nil {
-		ev.BaseEvent.ProcessContext = &ProcessContext{}
-	}
-	if ev.BaseEvent.ProcessContext.Ancestor == nil {
-		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
-	}
-	if ev.BaseEvent.ProcessContext.Parent == nil {
-		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
-	}
-
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
 }
 
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {

--- a/pkg/security/secl/model/accessors_helpers.go
+++ b/pkg/security/secl/model/accessors_helpers.go
@@ -12,6 +12,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
+	m := &Model{}
+	evaluator, err := m.GetEvaluator(field, "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := eval.NewContext(ev)
+	value := evaluator.Eval(ctx)
+	return value, nil
+}
+
+func (ev *Event) initProcess() {
+	if ev.BaseEvent.ProcessContext == nil {
+		ev.BaseEvent.ProcessContext = &ProcessContext{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
+	}
+
+	if ev.Exec.Process == nil {
+		ev.Exec.Process = &Process{}
+	}
+}
+
 // nolint: unused
 func (ev *Event) setStringArrayFieldValue(field string, fv *[]string, value interface{}) error {
 	switch rv := value.(type) {

--- a/pkg/security/secl/model/accessors_helpers.go
+++ b/pkg/security/secl/model/accessors_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+// GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	m := &Model{}
 	evaluator, err := m.GetEvaluator(field, "", 0)

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -31747,16 +31747,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"utimes.syscall.path",
 	}
 }
-func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
-	m := &Model{}
-	evaluator, err := m.GetEvaluator(field, "", 0)
-	if err != nil {
-		return nil, err
-	}
-	ctx := eval.NewContext(ev)
-	value := evaluator.Eval(ctx)
-	return value, nil
-}
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	switch field {
 	case "accept.addr.family":
@@ -35545,20 +35535,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "utimes", reflect.String, "string", nil
 	}
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
-}
-func (ev *Event) initProcess() {
-	if ev.BaseEvent.ProcessContext == nil {
-		ev.BaseEvent.ProcessContext = &ProcessContext{}
-	}
-	if ev.BaseEvent.ProcessContext.Ancestor == nil {
-		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
-	}
-	if ev.BaseEvent.ProcessContext.Parent == nil {
-		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
-	}
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {

--- a/pkg/security/secl/model/accessors_windows.go
+++ b/pkg/security/secl/model/accessors_windows.go
@@ -2321,16 +2321,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.path.length",
 	}
 }
-func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
-	m := &Model{}
-	evaluator, err := m.GetEvaluator(field, "", 0)
-	if err != nil {
-		return nil, err
-	}
-	ctx := eval.NewContext(ev)
-	value := evaluator.Eval(ctx)
-	return value, nil
-}
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	switch field {
 	case "change_permission.new_sd":
@@ -2659,20 +2649,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "write", reflect.Int, "int", nil
 	}
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
-}
-func (ev *Event) initProcess() {
-	if ev.BaseEvent.ProcessContext == nil {
-		ev.BaseEvent.ProcessContext = &ProcessContext{}
-	}
-	if ev.BaseEvent.ProcessContext.Ancestor == nil {
-		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
-	}
-	if ev.BaseEvent.ProcessContext.Parent == nil {
-		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
-	}
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {

--- a/pkg/security/seclwin/model/accessors_helpers.go
+++ b/pkg/security/seclwin/model/accessors_helpers.go
@@ -12,6 +12,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
+	m := &Model{}
+	evaluator, err := m.GetEvaluator(field, "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := eval.NewContext(ev)
+	value := evaluator.Eval(ctx)
+	return value, nil
+}
+
+func (ev *Event) initProcess() {
+	if ev.BaseEvent.ProcessContext == nil {
+		ev.BaseEvent.ProcessContext = &ProcessContext{}
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
+	}
+
+	if ev.Exec.Process == nil {
+		ev.Exec.Process = &Process{}
+	}
+}
+
 // nolint: unused
 func (ev *Event) setStringArrayFieldValue(field string, fv *[]string, value interface{}) error {
 	switch rv := value.(type) {

--- a/pkg/security/seclwin/model/accessors_helpers.go
+++ b/pkg/security/seclwin/model/accessors_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+// GetFieldValue retrieves the value of a field from the event using the evaluator.
 func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	m := &Model{}
 	evaluator, err := m.GetEvaluator(field, "", 0)

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -2319,16 +2319,6 @@ func (ev *Event) GetFields() []eval.Field {
 		"write.file.path.length",
 	}
 }
-func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
-	m := &Model{}
-	evaluator, err := m.GetEvaluator(field, "", 0)
-	if err != nil {
-		return nil, err
-	}
-	ctx := eval.NewContext(ev)
-	value := evaluator.Eval(ctx)
-	return value, nil
-}
 func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kind, string, error) {
 	switch field {
 	case "change_permission.new_sd":
@@ -2657,20 +2647,6 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "write", reflect.Int, "int", nil
 	}
 	return "", reflect.Invalid, "", &eval.ErrFieldNotFound{Field: field}
-}
-func (ev *Event) initProcess() {
-	if ev.BaseEvent.ProcessContext == nil {
-		ev.BaseEvent.ProcessContext = &ProcessContext{}
-	}
-	if ev.BaseEvent.ProcessContext.Ancestor == nil {
-		ev.BaseEvent.ProcessContext.Ancestor = &ProcessCacheEntry{}
-	}
-	if ev.BaseEvent.ProcessContext.Parent == nil {
-		ev.BaseEvent.ProcessContext.Parent = &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process
-	}
-	if ev.Exec.Process == nil {
-		ev.Exec.Process = &Process{}
-	}
 }
 func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	if strings.HasPrefix(field, "process.") || strings.HasPrefix(field, "exec.") {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Some of the generated accessors code is actually non-templated. This PR moves it out of the template. This is useful because the template is hard to edit (no IDE autocompletion etc).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->