### PR TITLE
Temporarily move macOS test on AArch64/ARM64 out of merge queue (ABLD-28 follow-up)

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -44,3 +44,7 @@ tests_macos_gitlab_amd64:
 tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   tags: ["macos:ventura-arm64", "specific:true"]
+  #TODO(regis): remove below `rules` section once enough `macos:ventura-arm64` runners are provisioned
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.tests_macos_gitlab, rules]


### PR DESCRIPTION
### Motivation
Since #37676 got merged, jobs on `macos:ventura-arm64` started [queuing for 20+ minutes](https://dd.slack.com/archives/C06TGQ49U1Z/p1753360024345999) prior to start - or timing out.

### Possible Drawbacks / Trade-offs
This is to be undone once enough `macos:ventura-arm64` runners are provisioned, see: https://app.datadoghq.com/s/yB5yjZ/zdt-veh-nzp