### PR TITLE
tools/gdb: various improvements to make it work on arm64

### DIFF
--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -21,7 +21,7 @@ GO_VERSION_FILE = "./.go-version"
 # - is_bugfix is True if the version in the match is a bugfix version, False if it's a minor
 GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     (GO_VERSION_FILE, "", "", True),  # the version is the only content of the file
-    ("./tools/gdb/Dockerfile", "https://go.dev/dl/go", ".linux-amd64.tar.gz", True),
+    ("./tools/gdb/Dockerfile", "https://go.dev/dl/go", ".linux-", True),
     ("./test/fakeintake/Dockerfile", "FROM golang:", "-alpine", True),
     ("./tasks/unit_tests/modules_tests.py", 'Go": "', '",', False),
     ("./devenv/scripts/Install-DevEnv.ps1", '$go_version = "', '"', True),

--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -1,4 +1,4 @@
-ARG AGENT_VERSION
+ARG AGENT_VERSION=7
 FROM datadog/agent:${AGENT_VERSION}
 
 RUN apt-get update

--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -15,7 +15,7 @@ RUN /go/bin/go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install datadog-agent-dbg at the right version
 RUN apt-get install -o Dpkg::Options::="--force-confold" --no-install-recommends -y gnupg dirmngr ca-certificates \
- && apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 33EE313BAD9589B7
+ && apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 E6266D4AC0962C7D
 ARG AGENT_VERSION
 ARG APT_REPO=apt.datadoghq.com
 ARG APT_DISTRIBUTION=stable

--- a/tools/gdb/Dockerfile
+++ b/tools/gdb/Dockerfile
@@ -6,7 +6,7 @@ RUN rm -vf /etc/ssl/openssl.cnf
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y gdb build-essential strace less vim
 
 # Install go
-RUN curl -fSL -o golang.tgz https://go.dev/dl/go1.24.5.linux-amd64.tar.gz
+RUN curl -fSL -o golang.tgz https://go.dev/dl/go1.24.5.linux-$(dpkg --print-architecture).tar.gz
 RUN tar xzvf golang.tgz
 RUN ln -s /go /goroot
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a few things in tools/gdb dockerfile:
- gives a default value for `AGENT_VERSION` otherwise docker is unhappy 
```
 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG datadog/agent:${AGENT_VERSION} results in empty or invalid base image name (line 2)
```
- fixes the go install to respect the current arch
- update the apt key to the most recent one to fix the apt(-get) calls

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->