### PR TITLE
dyninst/procmon: fix memory leak when nothing is interesting

### DIFF
--- a/pkg/dyninst/procmon/state.go
+++ b/pkg/dyninst/procmon/state.go
@@ -58,12 +58,19 @@ type effects interface {
 }
 
 type state struct {
-	alive    map[uint32]struct{}
-	queued   []uint32
+	// The set of processes that we have reported as alive, or that we are
+	// currently analyzing.
+	alive map[uint32]struct{}
+	// The set of processes that we have queued for analysis (excluding
+	// processes that are currently being analyzed).
+	queued []uint32
+	// True if we are currently analyzing a process.
 	inFlight bool
 
 	// The processes that are in the current update being built but have
-	// not yet been reported.
+	// not yet been reported. This map should only ever contain processes
+	// that are queued for analysis or in the update that is currently
+	// being built.
 	pending map[uint32]struct{}
 
 	updates  []ProcessUpdate
@@ -95,12 +102,15 @@ func (s *state) handle(ev event, eff effects) {
 					s.removals = append(s.removals, pid)
 				}
 			}
+			delete(s.pending, e.pid)
 		}
 	case *analysisResult:
 		s.inFlight = false
 		if e.err != nil || !e.interesting {
 			delete(s.alive, uint32(e.pid))
-		} else {
+			delete(s.pending, uint32(e.pid))
+		} else if _, ok := s.alive[e.pid]; ok {
+			delete(s.pending, e.pid)
 			s.updates = append(s.updates, ProcessUpdate{
 				ProcessID: ProcessID{
 					PID: int32(e.pid),
@@ -128,8 +138,6 @@ func (s *state) handle(ev event, eff effects) {
 	if !shouldReport {
 		return
 	}
-
-	clear(s.pending)
 
 	// Drop updates for processes that exited before we finished building.
 	isDead := func(pid uint32) bool { _, ok := s.alive[pid]; return !ok }

--- a/pkg/dyninst/procmon/state_test.go
+++ b/pkg/dyninst/procmon/state_test.go
@@ -9,6 +9,8 @@ package procmon
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,9 +18,10 @@ import (
 
 func TestStateMachine(t *testing.T) {
 	type step struct {
-		ev      event
-		analyze []uint32         // nil if no build expected after this step
-		update  *ProcessesUpdate // nil if no update expected after this step
+		ev       event
+		analyze  []uint32         // nil if no build expected after this step
+		update   *ProcessesUpdate // nil if no update expected after this step
+		expAlive *[]uint32
 	}
 
 	type opt func(*step)
@@ -50,6 +53,12 @@ func TestStateMachine(t *testing.T) {
 	analyze := func(procPids ...uint32) opt {
 		return func(s *step) {
 			s.analyze = append(s.analyze, procPids...)
+		}
+	}
+
+	alive := func(procPids ...uint32) opt {
+		return func(s *step) {
+			s.expAlive = &procPids
 		}
 	}
 
@@ -85,56 +94,53 @@ func TestStateMachine(t *testing.T) {
 		{
 			name: "simple exec interested",
 			steps: []step{
-				s(exec(1), analyze(1)),
-				s(res(1, true, nil), upd(1)),
+				s(exec(1), analyze(1), alive(1)),
+				s(res(1, true, nil), upd(1), alive(1)),
 			},
 		},
 		{
 			name: "exec then exit before build done",
 			steps: []step{
-				s(exec(2), analyze(2)),
-				s(exit(2)),
-				s(interesting(2)),
+				s(exec(2), analyze(2), alive(2)),
+				s(exit(2), alive()),
+				s(interesting(2), alive()),
 			},
 		},
 		{
 			name: "exec not interesting",
 			steps: []step{
-				s(exec(3), analyze(3)),
-				s(uninteresting(3)),
+				s(exec(3), analyze(3), alive(3)),
+				s(uninteresting(3), alive()),
 			},
 		},
 		{
 			name: "reported then removed",
 			steps: []step{
-				s(exec(4), analyze(4)),
-				s(interesting(4), upd(4)),
-				s(exit(4), rem(4)),
+				s(exec(4), analyze(4), alive(4)),
+				s(interesting(4), upd(4), alive(4)),
+				s(exit(4), rem(4), alive()),
 			},
 		},
 		{
 			name: "queueing delays reporting",
 			steps: []step{
-				s(exec(5), analyze(5)),
-				s(exec(6)),
-				s(exec(7)),
-				s(exec(8)),
-				s(interesting(5), analyze(6)),
-				s(uninteresting(6), analyze(7)),
+				s(exec(5), analyze(5), alive(5)),
+				s(exec(6), alive(5, 6)),
+				s(exec(7), alive(5, 6, 7)),
+				s(exec(8), alive(5, 6, 7, 8)),
+				s(interesting(5), analyze(6), alive(5, 6, 7, 8)),
+				s(uninteresting(6), analyze(7), alive(5, 7, 8)),
 				s(interesting(7), analyze(8)),
-				s(failed(8, fmt.Errorf("test error")), upd(5, 7)),
+				s(failed(8, fmt.Errorf("test error")), upd(5, 7), alive(5, 7)),
 				s(exit(6)),
-				s(exit(7), rem(7)),
-				s(exit(8)),
+				s(exit(7), rem(7), alive(5)),
+				s(exit(8), alive(5)),
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name != "queueing delays reporting" {
-				t.Skipf("skipping %q != %q", tc.name, "queueing delays reporting")
-			}
 			st := newState()
 			for i, s := range tc.steps {
 				if !t.Run(fmt.Sprint(i), func(t *testing.T) {
@@ -150,6 +156,15 @@ func TestStateMachine(t *testing.T) {
 						require.Empty(t, mock.updates)
 					}
 					require.Equal(t, s.analyze, mock.builds)
+					if s.expAlive != nil {
+						require.ElementsMatch(
+							t,
+							*s.expAlive,
+							slices.Collect(maps.Keys(st.alive)),
+						)
+					}
+					// Ensure that pending is always a subset of alive.
+					require.Subset(t, st.alive, st.pending)
 				}) {
 					break
 				}


### PR DESCRIPTION
### What does this PR do?

Prior to this change, we'd always add processes to the pending map but we'd only ever clear the map when we had something interesting to report. This results in a memory leak in the common situation when no processes are interesting to dynamic instrumentation.


### Motivation

Testing was expanded to assert that the pending map is always a subset of the alive map and the code was updated to uphold this invariant.

This was uncovered via a [profiler insight](https://ddstaging.datadoghq.com/profiling/comparison?agg_m=%40prof_go_lifetime_heap_bytes&compare_end_A=1753338600000&compare_end_B=1753387200000&compare_query_A=%28%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%20OR%20%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%29%20image_tag%3A7.69.0-rc.5-jmx%20service%3Asystem-probe%20container_id%3A147094605ed7b0e4eedf9e9550c75758332886f5fcf4e15bf381924953eaa016&compare_query_B=%28%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%20OR%20%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%29%20image_tag%3A7.69.0-rc.5-jmx%20service%3Asystem-probe%20container_id%3A147094605ed7b0e4eedf9e9550c75758332886f5fcf4e15bf381924953eaa016&compare_start_A=1753290000000&compare_start_B=1753338600001&compareValuesMode=absolute&group_by=line&my_code=disabled&profile_type=heap-live-size&zoom_B=696644749)! 

### Describe how you validated your changes

I added testing and tightened the invariants of the relevant code.

### Additional Notes

Fixes [DEBUG-4220](https://datadoghq.atlassian.net/browse/DEBUG-4220)

[DEBUG-4220]: https://datadoghq.atlassian.net/browse/DEBUG-4220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ