### PR TITLE
Retry once on any error, except for test lint e2e test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,18 +41,7 @@ include:
 
 default:
   retry:
-    max: 2
-    exit_codes:
-      - 42
-      - 101 # Failed to extract dependencies
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
-      - unknown_failure
-      - api_failure
-      - scheduler_failure
-      - stale_schedule
-      - data_integrity_failure
+    max: 1 # Retry everything once on failure 
 
 stages:
   - .pre
@@ -1108,3 +1097,18 @@ workflow:
 .except_coverage_pipeline:
   - <<: *if_coverage_pipeline
     when: never
+
+.retry_only_infra_failure:
+  retry:
+    max: 2
+    exit_codes:
+      - 42
+      - 101 # Failed to extract dependencies
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -103,6 +103,7 @@
     reports:
       annotations:
         - $EXTERNAL_LINKS_PATH
+  retry: !reference [.retry_only_infra_failure, retry]
 
 .needs_new_e2e_template:
   - go_e2e_deps

--- a/.gitlab/lint/linux.yml
+++ b/.gitlab/lint/linux.yml
@@ -14,7 +14,7 @@
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools
     - dda inv -- -e linter.go --cpus $KUBERNETES_CPU_REQUEST --debug $FLAVORS $EXTRA_OPTS
-
+  retry: !reference [.retry_only_infra_failure, retry]
 .linux_x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$CI_IMAGE_DEB_X64_SUFFIX:$CI_IMAGE_DEB_X64
   tags: ["arch:amd64"]

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -13,6 +13,7 @@ include:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
+  retry: !reference [.retry_only_infra_failure, retry]
 
 lint_macos_gitlab_amd64:
   extends: .lint_macos_gitlab

--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -4,6 +4,7 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$CI_IMAGE_LINUX_GLIBC_2_17_X64_SUFFIX:$CI_IMAGE_LINUX_GLIBC_2_17_X64
   tags: ["arch:amd64"]
   needs: []
+  retry: !reference [.retry_only_infra_failure, retry]
 
 lint_licenses:
   extends: .lint

--- a/.gitlab/lint/windows.yml
+++ b/.gitlab/lint/windows.yml
@@ -25,6 +25,7 @@
       ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-Linters.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+  retry: !reference [.retry_only_infra_failure, retry]
 
 lint_windows-x64:
   extends: .lint_windows_base

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -25,6 +25,7 @@
     - dda inv -- -e linter.go --build system-probe-unit-tests --cpus 4 --targets ./pkg
     - dda inv -- -e security-agent.run-ebpf-unit-tests --verbose
     - dda inv -- -e linter.go --targets=./pkg/security/tests --cpus 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata"
+  retry: !reference [.retry_only_infra_failure, retry]
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -44,6 +44,7 @@
       junit: "**/junit-out-*.xml"
       annotations:
         - $EXTERNAL_LINKS_PATH
+  retry: !reference [.retry_only_infra_failure, retry]
 
 .linux_x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$CI_IMAGE_DEB_X64_SUFFIX:$CI_IMAGE_DEB_X64

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -36,6 +36,7 @@ include:
       junit: "**/junit-out-*.xml"
       annotations:
         - $EXTERNAL_LINKS_PATH
+  retry: !reference [.retry_only_infra_failure, retry]
 
 tests_macos_gitlab_amd64:
   extends: .tests_macos_gitlab

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -59,6 +59,7 @@
       - junit-*.tgz
     reports:
       junit: "**/junit-out-*.xml"
+  retry: !reference [.retry_only_infra_failure, retry]
 
 tests_windows-x64:
   extends: .tests_windows_base


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change our strategy to improve reliability of the CI. We will now retry all the jobs once when they fail. Except the jobs that can be expected to fail like unit tests, linters and e2e tests.
Ideally we'd like tests and linters to be retried on main because they are not expected to fail there. However this is not possible to have such a precise configuration with current gitlab configuration.

What would be possible:
- Retry everything on main + never retry by default on PRs
- Have a separate service that watches the CI and is responsible for retries of the jobs. This would allow us to configure it as we want

### Motivation

Improve reliability and reduce flakiness of the CI

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->