### PR TITLE
retry msi error 1601

### DIFF
--- a/pkg/fleet/installer/msi/msiexec.go
+++ b/pkg/fleet/installer/msi/msiexec.go
@@ -319,6 +319,11 @@ func isRetryableExitCode(err error) bool {
 	var exitError exitCodeError
 	if errors.As(err, &exitError) {
 		if exitError.ExitCode() == int(windows.ERROR_INSTALL_ALREADY_RUNNING) {
+			// another MSI is already running, we have to wait for it to finish.
+			return true
+		} else if exitError.ExitCode() == int(windows.ERROR_INSTALL_SERVICE_FAILURE) {
+			// could not connect to msiserver service.
+			// it should auto start when the MSI is run, but maybe it failed or was too slow to start.
 			return true
 		}
 	}

--- a/pkg/fleet/installer/msi/msiexec_test.go
+++ b/pkg/fleet/installer/msi/msiexec_test.go
@@ -66,6 +66,11 @@ func TestIsRetryableExitCode(t *testing.T) {
 			isRetryable: true,
 		},
 		{
+			name:        "retryable exit code 1601",
+			err:         &mockExitError{code: int(windows.ERROR_INSTALL_SERVICE_FAILURE)},
+			isRetryable: true,
+		},
+		{
 			name:        "non-retryable exit code 1603",
 			err:         &mockExitError{code: 1603},
 			isRetryable: false,
@@ -103,6 +108,11 @@ func TestIsRetryableExitCode(t *testing.T) {
 			{
 				name:        "retryable exit code 1618 (ERROR_INSTALL_ALREADY_RUNNING)",
 				exitCode:    int(windows.ERROR_INSTALL_ALREADY_RUNNING), // 1618
+				isRetryable: true,
+			},
+			{
+				name:        "retryable exit code 1601 (ERROR_INSTALL_SERVICE_FAILURE)",
+				exitCode:    int(windows.ERROR_INSTALL_SERVICE_FAILURE), // 1601
 				isRetryable: true,
 			},
 			{

--- a/releasenotes/notes/windows-remote-update-retry-1601-51eab80e6fb0d11a.yaml
+++ b/releasenotes/notes/windows-remote-update-retry-1601-51eab80e6fb0d11a.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Remote Agent management on Windows now automatically retries when the MSI
+    returns error 1601 (``ERROR_INSTALL_SERVICE_FAILURE``).


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
retry when the MSI returns [exit code 1601](https://learn.microsoft.com/en-us/windows/win32/msi/error-codes) (`ERROR_INSTALL_SERVICE_FAILURE`) during remote updates on Windows

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1679
Be more resilient to `msiserver` issues

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
added to existing unit tests.

For manual testing, disable or force stop the msiserver service.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This error is distinct from the `Error 1719. The Windows Installer Service could not be accessed` error described at:
- https://support.gfi.com/article/114416-error-fatal-error-during-installation-when-installing-net-4-framework-on-a-64-bit-machine
- https://www.advancedinstaller.com/forums/viewtopic.php?t=50343\

These cases contain a log like
```
CustomAction XXX returned actual error code 1601
```
but the MSI actually fails with exit code 1603 (generic failure), so we can't identify these cases on exit code alone. maybe because the error occurred within a custom action? Will look into parsing the error out of the log file in a follow-up PR.