### PR TITLE
[CWS] make sure the client socket is closed in `TestAcceptEvent`

### DIFF
--- a/pkg/security/tests/accept_test.go
+++ b/pkg/security/tests/accept_test.go
@@ -136,6 +136,7 @@ func TestAcceptEvent(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer unix.Close(client)
 
 		ch := make(chan iouring.Result, 1)
 

--- a/pkg/security/tests/accept_test.go
+++ b/pkg/security/tests/accept_test.go
@@ -51,14 +51,14 @@ func TestAcceptEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const MIX = 4000
+	const MIN = 4000
 	const MAX = 5000
 
 	t.Run("accept-af-inet-any-tcp-success-no-sockaddrin", func(t *testing.T) {
 		if ebpfLessEnabled {
 			t.Skip("Not available for ebpfLess")
 		}
-		port := rand.IntN(MAX-MIX) + MIX
+		port := rand.IntN(MAX-MIN) + MIN
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "accept", "AF_INET", "0.0.0.0", "127.0.0.1", strconv.Itoa(port), "false")
@@ -75,7 +75,7 @@ func TestAcceptEvent(t *testing.T) {
 
 	t.Run("accept-af-inet-any-tcp-success-sockaddrin", func(t *testing.T) {
 
-		port := rand.IntN(MAX-MIX) + MIX
+		port := rand.IntN(MAX-MIN) + MIN
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "accept", "AF_INET", "0.0.0.0", "127.0.0.1", strconv.Itoa(port), "true")
@@ -92,7 +92,7 @@ func TestAcceptEvent(t *testing.T) {
 	t.Run("accept-af-inet-any-tcp-success-sockaddrin-io-uring", func(t *testing.T) {
 		SkipIfNotAvailable(t)
 
-		port := rand.IntN(MAX-MIX) + MIX
+		port := rand.IntN(MAX-MIN) + MIN
 
 		fd, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM, unix.IPPROTO_TCP)
 		if err != nil {
@@ -183,7 +183,7 @@ func TestAcceptEvent(t *testing.T) {
 			t.Skip("IPv6 is not supported")
 		}
 
-		port := rand.IntN(MAX-MIX) + MIX
+		port := rand.IntN(MAX-MIN) + MIN
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "accept", "AF_INET6", "::", "::1", strconv.Itoa(port), "false")
@@ -203,7 +203,7 @@ func TestAcceptEvent(t *testing.T) {
 			t.Skip("IPv6 is not supported")
 		}
 
-		port := rand.IntN(MAX-MIX) + MIX
+		port := rand.IntN(MAX-MIN) + MIN
 
 		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(context.Background(), t, syscallTester, "accept", "AF_INET6", "::", "::1", strconv.Itoa(port), "true")


### PR DESCRIPTION
### What does this PR do?

This PR fixes the TestAcceptEvent to correctly close the client socket after use, allowing to free the generated port for future use. It's important because this can conflict with following tests, especially the bind tests.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->