### PR TITLE
dyninst/module: support more env vars for config

### DIFF
--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -9,11 +9,15 @@ package module
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Config is the configuration for the dynamic instrumentation module.
@@ -30,19 +34,73 @@ func NewConfig(spConfig *sysconfigtypes.Config) (*Config, error) {
 	if spConfig != nil {
 		_, diEnabled = spConfig.EnabledModules[config.DynamicInstrumentationModule]
 	}
-	agentHost := getAgentHost()
+	traceAgentURL := getTraceAgentURL(os.Getenv)
 	return &Config{
 		Config:                        *ebpf.NewConfig(),
 		DynamicInstrumentationEnabled: diEnabled,
-		LogUploaderURL:                fmt.Sprintf("http://%s:8126/debugger/v1/input", agentHost),
-		DiagsUploaderURL:              fmt.Sprintf("http://%s:8126/debugger/v1/diagnostics", agentHost),
+		LogUploaderURL:                withPath(traceAgentURL, logUploaderPath),
+		DiagsUploaderURL:              withPath(traceAgentURL, diagsUploaderPath),
 	}, nil
 }
 
-func getAgentHost() string {
-	ddAgentHost := os.Getenv("DD_AGENT_HOST")
-	if ddAgentHost == "" {
-		ddAgentHost = "localhost"
+func withPath(u url.URL, path string) string {
+	u.Path = path
+	return u.String()
+}
+
+const (
+	agentHostEnvVar  = "DD_AGENT_HOST"
+	defaultAgentHost = "localhost"
+
+	traceAgentPortEnvVar  = "DD_TRACE_AGENT_PORT"
+	defaultTraceAgentPort = "8126"
+
+	traceAgentURLEnvVar  = "DD_TRACE_AGENT_URL"
+	defaultTraceAgentURL = "http://" + defaultAgentHost + ":" + defaultTraceAgentPort
+
+	logUploaderPath   = "/debugger/v1/input"
+	diagsUploaderPath = "/debugger/v1/diagnostics"
+)
+
+var errSchemeRequired = fmt.Errorf("scheme is required")
+
+// Parse the trace agent URL from the environment variables, falling back to the
+// default.
+//
+// TODO: Support unix socket via DD_AGENT_UNIX_DOMAIN_SOCKET.
+//
+// This is inspired by https://github.com/DataDog/dd-trace-java/blob/76639fbb/internal-api/src/main/java/datadog/trace/api/Config.java#L1356-L1429
+func getTraceAgentURL(getEnv func(string) string) url.URL {
+	if traceAgentURL := getEnv(traceAgentURLEnvVar); traceAgentURL != "" {
+		u, err := url.Parse(traceAgentURL)
+		if err == nil && u.Scheme == "" {
+			err = errSchemeRequired
+		}
+		if err == nil {
+			return *u
+		}
+		log.Warnf(
+			"%s is not properly configured: %v. ignoring",
+			traceAgentURLEnvVar, err,
+		)
 	}
-	return ddAgentHost
+	host := getEnv(agentHostEnvVar)
+	if host == "" {
+		host = defaultAgentHost
+	}
+	port := getEnv(traceAgentPortEnvVar)
+	if port == "" {
+		port = defaultTraceAgentPort
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		log.Warnf(
+			"%s is not a valid port: %v. ignoring",
+			traceAgentPortEnvVar, err,
+		)
+		port = defaultTraceAgentPort
+	}
+	return url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, port),
+	}
 }

--- a/pkg/dyninst/module/config_test.go
+++ b/pkg/dyninst/module/config_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTraceAgentURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{
+			name:     "default",
+			env:      map[string]string{},
+			expected: "http://localhost:8126",
+		},
+		{
+			name:     "agent host set",
+			env:      map[string]string{agentHostEnvVar: "my-host"},
+			expected: "http://my-host:8126",
+		},
+		{
+			name:     "trace agent port set",
+			env:      map[string]string{traceAgentPortEnvVar: "1234"},
+			expected: "http://localhost:1234",
+		},
+		{
+			name: "host and port set",
+			env: map[string]string{
+				agentHostEnvVar:      "my-host",
+				traceAgentPortEnvVar: "1234",
+			},
+			expected: "http://my-host:1234",
+		},
+		{
+			name:     "trace agent url set",
+			env:      map[string]string{traceAgentURLEnvVar: "http://my-url:5678"},
+			expected: "http://my-url:5678",
+		},
+		{
+			name:     "trace agent url set with https",
+			env:      map[string]string{traceAgentURLEnvVar: "https://my-url:5678"},
+			expected: "https://my-url:5678",
+		},
+		{
+			name:     "trace agent url set with unix socket",
+			env:      map[string]string{traceAgentURLEnvVar: "unix:///var/run/datadog/apm.socket"},
+			expected: "unix:///var/run/datadog/apm.socket",
+		},
+		{
+			name: "trace agent url has precedence",
+			env: map[string]string{
+				traceAgentURLEnvVar:  "http://my-url:5678",
+				agentHostEnvVar:      "my-host",
+				traceAgentPortEnvVar: "1234",
+			},
+			expected: "http://my-url:5678",
+		},
+		{
+			name: "invalid trace agent url",
+			env: map[string]string{
+				traceAgentURLEnvVar:  "not a url",
+				agentHostEnvVar:      "my-host",
+				traceAgentPortEnvVar: "1234",
+			},
+			expected: "http://my-host:1234",
+		},
+		{
+			name:     "invalid trace agent url and no fallbacks",
+			env:      map[string]string{traceAgentURLEnvVar: "not a url"},
+			expected: "http://localhost:8126",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getEnv := func(key string) string {
+				return tt.env[key]
+			}
+			actualURL := getTraceAgentURL(getEnv)
+			assert.Equal(t, tt.expected, actualURL.String())
+		})
+	}
+}


### PR DESCRIPTION
This is needed for the system tests to work. Other tracers use these internal env vars to control where they send data.

Part of [DEBUG-3904](https://datadoghq.atlassian.net/browse/DEBUG-3904).

[DEBUG-3904]: https://datadoghq.atlassian.net/browse/DEBUG-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ