### PR TITLE
fix(installer): Fix panic if platform information version is empty

### DIFF
--- a/pkg/fleet/installer/packages/selinux/selinux.go
+++ b/pkg/fleet/installer/packages/selinux/selinux.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	gopsutilhost "github.com/shirou/gopsutil/v4/host"
 )
@@ -93,7 +94,7 @@ func isSELinuxSupported() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("error getting platform information: %w", err)
 	}
-	return (family == "rhel" && version[0:1] == "7") && isInstalled("semodule"), nil
+	return (family == "rhel" && strings.HasPrefix(version, "7") && isInstalled("semodule")), nil
 }
 
 func isInstalled(program string) bool {


### PR DESCRIPTION
### What does this PR do?
Fixes a panic happening if the `version` field of `gopsutilhost.PlatformInformation()` is empty.

### Motivation
No panics during post-inst!

### Describe how you validated your changes
Not really testable by a unit test; but double-checked that `strings.HasPrefix` doesn't panic if the input string is empty.

### Possible Drawbacks / Trade-offs

### Additional Notes
