### PR TITLE
Remove global tag initialization from go routine and move to init method

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -92,8 +92,7 @@ func (c *WorkloadMetaCollector) initK8sResourcesMetaAsTags(resourcesLabelsAsTags
 
 // Run runs the continuous event watching loop and sends new tags to the
 // tagger based on the events sent by the workloadmeta.
-func (c *WorkloadMetaCollector) Run(ctx context.Context, datadogConfig config.Component) {
-	c.collectStaticGlobalTags(ctx, datadogConfig)
+func (c *WorkloadMetaCollector) Run(ctx context.Context) {
 	c.stream(ctx)
 }
 
@@ -171,7 +170,7 @@ func (c *WorkloadMetaCollector) stream(ctx context.Context) {
 }
 
 // NewWorkloadMetaCollector returns a new WorkloadMetaCollector.
-func NewWorkloadMetaCollector(_ context.Context, cfg config.Component, store workloadmeta.Component, p processor) *WorkloadMetaCollector {
+func NewWorkloadMetaCollector(ctx context.Context, cfg config.Component, store workloadmeta.Component, p processor) *WorkloadMetaCollector {
 	c := &WorkloadMetaCollector{
 		tagProcessor:                      p,
 		store:                             store,
@@ -194,6 +193,11 @@ func NewWorkloadMetaCollector(_ context.Context, cfg config.Component, store wor
 	// kubernetes resources metadata as tags
 	metadataAsTags := configutils.GetMetadataAsTags(cfg)
 	c.initK8sResourcesMetaAsTags(metadataAsTags.GetResourcesLabelsAsTags(), metadataAsTags.GetResourcesAnnotationsAsTags())
+
+	// initialize static global tags
+	if p != nil {
+		c.collectStaticGlobalTags(ctx, cfg)
+	}
 
 	return c
 }

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -123,7 +123,7 @@ func NewComponent(req Requires) (Provides, error) {
 
 		// Start the TagStore and the WorkloadMeta collector.
 		go taggerInstance.tagStore.Run(taggerInstance.ctx)
-		go taggerInstance.collector.Run(taggerInstance.ctx, taggerInstance.cfg)
+		go taggerInstance.collector.Run(taggerInstance.ctx)
 
 		return nil
 	}})

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -525,7 +525,6 @@ func TestPatchConfiguration(t *testing.T) {
 	initialDigest := checkConfig.Digest()
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
-	fakeTagger.SetGlobalTags([]string{"kube_cluster_name:testing"}, []string{}, []string{}, []string{})
 
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("cluster_name", "testing")
@@ -565,7 +564,6 @@ func TestPatchEndpointsConfiguration(t *testing.T) {
 	}
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
-	fakeTagger.SetGlobalTags([]string{"kube_cluster_name:testing"}, []string{}, []string{}, []string{})
 
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("cluster_name", "testing")
@@ -597,12 +595,12 @@ func TestExtraTags(t *testing.T) {
 		tagNameConfig     string
 		expected          []string
 	}{
-		{nil, "testing", "cluster_name", []string{"cluster_name:testing"}},
-		{nil, "mycluster", "custom_name", []string{"custom_name:mycluster"}},
+		{nil, "testing", "cluster_name", []string{"cluster_name:testing", "kube_cluster_name:testing"}},
+		{nil, "mycluster", "custom_name", []string{"custom_name:mycluster", "kube_cluster_name:mycluster"}},
 		{nil, "", "cluster_name", []string{}},
-		{nil, "testing", "", []string{}},
+		{nil, "testing", "", []string{"kube_cluster_name:testing"}},
 		{[]string{"one", "two"}, "", "", []string{"one", "two"}},
-		{[]string{"one", "two"}, "mycluster", "custom_name", []string{"one", "two", "custom_name:mycluster"}},
+		{[]string{"one", "two"}, "mycluster", "custom_name", []string{"one", "two", "custom_name:mycluster", "kube_cluster_name:mycluster"}},
 	} {
 		t.Run("", func(t *testing.T) {
 			fakeTagger := taggerfxmock.SetupFakeTagger(t)

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -16,7 +16,6 @@ import (
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -91,7 +90,6 @@ func GetStaticTags(ctx context.Context, datadogConfig config.Component) map[stri
 // GetClusterAgentStaticTags is similar to GetStaticTags, but returning a map[string][]string containing
 // <key>:<value> pairs for all global environment tags on the cluster agent. This includes:
 // DD_TAGS, DD_EXTRA_TAGS, DD_CLUSTER_CHECKS_EXTRA_TAGS, DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
-// and other cluster level tags like orch_cluster_id, cluster_name, etc.
 func GetClusterAgentStaticTags(config config.Reader) map[string][]string {
 	if flavor.GetFlavor() != flavor.ClusterAgent {
 		return nil
@@ -102,19 +100,6 @@ func GetClusterAgentStaticTags(config config.Reader) map[string][]string {
 
 	// DD_CLUSTER_CHECKS_EXTRA_TAGS / DD_ORCHESTRATOR_EXPLORER_EXTRA_TAGS
 	tags = append(tags, configUtils.GetConfiguredDCATags(config)...)
-
-	// ORCH_CLUSTER_ID
-	clusterIDValue, _ := clustername.GetClusterID()
-	if clusterIDValue != "" {
-		tags = append(tags, taggertags.OrchClusterID+":"+clusterIDValue)
-	}
-
-	// KUBE_CLUSTER_NAME
-	hname, _ := hostname.Get(context.TODO())
-	clusterTagValue := clustername.GetClusterName(context.TODO(), hname)
-	if clusterTagValue != "" {
-		tags = append(tags, taggertags.KubeClusterName+":"+clusterTagValue)
-	}
 
 	if tags == nil {
 		return nil

--- a/pkg/util/tags/static_tags_test.go
+++ b/pkg/util/tags/static_tags_test.go
@@ -105,15 +105,6 @@ func TestClusterAgentGlobalTags(t *testing.T) {
 	mockConfig.SetWithoutSource("cluster_checks.extra_tags", []string{"cluster:tag", "nocolon"})
 	mockConfig.SetWithoutSource("orchestrator_explorer.extra_tags", []string{"orch:tag", "missingcolon"})
 
-	// Custom cluster name tag
-	clusterName := "custom-name"
-	mockConfig.SetWithoutSource("hostname", "hostname-from-configuration")
-	mockConfig.SetWithoutSource("cluster_name", clusterName)
-
-	// Orch cluster ID tag
-	clusterID := "d801b2b1-4811-11ea-8618-121d4d0938a3"
-	t.Setenv("DD_ORCHESTRATOR_CLUSTER_ID", clusterID)
-
 	recordFlavor := flavor.GetFlavor()
 	defer func() {
 		flavor.SetFlavor(recordFlavor)
@@ -129,12 +120,10 @@ func TestClusterAgentGlobalTags(t *testing.T) {
 		flavor.SetFlavor(flavor.ClusterAgent)
 		globalTags := GetClusterAgentStaticTags(mockConfig)
 		assert.Equal(t, map[string][]string{
-			"some":              {"tag"},
-			"extra":             {"tag"},
-			"cluster":           {"tag"},
-			"orch":              {"tag"},
-			"orch_cluster_id":   {clusterID},
-			"kube_cluster_name": {clusterName},
+			"some":    {"tag"},
+			"extra":   {"tag"},
+			"cluster": {"tag"},
+			"orch":    {"tag"},
 		}, globalTags)
 	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Migrates the tagger's global tag initialization from taking place in a go routine, to in the workloadmeta collector's initialization stage.
* Revert `orch_cluster_id` and `kube_cluster_name` tag initialization to `dispatcher_main.go`

### Motivation

Solve race condition in the cluster agent's dispatcher which results in missing global tags in dispatched checks. 

[CONTP-910]

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit Tests and CI

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Could make sense to completely remove this logic from the workloadmeta collector entirely and make it part of the `newLocalTagger`. Would need more context if there's any other reason why it is located in the wmeta collector in the first place.

Additionally, suspect issues with the initialization order of the `orch_cluster_id`. It gets created in the cluster-agent's `command.go` function. It's possible the tagger's initialization occurs beforehand which causes the tag value to be missing.

[CONTP-910]: https://datadoghq.atlassian.net/browse/CONTP-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ