### PR TITLE
[AGENTRUN-583] add internal telemetry to Remote Agent Registry

### DIFF
--- a/comp/core/remoteagentregistry/def/types.go
+++ b/comp/core/remoteagentregistry/def/types.go
@@ -7,8 +7,9 @@ package remoteagentregistry
 
 // RegisteredAgent contains the information about a registered remote agent
 type RegisteredAgent struct {
-	DisplayName  string
-	LastSeenUnix int64
+	DisplayName          string
+	SanatizedDisplayName string
+	LastSeenUnix         int64
 }
 
 // StatusSection is a map of key-value pairs that represent a section of the status data

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry.go
@@ -91,62 +91,62 @@ func newRemoteAgent(reqs Requires) *remoteAgentRegistry {
 }
 
 type telemetryStore struct {
-	// remoteAgentRegistry tracks how many remote agents are registered.
-	remoteAgentRegistry telemetry.Counter
-	// remoteAgentRegistryError tracks how many remote agents failed to register.
-	remoteAgentRegistryError telemetry.Counter
-	// remoteAgentRegistryUpdate tracks how many remote agents are updated.
-	remoteAgentRegistryUpdate telemetry.Counter
-	// remoteAgentRegistryUpdateError tracks how many remote agents failed to update.
-	remoteAgentRegistryUpdateError telemetry.Counter
-	// remoteAgentRegistryDeregister tracks how many remote agents are deregistered.
-	remoteAgentRegistryDeregister telemetry.Counter
-	// remoteAgentRegistryActionError tracks the number of errors encountered while performing actions on the remote agent registry.
-	remoteAgentRegistryActionError telemetry.Counter
-	// remoteAgentRegistryActionDuration tracks the duration of actions performed on the remote agent registry.
-	remoteAgentRegistryActionDuration telemetry.Histogram
-	// remoteAgentRegistryActionTimeout tracks the number of times an action on the remote agent registry timed out.
-	remoteAgentRegistryActionTimeout telemetry.Counter
+	// remoteAgentRegistered tracks how many remote agents are registered.
+	remoteAgentRegistered telemetry.Counter
+	// remoteAgentRegisteredError tracks how many remote agents failed to register.
+	remoteAgentRegisteredError telemetry.Counter
+	// remoteAgentUpdated tracks how many remote agents are updated.
+	remoteAgentUpdated telemetry.Counter
+	// remoteAgentUpdatedError tracks how many remote agents failed to update.
+	remoteAgentUpdatedError telemetry.Counter
+	// remoteAgentDeregistered tracks how many remote agents are deregistered.
+	remoteAgentDeregistered telemetry.Counter
+	// remoteAgentActionError tracks the number of errors encountered while performing actions on the remote agent registry.
+	remoteAgentActionError telemetry.Counter
+	// remoteAgentActionDuration tracks the duration of actions performed on the remote agent registry.
+	remoteAgentActionDuration telemetry.Histogram
+	// remoteAgentActionTimeout tracks the number of times an action on the remote agent registry timed out.
+	remoteAgentActionTimeout telemetry.Counter
 }
 
 func newTelemetryStore(telemetryComp telemetry.Component) *telemetryStore {
 	return &telemetryStore{
-		remoteAgentRegistry: telemetryComp.NewCounterWithOpts(
+		remoteAgentRegistered: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
-			"registered_agents",
+			"registered",
 			[]string{"name"},
 			"Number of remote agents registered in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryError: telemetryComp.NewCounterWithOpts(
+		remoteAgentRegisteredError: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
-			"registered_agents_error",
+			"registered_error",
 			[]string{"name", "error"},
 			"Number of remote agents that failed to register in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryUpdate: telemetryComp.NewCounterWithOpts(
+		remoteAgentUpdated: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
-			"registered_agents_update",
+			"updated",
 			[]string{"name"},
 			"Number of remote agents updated in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryUpdateError: telemetryComp.NewCounterWithOpts(
+		remoteAgentUpdatedError: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
-			"registered_agents_update_error",
+			"updated_error",
 			[]string{"name", "error"},
 			"Number of remote agents that failed to update in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryDeregister: telemetryComp.NewCounterWithOpts(
+		remoteAgentDeregistered: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
-			"deregistered_agents",
+			"deregistered",
 			[]string{"name"},
 			"Number of remote agents deregistered in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryActionDuration: telemetryComp.NewHistogramWithOpts(
+		remoteAgentActionDuration: telemetryComp.NewHistogramWithOpts(
 			"remote_agent_registry",
 			"action_duration_seconds",
 			[]string{"name", "action"},
@@ -155,14 +155,14 @@ func newTelemetryStore(telemetryComp telemetry.Component) *telemetryStore {
 			prometheus.DefBuckets,
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryActionError: telemetryComp.NewCounterWithOpts(
+		remoteAgentActionError: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
 			"action_error",
 			[]string{"name", "action"},
 			"Number of errors encountered while performing actions on the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
-		remoteAgentRegistryActionTimeout: telemetryComp.NewCounterWithOpts(
+		remoteAgentActionTimeout: telemetryComp.NewCounterWithOpts(
 			"remote_agent_registry",
 			"action_timeout",
 			[]string{"action"},
@@ -210,14 +210,14 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 		// connecting when we try to query the remote agent for status or flare data.
 		details, err := newRemoteAgentDetails(registration)
 		if err != nil {
-			ra.telemetryStore.remoteAgentRegistryError.Inc(registration.DisplayName, err.Error())
+			ra.telemetryStore.remoteAgentRegisteredError.Inc(registration.DisplayName, err.Error())
 			return 0, err
 		}
 
 		log.Infof("Remote agent '%s' registered.", agentID)
 
 		ra.agentMap[agentID] = details
-		ra.telemetryStore.remoteAgentRegistry.Inc(registration.DisplayName)
+		ra.telemetryStore.remoteAgentRegistered.Inc(registration.DisplayName)
 
 		return recommendedRefreshInterval, nil
 	}
@@ -229,7 +229,7 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 
 		client, err := newRemoteAgentClient(registration)
 		if err != nil {
-			ra.telemetryStore.remoteAgentRegistryUpdateError.Inc(registration.DisplayName, err.Error())
+			ra.telemetryStore.remoteAgentUpdatedError.Inc(registration.DisplayName, err.Error())
 			return 0, err
 		}
 
@@ -239,7 +239,7 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 		entry.lastSeen = time.Now()
 	}
 
-	ra.telemetryStore.remoteAgentRegistryUpdate.Inc(registration.DisplayName)
+	ra.telemetryStore.remoteAgentUpdated.Inc(registration.DisplayName)
 
 	return recommendedRefreshInterval, nil
 }
@@ -279,7 +279,7 @@ func (ra *remoteAgentRegistry) start() {
 					if ok {
 						delete(ra.agentMap, id)
 						log.Infof("Remote agent '%s' deregistered after being idle for %s.", id, remoteAgentIdleTimeout)
-						ra.telemetryStore.remoteAgentRegistryDeregister.Inc(details.displayName)
+						ra.telemetryStore.remoteAgentDeregistered.Inc(details.displayName)
 					}
 				}
 
@@ -332,7 +332,7 @@ func (c *registryCollector) getRegisteredAgentsTelemetry(ch chan<- prometheus.Me
 		go func() {
 			start := time.Now()
 			defer func() {
-				c.telemetryStore.remoteAgentRegistryActionDuration.Observe(
+				c.telemetryStore.remoteAgentActionDuration.Observe(
 					time.Since(start).Seconds(),
 					details.displayName,
 					"telemetry",
@@ -341,7 +341,7 @@ func (c *registryCollector) getRegisteredAgentsTelemetry(ch chan<- prometheus.Me
 			resp, err := details.client.GetTelemetry(ctx, &pb.GetTelemetryRequest{}, grpc.WaitForReady(true))
 			if err != nil {
 				log.Warnf("Failed to query remote agent '%s' for telemetry data: %v", agentID, err)
-				c.telemetryStore.remoteAgentRegistryActionError.Inc(details.displayName, "telemetry")
+				c.telemetryStore.remoteAgentActionError.Inc(details.displayName, "telemetry")
 				return
 			}
 			if promText, ok := resp.Payload.(*pb.GetTelemetryResponse_PromText); ok {
@@ -362,7 +362,7 @@ collect:
 		case <-data:
 			responsesRemaining--
 		case <-timeout:
-			c.telemetryStore.remoteAgentRegistryActionTimeout.Inc("telemetry")
+			c.telemetryStore.remoteAgentActionTimeout.Inc("telemetry")
 			break collect
 		default:
 			if responsesRemaining == 0 {
@@ -470,7 +470,7 @@ func (ra *remoteAgentRegistry) GetRegisteredAgentStatuses() []*remoteagentregist
 		go func() {
 			start := time.Now()
 			defer func() {
-				ra.telemetryStore.remoteAgentRegistryActionDuration.Observe(
+				ra.telemetryStore.remoteAgentActionDuration.Observe(
 					time.Since(start).Seconds(),
 					details.displayName,
 					"status",
@@ -485,7 +485,7 @@ func (ra *remoteAgentRegistry) GetRegisteredAgentStatuses() []*remoteagentregist
 					DisplayName:   displayName,
 					FailureReason: fmt.Sprintf("Failed to query for status: %v", err),
 				}
-				ra.telemetryStore.remoteAgentRegistryActionError.Inc(displayName, "status")
+				ra.telemetryStore.remoteAgentActionError.Inc(displayName, "status")
 				return
 			}
 
@@ -505,7 +505,7 @@ collect:
 			statusMap[statusData.AgentID] = statusData
 			responsesRemaining--
 		case <-timeout:
-			ra.telemetryStore.remoteAgentRegistryActionTimeout.Inc("status")
+			ra.telemetryStore.remoteAgentActionTimeout.Inc("status")
 			break collect
 		default:
 			if responsesRemaining == 0 {
@@ -545,7 +545,7 @@ func (ra *remoteAgentRegistry) fillFlare(builder flarebuilder.FlareBuilder) erro
 		go func() {
 			start := time.Now()
 			defer func() {
-				ra.telemetryStore.remoteAgentRegistryActionDuration.Observe(
+				ra.telemetryStore.remoteAgentActionDuration.Observe(
 					time.Since(start).Seconds(),
 					details.displayName,
 					"flare",
@@ -555,7 +555,7 @@ func (ra *remoteAgentRegistry) fillFlare(builder flarebuilder.FlareBuilder) erro
 			// We push any errors into "failure reason" which ends up getting shown in the status details.
 			resp, err := details.client.GetFlareFiles(ctx, &pb.GetFlareFilesRequest{}, grpc.WaitForReady(true))
 			if err != nil {
-				ra.telemetryStore.remoteAgentRegistryActionError.Inc(details.displayName, "flare")
+				ra.telemetryStore.remoteAgentActionError.Inc(details.displayName, "flare")
 				log.Warnf("Failed to query remote agent '%s' for flare data: %v", agentID, err)
 				data <- nil
 				return
@@ -577,7 +577,7 @@ collect:
 			flareMap[flareData.AgentID] = flareData
 			responsesRemaining--
 		case <-timeout:
-			ra.telemetryStore.remoteAgentRegistryActionTimeout.Inc("flare")
+			ra.telemetryStore.remoteAgentActionTimeout.Inc("flare")
 			break collect
 		default:
 			if responsesRemaining == 0 {

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry.go
@@ -234,10 +234,10 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 		}
 
 		entry.client = client
-	} else {
-		entry.displayName = registration.DisplayName
-		entry.lastSeen = time.Now()
 	}
+
+	entry.displayName = registration.DisplayName
+	entry.lastSeen = time.Now()
 
 	ra.telemetryStore.remoteAgentUpdated.Inc(registration.DisplayName)
 

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry.go
@@ -215,7 +215,6 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 		}
 
 		log.Infof("Remote agent '%s' registered.", agentID)
-
 		ra.agentMap[agentID] = details
 		ra.telemetryStore.remoteAgentRegistered.Inc(registration.DisplayName)
 
@@ -232,7 +231,6 @@ func (ra *remoteAgentRegistry) RegisterRemoteAgent(registration *remoteagentregi
 			ra.telemetryStore.remoteAgentUpdatedError.Inc(registration.DisplayName, err.Error())
 			return 0, err
 		}
-
 		entry.client = client
 	}
 

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry.go
@@ -110,38 +110,40 @@ type telemetryStore struct {
 	remoteAgentActionTimeout telemetry.Counter
 }
 
+const namespace = "remote_agent_registry"
+
 func newTelemetryStore(telemetryComp telemetry.Component) *telemetryStore {
 	return &telemetryStore{
 		remoteAgentRegistered: telemetryComp.NewGaugeWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"registered",
 			[]string{"name"},
 			"Number of remote agents registered in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentRegisteredError: telemetryComp.NewCounterWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"registered_error",
 			[]string{"name"},
 			"Number of remote agents that failed to register in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentUpdated: telemetryComp.NewCounterWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"updated",
 			[]string{"name"},
 			"Number of remote agents updated in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentUpdatedError: telemetryComp.NewCounterWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"updated_error",
 			[]string{"name"},
 			"Number of remote agents that failed to update in the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentActionDuration: telemetryComp.NewHistogramWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"action_duration_seconds",
 			[]string{"name", "action"},
 			"Duration of actions performed on the remote agent registry.",
@@ -150,14 +152,14 @@ func newTelemetryStore(telemetryComp telemetry.Component) *telemetryStore {
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentActionError: telemetryComp.NewCounterWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"action_error",
 			[]string{"name", "action", "error"},
 			"Number of errors encountered while performing actions on the remote agent registry.",
 			telemetry.Options{NoDoubleUnderscoreSep: true},
 		),
 		remoteAgentActionTimeout: telemetryComp.NewCounterWithOpts(
-			"remote_agent_registry",
+			namespace,
 			"action_timeout",
 			[]string{"action"},
 			"Number of times an action on the remote agent registry timed out.",

--- a/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
@@ -94,6 +94,7 @@ func TestGetRegisteredAgents(t *testing.T) {
 	agents := component.GetRegisteredAgents()
 	require.Len(t, agents, 1)
 	require.Equal(t, "Test Agent", agents[0].DisplayName)
+	require.Equal(t, "test-agent", agents[0].SanatizedDisplayName)
 }
 
 func TestGetRegisteredAgentStatuses(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds internal metrics for the Remote Agent Registry. 

With the upcoming work and the importance of this component, it is important to be able to observe changes during the increased usage of the component when deploying to staging and production. 

Once we start deploying, we can create an internal dashboard that will facilitate consuming the information

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->