### PR TITLE
dyninst/uploader: always send probeVersion

### DIFF
--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -73,7 +73,7 @@ type Diagnostic struct {
 	RuntimeID    string `json:"runtimeId"`
 	ProbeID      string `json:"probeId"`
 	Status       Status `json:"status"`
-	ProbeVersion int    `json:"probeVersion,omitempty"`
+	ProbeVersion int    `json:"probeVersion"`
 
 	*DiagnosticException `json:"exception,omitempty"`
 }


### PR DESCRIPTION
The system-tests didn't like that we omitted the probe version even when it's 0.

Relates to [DEBUG-3904](https://datadoghq.atlassian.net/browse/DEBUG-3904)

[DEBUG-3904]: https://datadoghq.atlassian.net/browse/DEBUG-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ