### PR TITLE
[Backport 7.69.x] Bumping the secret-generic-connector side binary to 1.0.1

### DIFF
--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -16,7 +16,7 @@
 require './lib/ostools.rb'
 
 name "secret-generic-connector"
-default_version "0.2.5"
+default_version "1.0.1"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -38,16 +38,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
   "linux" => {
-    "amd64" => "6b48831a7236013f082fec611e9ab67357fa37244ecee6d8f0f80475dbd6013a",
-    "arm64" => "83178ec13af5f3bc6b19169236563c4e7417937c2183e720f7cfc8659fc01217"
+    "amd64" => "76add0ba9b638c41c2cd98b8ef29fe89c65c217bfad3b58f176889a8f7e555bd",
+    "arm64" => "16d31666d039622ce6bd526bb0c2aabbfebb24b95b6de4a96319d4db9b87101b"
   },
   "windows" => {
-    "amd64" => "e998a9a5685e54e184e4a2e51fb1ad760c0387f6b96c5f817ae422b4ebe926a8",
-    "arm64" => "3b44c9950d3364315c93fb283e9dffa6ec4257ce99d05ba35d2b0364f40b1569"
+    "amd64" => "e536450a4885b526df41279c76798b9486b5550fb2c4b4bef4f216a1788a2e88",
+    "arm64" => "2cde0c06797eb4d2bd463e0e2c71a6c8bdc3b6e43632b7ec34301fcd5ad7a7f5"
   },
   "darwin" => {
-    "amd64" => "a8dbba5b9ce02127f5d09f897af10a9c5ba6fd6b2cbc01861ea489f959c56ee6",
-    "arm64" => "619d5c77dcc9d43baf95c9d0e8a9d253dd9ba7e132014a6bf16e2135ce6524ed"
+    "amd64" => "044b34b3bd160914e6e40a95cf4a11dd41aefebac74c35ef193ae0b0199f6dee",
+    "arm64" => "1c22332ca6fbb3f1453a6395c665905237bc27d6893f45770a38aee418983bf6"
   },
 }
 

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -8,7 +8,6 @@ static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 367.87 MiB
   max_on_wire_size: 100.05 MiB
 static_quality_gate_agent_msi:
-<<<<<<< HEAD
   max_on_disk_size: 979.82 MiB
   max_on_wire_size: 149.31 MiB
 static_quality_gate_agent_rpm_amd64:

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -44,32 +44,32 @@ static_quality_gate_docker_agent_jmx_amd64:
   max_on_disk_size: 980.55 MiB
   max_on_wire_size: 341.08 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-# static_quality_gate_docker_agent_windows1809:
-#   max_on_disk_size: 1190.61 MiB
-#   max_on_wire_size: 420.48 MiB
-# static_quality_gate_docker_agent_windows1809_core:
-#   max_on_disk_size: 5920.75 MiB
-#   max_on_wire_size: 2048.95 MiB
-# static_quality_gate_docker_agent_windows1809_core_jmx:
-#   max_on_disk_size: 6042.32 MiB
-#   max_on_wire_size: 2048.95 MiB
-# static_quality_gate_docker_agent_windows1809_jmx:
-#   max_on_disk_size: 1312.42 MiB
-#   max_on_wire_size: 462.77 MiB
-# static_quality_gate_docker_agent_windows2022:
-#   max_on_disk_size: 1209.9 MiB
-#   max_on_wire_size: 433.24 MiB
-# static_quality_gate_docker_agent_windows2022_core:
-#   max_on_disk_size: 5893.81 MiB
-#   max_on_wire_size: 2048.95 MiB
-# static_quality_gate_docker_agent_windows2022_core_jmx:
-#   max_on_disk_size: 6015.45 MiB
-#   max_on_wire_size: 2048.95 MiB
-# static_quality_gate_docker_agent_windows2022_jmx:
-#   max_on_disk_size: 1331.48 MiB
-#   max_on_wire_size: 475.53 MiB
   max_on_disk_size: 982.42 MiB
   max_on_wire_size: 324.75 MiB
+static_quality_gate_docker_agent_windows1809:
+  max_on_disk_size: 1195.03 MiB
+  max_on_wire_size: 424.31 MiB
+static_quality_gate_docker_agent_windows1809_core:
+  max_on_disk_size: 5930.43 MiB
+  max_on_wire_size: 2049.0 MiB
+static_quality_gate_docker_agent_windows1809_core_jmx:
+  max_on_disk_size: 6068.68 MiB
+  max_on_wire_size: 2054.45 MiB
+static_quality_gate_docker_agent_windows1809_jmx:
+  max_on_disk_size: 1316.42 MiB
+  max_on_wire_size: 466.29 MiB
+static_quality_gate_docker_agent_windows2022:
+  max_on_disk_size: 1213.94 MiB
+  max_on_wire_size: 436.85 MiB
+static_quality_gate_docker_agent_windows2022_core:
+  max_on_disk_size: 5897.98 MiB
+  max_on_wire_size: 2050.9 MiB
+static_quality_gate_docker_agent_windows2022_core_jmx:
+  max_on_disk_size: 6019.20 MiB
+  max_on_wire_size: 2054.29 MiB
+static_quality_gate_docker_agent_windows2022_jmx:
+  max_on_disk_size: 1335.89 MiB
+  max_on_wire_size: 479.09 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 214.5 MiB
   max_on_wire_size: 73.51 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -8,17 +8,18 @@ static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 367.87 MiB
   max_on_wire_size: 100.05 MiB
 static_quality_gate_agent_msi:
+<<<<<<< HEAD
   max_on_disk_size: 979.82 MiB
-  max_on_wire_size: 149.26 MiB
+  max_on_wire_size: 149.31 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 705.56 MiB
   max_on_wire_size: 180.29 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 704.77 MiB
-  max_on_wire_size: 179.83 MiB
+  max_on_wire_size: 179.85 MiB
 static_quality_gate_agent_rpm_arm64:
   max_on_disk_size: 695.45 MiB
-  max_on_wire_size: 163.94 MiB
+  max_on_wire_size: 163.96 MiB
 static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 694.75 MiB
   max_on_wire_size: 163.06 MiB
@@ -30,7 +31,7 @@ static_quality_gate_agent_suse_amd64_fips:
   max_on_wire_size: 180.01 MiB
 static_quality_gate_agent_suse_arm64:
   max_on_disk_size: 695.38 MiB
-  max_on_wire_size: 163.95 MiB
+  max_on_wire_size: 163.96 MiB
 static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 694.73 MiB
   max_on_wire_size: 163.06 MiB
@@ -44,32 +45,32 @@ static_quality_gate_docker_agent_jmx_amd64:
   max_on_disk_size: 980.55 MiB
   max_on_wire_size: 341.08 MiB
 static_quality_gate_docker_agent_jmx_arm64:
+# static_quality_gate_docker_agent_windows1809:
+#   max_on_disk_size: 1190.61 MiB
+#   max_on_wire_size: 420.48 MiB
+# static_quality_gate_docker_agent_windows1809_core:
+#   max_on_disk_size: 5920.75 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows1809_core_jmx:
+#   max_on_disk_size: 6042.32 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows1809_jmx:
+#   max_on_disk_size: 1312.42 MiB
+#   max_on_wire_size: 462.77 MiB
+# static_quality_gate_docker_agent_windows2022:
+#   max_on_disk_size: 1209.9 MiB
+#   max_on_wire_size: 433.24 MiB
+# static_quality_gate_docker_agent_windows2022_core:
+#   max_on_disk_size: 5893.81 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows2022_core_jmx:
+#   max_on_disk_size: 6015.45 MiB
+#   max_on_wire_size: 2048.95 MiB
+# static_quality_gate_docker_agent_windows2022_jmx:
+#   max_on_disk_size: 1331.48 MiB
+#   max_on_wire_size: 475.53 MiB
   max_on_disk_size: 982.42 MiB
   max_on_wire_size: 324.75 MiB
-static_quality_gate_docker_agent_windows1809:
-  max_on_disk_size: 1195.03 MiB
-  max_on_wire_size: 424.31 MiB
-static_quality_gate_docker_agent_windows1809_core:
-  max_on_disk_size: 5930.43 MiB
-  max_on_wire_size: 2049.0 MiB
-static_quality_gate_docker_agent_windows1809_core_jmx:
-  max_on_disk_size: 6068.68 MiB
-  max_on_wire_size: 2054.45 MiB
-static_quality_gate_docker_agent_windows1809_jmx:
-  max_on_disk_size: 1316.42 MiB
-  max_on_wire_size: 466.29 MiB
-static_quality_gate_docker_agent_windows2022:
-  max_on_disk_size: 1213.94 MiB
-  max_on_wire_size: 436.85 MiB
-static_quality_gate_docker_agent_windows2022_core:
-  max_on_disk_size: 5897.98 MiB
-  max_on_wire_size: 2050.9 MiB
-static_quality_gate_docker_agent_windows2022_core_jmx:
-  max_on_disk_size: 6019.20 MiB
-  max_on_wire_size: 2054.29 MiB
-static_quality_gate_docker_agent_windows2022_jmx:
-  max_on_disk_size: 1335.89 MiB
-  max_on_wire_size: 479.09 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 214.5 MiB
   max_on_wire_size: 73.51 MiB


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Backport [c53ea1e](https://github.com/DataDog/datadog-agent/commit/57027c9fdf22255b70fcf1f63b62bca66c53ea1e) from [38674](https://github.com/DataDog/datadog-agent/pull/38674).

### Motivation
We are releasing a new major version of the sgc binary, which is shipped alongside the agent. It is necessary to utilize changes made to the Datadog Agent in version 7.69.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->