### PR TITLE
Add Windows zip package build of ddot

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -75,9 +75,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
     AGENT_FLAVOR: fips
   timeout: 2h
 
-
-# azure-app-services build for Windows
-windows_zip_agent_binaries_x64-a7:
+.windows_zip_base:
   stage: package_build
   rules:
     - !reference [.except_mergequeue]
@@ -86,7 +84,6 @@ windows_zip_agent_binaries_x64-a7:
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     ARCH: "x64"
-    OMNIBUS_TARGET: agent-binaries
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -124,3 +121,14 @@ windows_zip_agent_binaries_x64-a7:
     expire_in: 2 weeks
     paths:
       - omnibus/pkg/pipeline-$CI_PIPELINE_ID
+
+# azure-app-services build for Windows
+windows_zip_agent_binaries_x64-a7:
+  extends: .windows_zip_base
+  variables:
+    OMNIBUS_TARGET: agent-binaries
+
+windows_zip_ddot_x64:
+  extends: .windows_zip_base
+  variables:
+    OMNIBUS_TARGET: ddot

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -95,6 +95,11 @@ exclude 'bundler\/git'
 strip_build windows_target? || do_build
 debug_path ".debug"  # the strip symbols will be in here
 
+if windows_target?
+  windows_symbol_stripping_file "#{install_dir}\\embedded\\bin\\otel-agent.exe"
+  sign_file "#{install_dir}\\embedded\\bin\\otel-agent.exe"
+end
+
 # ------------------------------------
 # Packaging
 # ------------------------------------

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -105,9 +105,7 @@ end
 # ------------------------------------
 
 # Maintainer names are chosen to match those on agent.rb
-if windows_target?
-  maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
-elsif debian_target?
+if debian_target?
   maintainer 'Datadog Packages <package@datadoghq.com>'
   # Use sanitized version to ensure it matches the actual version used for datadog-agent
   safe_version = Omnibus::Packager::DEB::safe_version(build_version)

--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -37,7 +37,7 @@ if windows_target?
   # Note: this is the path used by Omnibus to build the agent, the final install
   # dir will be determined by the Windows installer. This path must not contain
   # spaces because Omnibus doesn't quote the Git commands it launches.
-  INSTALL_DIR = 'C:/opt/datadog-agent/'
+  INSTALL_DIR = 'C:/opt/datadog-agent'
 else
   INSTALL_DIR = ENV["INSTALL_DIR"] || '/opt/datadog-agent'
 end

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -48,7 +48,12 @@ build do
     mkdir embedded_bin_dir
 
     command "dda inv -- -e otel-agent.build", :env => env
-    copy 'bin/otel-agent/otel-agent', embedded_bin_dir
+
+    if windows_target?
+      copy 'bin/otel-agent/otel-agent.exe', embedded_bin_dir
+    else
+      copy 'bin/otel-agent/otel-agent', embedded_bin_dir
+    end
 
     move 'bin/otel-agent/dist/otel-config.yaml', "#{conf_dir}/otel-config.yaml.example"
 end

--- a/omnibus/config/software/datadog-otel-agent.rb
+++ b/omnibus/config/software/datadog-otel-agent.rb
@@ -41,7 +41,11 @@ build do
     # include embedded path (mostly for `pkg-config` binary)
     env = with_standard_compiler_flags(with_embedded_path(env))
 
-    conf_dir = "/etc/datadog-agent"
+    if windows_target?
+      conf_dir = "#{install_dir}/etc/datadog-agent"
+    else
+      conf_dir = "/etc/datadog-agent"
+    end
     embedded_bin_dir = "#{install_dir}/embedded/bin"
 
     mkdir conf_dir


### PR DESCRIPTION
### What does this PR do?

Adds Windows (zip) package build for ddot.

### Motivation

[ABLD-95](https://datadoghq.atlassian.net/browse/ABLD-95)

### Describe how you validated your changes

Manually inspected zip files output by this job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1050320323

### Possible Drawbacks / Trade-offs

### Additional Notes

[ABLD-95]: https://datadoghq.atlassian.net/browse/ABLD-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ