### PR TITLE
Adding test for parsing CRL tags

### DIFF
--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate.go
@@ -148,7 +148,7 @@ func (w *WinCertChk) Configure(senderManager sender.SenderManager, integrationCo
 
 	schemaString, err := createConfigSchema()
 	if err != nil {
-		return fmt.Errorf("failed to create config validationschema: %s", err)
+		return fmt.Errorf("failed to create config validation schema: %s", err)
 	}
 
 	schemaLoader := gojsonschema.NewBytesLoader(schemaString)
@@ -272,7 +272,7 @@ func (w *WinCertChk) Run() error {
 			if cert.TrustStatusError != 0 {
 				log.Debugf("Certificate %s has trust status error: %d", cert.Certificate.Subject.String(), cert.TrustStatusError)
 				trustStatusErrors := getCertChainTrustStatusErrors(cert.TrustStatusError)
-				message := fmt.Sprintf("Certificate Validaiton failed. The certificates in the certificate chain have the following errors: %s", strings.Join(trustStatusErrors, ", "))
+				message := fmt.Sprintf("Certificate Validation failed. The certificates in the certificate chain have the following errors: %s", strings.Join(trustStatusErrors, ", "))
 				if cert.ChainPolicyError != 0 {
 					chainPolicyError := getCertChainPolicyErrors(cert.ChainPolicyError)
 					message = fmt.Sprintf("%s, %s", message, chainPolicyError)

--- a/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
+++ b/pkg/collector/corechecks/system/windowscertificate/windows_certificate_test.go
@@ -367,3 +367,26 @@ cert_chain_validation:
 	m.AssertNumberOfCalls(t, "ServiceCheck", 0)
 	m.AssertNumberOfCalls(t, "Commit", 1)
 }
+
+func TestCRLIssuerTags(t *testing.T) {
+	issuer := "L=Internet\r\n O=\"VeriSign, Inc.\"\r\n OU=VeriSign Commercial Software Publishers CA"
+	tags := getCrlIssuerTags(issuer)
+	require.Equal(t, []string{"crl_issuer_L:Internet", "crl_issuer_O:VeriSign, Inc.", "crl_issuer_OU:VeriSign Commercial Software Publishers CA"}, tags)
+
+	issuer = "L=Internet\r\n O=\"VeriSign, Inc.\"\r\n OU=VeriSign Commercial Software Publishers CA\r\n CN=VeriSign Class 3 Public Primary Certification Authority - G5"
+	tags = getCrlIssuerTags(issuer)
+	require.Equal(t, []string{"crl_issuer_L:Internet", "crl_issuer_O:VeriSign, Inc.", "crl_issuer_OU:VeriSign Commercial Software Publishers CA", "crl_issuer_CN:VeriSign Class 3 Public Primary Certification Authority - G5"}, tags)
+
+	issuer = "CN=GlobalSign Root CA\r\n OU=GlobalSign\r\n O=GlobalSign nv-sa\r\n C=BE"
+	tags = getCrlIssuerTags(issuer)
+	require.Equal(t, []string{"crl_issuer_CN:GlobalSign Root CA", "crl_issuer_OU:GlobalSign", "crl_issuer_O:GlobalSign nv-sa", "crl_issuer_C:BE"}, tags)
+
+	issuer = "C=US\r\n S=Arizona\r\n L=Scottsdale\r\n O=\"GoDaddy.com, Inc.\"\r\n OU=http://certificates.godaddy.com/repository\r\n CN=Go Daddy Secure Certification Authority\r\n SERIALNUMBER=07969287"
+	tags = getCrlIssuerTags(issuer)
+	require.Equal(t, []string{"crl_issuer_C:US", "crl_issuer_S:Arizona",
+		"crl_issuer_L:Scottsdale",
+		"crl_issuer_O:GoDaddy.com, Inc.",
+		"crl_issuer_OU:http://certificates.godaddy.com/repository",
+		"crl_issuer_CN:Go Daddy Secure Certification Authority",
+		"crl_issuer_SERIALNUMBER:07969287"}, tags)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a test for parsing CRL tags.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1565
https://github.com/DataDog/datadog-agent/pull/39107#discussion_r2226254316

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran tests with
```
dda inv test --targets=./pkg/collector/corechecks/system/windowscertificate
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->