### PR TITLE
[AGTMETRICS-272]Add more syncronization to `TestForwarderEndtoEnd` test

### DIFF
--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -400,12 +400,15 @@ func TestForwarderEndtoEnd(t *testing.T) {
 	// reseting DroppedOnInput
 	highPriorityQueueFull.Set(0)
 
+	var wg sync.WaitGroup
 	requests := atomic.NewInt64(0)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("%#v\n", r.URL)
 		requests.Inc()
 		w.WriteHeader(http.StatusOK)
+		wg.Done()
 	}))
+	defer ts.Close()
 	mockConfig := mock.New(t)
 	mockConfig.SetWithoutSource("dd_url", ts.URL)
 
@@ -425,36 +428,53 @@ func TestForwarderEndtoEnd(t *testing.T) {
 
 	// - 2 requests to check the validity of the two api_key
 	numReqs := int64(2)
+	wg.Add(2)
 
 	// for each call, we send 2 payloads * 2 api_keys
 	assert.Nil(t, f.SubmitV1Series(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitSeries(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitV1Intake(payload, transaction.Series, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitV1CheckRuns(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitSketchSeries(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitHostMetadata(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
 	assert.Nil(t, f.SubmitMetadata(payload, headers))
 	numReqs += 4
+	wg.Add(4)
 
-	// let's wait a second for every channel communication to trigger
-	<-time.After(1 * time.Second)
+	// Wait for all the requests to have been received.
+	// Timeout after 5 seconds.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
 
-	// We should receive the following requests:
-	// - 9 transactions * 2 payloads per transactions * 2 api_keys
-	ts.Close()
-	assert.Equal(t, numReqs, requests.Load())
+	select {
+	case <-done:
+		// We should receive the following requests:
+		// - 9 transactions * 2 payloads per transactions * 2 api_keys
+		assert.Equal(t, numReqs, requests.Load())
+	case <-time.After(5 * time.Second):
+		assert.Fail(t, "timed out waiting for requests")
+	}
 }
 
 func TestTransactionEventHandlers(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a wait group to the `TestForwarderEndtoEnd` test to ensure all received requests are counted before testing the correct amount received.

### Motivation

This test has failed a few times on Windows over the past month and seems slightly flakey. Hopefully this removes the flake.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The test passes on Linux. We will only know over time if this fixes the flakiness on Windows.

### Possible Drawbacks / Trade-offs

It timesout after 5 seconds, so a test failure could potentially take slightly longer to run if the requests are not sent correctly.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->