### PR TITLE
[CWS] make sure `TestActionKillExcludeBinary` actually kills the sleep process

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -225,14 +225,15 @@ func TestActionKillExcludeBinary(t *testing.T) {
 	}
 	defer test.Close()
 
+	sleepCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	killed := atomic.NewBool(false)
 
 	err = test.GetEventSent(t, func() error {
 		go func() {
-			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
 
-			cmd := exec.CommandContext(timeoutCtx, "sleep", "1234567")
+			cmd := exec.CommandContext(sleepCtx, "sleep", "1234567")
 			_ = cmd.Run()
 
 			killed.Store(true)


### PR DESCRIPTION
### What does this PR do?

This PR ensures the sleep process is correctly stopped in TestActionKillExcludeBinary and makes sure we aren't leaving some zombie processes behind.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->