### PR TITLE
dyninst: ensure processes are not missed

### DIFF
--- a/pkg/dyninst/procmon/state_test.go
+++ b/pkg/dyninst/procmon/state_test.go
@@ -141,7 +141,7 @@ func TestStateMachine(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			st := newState()
+			st := makeState()
 			for i, s := range tc.steps {
 				if !t.Run(fmt.Sprint(i), func(t *testing.T) {
 					mock := &mockEffects{}
@@ -172,6 +172,21 @@ func TestStateMachine(t *testing.T) {
 		})
 	}
 }
+
+func (s *state) handle(ev event, eff effects) {
+	switch e := ev.(type) {
+	case *processEvent:
+		s.handleProcessEvent(*e)
+	case *analysisResult:
+		s.handleAnalysisResult(*e)
+	}
+	s.analyzeOrReport(eff)
+}
+
+type event interface{ event() }
+
+func (e *processEvent) event()   {}
+func (r *analysisResult) event() {}
 
 // It can synchronously feed processResult events back into the state machine
 // and records every ProcessesUpdate sent to the actuator.


### PR DESCRIPTION
We see cases where process events are dropped. I found an example of
such a runtime trace [here][1]. The bouncing between goroutines leads
us to quickly get unscheduled. Mostly we're just updating a hash map,
so I'd expect if we make this fast we won't see this sort of drop
very often. That being said, we're also going to want to do some syncing.



Fixes https://datadoghq.atlassian.net/browse/DEBUG-4225

[1]: https://ddstaging.datadoghq.com/profiling/explorer?query=%28%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%20OR%20%28kube_container_name%3Asystem-probe%20kube_cluster_name%3Agizmo%29%29%20image_tag%3A7.69.0-rc.5-jmx%20service%3Asystem-probe%20pod_name%3Adatadog-agent-h2jlm-6kpf9&agg_m=%40prof_core_cpu_cores&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=sum&fromUser=true&my_code=disabled&overview_facet=log_prof_go_cpu_cores&p_tl_expanded_lines=260319940%2C-1774851417%2C1058006749&p_tl_item=1229525265%3A1847126331&p_tl_selected_lines=-429650032&p_tl_summary_tab=flame-graph&p_tl_tb=1753324944021000000&p_tl_tf_f_0=0&p_tl_tf_f_1=77286919232&p_tl_tf_s_0=36315642880&p_tl_tf_s_1=36426179581.76797&p_tl_tf_us_0=36315642880&p_tl_tf_us_1=36426179581.76797&selected_tf=1753324944021%2C1753325244278&top_n=100&top_o=top&viz=thread_timeline&x_missing=true&start=1753281407070&end=1753342916472&paused=true
