### PR TITLE
feat: add new service discovery payload data

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -136,14 +136,12 @@ func GetFxOptions() fx.Option {
 
 // isProcessCollectionEnabled returns a boolean indicating if the process collector is enabled
 func (c *collector) isProcessCollectionEnabled() bool {
-	return c.config.GetBool("process_config.process_collection.enabled") &&
-		// TODO: process_config.process_collection.use_wlm is temporary and will eventually be removed
-		c.config.GetBool("process_config.process_collection.use_wlm")
+	return c.config.GetBool("process_config.process_collection.enabled")
 }
 
 // isServiceDiscoveryEnabled returns a boolean indicating if service discovery is enabled
 func (c *collector) isServiceDiscoveryEnabled() bool {
-	return c.systemProbeConfig.GetBool("system_probe_config.enabled") && c.systemProbeConfig.GetBool("discovery.enabled")
+	return c.systemProbeConfig.GetBool("discovery.enabled")
 }
 
 // isLanguageCollectionEnabled returns a boolean indicating if language collection is enabled
@@ -161,7 +159,10 @@ func (c *collector) collectionIntervalConfig() time.Duration {
 // is done. It also gets a reference to the store that started it so it
 // can use Notify, or get access to other entities in the store.
 func (c *collector) Start(ctx context.Context, store workloadmeta.Component) error {
-	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
+	// TODO: process_config.process_collection.use_wlm is temporary and will eventually be removed
+	// we want to gate everything for this new collector by the use_wlm config, but eventually
+	// this collector will be gated separately for process_collector OR service discovery
+	if !c.config.GetBool("process_config.process_collection.use_wlm") && !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
 		return errors.NewDisabled(componentName, "process collection and service discovery are disabled")
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -162,8 +162,12 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	// TODO: process_config.process_collection.use_wlm is temporary and will eventually be removed
 	// we want to gate everything for this new collector by the use_wlm config, but eventually
 	// this collector will be gated separately for process_collector OR service discovery
-	if !c.config.GetBool("process_config.process_collection.use_wlm") && !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
-		return errors.NewDisabled(componentName, "process collection and service discovery are disabled")
+	if !c.config.GetBool("process_config.process_collection.use_wlm") {
+		return errors.NewDisabled(componentName, "wlm process collection disabled")
+	}
+
+	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
+		return errors.NewDisabled(componentName, "wlm process collection and service discovery are disabled")
 	}
 
 	if c.containerProvider == nil {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -136,8 +136,7 @@ func GetFxOptions() fx.Option {
 
 // isProcessCollectionEnabled returns a boolean indicating if the process collector is enabled
 func (c *collector) isProcessCollectionEnabled() bool {
-	return c.config.GetBool("process_config.run_in_core_agent.enabled") &&
-		c.config.GetBool("process_config.process_collection.enabled") &&
+	return c.config.GetBool("process_config.process_collection.enabled") &&
 		// TODO: process_config.process_collection.use_wlm is temporary and will eventually be removed
 		c.config.GetBool("process_config.process_collection.use_wlm")
 }

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -135,13 +135,11 @@ func GetFxOptions() fx.Option {
 }
 
 // isProcessCollectionEnabled returns a boolean indicating if the process collector is enabled
-func (c *collector) isRunningInCoreAgent() bool {
-	return c.config.GetBool("process_config.run_in_core_agent.enabled")
-}
-
-// isProcessCollectionEnabled returns a boolean indicating if the process collector is enabled
 func (c *collector) isProcessCollectionEnabled() bool {
-	return c.config.GetBool("process_config.process_collection.use_wlm")
+	return c.config.GetBool("process_config.run_in_core_agent.enabled") &&
+		c.config.GetBool("process_config.process_collection.enabled") &&
+		// TODO: process_config.process_collection.use_wlm is temporary and will eventually be removed
+		c.config.GetBool("process_config.process_collection.use_wlm")
 }
 
 // isServiceDiscoveryEnabled returns a boolean indicating if service discovery is enabled
@@ -164,10 +162,6 @@ func (c *collector) collectionIntervalConfig() time.Duration {
 // is done. It also gets a reference to the store that started it so it
 // can use Notify, or get access to other entities in the store.
 func (c *collector) Start(ctx context.Context, store workloadmeta.Component) error {
-	if !c.isRunningInCoreAgent() {
-		return errors.NewDisabled(componentName, "core process collection not running in core agent")
-	}
-
 	if !c.isProcessCollectionEnabled() && !c.isServiceDiscoveryEnabled() {
 		return errors.NewDisabled(componentName, "process collection and service discovery are disabled")
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -639,6 +639,7 @@ func TestStartConfiguration(t *testing.T) {
 			description: "everything enabled correctly",
 			configOverrides: map[string]interface{}{
 				"process_config.run_in_core_agent.enabled":  true,
+				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": true,
 			},
 			sysConfigOverrides: map[string]interface{}{
@@ -648,21 +649,36 @@ func TestStartConfiguration(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			description: "not running in core agent",
+			description: "service discovery enabled, process collection not running in core agent",
 			configOverrides: map[string]interface{}{
 				"process_config.run_in_core_agent.enabled":  false,
+				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": true,
 			},
 			sysConfigOverrides: map[string]interface{}{
 				"system_probe_config.enabled": true,
 				"discovery.enabled":           true,
 			},
-			expectedError: errors.NewDisabled(componentName, "core process collection not running in core agent"),
+			expectedError: nil,
 		},
 		{
-			description: "only process collection not enabled",
+			description: "service discovery enabled, process collection not enabled",
 			configOverrides: map[string]interface{}{
 				"process_config.run_in_core_agent.enabled":  true,
+				"process_config.process_collection.enabled": false,
+				"process_config.process_collection.use_wlm": true,
+			},
+			sysConfigOverrides: map[string]interface{}{
+				"system_probe_config.enabled": true,
+				"discovery.enabled":           true,
+			},
+			expectedError: nil,
+		},
+		{
+			description: "service discovery enabled, process collection wlm not enabled",
+			configOverrides: map[string]interface{}{
+				"process_config.run_in_core_agent.enabled":  true,
+				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": false,
 			},
 			sysConfigOverrides: map[string]interface{}{
@@ -672,9 +688,23 @@ func TestStartConfiguration(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			description: "only service discovery not enabled",
+			description: "only service discovery enabled",
+			configOverrides: map[string]interface{}{
+				"process_config.run_in_core_agent.enabled":  false,
+				"process_config.process_collection.enabled": false,
+				"process_config.process_collection.use_wlm": false,
+			},
+			sysConfigOverrides: map[string]interface{}{
+				"system_probe_config.enabled": true,
+				"discovery.enabled":           true,
+			},
+			expectedError: nil,
+		},
+		{
+			description: "only process collection enabled",
 			configOverrides: map[string]interface{}{
 				"process_config.run_in_core_agent.enabled":  true,
+				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": true,
 			},
 			sysConfigOverrides: map[string]interface{}{
@@ -686,7 +716,8 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "process collection and service discovery not enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  true,
+				"process_config.run_in_core_agent.enabled":  false,
+				"process_config.process_collection.enabled": false,
 				"process_config.process_collection.use_wlm": false,
 			},
 			sysConfigOverrides: map[string]interface{}{

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -638,7 +638,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "everything enabled correctly",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  true,
 				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": true,
 			},
@@ -649,7 +648,7 @@ func TestStartConfiguration(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			description: "service discovery enabled, process collection not running in core agent",
+			description: "service discovery enabled, process collection not running in core agent but still collecting",
 			configOverrides: map[string]interface{}{
 				"process_config.run_in_core_agent.enabled":  false,
 				"process_config.process_collection.enabled": true,
@@ -664,7 +663,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "service discovery enabled, process collection not enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  true,
 				"process_config.process_collection.enabled": false,
 				"process_config.process_collection.use_wlm": true,
 			},
@@ -677,7 +675,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "service discovery enabled, process collection wlm not enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  true,
 				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": false,
 			},
@@ -690,7 +687,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "only service discovery enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  false,
 				"process_config.process_collection.enabled": false,
 				"process_config.process_collection.use_wlm": false,
 			},
@@ -703,7 +699,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "only process collection enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  true,
 				"process_config.process_collection.enabled": true,
 				"process_config.process_collection.use_wlm": true,
 			},
@@ -716,7 +711,6 @@ func TestStartConfiguration(t *testing.T) {
 		{
 			description: "process collection and service discovery not enabled",
 			configOverrides: map[string]interface{}{
-				"process_config.run_in_core_agent.enabled":  false,
 				"process_config.process_collection.enabled": false,
 				"process_config.process_collection.use_wlm": false,
 			},

--- a/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector.go
@@ -77,6 +77,10 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 		return errors.NewDisabled(componentName, "language detection or core agent process collection is disabled")
 	}
 
+	if pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm") {
+		return errors.NewDisabled(componentName, "replacement process collector with language detection is active")
+	}
+
 	c.store = store
 
 	// If process collection is disabled, the collector will gather the basic process and container data

--- a/comp/process/processcheck/processcheckimpl/check_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_test.go
@@ -32,9 +32,10 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 		enabled         bool
 	}{
 		{
-			name: "enabled: collection enabled, discovery enabled",
+			name: "check enabled: collection enabled, discovery enabled",
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled": true,
+				"process_config.process_collection.use_wlm": true, // temporarily used to gate discovery check
 			},
 			sysProbeConfigs: map[string]interface{}{
 				"discovery.enabled": true,
@@ -42,9 +43,10 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 			enabled: true,
 		},
 		{
-			name: "enabled: collection enabled, discovery disabled",
+			name: "check enabled: collection enabled, discovery disabled",
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled": true,
+				"process_config.process_collection.use_wlm": false, // temporarily used to gate discovery check
 			},
 			sysProbeConfigs: map[string]interface{}{
 				"discovery.enabled": false,
@@ -52,9 +54,10 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 			enabled: true,
 		},
 		{
-			name: "enabled: collection disabled, discovery enabled",
+			name: "check enabled: collection disabled, discovery enabled",
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled": false,
+				"process_config.process_collection.use_wlm": true, // temporarily used to gate discovery check
 			},
 			sysProbeConfigs: map[string]interface{}{
 				"discovery.enabled": true,
@@ -62,9 +65,21 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 			enabled: true,
 		},
 		{
-			name: "disabled: collection disabled, discovery disabled",
+			name: "check disabled: collection disabled, discovery enabled but use_wlm disabled",
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled": false,
+				"process_config.process_collection.use_wlm": false, // temporarily used to gate discovery check
+			},
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": true,
+			},
+			enabled: false,
+		},
+		{
+			name: "check disabled: collection disabled, discovery disabled",
+			configs: map[string]interface{}{
+				"process_config.process_collection.enabled": false,
+				"process_config.process_collection.use_wlm": false, // temporarily used to gate discovery check
 			},
 			sysProbeConfigs: map[string]interface{}{
 				"discovery.enabled": false,

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -71,7 +71,12 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, instance
 	if newOSImpl == nil {
 		return errors.New("service_discovery check not implemented on " + runtime.GOOS)
 	}
-	if !pkgconfigsetup.SystemProbe().GetBool("discovery.enabled") {
+	// we want to disable the old discovery check when the new one is enabled via the temporary config process_config.process_collection.use_wlm
+	// discovery False + use_wlm True = true = disabled
+	// discovery False + use_wlm false = true = disabled
+	// discovery true + use_wlm True = true = disabled (new check running)
+	// discovery true + use_wlm false = false = enabled (old check running)
+	if !pkgconfigsetup.SystemProbe().GetBool("discovery.enabled") && pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm") {
 		return errors.New("service discovery is disabled")
 	}
 	if err := c.CommonConfigure(senderManager, initConfig, instanceConfig, source); err != nil {

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -76,7 +76,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, instance
 	// discovery False + use_wlm false = true = disabled
 	// discovery true + use_wlm True = true = disabled (new check running)
 	// discovery true + use_wlm false = false = enabled (old check running)
-	if !pkgconfigsetup.SystemProbe().GetBool("discovery.enabled") && pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm") {
+	if !pkgconfigsetup.SystemProbe().GetBool("discovery.enabled") || pkgconfigsetup.Datadog().GetBool("process_config.process_collection.use_wlm") {
 		return errors.New("service discovery is disabled")
 	}
 	if err := c.CommonConfigure(senderManager, initConfig, instanceConfig, source); err != nil {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -494,7 +494,6 @@ func fmtProcesses(
 
 		// Hide disallow-listed args if the Scrubber is enabled
 		fp.Cmdline = scrubber.ScrubProcessCommand(fp)
-
 		proc := &model.Process{
 			Pid:                    fp.Pid,
 			NsPid:                  fp.NsPid,

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -184,7 +184,7 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo, oneShot bool
 
 	p.extractors = append(p.extractors, p.serviceExtractor)
 
-	if !oneShot && workloadmeta.Enabled(p.config) {
+	if !oneShot && workloadmeta.Enabled(p.config) && !p.useWLMCollection() {
 		p.workloadMetaExtractor = workloadmeta.GetSharedWorkloadMetaExtractor(pkgconfigsetup.SystemProbe())
 
 		// The server is only needed on the process agent
@@ -245,7 +245,7 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 		return nil, errEmptyCPUTime
 	}
 
-	procs, err := p.processesByPID(true)
+	procs, err := p.processesByPID()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -492,11 +492,6 @@ func fmtProcesses(
 		// Hide disallow-listed args if the Scrubber is enabled
 		fp.Cmdline = scrubber.ScrubProcessCommand(fp)
 
-		// service info will be nil for non-linux platforms so safely access/assign portinfo
-		var ports []uint16
-		if fp.Service != nil {
-			ports = fp.Service.Ports
-		}
 		proc := &model.Process{
 			Pid:                    fp.Pid,
 			NsPid:                  fp.NsPid,
@@ -513,7 +508,7 @@ func fmtProcesses(
 			ContainerId:            ctrByProc[int(fp.Pid)],
 			ProcessContext:         serviceExtractor.GetServiceContext(fp.Pid),
 			// SERVICE DISCOVERY FIELDS
-			PortInfo:         formatPorts(ports),                 // only populated if service discovery is enabled + linux
+			PortInfo:         formatPorts(fp.Ports),              // only populated if service discovery is enabled + linux
 			Language:         formatLanguage(fp.Language),        // only populated if language detection is enabled + linux
 			ServiceDiscovery: formatServiceDiscovery(fp.Service), // only populated if service discovery is enabled + linux
 		}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -491,6 +491,12 @@ func fmtProcesses(
 
 		// Hide disallow-listed args if the Scrubber is enabled
 		fp.Cmdline = scrubber.ScrubProcessCommand(fp)
+
+		// service info will be nil for non-linux platforms so safely access/assign portinfo
+		var ports []uint16
+		if fp.Service != nil {
+			ports = fp.Service.Ports
+		}
 		proc := &model.Process{
 			Pid:                    fp.Pid,
 			NsPid:                  fp.NsPid,
@@ -506,6 +512,10 @@ func fmtProcesses(
 			InvoluntaryCtxSwitches: uint64(fp.Stats.CtxSwitches.Involuntary),
 			ContainerId:            ctrByProc[int(fp.Pid)],
 			ProcessContext:         serviceExtractor.GetServiceContext(fp.Pid),
+			// SERVICE DISCOVERY FIELDS
+			PortInfo:         formatPorts(ports),                 // only populated if service discovery is enabled + linux
+			Language:         formatLanguage(fp.Language),        // only populated if language detection is enabled + linux
+			ServiceDiscovery: formatServiceDiscovery(fp.Service), // only populated if service discovery is enabled + linux
 		}
 
 		if tags, ok := pidToGPUTags[fp.Pid]; ok {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -214,7 +214,9 @@ func (p *ProcessCheck) IsEnabled() bool {
 		return false
 	}
 
-	return p.config.GetBool("process_config.process_collection.enabled") || p.sysConfig.GetBool("discovery.enabled")
+	// we want the check to be run for process collection or when the new service discovery collection is enabled
+	return p.config.GetBool("process_config.process_collection.enabled") ||
+		(p.sysConfig.GetBool("discovery.enabled") && p.config.GetBool("process_config.process_collection.use_wlm"))
 }
 
 // SupportsRunOptions returns true if the check supports RunOptions

--- a/pkg/process/checks/process_fallback.go
+++ b/pkg/process/checks/process_fallback.go
@@ -23,8 +23,8 @@ func (p *ProcessCheck) useWLMCollection() bool {
 
 // processesByPID returns the processes by pid from the process probe for non-linux platforms
 // because the workload meta process collection is only available on linux
-func (p *ProcessCheck) processesByPID(collectStats bool) (map[int32]*procutil.Process, error) {
-	procs, err := p.probe.ProcessesByPID(p.clock.Now(), collectStats)
+func (p *ProcessCheck) processesByPID() (map[int32]*procutil.Process, error) {
+	procs, err := p.probe.ProcessesByPID(p.clock.Now(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/checks/process_fallback.go
+++ b/pkg/process/checks/process_fallback.go
@@ -8,6 +8,8 @@
 package checks
 
 import (
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -27,4 +29,19 @@ func (p *ProcessCheck) processesByPID(collectStats bool) (map[int32]*procutil.Pr
 		return nil, err
 	}
 	return procs, nil
+}
+
+// formatPorts is a stub for non-linux platforms
+func formatPorts(_ []uint16) *model.PortInfo {
+	return nil
+}
+
+// formatLanguage is a stub for non-linux platforms
+func formatLanguage(_ *languagemodels.Language) model.Language {
+	return model.Language_LANGUAGE_UNKNOWN
+}
+
+// formatServiceDiscovery is a stub for non-linux platforms
+func formatServiceDiscovery(_ *procutil.Service) *model.ServiceDiscovery {
+	return nil
 }

--- a/pkg/process/checks/process_fallback_test.go
+++ b/pkg/process/checks/process_fallback_test.go
@@ -47,7 +47,7 @@ func TestProcessByPID(t *testing.T) {
 			mockProbe.EXPECT().ProcessesByPID(mockConstantClock.Now(), mock.Anything).Return(nil, nil).Once()
 			// TESTING
 			// collectStats is irrelevant since it should not impact which functions are called
-			_, err := processCheck.processesByPID(true)
+			_, err := processCheck.processesByPID()
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -52,7 +52,7 @@ var serviceNameSourceMap = map[string]model.ServiceNameSource{
 // useWLMCollection checks the configuration to use the workloadmeta process collector or not in linux
 // TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 func (p *ProcessCheck) useWLMCollection() bool {
-	return p.config.GetBool("process_config.run_in_core_agent.enabled") && p.config.GetBool("process_config.process_collection.use_wlm")
+	return p.config.GetBool("process_config.process_collection.use_wlm")
 }
 
 // processesByPID returns the processes by pid from different sources depending on the configuration (process probe or workloadmeta)

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -73,7 +73,13 @@ func (p *ProcessCheck) processesByPID() (map[int32]*procutil.Process, error) {
 		// map to common process type used by other versions of the check
 		procs := make(map[int32]*procutil.Process, len(wlmProcList))
 		for _, wlmProc := range wlmProcList {
-			procs[wlmProc.Pid] = mapWLMProcToProc(wlmProc, statsForProcess[wlmProc.Pid])
+			stats, exists := statsForProcess[wlmProc.Pid]
+			// we need to check if the stats exist because there can be a lag between when a process is stored into WLM and when we query for its stats
+			// ex. a process is stopped but still exists in WLM, so the stats don't exist, and we shouldn't report it anymore
+			if !exists {
+				continue
+			}
+			procs[wlmProc.Pid] = mapWLMProcToProc(wlmProc, stats)
 		}
 		return procs, nil
 	}

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -79,7 +79,7 @@ func (p *ProcessCheck) processesByPID() (map[int32]*procutil.Process, error) {
 			// we also want to verify that the stats are from the same collected process and not just the same PID coincidence by checking the start time
 			// ex. a process is stopped but still exists in WLM, so the stats don't exist, and we shouldn't report it anymore,
 			// additionally a new process with the same pid could spin up in between wlm collection and stat collection
-			if !exists || (stats.CreateTime != wlmProc.CreationTime.Unix()) {
+			if !exists || (stats.CreateTime != wlmProc.CreationTime.UnixMilli()) {
 				log.Debugf("stats do not exist for dead process %v - skipping", wlmProc.Pid)
 				continue
 			}

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -57,7 +57,7 @@ func (p *ProcessCheck) useWLMCollection() bool {
 
 // processesByPID returns the processes by pid from different sources depending on the configuration (process probe or workloadmeta)
 // workload meta process collection is only available on linux and TODO: will eventually be the only source for linux process collection
-func (p *ProcessCheck) processesByPID(collectStats bool) (map[int32]*procutil.Process, error) {
+func (p *ProcessCheck) processesByPID() (map[int32]*procutil.Process, error) {
 	if p.useWLMProcessCollection {
 		wlmProcList := p.wmeta.ListProcesses()
 		pids := make([]int32, len(wlmProcList))
@@ -65,13 +65,9 @@ func (p *ProcessCheck) processesByPID(collectStats bool) (map[int32]*procutil.Pr
 			pids[i] = wlmProc.Pid
 		}
 
-		statsForProcess := make(map[int32]*procutil.Stats)
-		if collectStats {
-			var err error
-			statsForProcess, err = p.probe.StatsForPIDs(pids, p.clock.Now())
-			if err != nil {
-				return nil, err
-			}
+		statsForProcess, err := p.probe.StatsForPIDs(pids, p.clock.Now())
+		if err != nil {
+			return nil, err
 		}
 
 		// map to common process type used by other versions of the check
@@ -81,7 +77,7 @@ func (p *ProcessCheck) processesByPID(collectStats bool) (map[int32]*procutil.Pr
 		}
 		return procs, nil
 	}
-	procs, err := p.probe.ProcessesByPID(p.clock.Now(), collectStats)
+	procs, err := p.probe.ProcessesByPID(p.clock.Now(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/checks/process_linux.go
+++ b/pkg/process/checks/process_linux.go
@@ -52,7 +52,7 @@ var serviceNameSourceMap = map[string]model.ServiceNameSource{
 // useWLMCollection checks the configuration to use the workloadmeta process collector or not in linux
 // TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 func (p *ProcessCheck) useWLMCollection() bool {
-	return p.config.GetBool("process_config.process_collection.use_wlm")
+	return p.config.GetBool("process_config.run_in_core_agent.enabled") && p.config.GetBool("process_config.process_collection.use_wlm")
 }
 
 // processesByPID returns the processes by pid from different sources depending on the configuration (process probe or workloadmeta)

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -140,6 +140,7 @@ func TestFormatLanguage(t *testing.T) {
 			language: &languagemodels.Language{
 				Name: languagemodels.Go,
 			},
+			expectedLanguage: model.Language_LANGUAGE_GO,
 		},
 		{
 			description: "node",
@@ -305,11 +306,15 @@ func TestFormatServiceDiscovery(t *testing.T) {
 				APMInstrumentation: "provided",
 			},
 			expectedService: &model.ServiceDiscovery{
-				ServiceNames: []*model.ServiceName{
-					{
-						Name:   "gen_name",
-						Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
-					},
+				GeneratedServiceName: &model.ServiceName{
+					Name:   "gen_name",
+					Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
+				},
+				DdServiceName: &model.ServiceName{
+					Name:   "dd_service_name",
+					Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_DD_SERVICE,
+				},
+				AdditionalGeneratedNames: []*model.ServiceName{
 					{
 						Name:   "additional_name1",
 						Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
@@ -317,10 +322,6 @@ func TestFormatServiceDiscovery(t *testing.T) {
 					{
 						Name:   "additional_name2",
 						Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_UNKNOWN,
-					},
-					{
-						Name:   "dd_service_name",
-						Source: model.ServiceNameSource_SERVICE_NAME_SOURCE_DD_SERVICE,
 					},
 				},
 				TracerMetadata: []*model.TracerMetadata{
@@ -334,6 +335,22 @@ func TestFormatServiceDiscovery(t *testing.T) {
 					},
 				},
 				ApmInstrumentation: true,
+			},
+		},
+		{
+			description: "empty service names",
+			service: &procutil.Service{
+				GeneratedName:            "",
+				GeneratedNameSource:      "",
+				AdditionalGeneratedNames: []string{"", ""},
+				DDService:                "",
+				APMInstrumentation:       "none",
+			},
+			expectedService: &model.ServiceDiscovery{
+				GeneratedServiceName:     nil,
+				DdServiceName:            nil,
+				AdditionalGeneratedNames: nil,
+				ApmInstrumentation:       false,
 			},
 		},
 		{

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -38,12 +38,7 @@ func TestProcessesByPIDWLM(t *testing.T) {
 		collectStats bool
 	}{
 		{
-			description:  "wlm collection ENABLED, with stats ENABLED",
-			collectStats: true,
-		},
-		{
-			description:  "wlm collection ENABLED, with stats DISABLED",
-			collectStats: false,
+			description: "normal wlm collection",
 		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
@@ -73,11 +68,10 @@ func TestProcessesByPIDWLM(t *testing.T) {
 			for _, p := range procs {
 				mockWLM.Set(p)
 			}
-			if tc.collectStats {
-				// elevatedPermissions is irrelevant since we are mocking the probe so no internal logic is tested
-				statsByPid = createTestWLMProcessStats([]*wmdef.Process{proc1, proc2, proc3, proc4}, true)
-				mockProbe.EXPECT().StatsForPIDs(mock.Anything, mockConstantClock.Now()).Return(statsByPid, nil).Once()
-			}
+
+			// elevatedPermissions is irrelevant since we are mocking the probe so no internal logic is tested
+			statsByPid = createTestWLMProcessStats([]*wmdef.Process{proc1, proc2, proc3, proc4}, true)
+			mockProbe.EXPECT().StatsForPIDs(mock.Anything, mockConstantClock.Now()).Return(statsByPid, nil).Once()
 
 			// EXPECTED
 			expected := map[int32]*procutil.Process{
@@ -88,7 +82,7 @@ func TestProcessesByPIDWLM(t *testing.T) {
 			}
 
 			// TESTING
-			actual, err := processCheck.processesByPID(tc.collectStats)
+			actual, err := processCheck.processesByPID()
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
 		})

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -34,12 +34,12 @@ import (
 // TestProcessesByPIDWLM tests processesByPID map creation when WLM collection is ON
 func TestProcessesByPIDWLM(t *testing.T) {
 	mockConstantClock := constantMockClock(time.Now())
-	nowSeconds := mockConstantClock.Now().UnixMilli()
+	nowMs := mockConstantClock.Now().UnixMilli()
 	// TEST DATA 1
-	proc1 := wlmProcessWithCreateTime(1, "git clone google.com", nowSeconds)
-	proc2 := wlmProcessWithCreateTime(2, "mine-bitcoins -all -x", nowSeconds-1)
-	proc3 := wlmProcessWithCreateTime(3, "datadog-agent --cfgpath datadog.conf", nowSeconds+2)
-	proc4 := wlmProcessWithServiceDiscovery(4, "/bin/bash/usr/local/bin/cilium-agent-bpf-map-metrics.sh", nowSeconds-3)
+	proc1 := wlmProcessWithCreateTime(1, "git clone google.com", nowMs)
+	proc2 := wlmProcessWithCreateTime(2, "mine-bitcoins -all -x", nowMs-1)
+	proc3 := wlmProcessWithCreateTime(3, "datadog-agent --cfgpath datadog.conf", nowMs+2)
+	proc4 := wlmProcessWithServiceDiscovery(4, "/bin/bash/usr/local/bin/cilium-agent-bpf-map-metrics.sh", nowMs-3)
 	wlmProcesses := []*wmdef.Process{proc1, proc2, proc3, proc4}
 	statsByPid := createTestWLMProcessStats([]*wmdef.Process{proc1, proc2, proc3, proc4}, true)
 	expected1 := map[int32]*procutil.Process{
@@ -58,7 +58,7 @@ func TestProcessesByPIDWLM(t *testing.T) {
 	}
 
 	// TEST DATA 3
-	newProc1 := wlmProcessWithCreateTime(1, "git clone google.com", nowSeconds+10)
+	newProc1 := wlmProcessWithCreateTime(1, "git clone google.com", nowMs+10)
 	statsByPidNewProc1 := createTestWLMProcessStats([]*wmdef.Process{newProc1, proc2, proc3, proc4}, true)
 	expected3 := map[int32]*procutil.Process{
 		proc2.Pid: mapWLMProcToProc(proc2, statsByPidNewProc1[proc2.Pid]),
@@ -432,7 +432,7 @@ func wlmProcessWithServiceDiscovery(pid int32, spaceSeparatedCmdline string, cre
 func createTestWLMProcessStats(wlmProcs []*wmdef.Process, elevatedPermissions bool) map[int32]*procutil.Stats {
 	statsByPid := make(map[int32]*procutil.Stats, len(wlmProcs))
 	for _, wlmProc := range wlmProcs {
-		statsByPid[wlmProc.Pid] = randomProcessStats(wlmProc.CreationTime.Unix(), elevatedPermissions)
+		statsByPid[wlmProc.Pid] = randomProcessStats(wlmProc.CreationTime.UnixMilli(), elevatedPermissions)
 	}
 	return statsByPid
 }

--- a/pkg/process/checks/process_linux_test.go
+++ b/pkg/process/checks/process_linux_test.go
@@ -64,13 +64,12 @@ func TestProcessesByPIDWLM(t *testing.T) {
 			proc3 := wlmProcessWithCreateTime(3, "datadog-agent --cfgpath datadog.conf", nowSeconds+2)
 			proc4 := wlmProcessWithServiceDiscovery(4, "/bin/bash/usr/local/bin/cilium-agent-bpf-map-metrics.sh", nowSeconds-3)
 			procs := []*wmdef.Process{proc1, proc2, proc3, proc4}
-			statsByPid := make(map[int32]*procutil.Stats)
 			for _, p := range procs {
 				mockWLM.Set(p)
 			}
 
 			// elevatedPermissions is irrelevant since we are mocking the probe so no internal logic is tested
-			statsByPid = createTestWLMProcessStats([]*wmdef.Process{proc1, proc2, proc3, proc4}, true)
+			statsByPid := createTestWLMProcessStats([]*wmdef.Process{proc1, proc2, proc3, proc4}, true)
 			mockProbe.EXPECT().StatsForPIDs(mock.Anything, mockConstantClock.Now()).Return(statsByPid, nil).Once()
 
 			// EXPECTED

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -83,7 +83,7 @@ func (p *Process) DeepCopy() *Process {
 
 // Stats holds all relevant stats metrics of a process
 type Stats struct {
-	CreateTime int64
+	CreateTime int64 // milliseconds
 	// Status returns the process status. https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
 	// Supported return values:
 	// U: unknown state

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -6,6 +6,8 @@
 package procutil
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/gopsutil/cpu"
 	// using process.FilledProcess
 	"github.com/DataDog/gopsutil/process"
@@ -24,8 +26,10 @@ type Process struct {
 	Username string // (Windows only)
 	Uids     []int32
 	Gids     []int32
+	Language *languagemodels.Language
 
-	Stats *Stats
+	Stats   *Stats
+	Service *Service
 }
 
 //nolint:revive // TODO(PROC) Fix revive linter
@@ -97,6 +101,30 @@ type Stats struct {
 	IOStat      *IOCountersStat
 	IORateStat  *IOCountersRateStat
 	CtxSwitches *NumCtxSwitchesStat
+}
+
+// Service holds service discovery data for a process
+type Service struct {
+	// GeneratedName is the name generated from the process info
+	GeneratedName string
+
+	// GeneratedNameSource indicates the source of the generated name
+	GeneratedNameSource string
+
+	// AdditionalGeneratedNames contains other potential names for the service
+	AdditionalGeneratedNames []string
+
+	// TracerMetadata contains APM tracer metadata
+	TracerMetadata []tracermetadata.TracerMetadata
+
+	// DDService is the value from DD_SERVICE environment variable
+	DDService string
+
+	// Ports is the list of ports the service is listening on
+	Ports []uint16
+
+	// APMInstrumentation indicates the APM instrumentation status
+	APMInstrumentation string
 }
 
 // DeepCopy creates a deep copy of Stats

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -28,6 +28,10 @@ type Process struct {
 	Gids     []int32
 	Language *languagemodels.Language
 
+	// ports are stored on the process because they may/should be collected by default in the future
+	// however, currently this data is collected by service discovery collection
+	Ports []uint16
+
 	Stats   *Stats
 	Service *Service
 }
@@ -119,9 +123,6 @@ type Service struct {
 
 	// DDService is the value from DD_SERVICE environment variable
 	DDService string
-
-	// Ports is the list of ports the service is listening on
-	Ports []uint16
 
 	// APMInstrumentation indicates the APM instrumentation status
 	APMInstrumentation string


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Updates **process check** to include service discovery data for linux only
- config changes
  - process check
      - `IsEnabled()` considers service discovery process probe configuration `discovery.enabled` because we want the check to continue to submit service discovery data even when process collection is disabled
  - process collector
      - `isProcessCollectionEnabled()` now considers
          - `process_config.process_collection.enabled`
      - `isServiceDiscoveryEnabled()` removes hardcoded disabling of service discovery collection to now consider
          - `discovery.enabled`
  - discovery check is disabled when `process_config.process_collection.use_wlm` is enabled (since we don't both duplicate discovery data being sent and this makes it easier to compare)
        
## Phase 1 Configuration
<img width="4242" height="4222" alt="image" src="https://github.com/user-attachments/assets/184831ab-8cd9-4857-b06a-18fa110f03c4" />

## Phase 2 Temporary Config `use_wlm` removal + old service discovery check removal
<img width="4374" height="2570" alt="image" src="https://github.com/user-attachments/assets/6acb368c-1b30-45a9-be6f-dd6472298e74" />

### Motivation
- as part of the processes + service discovery consolidation, we are finally sending the new service discovery data to the backend via the process check. RFC - https://datadoghq.atlassian.net/wiki/spaces/cxg/pages/5013111768/RFC+Processes+and+Service+Discovery+Agent+Consolidation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- adds a unit test for the wlm implementation of `ProcessesByPID` that includes service discovery data
- adds a unit test for process collector configuration
- adds unit tests for process check data formatting
- run on ubuntu 24 vm and demonstrated that nginx shows service discovery data by viewing `sudo datadog-agent workload-list`

<img width="714" height="475" alt="image" src="https://github.com/user-attachments/assets/c4875765-0d00-4659-981d-f526b8b5f49b" />


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->