### PR TITLE
[CSPM] remove `image_repo` from container image

### DIFF
--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -590,14 +590,10 @@ func (r *defaultResolver) resolveDocker(ctx context.Context, spec InputSpecDocke
 			if err != nil {
 				return nil, err
 			}
-			// Ignore deprecation warning
-			//nolint:staticcheck
-			imageRepo := parseImageRepo(image.ContainerConfig.Image)
 			resolved = append(resolved, map[string]interface{}{
-				"id":         image.ID,
-				"tags":       image.RepoTags,
-				"image_repo": imageRepo,
-				"inspect":    image,
+				"id":      image.ID,
+				"tags":    image.RepoTags,
+				"inspect": image,
 			})
 		}
 	case "container":


### PR DESCRIPTION
### What does this PR do?

The image repo field is unused (for container images, it is used for containers), and with the recent docker bump using it is deprecated. This PR removes the field altogether.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->