### PR TITLE
fix(assess_permissions): Enable trigger of the assess_permission workflow

### DIFF
--- a/.github/workflows/assess_permissions.yml
+++ b/.github/workflows/assess_permissions.yml
@@ -3,6 +3,15 @@ name: Assess Repository Permissions
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Which permissions to assess: "repo" or "agent-all"'
+        required: true
+        default: 'repo'
+        type: choice
+        options:
+          - repo
+          - agent-all
   schedule:
     - cron: '0 4 2 * *' # At 4 UTC every 2nd day of the month (out of business hours for rate limiting)
     - cron: '0 6 2 * *' # Later for the simple permission display
@@ -12,7 +21,7 @@ permissions: {}
 jobs:
   assess_repo_permission:
     runs-on: ubuntu-latest
-    if: github.event.schedule == '0 6 2 * * *'
+    if: (github.event.schedule == '0 6 2 * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'repo'))
     strategy:
       matrix:
         value: ['datadog-agent', 'datadog-agent-buildimages', 'omnibus-ruby', 'agent-release-management']
@@ -35,7 +44,6 @@ jobs:
           features: legacy-tasks legacy-github
 
       - name: Assess Repository Permissions
-        if: github.event.schedule == '0 4 2 * * *'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
@@ -43,7 +51,7 @@ jobs:
 
   assess_agent_all_permission:
     runs-on: ubuntu-latest
-    if: github.event.schedule == '0 4 2 * * *'
+    if: github.event.schedule == '0 4 2 * *' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'agent-all')
     environment:
       name: main
     steps:
@@ -62,7 +70,6 @@ jobs:
           features: legacy-tasks legacy-github
 
       - name: Assess agent-all Permissions
-        if: github.event.schedule == '0 4 2 * * *'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -626,7 +626,7 @@ def check_permissions(
         gh = GithubAPI()
         root = gh.get_team(name)
         depth = None
-        admins = root.get_members(role='maintainer')
+        admins = list(root.get_members(role='maintainer'))
     else:
         gh = GithubAPI(f"datadog/{name}")
         root = gh._repository

--- a/tasks/unit_tests/github_tasks_tests.py
+++ b/tasks/unit_tests/github_tasks_tests.py
@@ -518,10 +518,12 @@ class TestCheckPermissions(unittest.TestCase):
     @patch('slack_sdk.WebClient', autospec=True)
     @patch("tasks.libs.ciproviders.github_api.GithubAPI", autospec=True)
     def test_empty_team(self, gh_mock, web_mock):
-        gh_api, team_a, client_mock = MagicMock(), MagicMock(), MagicMock()
+        gh_api, team_a, team_b, client_mock = MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        team_b.get_members.return_value = []
         team_a.slug = "secret-agent"
         team_a.html_url = "http://secret-agent"
         team_a.members_count = 0
+        gh_api.get_team.return_value = team_b
         gh_api.find_teams.return_value = [team_a]
         gh_mock.return_value = gh_api
         web_mock.return_value = client_mock


### PR DESCRIPTION
### What does this PR do?
- Fix the erroneous cron instruction to re-enable the scheduled workflow
- Add the capacity to trigger the workflow manually

### Motivation

### Describe how you validated your changes
The cron was a mistake, and I validated with a manual trigger on the branch for the workflow

