### PR TITLE
Revert "Update omnibus-ruby digest to 6c5d581 (#39256)"

### DIFF
--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
     "base_branch": "main",
     "current_milestone": "7.70.0",
     "dependencies": {
-        "OMNIBUS_RUBY_VERSION": "6c5d581967e2880998cc621ad6e5f07a5c99f04a",
+        "OMNIBUS_RUBY_VERSION": "fb400d576cc38bdf07cce4dca3e57a42a7976dff",
         "JMXFETCH_VERSION": "0.49.9",
         "JMXFETCH_HASH": "0f33f0f0d95ba9286bb1c02ee39955ab6709c5b7f923d318a796a71ef2e6b706",
         "WINDOWS_DDNPM_DRIVER": "release-signed",


### PR DESCRIPTION
### What does this PR do?
This reverts commit 1462af5da0da62479371e21dd9e077b5fbcfe1da.

### Motivation
Because `dda` version is too old and doesn't bring `dmgbuild`. This would be fixed by #38446, but there's reluctance to merge that change.