### PR TITLE
Move macOS test on AArch64/ARM64 back to merge queue (ABLD-28 follow-up)

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -44,7 +44,3 @@ tests_macos_gitlab_amd64:
 tests_macos_gitlab_arm64:
   extends: .tests_macos_gitlab
   tags: ["macos:ventura-arm64", "specific:true"]
-  #TODO(regis): remove below `rules` section once enough `macos:ventura-arm64` runners are provisioned
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.tests_macos_gitlab, rules]


### PR DESCRIPTION
### What does this PR do?
This reverts "Temporarily move macOS test on AArch64/ARM64 out of merge queue (ABLD-28 follow-up) (#39241)", commit 666ad9dd24084fb50fca88c4f7445f46cbff8c32.

### Motivation
There are now 5 times more `macos:ventura-arm64` runners available (25), so we should be good to go without much contention, see corresponding [queue time dashboard](https://app.datadoghq.com/dashboard/5ki-mv5-w74/ci-execution-gitlab-runner-macos?fromUser=false&fullscreen_end_ts=1753430506180&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_start_ts=1753416106180&fullscreen_widget=2004175550845916&refresh_mode=paused&tile_focus=2004175550845916&tpl_var_ci-project-name%5B0%5D=datadog-agent&tpl_var_runner_type%5B0%5D=macos%3Aventura-arm64_specific%3Atrue&from_ts=1753345825972&to_ts=1753360225972&live=false).