### PR TITLE
[CWS] run zombie detector when closing test module

### DIFF
--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -990,6 +991,10 @@ func (tm *testModule) validateSyscallsInFlight() {
 }
 
 func (tm *testModule) Close() {
+	tm.CloseWithOptions(true)
+}
+
+func (tm *testModule) CloseWithOptions(zombieCheck bool) {
 	if !tm.opts.staticOpts.disableRuntimeSecurity {
 		tm.eventMonitor.SendStats()
 	}
@@ -1014,6 +1019,12 @@ func (tm *testModule) Close() {
 
 	if logStatusMetrics {
 		tm.t.Logf("%s exit stats: %s", tm.t.Name(), GetEBPFStatusMetrics(tm.probe))
+	}
+
+	if zombieCheck {
+		if err := tm.CheckZombieProcesses(); err != nil {
+			tm.t.Errorf("failed checking for zombie processes: %v", err)
+		}
 	}
 
 	if withProfile {
@@ -1763,4 +1774,68 @@ func (tm *testModule) GetProfileVersions(imageName string) ([]string, error) {
 	}
 
 	return profile.GetVersions(), nil
+}
+
+func (tm *testModule) CheckZombieProcesses() error {
+	myPid := os.Getpid()
+
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return fmt.Errorf("failed to read /proc: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pidStr := entry.Name()
+		if pidStr == strconv.Itoa(myPid) {
+			continue // skip our own process
+		}
+
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue // not a valid pid
+		}
+
+		statusPath := filepath.Join("/proc", pidStr, "status")
+		statusFile, err := os.Open(statusPath)
+		if err != nil {
+			continue // could not read status file
+		}
+		defer statusFile.Close()
+
+		scanner := bufio.NewScanner(statusFile)
+		state := ""
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if stateStr, ok := strings.CutPrefix(line, "State:"); ok {
+				state = strings.TrimSpace(stateStr)
+			} else if ppidStr, ok := strings.CutPrefix(line, "PPid:"); ok {
+				ppidStr = strings.TrimSpace(ppidStr)
+				ppid, err := strconv.Atoi(ppidStr)
+				if err != nil {
+					return fmt.Errorf("failed to parse PPid for PID %d: %w", pid, err)
+				}
+
+				comm, err := os.ReadFile(filepath.Join("/proc", pidStr, "comm"))
+				if err != nil {
+					return fmt.Errorf("failed to read comm for PID %d: %w", pid, err)
+				}
+				commStr := strings.TrimSpace(string(comm))
+
+				if ppid == myPid {
+					// Found a zombie process with our PID as its parent
+					return fmt.Errorf("found zombie process with PID %d and PPID %d (state=%s, comm=%s)", pid, ppid, state, commStr)
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading status file for PPID %d: %w", pid, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new validation layer at the end of test module tests, allowing to check if the given test left over some zombie processes. `TestTCFilter` was slightly modified to be able to run the validation at the end of the test as well.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->