### PR TITLE
[NDMII-3554] Do not re-query an OID that is missing from a device for a certain delay

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -53,7 +53,8 @@ const (
 	pingPacketLoss          = "networkdevice.ping.packet_loss"
 	pingAvgRttMetric        = "networkdevice.ping.avg_rtt"
 	deviceHostnamePrefix    = "device:"
-	checkDurationThreshold  = 30 // Thirty seconds
+	checkDurationThreshold  = 30  // Thirty seconds
+	profileRefreshDelay     = 600 // Number of seconds after which a profile needs to be refreshed
 )
 
 type profileCache struct {
@@ -77,7 +78,7 @@ func (pc *profileCache) GetProfile() profiledefinition.ProfileDefinition {
 }
 
 func (pc *profileCache) Update(sysObjectID string, now time.Time, config *checkconfig.CheckConfig) (profiledefinition.ProfileDefinition, error) {
-	if pc.IsOutdated(sysObjectID, config.ProfileName, config.ProfileProvider.LastUpdated()) {
+	if pc.IsOutdated(sysObjectID, config.ProfileName, now, config.ProfileProvider.LastUpdated()) {
 		// we cache the value even if there's an error, because an error indicates that
 		// the ProfileProvider couldn't find a match for either config.ProfileName or
 		// the given sysObjectID, and we're going to have the same error if we call this
@@ -92,7 +93,7 @@ func (pc *profileCache) Update(sysObjectID string, now time.Time, config *checkc
 	return pc.GetProfile(), pc.err
 }
 
-func (pc *profileCache) IsOutdated(sysObjectID string, profileName string, lastUpdate time.Time) bool {
+func (pc *profileCache) IsOutdated(sysObjectID string, profileName string, now time.Time, lastUpdate time.Time) bool {
 	if pc.profile == nil {
 		return true
 	}
@@ -104,10 +105,31 @@ func (pc *profileCache) IsOutdated(sysObjectID string, profileName string, lastU
 		// If we're auto-detecting profiles and the sysObjectID has changed, we're out of date.
 		return true
 	}
+	if now.Sub(pc.timestamp) > profileRefreshDelay*time.Second {
+		// If the profile refresh delay has been exceeded, we're out of date.
+		return true
+	}
 	// If we get here then either we're auto-detecting but the sysobjectid hasn't
 	// changed, or we have a static name; either way we're out of date if and only
 	// if the profile provider has updated.
 	return pc.timestamp.Before(lastUpdate)
+}
+
+func (pc *profileCache) RemoveMissingOIDs(values *valuestore.ResultValueStore) {
+	var scalarOIDs []string
+	var columnOIDs []string
+	for _, oid := range pc.scalarOIDs {
+		if values.ContainsScalarValue(oid) {
+			scalarOIDs = append(scalarOIDs, oid)
+		}
+	}
+	for _, oid := range pc.columnOIDs {
+		if values.ContainsColumnValue(oid) {
+			columnOIDs = append(columnOIDs, oid)
+		}
+	}
+	pc.scalarOIDs = scalarOIDs
+	pc.columnOIDs = columnOIDs
 }
 
 // DeviceCheck hold info necessary to collect info for a single device
@@ -230,6 +252,8 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		tags = append(tags, d.savedDynamicTags...)
 		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckCritical, tags, checkErr.Error())
 	} else {
+		d.profileCache.RemoveMissingOIDs(values)
+
 		if !reflect.DeepEqual(d.savedDynamicTags, dynamicTags) {
 			d.savedDynamicTags = dynamicTags
 			d.writeTagsInCache()
@@ -362,6 +386,8 @@ func (d *DeviceCheck) getValuesAndTags() (bool, profiledefinition.ProfileDefinit
 
 	tags = append(tags, profile.StaticTags...)
 
+	fmt.Println(d.profileCache.scalarOIDs)
+	fmt.Println(d.profileCache.columnOIDs)
 	valuesStore, err := fetch.Fetch(d.session, d.profileCache.scalarOIDs, d.profileCache.columnOIDs, d.config.OidBatchSize,
 		d.config.BulkMaxRepetitions)
 	if log.ShouldLog(log.DebugLvl) {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -124,7 +124,7 @@ func (pc *profileCache) RemoveMissingOIDs(values *valuestore.ResultValueStore) {
 		}
 	}
 	for _, oid := range pc.columnOIDs {
-		if values.ContainsColumnValue(oid) {
+		if values.ContainsColumnValues(oid) {
 			columnOIDs = append(columnOIDs, oid)
 		}
 	}
@@ -386,8 +386,6 @@ func (d *DeviceCheck) getValuesAndTags() (bool, profiledefinition.ProfileDefinit
 
 	tags = append(tags, profile.StaticTags...)
 
-	fmt.Println(d.profileCache.scalarOIDs)
-	fmt.Println(d.profileCache.columnOIDs)
 	valuesStore, err := fetch.Fetch(d.session, d.profileCache.scalarOIDs, d.profileCache.columnOIDs, d.config.OidBatchSize,
 		d.config.BulkMaxRepetitions)
 	if log.ShouldLog(log.DebugLvl) {

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values.go
@@ -32,6 +32,12 @@ type ResultValueStore struct {
 	ColumnValues ColumnResultValuesType `json:"column_values"`
 }
 
+// ContainsScalarValue returns whether a scalar oid is present in ResultValueStore
+func (v *ResultValueStore) ContainsScalarValue(oid string) bool {
+	_, ok := v.ScalarValues[oid]
+	return ok
+}
+
 // GetScalarValue look for oid in ResultValueStore and returns the value and boolean
 // weather valid value has been found
 func (v *ResultValueStore) GetScalarValue(oid string) (ResultValue, error) {
@@ -40,6 +46,12 @@ func (v *ResultValueStore) GetScalarValue(oid string) (ResultValue, error) {
 		return ResultValue{}, fmt.Errorf("value for Scalar OID `%s` not found in results", oid)
 	}
 	return value, nil
+}
+
+// ContainsColumnValue returns whether a column oid is present in ResultValueStore
+func (v *ResultValueStore) ContainsColumnValue(oid string) bool {
+	_, ok := v.ColumnValues[oid]
+	return ok
 }
 
 // GetColumnValues look for oid in ResultValueStore and returns a map[<fullIndex>]ResultValue

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values.go
@@ -48,8 +48,8 @@ func (v *ResultValueStore) GetScalarValue(oid string) (ResultValue, error) {
 	return value, nil
 }
 
-// ContainsColumnValue returns whether a column oid is present in ResultValueStore
-func (v *ResultValueStore) ContainsColumnValue(oid string) bool {
+// ContainsColumnValues returns whether a column oid is present in ResultValueStore
+func (v *ResultValueStore) ContainsColumnValues(oid string) bool {
 	_, ok := v.ColumnValues[oid]
 	return ok
 }

--- a/pkg/collector/corechecks/snmp/internal/valuestore/values_test.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/values_test.go
@@ -30,6 +30,23 @@ var storeMock = &ResultValueStore{
 	},
 }
 
+func Test_resultValueStore_ContainsScalarValue(t *testing.T) {
+	assert.True(t, storeMock.ContainsScalarValue("1.1.1.1.0"))
+	assert.True(t, storeMock.ContainsScalarValue("1.1.1.2.0"))
+	assert.True(t, storeMock.ContainsScalarValue("1.1.1.3.0"))
+
+	assert.False(t, storeMock.ContainsScalarValue("1.1.1.2"))
+	assert.False(t, storeMock.ContainsScalarValue("1.1.1.10.0"))
+}
+
+func Test_resultValueStore_ContainsColumnValues(t *testing.T) {
+	assert.True(t, storeMock.ContainsColumnValues("1.1.1"))
+	assert.True(t, storeMock.ContainsColumnValues("1.1.2"))
+
+	assert.False(t, storeMock.ContainsColumnValues("1.1.6"))
+	assert.False(t, storeMock.ContainsColumnValues("1.1.1.1"))
+}
+
 func Test_resultValueStore_getColumnValueAsFloat(t *testing.T) {
 	assert.Equal(t, float64(0), storeMock.GetColumnValueAsFloat("0.0", "1"))    // wrong column
 	assert.Equal(t, float64(10), storeMock.GetColumnValueAsFloat("1.1.1", "1")) // ok float value


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds logic to not try to re-get an OID from a device when the device does not report this OID for the next `profileRefreshDelay` seconds in the SNMP check.

### Motivation

Decrease the number of SNMP queries we do to the device every checks.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Changes has been tried in mimic, and we check that the number of submitted metrics is still the same before and after the changes:
<img width="1060" height="505" alt="image" src="https://github.com/user-attachments/assets/4af8b64a-525f-45e8-83f0-68cbb3a32f2f" />
The agent was installed at around 14:15, and we can see that the number of submitted metrics is still the same (don't pay attention to the peak at 14:15, it happens when we install a new agent).

It has also been tested on CiscoCML by checking the list of queried OIDs: we check that the missing OIDs have been removed from the list of queried OIDs. And that if the device does start to report an OID that was missing, this OID is re-added back to the list of queried OIDs after `profileRefreshDelay`.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->