### PR TITLE
dogstatsd/listeners: fail gracefully on nil connection in TestNewUDPListenerWhenBusyWithSoRcvBufSet

### DIFF
--- a/comp/dogstatsd/listeners/udp_test.go
+++ b/comp/dogstatsd/listeners/udp_test.go
@@ -163,7 +163,7 @@ func TestNewUDPListenerWhenBusyWithSoRcvBufSet(t *testing.T) {
 	assert.Nil(t, err)
 	address, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	conn, err := net.ListenUDP("udp", address)
-	assert.NotNil(t, conn)
+	require.NotNil(t, conn)
 	assert.Nil(t, err)
 	defer conn.Close()
 


### PR DESCRIPTION
### What does this PR do?

Avoid a panic when the unit test fails by bailing out earlier.
