### PR TITLE
[CWS-4860] Avoid using kernel event go routine to load profiles

### DIFF
--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -467,11 +467,7 @@ func (m *Manager) SendStats() error {
 		profileVersions := make(map[string]int)
 		for selector, profile := range m.profiles {
 			if profile.LoadedInKernel.Load() { // make sure the profile is loaded
-				profile.InstancesLock.Lock()
-				instanceCount := len(profile.Instances)
-				profile.InstancesLock.Unlock()
-
-				profileVersions[selector.Image] = instanceCount
+				profileVersions[selector.Image] = len(profile.Instances)
 				if err := profile.SendStats(m.statsdClient); err != nil {
 					return fmt.Errorf("couldn't send metrics for [%s]: %w", profile.GetSelectorStr(), err)
 				}

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -467,7 +467,11 @@ func (m *Manager) SendStats() error {
 		profileVersions := make(map[string]int)
 		for selector, profile := range m.profiles {
 			if profile.LoadedInKernel.Load() { // make sure the profile is loaded
-				profileVersions[selector.Image] = len(profile.Instances)
+				profile.InstancesLock.Lock()
+				instanceCount := len(profile.Instances)
+				profile.InstancesLock.Unlock()
+
+				profileVersions[selector.Image] = instanceCount
 				if err := profile.SendStats(m.statsdClient); err != nil {
 					return fmt.Errorf("couldn't send metrics for [%s]: %w", profile.GetSelectorStr(), err)
 				}

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -127,6 +127,9 @@ type Manager struct {
 
 	// chan used to move an ActivityDump profile to a SecurityProfile profile
 	newProfiles chan *profile.Profile
+
+	workloadSelectorResolved chan *tags.Workload
+	workloadDeleted          chan *tags.Workload
 }
 
 // NewManager returns a new instance of the security profile manager
@@ -294,6 +297,9 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 		eventFiltering: make(map[eventFilteringEntry]*atomic.Uint64),
 
 		newProfiles: make(chan *profile.Profile, 100),
+
+		workloadSelectorResolved: make(chan *tags.Workload, 100),
+		workloadDeleted:          make(chan *tags.Workload, 100),
 	}
 
 	m.initMetricsMap()
@@ -311,6 +317,16 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 	}
 
 	return m, nil
+}
+
+// queueWorkloadEvent attempts to queue a workload event to the specified channel
+func (m *Manager) queueWorkloadEvent(ch chan<- *tags.Workload, workload *tags.Workload, eventType string) {
+	select {
+	case ch <- workload:
+		// Successfully queued
+	default:
+		seclog.Warnf("Failed to queue %s event for %v", eventType, workload.Selector.String())
+	}
 }
 
 func (m *Manager) initMetricsMap() {
@@ -361,8 +377,12 @@ func (m *Manager) Start(ctx context.Context) {
 	}
 
 	if m.config.RuntimeSecurity.SecurityProfileEnabled {
-		_ = m.resolvers.TagsResolver.RegisterListener(tags.WorkloadSelectorResolved, m.onWorkloadSelectorResolvedEvent)
-		_ = m.resolvers.TagsResolver.RegisterListener(tags.WorkloadSelectorDeleted, m.onWorkloadDeletedEvent)
+		_ = m.resolvers.TagsResolver.RegisterListener(tags.WorkloadSelectorResolved, func(workload *tags.Workload) {
+			m.queueWorkloadEvent(m.workloadSelectorResolved, workload, "workload selector resolved")
+		})
+		_ = m.resolvers.TagsResolver.RegisterListener(tags.WorkloadSelectorDeleted, func(workload *tags.Workload) {
+			m.queueWorkloadEvent(m.workloadDeleted, workload, "workload deleted")
+		})
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -388,6 +408,10 @@ func (m *Manager) Start(ctx context.Context) {
 			m.handleSilentWorkloads()
 		case newProfile := <-m.newProfiles:
 			m.onNewProfile(newProfile)
+		case workload := <-m.workloadSelectorResolved:
+			m.onWorkloadSelectorResolvedEvent(workload)
+		case workload := <-m.workloadDeleted:
+			m.onWorkloadDeletedEvent(workload)
 		}
 	}
 }

--- a/pkg/security/security_profile/profile/grpc.go
+++ b/pkg/security/security_profile/profile/grpc.go
@@ -198,12 +198,12 @@ func (p *Profile) ToSecurityProfileMessage(timeResolver *ktime.Resolver) *api.Se
 	}
 
 	p.InstancesLock.Lock()
+	defer p.InstancesLock.Unlock()
 	for _, inst := range p.Instances {
 		msg.Instances = append(msg.Instances, &api.InstanceMessage{
 			ContainerID: string(inst.ContainerID),
 			Tags:        inst.Tags,
 		})
 	}
-	p.InstancesLock.Unlock()
 	return msg
 }

--- a/pkg/security/security_profile/profile/grpc.go
+++ b/pkg/security/security_profile/profile/grpc.go
@@ -197,11 +197,13 @@ func (p *Profile) ToSecurityProfileMessage(timeResolver *ktime.Resolver) *api.Se
 		msg.EventTypes = append(msg.EventTypes, evt.String())
 	}
 
+	p.InstancesLock.Lock()
 	for _, inst := range p.Instances {
 		msg.Instances = append(msg.Instances, &api.InstanceMessage{
 			ContainerID: string(inst.ContainerID),
 			Tags:        inst.Tags,
 		})
 	}
+	p.InstancesLock.Unlock()
 	return msg
 }

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -628,11 +628,7 @@ func (p *Profile) LoadFromNewProfile(newProfile *Profile) {
 func (p *Profile) Reset() {
 	p.LoadedInKernel.Store(false)
 	p.LoadedNano.Store(0)
-
-	p.InstancesLock.Lock()
 	p.Instances = nil
-	p.InstancesLock.Unlock()
-
 	// keep the profileCookie in case we end up reloading the profile from the cache
 }
 
@@ -725,10 +721,10 @@ func (p *Profile) ListAllVersionStates() {
 		}
 		fmt.Printf("Instances:\n")
 		p.InstancesLock.Lock()
+		defer p.InstancesLock.Unlock()
 		for _, instance := range p.Instances {
 			fmt.Printf("  - %+v\n", instance.ContainerID)
 		}
-		p.InstancesLock.Unlock()
 
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Currently the kernel event go routine can load security profiles, This PR moves this task to the security profile manager go routine.
### Motivation
Less overhead for the kernel event go routine.
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->