### PR TITLE
Mark disk check test as flake

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -62,6 +63,7 @@ instances:
 	p := math.Pow10(v.metricCompareDecimals)
 	for _, testCase := range testCases {
 		v.Run(testCase.name, func() {
+			flake.Mark(v.T())
 			v.T().Log("run the disk check using old version")
 			pythonMetrics := v.runDiskCheck(testCase.agentConfig, testCase.checkConfig, false)
 			v.T().Log("run the disk check using new version")


### PR DESCRIPTION
### What does this PR do?

### Motivation

Test is [flaking](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1049532270#L1961) on 7.68.x branch. This was fixed / improved in https://github.com/DataDog/datadog-agent/pull/38434 for main, but the code has shifted around enough that a direct backport is not feasible and manually porting the fix to 7.68 is not worth the effort.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->