### PR TITLE
[NDMII-3554] Add `datadog.snmp.requests` metric

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -442,9 +442,9 @@ func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string)
 	d.sender.MonotonicCount("datadog.snmp.check_interval", time.Duration(startTime.UnixNano()).Seconds(), newTags)
 	d.sender.Gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), newTags)
 	d.sender.Gauge("datadog.snmp.submitted_metrics", float64(d.sender.GetSubmittedMetrics()), newTags)
-	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetCount()), append(newTags, snmpGetRequestTag))
-	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetBulkCount()), append(newTags, snmpGetBulkRequestTag))
-	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetNextCount()), append(newTags, snmpGetNextReqestTag))
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetCount()), append(utils.CopyStrings(newTags), snmpGetRequestTag))
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetBulkCount()), append(utils.CopyStrings(newTags), snmpGetBulkRequestTag))
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetNextCount()), append(utils.CopyStrings(newTags), snmpGetNextReqestTag))
 }
 
 // GetDiagnoses collects diagnoses for diagnose CLI

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -45,6 +45,10 @@ import (
 
 const (
 	snmpLoaderTag           = "loader:core"
+	snmpRequestMetric       = "datadog.snmp.requests"
+	snmpGetRequestTag       = "request_type:get"
+	snmpGetBulkRequestTag   = "request_type:getbulk"
+	snmpGetNextReqestTag    = "request_type:getnext"
 	serviceCheckName        = "snmp.can_check"
 	deviceReachableMetric   = "snmp.device.reachable"
 	deviceUnreachableMetric = "snmp.device.unreachable"
@@ -414,6 +418,9 @@ func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string)
 	d.sender.MonotonicCount("datadog.snmp.check_interval", time.Duration(startTime.UnixNano()).Seconds(), newTags)
 	d.sender.Gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), newTags)
 	d.sender.Gauge("datadog.snmp.submitted_metrics", float64(d.sender.GetSubmittedMetrics()), newTags)
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetCount()), append(newTags, snmpGetRequestTag))
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetBulkCount()), append(newTags, snmpGetBulkRequestTag))
+	d.sender.Gauge(snmpRequestMetric, float64(d.session.GetSnmpGetNextCount()), append(newTags, snmpGetNextReqestTag))
 }
 
 // GetDiagnoses collects diagnoses for diagnose CLI

--- a/releasenotes/notes/ndm-add-snmp-requests-metric-e7145ffe54d9dabd.yaml
+++ b/releasenotes/notes/ndm-add-snmp-requests-metric-e7145ffe54d9dabd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the ``datadog.snmp.requests`` metric, which tracks the number of SNMP requests sent by the Agent to devices.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the `datadog.snmp.requests` metric to track the number of SNMP requests sent to a device. It is tagged by `request_type`: get/getbulk/getnext

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The metric can be seen here:
https://dd.datad0g.com/metric/explorer?fromUser=true&state=H4sIAAAAAAAAE12R3WrDMAyF30WXw5RmbdfVrzKKMbGcCuw4tZRCGvLuQ03bwfCN9HF89DfDDStT6cHC5_Zz75rGbRsw0FU_XBjszwwBI_UkD9EMQpIQLIBZQ8d017z5ehOfqFPDhFEUToMKhDIyVkIGAxWvI7KsBSryUHpGF0vNXv5rr-MaqbT3Wb0UTdpm8OIdl7G2ijNKpfb1ZwIL_tZZnlgwb9ph3IyMdf5YYDkb0GJj8qvvM_mzXs7LeVEZD4nEBcrY655U_qZt6SN1D4NEmQRsszXApYpuqtSAFSwE5BYeXjpWrI8RZmDxqmuOh92-OZ3238fdwQD24cn0raxirMgXl0vQKTlRoL4DA4MfGQPY6BPjYiBSEqzPFt8tuxvd3esIZUjEAssvI8EbkPkBAAA&start=1753419948735&end=1753434348735&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyMkIGFA4MAB0GiKq8o1GQRoWwBjwIghOjDjdyKo+EJkAtIwYU-K6HnE8AAQARlgrwJ1m3U5yijwgPAC6VK7ueJih4ReqVxgxpfHHZyDdWGg5oPIYXwgIHJJBpOTLXDSTRJoURwfYKIHpaFQKEwpz0JjKERuDxoY78CD2TBYOGKZTQkRKU48PjveTQhAAYSkwhgKBEVzQPCAA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->