### PR TITLE
dyninst/procmon: properly check for uninteresting errors

### DIFF
--- a/pkg/dyninst/procmon/analyze_test.go
+++ b/pkg/dyninst/procmon/analyze_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -153,18 +154,20 @@ func TestAnalyzeProcess(t *testing.T) {
 		cfgs := testprogs.MustGetCommonConfigs(t)
 		bin := testprogs.MustGetBinary(t, "sample", cfgs[0])
 
-		_, procRoot, cleanup := makeProcFS(t, pid, envTrue, false)
+		tmpDir, procRoot, cleanup := makeProcFS(t, pid, envTrue, false)
 		defer cleanup()
 
 		procDir := filepath.Join(procRoot, strconv.Itoa(pid))
 		// Create the exe symlink pointing to the bogus path.
 		require.NoError(t, os.Symlink(exeLinkTarget, filepath.Join(procDir, "exe")))
-
-		// Now place the real binary under /proc/<pid>/root/<trimmed exeLinkTarget>.
-		rootTargetPath := filepath.Join(procDir, "root", strings.TrimPrefix(exeLinkTarget, "/"))
-		require.NoError(t, os.MkdirAll(filepath.Dir(rootTargetPath), 0o755))
+		// root should be a symlink to a directory that does exist and does
+		// contain the real exeLinkTarget.
+		fakeRoot := filepath.Join(tmpDir, "fake_root")
+		realExePath := filepath.Join(fakeRoot, strings.TrimPrefix(exeLinkTarget, "/"))
+		realExeDir := filepath.Dir(realExePath)
+		require.NoError(t, os.MkdirAll(realExeDir, 0o755))
 		{
-			f, err := os.Create(rootTargetPath)
+			f, err := os.Create(realExePath)
 			require.NoError(t, err)
 			binReader, err := os.Open(bin)
 			require.NoError(t, err)
@@ -173,12 +176,61 @@ func TestAnalyzeProcess(t *testing.T) {
 			require.NoError(t, f.Close())
 			require.NoError(t, binReader.Close())
 		}
+		require.NoError(t, os.Symlink(fakeRoot, filepath.Join(procDir, "root")))
 
 		res, err := analyzeProcess(pid, procRoot, noopContainerResolver{}, analyzer)
 		require.NoError(t, err)
 		require.True(t, res.interesting)
-		require.Equal(t, rootTargetPath, res.exe.Path)
+		expExePath := path.Join(
+			strings.TrimPrefix(procDir, tmpDir),
+			"root",
+			exeLinkTarget,
+		)
+		gotExePath := strings.TrimPrefix(res.exe.Path, tmpDir)
+		require.Equal(t, expExePath, gotExePath)
 		require.Equal(t, "foo", res.service)
+	})
+
+	t.Run("exe does not exist in either results in nil error", func(t *testing.T) {
+		const (
+			pid           = 107
+			exeLinkTarget = "/does/not/exist/sample"
+		)
+
+		tmpDir, procRoot, cleanup := makeProcFS(t, pid, envTrue, false)
+		defer cleanup()
+
+		procDir := filepath.Join(procRoot, strconv.Itoa(pid))
+		require.NoError(t, os.Symlink(exeLinkTarget, filepath.Join(procDir, "exe")))
+
+		fakeRoot := filepath.Join(tmpDir, "fake_root")
+		require.NoError(t, os.Symlink(fakeRoot, filepath.Join(procDir, "root")))
+
+		res, err := analyzeProcess(pid, procRoot, noopContainerResolver{}, analyzer)
+		require.NoError(t, err)
+		require.False(t, res.interesting)
+		require.Empty(t, res.exe)
+	})
+
+	t.Run("exe no perms in root results in nil error", func(t *testing.T) {
+		const (
+			pid           = 107
+			exeLinkTarget = "/does/not/exist/sample"
+		)
+
+		tmpDir, procRoot, cleanup := makeProcFS(t, pid, envTrue, false)
+		defer cleanup()
+
+		procDir := filepath.Join(procRoot, strconv.Itoa(pid))
+		require.NoError(t, os.Symlink(exeLinkTarget, filepath.Join(procDir, "exe")))
+
+		fakeRoot := filepath.Join(tmpDir, "fake_root")
+		require.NoError(t, os.Symlink(fakeRoot, filepath.Join(procDir, "root")))
+
+		res, err := analyzeProcess(pid, procRoot, noopContainerResolver{}, analyzer)
+		require.NoError(t, err)
+		require.False(t, res.interesting)
+		require.Empty(t, res.exe)
 	})
 }
 


### PR DESCRIPTION
We're back to logging once a second when files go missing (happens on short-lived processes) because os.Is* are deprecated and don't check error wrapping. This change does remove that wrapping because it wasn't serving anybody. It adds a test to make sure that we don't regress here.

> This function predates [errors.Is](https://pkg.go.dev/errors#Is). It only supports errors returned by the os package. New code should use errors.Is(err, fs.ErrPermission).

See https://pkg.go.dev/os#IsNotExist