### PR TITLE
[CWS/CSPM] Allow excluding containers

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -214,7 +214,7 @@ func NewAgent(telemetrySender telemetry.SimpleTelemetrySender, wmeta workloadmet
 
 // Start starts the compliance agent.
 func (a *Agent) Start() error {
-	telemetry, err := telemetry.NewContainersTelemetry(a.telemetrySender, a.wmeta)
+	telemetry, err := telemetry.NewContainersTelemetry(a.telemetrySender, a.wmeta, pkgconfigsetup.Datadog(), "compliance_config.")
 	if err != nil {
 		log.Errorf("could not start containers telemetry: %v", err)
 		return err

--- a/pkg/compliance/utils/filters.go
+++ b/pkg/compliance/utils/filters.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils is a compliance internal submodule implementing various utilies.
+package utils
+
+import (
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// NewContainerFilter returns a new include/exclude filter for containers from compliance
+func NewContainerFilter() (*containers.Filter, error) {
+	return containers.NewContainerFilter(pkgconfigsetup.Datadog(), "compliance_config.")
+}

--- a/pkg/compliance/utils/filters.go
+++ b/pkg/compliance/utils/filters.go
@@ -8,10 +8,11 @@ package utils
 
 import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 // NewContainerFilter returns a new include/exclude filter for containers from compliance
 func NewContainerFilter() (*containers.Filter, error) {
-	return containers.NewContainerFilter(pkgconfigsetup.Datadog(), "compliance_config.")
+	return common.NewContainerFilter(pkgconfigsetup.Datadog(), "compliance_config.")
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -989,6 +989,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 	config.BindEnvAndSetDefault("compliance_config.metrics.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.opa.metrics.enabled", false)
+	config.BindEnvAndSetDefault("compliance_config.container_include", []string{})
+	config.BindEnvAndSetDefault("compliance_config.container_exclude", []string{})
+	config.BindEnvAndSetDefault("compliance_config.exclude_pause_container", true)
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -41,6 +41,9 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.on_demand.rate_limiter.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.reduced_proc_pid_cache_size", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.env_as_tags", []string{})
+	cfg.BindEnvAndSetDefault("runtime_security_config.container_exclude", []string{})
+	cfg.BindEnvAndSetDefault("runtime_security_config.container_include", []string{})
+	cfg.BindEnvAndSetDefault("runtime_security_config.exclude_pause_container", true)
 
 	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
 	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)

--- a/pkg/security/common/filters.go
+++ b/pkg/security/common/filters.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package common holds common related files
+package common
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// NewContainerFilter returns a new include/exclude filter for containers
+func NewContainerFilter(cfg model.Config, prefix string) (*containers.Filter, error) {
+	includeList := cfg.GetStringSlice(prefix + "container_include")
+	excludeList := cfg.GetStringSlice(prefix + "container_exclude")
+
+	if cfg.GetBool(prefix + "exclude_pause_container") {
+		excludeList = append(excludeList, containers.GetPauseContainerExcludeList()...)
+	}
+
+	return containers.NewFilter(containers.GlobalFilter, includeList, excludeList)
+}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -237,7 +237,11 @@ func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg) bool) {
 			return true
 		}
 
-		if msg.skip || msg.retry >= maxRetry {
+		if msg.skip {
+			return true
+		}
+
+		if msg.retry >= maxRetry {
 			seclog.Errorf("failed to sent event, max retry reached: %d", msg.retry)
 			return true
 		}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -70,6 +71,7 @@ type pendingMsg struct {
 	extTagsCb       func() ([]string, bool)
 	sendAfter       time.Time
 	retry           int
+	skip            bool
 }
 
 func (p *pendingMsg) isResolved() bool {
@@ -144,6 +146,7 @@ type APIServer struct {
 	msgSender          MsgSender
 	connEstablished    *atomic.Bool
 	envAsTags          []string
+	containerFilter    *containers.Filter
 
 	// os release data
 	kernelVersion string
@@ -234,7 +237,7 @@ func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg) bool) {
 			return true
 		}
 
-		if msg.retry >= maxRetry {
+		if msg.skip || msg.retry >= maxRetry {
 			seclog.Errorf("failed to sent event, max retry reached: %d", msg.retry)
 			return true
 		}
@@ -318,6 +321,12 @@ func (a *APIServer) start(ctx context.Context) {
 
 				// not fully resolved, retry
 				if !msg.isResolved() && msg.retry < maxRetry {
+					return false
+				}
+
+				containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
+				if a.containerFilter != nil && a.containerFilter.IsExcluded(nil, containerName, imageName, podNamespace) {
+					msg.skip = true
 					return false
 				}
 
@@ -654,6 +663,10 @@ func getEnvAsTags(cfg *config.RuntimeSecurityConfig) []string {
 // NewAPIServer returns a new gRPC event server
 func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSender MsgSender, client statsd.ClientInterface, selfTester *selftests.SelfTester, compression compression.Component, ipc ipc.Component) (*APIServer, error) {
 	stopper := startstop.NewSerialStopper()
+	containerFilter, err := utils.NewContainerFilter()
+	if err != nil {
+		return nil, err
+	}
 
 	as := &APIServer{
 		msgs:            make(chan *api.SecurityEventMessage, cfg.EventServerBurst*3),
@@ -670,6 +683,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 		msgSender:       msgSender,
 		connEstablished: atomic.NewBool(false),
 		envAsTags:       getEnvAsTags(cfg),
+		containerFilter: containerFilter,
 	}
 
 	as.collectOSReleaseData()

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -369,6 +369,11 @@ func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 		return
 	}
 
+	containerName, imageName, podNamespace := utils.GetContainerFilterTags(workload.Tags)
+	if m.containerFilters != nil && m.containerFilters.IsExcluded(nil, containerName, imageName, podNamespace) {
+		return
+	}
+
 	defaultConfigs, err := m.getDefaultLoadConfigs()
 	if err != nil {
 		seclog.Errorf("couldn't get default load configs: %v", err)

--- a/pkg/security/telemetry/containers_running_telemetry_linux.go
+++ b/pkg/security/telemetry/containers_running_telemetry_linux.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
@@ -25,7 +27,7 @@ type ContainersRunningTelemetry struct {
 // NewContainersRunningTelemetry creates a new ContainersRunningTelemetry instance
 func NewContainersRunningTelemetry(cfg ContainersRunningTelemetryConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	telemetrySender := NewSimpleTelemetrySenderFromStatsd(statsdClient)
-	containersTelemetry, err := NewContainersTelemetry(telemetrySender, wmeta)
+	containersTelemetry, err := NewContainersTelemetry(telemetrySender, wmeta, pkgconfigsetup.SystemProbe(), "runtime_security_config.")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/telemetry/telemetry.go
+++ b/pkg/security/telemetry/telemetry.go
@@ -12,6 +12,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/constants"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -26,7 +27,7 @@ type ContainersTelemetry struct {
 
 // NewContainersTelemetry returns a new ContainersTelemetry based on default/global objects
 func NewContainersTelemetry(telemetrySender SimpleTelemetrySender, wmeta workloadmeta.Component, cfg model.Config, prefix string) (*ContainersTelemetry, error) {
-	containerFilter, err := containers.NewContainerFilter(cfg, prefix)
+	containerFilter, err := common.NewContainerFilter(cfg, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/utils/filters.go
+++ b/pkg/security/utils/filters.go
@@ -8,10 +8,11 @@ package utils
 
 import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 // NewContainerFilter returns a new include/exclude filter for containers from runtime security
 func NewContainerFilter() (*containers.Filter, error) {
-	return containers.NewContainerFilter(pkgconfigsetup.SystemProbe(), "runtime_security_config.")
+	return common.NewContainerFilter(pkgconfigsetup.SystemProbe(), "runtime_security_config.")
 }

--- a/pkg/security/utils/filters.go
+++ b/pkg/security/utils/filters.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils is a compliance internal submodule implementing various utilies.
+package utils
+
+import (
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// NewContainerFilter returns a new include/exclude filter for containers from runtime security
+func NewContainerFilter() (*containers.Filter, error) {
+	return containers.NewContainerFilter(pkgconfigsetup.SystemProbe(), "runtime_security_config.")
+}

--- a/pkg/security/utils/tags.go
+++ b/pkg/security/utils/tags.go
@@ -34,3 +34,12 @@ func GetTagName(tag string) string {
 
 	return key
 }
+
+// GetContainerFilterTags returns the tags used for container filtering
+func GetContainerFilterTags(tags []string) (string, string, string) {
+	containerName := GetTagValue("container_name", tags)
+	imageName := GetTagValue("image_name", tags)
+	kubeNamespace := GetTagValue("kube_namespace", tags)
+
+	return containerName, imageName, kubeNamespace
+}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -214,18 +213,6 @@ func GetPauseContainerFilter() (*Filter, error) {
 	}
 
 	return NewFilter(GlobalFilter, nil, excludeList)
-}
-
-// NewContainerFilter returns a new include/exclude filter for containers
-func NewContainerFilter(cfg model.Config, prefix string) (*Filter, error) {
-	includeList := cfg.GetStringSlice(prefix + "container_include")
-	excludeList := cfg.GetStringSlice(prefix + "container_exclude")
-
-	if cfg.GetBool(prefix + "exclude_pause_container") {
-		excludeList = append(excludeList, GetPauseContainerExcludeList()...)
-	}
-
-	return NewFilter(GlobalFilter, includeList, excludeList)
 }
 
 // ResetSharedFilter is only to be used in unit tests: it resets the global

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -213,6 +214,18 @@ func GetPauseContainerFilter() (*Filter, error) {
 	}
 
 	return NewFilter(GlobalFilter, nil, excludeList)
+}
+
+// NewContainerFilter returns a new include/exclude filter for containers
+func NewContainerFilter(cfg model.Config, prefix string) (*Filter, error) {
+	includeList := cfg.GetStringSlice(prefix + "container_include")
+	excludeList := cfg.GetStringSlice(prefix + "container_exclude")
+
+	if cfg.GetBool(prefix + "exclude_pause_container") {
+		excludeList = append(excludeList, GetPauseContainerExcludeList()...)
+	}
+
+	return NewFilter(GlobalFilter, includeList, excludeList)
 }
 
 // ResetSharedFilter is only to be used in unit tests: it resets the global


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow excluding containers from compliance and runtime security products.

### Motivation

This PR allows excluding containers from compliance and runtime security
monitoring in the same way than infrastructure monitoring.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->