### PR TITLE
feat(rc): set User-Agent header for RC requests

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -22,11 +22,12 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/gorilla/websocket"
+
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/gorilla/websocket"
 )
 
 const (

--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -103,7 +103,7 @@ func NewHTTPClient(auth Auth, cfg model.Reader, baseURL *url.URL) (*HTTPClient, 
 	// agent making the request at the transport level.
 	version, err := version.Agent()
 	if err != nil {
-		header.Set("User-Agent", fmt.Sprintf("datadog-agent/%s (%s)", version.GetNumber(), runtime.Version()))
+		header.Set("User-Agent", fmt.Sprintf("datadog-agent/%s (%s)", version.String(), runtime.Version()))
 	} else {
 		header.Set("User-Agent", fmt.Sprintf("datadog-agent/unknown (%s)", runtime.Version()))
 	}

--- a/pkg/config/remote/api/http_test.go
+++ b/pkg/config/remote/api/http_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 // Test WebSocket connectivity under varying transport configurations, and

--- a/pkg/config/remote/go.mod
+++ b/pkg/config/remote/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.59.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/benbjohnson/clock v1.3.5
+	github.com/coreos/go-semver v0.3.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.9.0
@@ -49,7 +50,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.64.1
 	github.com/DataDog/go-tuf v1.1.0-0.5.2
 	github.com/DataDog/viper v1.14.1-0.20250612143030-1b15c8822ed4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/pkg/config/remote/go.sum
+++ b/pkg/config/remote/go.sum
@@ -48,6 +48,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This will help identify requests in the RC backend at the transport level, suitable for traffic routing by L7 proxies.

---

* refactor: import tidying (68022a3620)
      
      Normalise imports into std, 3rd party, datadog.

* feat(rc): set User-Agent header for RC requests (7fa2dd8e21)
      
      This causes all Agent HTTP (and WebSocket handshake) requests to the
      remote config backend to present a user agent in the form of:
      
          datadog-agent/7.68.2 (go1.24.5)
      
      While the Agent does declare its version in some request payloads, this
      only works for those specific requests, and only if those payload can be
      successfully parsed.
      
      Setting the user agent on the HTTP request can be used to identify the
      version of the agent making a request to RC without attempting to parse
      the payload, prior to reading the body at all.