### PR TITLE
dyninst/symdb: support filtering out 3rd-party symbols

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -680,7 +680,7 @@ func (b *SymDBBuilder) exploreCompileUnit(entry *dwarf.Entry, reader *dwarf.Read
 	}
 	b.filesInCurrentCompileUnit = files
 
-	// We recognize subprograms and types.
+	// Go through the children, looking for subprograms.
 	for child, err := reader.Next(); child != nil; child, err = reader.Next() {
 		if err != nil {
 			return Package{}, err

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -32,7 +32,7 @@ func TestSymDB(t *testing.T) {
 			t.Logf("exploring binary: %s", binaryPath)
 			symBuilder, err := symdb.NewSymDBBuilder(binaryPath)
 			require.NoError(t, err)
-			symbols, err := symBuilder.ExtractSymbols()
+			symbols, err := symBuilder.ExtractSymbols(symdb.ExtractScopeAllSymbols)
 			require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
 			require.NotEmpty(t, symbols.Packages)
 
@@ -73,16 +73,13 @@ func TestSymDBSnapshot(t *testing.T) {
 					t.Logf("exploring binary: %s", binaryPath)
 					symBuilder, err := symdb.NewSymDBBuilder(binaryPath)
 					require.NoError(t, err)
-					symbols, err := symBuilder.ExtractSymbols()
+					symbols, err := symBuilder.ExtractSymbols(symdb.ExtractScopeMainModuleOnly)
 					require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
 					require.NotEmpty(t, symbols.Packages)
 
 					var sb strings.Builder
 					symbols.Serialize(symdbutil.MakePanickingWriter(&sb),
 						symdb.SerializationOptions{
-							// Keep the size of the snapshot small by only
-							// including the main module.
-							OnlyMainModule: true,
 							PackageSerializationOptions: symdb.PackageSerializationOptions{
 								// Make the snapshot machine-independent by
 								// removing local file paths (given that the

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -1,3 +1,4 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -1,3 +1,4 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: )


### PR DESCRIPTION
For purposes of saving on both resources while processing DWARF and the
amount of data produced for SymDB, we'll want to restrict the symbols we
collect to 1st party code (at least optionally). This patch teaches the
extractor to distinguish 1st party vs 3rd party. For binaries with
buildinfo (i.e. not built by Bazel), we look at the URL of the main
module and select the github org. For Bazel binaries, we exclude some
file prefixes.