### PR TITLE
[CONTP-899] Enable cluster checks advanced dispatching in DCA by default

### DIFF
--- a/comp/metadata/clusteragent/README.md
+++ b/comp/metadata/clusteragent/README.md
@@ -54,7 +54,7 @@ source_local_configuration - string: the Cluster-Agent configuration synchronize
         "feature_admission_controller_validation_enabled": true,
         "feature_apm_config_instrumentation_enabled": false,
         "feature_autoscaling_workload_enabled": false,
-        "feature_cluster_checks_advanced_dispatching_enabled": false,
+        "feature_cluster_checks_advanced_dispatching_enabled": true,
         "feature_cluster_checks_enabled": true,
         "feature_cluster_checks_exclude_checks": [],
         "feature_compliance_config_enabled": false,

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
@@ -17,14 +17,49 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+// isolateTestClcRunnerClient mocks the clcRunnersClient for advanced dispatching tests in this file only
+type isolateTestClcRunnerClient struct{}
+
+func (d *isolateTestClcRunnerClient) GetVersion(_IP string) (version.Version, error) {
+	return version.Version{}, nil
+}
+
+func (d *isolateTestClcRunnerClient) GetRunnerStats(IP string) (types.CLCRunnersStats, error) {
+	// Return dummy stats for nodes "A" and "B" to match the test setup
+	stats := map[string]types.CLCRunnersStats{
+		"A": {
+			"checkA0": {AverageExecutionTime: 50, MetricSamples: 10, IsClusterCheck: true},
+			"checkA1": {AverageExecutionTime: 20, MetricSamples: 10, IsClusterCheck: true},
+			"checkA2": {AverageExecutionTime: 100, MetricSamples: 10, IsClusterCheck: true},
+		},
+		"B": {
+			"checkB0": {AverageExecutionTime: 50, MetricSamples: 10, IsClusterCheck: true},
+			"checkB1": {AverageExecutionTime: 20, MetricSamples: 10, IsClusterCheck: true},
+			"checkB2": {AverageExecutionTime: 100, MetricSamples: 10, IsClusterCheck: true},
+		},
+	}
+	return stats[IP], nil
+}
+
+func (d *isolateTestClcRunnerClient) GetRunnerWorkers(IP string) (types.Workers, error) {
+	// Return 1 worker for node "A" and 1 worker for node "B"
+	workers := map[string]types.Workers{
+		"A": {Count: 1, Instances: map[string]types.WorkerInfo{"workerA": {Utilization: 0.1}}},
+		"B": {Count: 1, Instances: map[string]types.WorkerInfo{"workerB": {Utilization: 0.1}}},
+	}
+	return workers[IP], nil
+}
 
 func TestIsolateCheckSuccessful(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
+	testDispatcher.store.nodes["B"] = newNodeStore("B", "B")
 	testDispatcher.store.nodes["B"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{
@@ -103,9 +138,10 @@ func TestIsolateCheckSuccessful(t *testing.T) {
 func TestIsolateNonExistentCheckFails(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
+	testDispatcher.store.nodes["B"] = newNodeStore("B", "B")
 	testDispatcher.store.nodes["B"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{
@@ -182,7 +218,8 @@ func TestIsolateNonExistentCheckFails(t *testing.T) {
 func TestIsolateCheckOnlyOneRunnerFails(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -19,7 +19,32 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+// rebalanceTestClcRunnerClient mocks the clcRunnersClient for rebalance tests
+type rebalanceTestClcRunnerClient struct {
+	testStats map[string]types.CLCRunnersStats
+}
+
+func (d *rebalanceTestClcRunnerClient) GetVersion(_ip string) (version.Version, error) {
+	return version.Version{}, nil
+}
+
+func (d *rebalanceTestClcRunnerClient) GetRunnerStats(ip string) (types.CLCRunnersStats, error) {
+	// Return the stored test stats for this IP, or empty if not found
+	if d.testStats != nil {
+		if stats, found := d.testStats[ip]; found {
+			return stats, nil
+		}
+	}
+	return types.CLCRunnersStats{}, nil
+}
+
+func (d *rebalanceTestClcRunnerClient) GetRunnerWorkers(_ip string) (types.Workers, error) {
+	// Return default worker count
+	return types.Workers{Count: pkgconfigsetup.DefaultNumWorkers}, nil
+}
 
 func TestRebalance(t *testing.T) {
 	for i, tc := range []struct {
@@ -1381,17 +1406,27 @@ func TestRebalance(t *testing.T) {
 			fakeTagger := taggerfxmock.SetupFakeTagger(t)
 			dispatcher := newDispatcher(fakeTagger)
 
+			// Create a mock CLC runner client to avoid nil pointer errors
+			mockClient := &rebalanceTestClcRunnerClient{
+				testStats: make(map[string]types.CLCRunnersStats),
+			}
+			dispatcher.clcRunnersClient = mockClient
+
 			// prepare store
 			dispatcher.store.active = true
 			for node, store := range tc.in {
-				// init nodeStore
-				dispatcher.store.nodes[node] = newNodeStore(node, "") // no need to setup the clientIP in this test
+				// Give each node a unique IP so the mock can distinguish them
+				nodeIP := fmt.Sprintf("10.0.0.%d", len(mockClient.testStats)+1)
+				dispatcher.store.nodes[node] = newNodeStore(node, nodeIP)
 				// setup input
 				dispatcher.store.nodes[node].clcRunnerStats = store.clcRunnerStats
+				// Store the test data in the mock so it can return it
+				mockClient.testStats[nodeIP] = store.clcRunnerStats
 			}
 
-			// rebalance checks
-			dispatcher.rebalance(false)
+			// Use busyness-based rebalancing directly for these legacy tests
+			// (preserves test coverage for busyness algorithm while allowing utilization as default)
+			dispatcher.rebalanceUsingBusyness()
 
 			// assert runner stats repartition is updated correctly
 			for node, store := range tc.out {
@@ -1525,13 +1560,20 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 
+	// Create a mock CLC runner client to avoid nil pointer errors
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+	testDispatcher.advancedDispatching = true // Enable advanced dispatching for utilization tests
+
 	testDispatcher.store.active = true
-	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "")
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
 	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "")
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
 	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
 
-	testDispatcher.store.nodes["node1"].clcRunnerStats = map[string]types.CLCRunnerStats{
+	node1Stats := map[string]types.CLCRunnerStats{
 		// This is the check with the highest utilization. The code will try to
 		// place this one first, but it'll give precedence to the node where the
 		// check is already running, so the check won't move.
@@ -1550,6 +1592,11 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 			IsClusterCheck:       false,
 		},
 	}
+
+	// Assign the stats to node1 and store in mock
+	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+	mockClient.testStats["10.0.0.1"] = node1Stats
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{} // node2 has no initial stats
 
 	// check3 not included because it's a cluster check.
 	testDispatcher.store.idToDigest = map[checkid.ID]string{

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3074,12 +3074,18 @@ api_key:
   # extra_tags:
   #   - <TAG_KEY>:<TAG_VALUE>
 
-  ## @param advanced_dispatching_enabled - boolean - optional - default: false
-  ## @env DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED - boolean - optional - default: false
+  ## @param advanced_dispatching_enabled - boolean - optional - default: true
+  ## @env DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED - boolean - optional - default: true
   ## If advanced_dispatching_enabled is true the leader cluster-agent collects stats
   ## from the cluster level check runners to optimize the check dispatching logic.
   #
-  # advanced_dispatching_enabled: false
+  # advanced_dispatching_enabled: true
+
+  ## @param rebalance_with_utilization - boolean - optional - default: true
+  ## @env DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION - boolean - optional - default: true
+  ## If rebalance_with_utilization is true, the cluster-agent will rebalance cluster checks using node utilization.
+  #
+  # rebalance_with_utilization: true
 
   ## @param clc_runners_port - integer - optional - default: 5005
   ## @env DD_CLUSTER_CHECKS_CLC_RUNNERS_PORT - integer - optional - default: 5005

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -743,8 +743,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.unscheduled_check_threshold", 60) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
-	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", false)        // Experimental. Subject to change. Uses the runners utilization to balance.
+	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})

--- a/releasenotes/notes/enable-clustercheck-advanced-dispatching-edb4ed5f834c2ac6.yaml
+++ b/releasenotes/notes/enable-clustercheck-advanced-dispatching-edb4ed5f834c2ac6.yaml
@@ -1,0 +1,14 @@
+---
+enhancement:
+  - |
+    The Cluster Agent now enables both `CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
+    and `CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default.
+
+    These options are now set to `true` in both the configuration template and the code,
+    improving cluster check dispatching and balancing based on node utilization out of the box.
+
+    To disable these features, user must now explicitly set them to `false` via the following config options:
+      - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
+        value: "false"
+      - name: DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION
+        value: "false"

--- a/releasenotes/notes/enable-clustercheck-advanced-dispatching-edb4ed5f834c2ac6.yaml
+++ b/releasenotes/notes/enable-clustercheck-advanced-dispatching-edb4ed5f834c2ac6.yaml
@@ -1,13 +1,13 @@
 ---
-enhancement:
+enhancements:
   - |
-    The Cluster Agent now enables both `CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
-    and `CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default.
+    The Cluster Agent now enables both `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
+    and `DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default.
 
     These options are now set to `true` in both the configuration template and the code,
-    improving cluster check dispatching and balancing based on node utilization out of the box.
+    improving cluster check dispatching and balancing based on node utilization out-of-the-box.
 
-    To disable these features, user must now explicitly set them to `false` via the following config options:
+    To disable these features, a user must now explicitly set them to `false` with the following config options:
       - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
         value: "false"
       - name: DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The PR enables `CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` and `CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default. 

### Motivation
Enabling these features by default improves cluster check dispatching and balancing based on node utilization, providing better out-of-the-box performance and reliability for users running the Cluster Agent. This change ensures that advanced dispatching and utilization-based rebalancing are active unless explicitly disabled, making it easier for users to benefit from these enhancements without additional configuration.

Note:
if clc runner is not enabled, advancedDispatching will be disabled automatically by dispatcher_main.go

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The feature has been used on internal prod and staging clusters for long time. Run cli command:
```
# cluster-agent config | grep advanced
  advanced_dispatching_enabled: true
# cluster-agent config | grep rebalance 
  rebalance_min_percentage_improvement: 10
  rebalance_period: 10m0s
  rebalance_with_utilization: true

```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->