### PR TITLE
Fix object memory sizes in Python interpreter memory usage summary

### DIFF
--- a/cmd/agent/dist/utils/py_mem.py
+++ b/cmd/agent/dist/utils/py_mem.py
@@ -12,7 +12,7 @@ def get_mem_stats():
 
         stat = stats.get(entry_type, {})
         stat['num'] = stat.get('num', 0) + n
-        stat['sz'] = stat.get('sz', 0) + n * sz
+        stat['sz'] = stat.get('sz', 0) + sz
 
         entries = stat.get('entries', [])
         entries.append([ref, n, sz])


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a bug in the Python interpreter memory usage summary. Object memory sizes were incorrectly multiplied by the number of instances, even though the sizes already accounted for that.

### Motivation

The Python interpreter summary wasn't correct, object memory sizes were far too high.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The definition of a `pympler.summary` is defined  [here](https://pympler.readthedocs.io/en/latest/library/summary.html).

The `size` in each entry corresponds to the total size of the objects, not the size of one object.
So there's no need to multiply the size with the number of objects.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->