### PR TITLE
[autodiscovery/prometheus] Return empty configs when prometheus port annotation has no matching container

### DIFF
--- a/comp/core/autodiscovery/providers/prometheus_pods_test.go
+++ b/comp/core/autodiscovery/providers/prometheus_pods_test.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+func TestGetConfigErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []*kubelet.Pod
+		wantErrs bool
+	}{
+		{
+			name: "pod with invalid port annotation",
+			pods: []*kubelet.Pod{
+				{
+					Metadata: kubelet.PodMetadata{
+						Name:      "test-pod",
+						Namespace: "default",
+						UID:       "test-uid",
+						Annotations: map[string]string{
+							"prometheus.io/scrape": "true",
+							"prometheus.io/port":   "invalid",
+						},
+					},
+					Spec: kubelet.Spec{
+						Containers: []kubelet.ContainerSpec{
+							{
+								Name: "test-container",
+								Ports: []kubelet.ContainerPortSpec{
+									{ContainerPort: 8080},
+								},
+							},
+						},
+					},
+					Status: kubelet.Status{
+						AllContainers: []kubelet.ContainerStatus{
+							{Name: "test-container", ID: "test-id"},
+						},
+					},
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			name: "pod with port annotation but no matching container",
+			pods: []*kubelet.Pod{
+				{
+					Metadata: kubelet.PodMetadata{
+						Name:      "test-pod",
+						Namespace: "default",
+						UID:       "test-uid",
+						Annotations: map[string]string{
+							"prometheus.io/scrape": "true",
+							"prometheus.io/port":   "9999",
+						},
+					},
+					Spec: kubelet.Spec{
+						Containers: []kubelet.ContainerSpec{
+							{
+								Name: "test-container",
+								Ports: []kubelet.ContainerPortSpec{
+									{ContainerPort: 8080}, // Different port
+								},
+							},
+						},
+					},
+					Status: kubelet.Status{
+						AllContainers: []kubelet.ContainerStatus{
+							{Name: "test-container", ID: "test-id"},
+						},
+					},
+				},
+			},
+			wantErrs: true,
+		},
+		{
+			name: "valid pod should not generate errors",
+			pods: []*kubelet.Pod{
+				{
+					Metadata: kubelet.PodMetadata{
+						Name:      "test-pod",
+						Namespace: "default",
+						UID:       "test-uid",
+						Annotations: map[string]string{
+							"prometheus.io/scrape": "true",
+						},
+					},
+					Spec: kubelet.Spec{
+						Containers: []kubelet.ContainerSpec{
+							{
+								Name: "test-container",
+								Ports: []kubelet.ContainerPortSpec{
+									{ContainerPort: 8080},
+								},
+							},
+						},
+					},
+					Status: kubelet.Status{
+						AllContainers: []kubelet.ContainerStatus{
+							{Name: "test-container", ID: "test-id"},
+						},
+					},
+				},
+			},
+			wantErrs: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider, err := NewPrometheusPodsConfigProvider(nil, nil)
+			require.NoError(t, err)
+
+			prometheusProvider := provider.(*PrometheusPodsConfigProvider)
+
+			_ = prometheusProvider.parsePodlist(test.pods)
+			errors := provider.GetConfigErrors()
+
+			if test.wantErrs {
+				assert.NotEmpty(t, errors)
+			} else {
+				assert.Empty(t, errors)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/contp-903-prometheus-ad-no-matching-port-3be7c25adfddec23.yaml
+++ b/releasenotes/notes/contp-903-prometheus-ad-no-matching-port-3be7c25adfddec23.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When the ``prometheus_scrape.enabled`` option is set to true and the pod has
+    a ``prometheus.io/port`` annotation, containers must expose that port in
+    their spec in order for the Agent to schedule ``openmetrics`` checks.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the Prometheus autodiscovery provider where incorrect configurations were generated when the `prometheus.io/port` annotation specified a port that no container exposed.

When a pod had the `prometheus.io/port` annotation but no container declared that port, the provider would generate openmetrics check configurations for all containers in the pod, using the annotated port in the URL. This resulted in multiple failing checks since none of the containers were actually listening on the specified port.

### Describe how you validated your changes

I added unit tests that cover the bug.

I also tested manually. I enabled prometheus scraping (`datadog.prometheusScrape.enabled` in the Helm chart) and created a Prometheus deployment with the `prometheus.io/port` annotation.