### PR TITLE
[CWS] make sure sleep is stopped before the end of `TestSnapshot`

### DIFF
--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -91,6 +92,10 @@ type dockerCmdWrapper struct {
 }
 
 func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *exec.Cmd {
+	return d.CommandContext(context.TODO(), bin, args, envs)
+}
+
+func (d *dockerCmdWrapper) CommandContext(ctx context.Context, bin string, args []string, envs []string) *exec.Cmd {
 	dockerArgs := []string{"exec"}
 	for _, env := range envs {
 		dockerArgs = append(dockerArgs, "-e"+env)
@@ -98,7 +103,7 @@ func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *ex
 	dockerArgs = append(dockerArgs, d.containerName, bin)
 	dockerArgs = append(dockerArgs, args...)
 
-	cmd := exec.Command(d.executable, dockerArgs...)
+	cmd := exec.CommandContext(ctx, d.executable, dockerArgs...)
 	cmd.Env = envs
 
 	return cmd


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `CommandContext` to the docker cmd wrapper (similar to the stdlib one), and uses it to ensure the sleep process is stopped before the end of `TestSnapshot` ensuring no zombie process leftover.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->