### PR TITLE
Use the same version of `dda` as builds across CI

### DIFF
--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -16,7 +16,8 @@ runs:
   - name: Set version
     id: set-version
     run: |-
-      buildimages_commit="$(python -c "from pathlib import Path;import yaml;print(yaml.safe_load(Path('.gitlab-ci.yml').read_text().replace('!reference', 'reference'))['variables']['CI_IMAGE_LINUX'].split('-')[1])")"
+      buildimages_version="$(yq '.variables.CI_IMAGE_LINUX' .gitlab-ci.yml)"
+      buildimages_commit="${buildimages_version#*-}"
       version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
       echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Set version
     id: set-version
     run: |-
-      buildimages_commit="$(python -c "from pathlib import Path;print(Path('.gitlab-ci.yml').read_text().split('CI_IMAGE_LINUX_GLIBC_2_23_ARM64:')[1].split()[0].split('-')[1])")"
+      buildimages_commit="$(python -c "from pathlib import Path;import yaml;print(yaml.safe_load(Path('.gitlab-ci.yml').read_text().replace('!reference', 'reference'))['variables']['CI_IMAGE_LINUX_GLIBC_2_23_ARM64'].split('-')[1])")"
       version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
       echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -16,7 +16,7 @@ runs:
   - name: Set version
     id: set-version
     run: |-
-      buildimages_commit="$(python -c "from pathlib import Path;import yaml;print(yaml.safe_load(Path('.gitlab-ci.yml').read_text().replace('!reference', 'reference'))['variables']['CI_IMAGE_LINUX_GLIBC_2_23_ARM64'].split('-')[1])")"
+      buildimages_commit="$(python -c "from pathlib import Path;import yaml;print(yaml.safe_load(Path('.gitlab-ci.yml').read_text().replace('!reference', 'reference'))['variables']['CI_IMAGE_LINUX'].split('-')[1])")"
       version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
       echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash

--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -15,11 +15,14 @@ runs:
   steps:
   - name: Set version
     id: set-version
-    run: echo "version=$(cat .dda/version)" >> $GITHUB_OUTPUT
+    run: |-
+      buildimages_commit="$(python -c "from pathlib import Path;print(Path('.gitlab-ci.yml').read_text().split('CI_IMAGE_LINUX_GLIBC_2_23_ARM64:')[1].split()[0].split('-')[1])")"
+      version="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${buildimages_commit}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+      echo "version=${version}" >> $GITHUB_OUTPUT
     shell: bash
 
   - name: Install dda
-    uses: DataDog/datadog-agent-dev@1c61de50a7dfef056026a4ba7cad75239b5ab324
+    uses: DataDog/datadog-agent-dev@1bc144c32a57327b768fb7161081b6a25a5c485e
     with:
       version: ${{ inputs.version || steps.set-version.outputs.version }}
       features: ${{ inputs.features }}

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -21,16 +21,15 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Install dependencies
-      # Dependencies are installed at runtime. Otherwise it would create a huge image see https://hub.docker.com/r/pytorch/pytorch/tags
-      run: |
-        pip install --upgrade pip
-        pip install --no-compile --no-cache-dir torch transformers "dda==$(cat .dda/version)"
-        dda self dep sync -f legacy-tasks
+    - name: Install dda
+      uses: ./.github/actions/install-dda
+      with:
+        features: legacy-tasks
     - name: Assign issue
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
-        DDA_NO_DYNAMIC_DEPS: "1"
-      run: |
-        dda inv -- -e issue.assign-owner -i ${{ github.event.issue.number }}
+      run: >-
+        dda inv --dep torch --dep transformers
+        --
+        -e issue.assign-owner -i ${{ github.event.issue.number }}

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -21,10 +21,6 @@ test_gitlab_compare_to:
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - !reference [.setup_agent_github_app]
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
     - dda self dep sync -f legacy-tasks
     - dda inv -- pipeline.compare-to-itself
 

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -10,7 +10,9 @@ benchmark:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
-    - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
+    - export BUILDIMAGES_COMMIT="$(python -c "from pathlib import Path;print(Path('.gitlab-ci.yml').read_text().split('CI_IMAGE_LINUX_GLIBC_2_23_ARM64:')[1].split()[0].split('-')[1])")"
+    - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+    - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
     - dda self dep sync -f legacy-tasks
     - ./test/benchmarks/apm_scripts/capture-hardware-software-info.sh
     - ./test/benchmarks/apm_scripts/run-benchmarks.sh

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -10,7 +10,7 @@ benchmark:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
-    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX_GLIBC_2_23_ARM64#*-}"
+    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
     - dda self dep sync -f legacy-tasks

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -10,7 +10,7 @@ benchmark:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/artifacts" && mkdir -p $ARTIFACTS_DIR
-    - export BUILDIMAGES_COMMIT="$(python -c "from pathlib import Path;print(Path('.gitlab-ci.yml').read_text().split('CI_IMAGE_LINUX_GLIBC_2_23_ARM64:')[1].split()[0].split('-')[1])")"
+    - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX_GLIBC_2_23_ARM64#*-}"
     - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
     - pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}"
     - dda self dep sync -f legacy-tasks

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -93,7 +93,7 @@
 
 .install_python_dependencies:
   # Get the commit from the build image variable in the format `vPIPELINE_ID-COMMIT`
-  - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX_GLIBC_2_23_ARM64#*-}"
+  - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX#*-}"
   - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
   - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}" --break-system-packages
   - pyenv rehash

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -92,10 +92,10 @@
   - pyenv activate $VENV_NAME
 
 .install_python_dependencies:
-  # Python 3.12 changes default behavior how packages are installed.
-  # In particular, --break-system-packages command line option is
-  # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-  - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
+  # Get the commit from the build image variable in the format `vPIPELINE_ID-COMMIT`
+  - export BUILDIMAGES_COMMIT="${CI_IMAGE_LINUX_GLIBC_2_23_ARM64#*-}"
+  - export DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/${BUILDIMAGES_COMMIT}/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')"
+  - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}" --break-system-packages
   - pyenv rehash
   - python3 -m dda self dep sync -f legacy-tasks
   - pyenv rehash

--- a/.gitlab/fuzz/infra.yaml
+++ b/.gitlab/fuzz/infra.yaml
@@ -8,7 +8,5 @@ test_fuzz:
   needs: []
   allow_failure: true
   script:
-    - |
-      python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
-      dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - dda inv -- build-and-upload-fuzz

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -69,7 +69,6 @@ notify-slack:
   allow_failure: true
   script:
     - export SDM_JWT=$(vault read -field=token identity/oidc/token/sdm)
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
     - dda self dep sync -f legacy-tasks -f legacy-notifications
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- pipeline.changelog ${CI_COMMIT_SHORT_SHA} || exit $?

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -6,7 +6,6 @@
   - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
   - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
-  - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
   - dda self dep sync -f legacy-tasks -f legacy-notifications
 
 # Notify jobs are allowed to fail but are monitored by https://app.datadoghq.com/monitors/132367692
@@ -24,7 +23,6 @@ notify-on-tagged-success:
   script: |
     MESSAGE_TEXT=":host-green: Tagged build <$CI_PIPELINE_URL|$CI_PIPELINE_ID> succeeded.
     *$CI_COMMIT_REF_NAME* is available in the staging repositories."
-    python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
     dda self dep sync -f legacy-tasks -f legacy-notifications
     SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     dda inv notify.post-message -c "#agent-release-sync" -m "$MESSAGE_TEXT"
@@ -66,10 +64,6 @@ notify_gitlab_ci_changes:
           - .gitlab/**/*.yml
         compare_to: $COMPARE_TO_BRANCH
   script:
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
     - python3 -m dda self dep sync -f legacy-tasks
     - !reference [.setup_agent_github_app]
     - dda inv -- -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment
@@ -135,6 +129,5 @@ close_failing_tests_stale_issues:
     - DD_APP_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_APP_KEY_ORG2 token) || exit $?; export DD_APP_KEY
     - ATLASSIAN_PASSWORD=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE token) || exit $?; export ATLASSIAN_PASSWORD
     - ATLASSIAN_USERNAME=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE user) || exit $?; export ATLASSIAN_USERNAME
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - dda inv -- -e notify.close-failing-tests-stale-issues

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -16,11 +16,7 @@
     - !reference [.retrieve_linux_go_tools_deps]
     - rm -f $OMNIBUS_PACKAGE_DIR/*-dbg-*.tar.xz
     - ls -l $OMNIBUS_PACKAGE_DIR
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - set +x
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
     - go env -w GOPRIVATE="github.com/DataDog/*"

--- a/.gitlab/post_rc_build/post_rc_tasks.yml
+++ b/.gitlab/post_rc_build/post_rc_tasks.yml
@@ -21,11 +21,7 @@ update_rc_build_links:
   script:
     - ATLASSIAN_PASSWORD=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE token) || exit $?; export ATLASSIAN_PASSWORD
     - ATLASSIAN_USERNAME=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE user) || exit $?; export ATLASSIAN_USERNAME
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - PATCH=$(echo "$CI_COMMIT_REF_NAME" | cut -d'.' -f3 | cut -c1)
     - if [[ "$PATCH" == "0" ]]; then PATCH_OPTION=""; else PATCH_OPTION="-p"; fi
     - dda inv -- -e release.update-build-links ${CI_COMMIT_REF_NAME} ${PATCH_OPTION}

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -28,11 +28,7 @@ github_rate_limit_info:
     - !reference [.except_mergequeue]
     - when: on_success
   script:
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     # Send stats for app 1
     - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 key_b64) || exit $?; export GITHUB_KEY_B64
     - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 app_id) || exit $?; export GITHUB_APP_ID

--- a/.gitlab/source_test/notify.yml
+++ b/.gitlab/source_test/notify.yml
@@ -7,11 +7,7 @@ unit_tests_notify:
     - !reference [.except_disable_unit_tests]
     - when: always
   script:
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - !reference [.setup_agent_github_app]
     - dda inv -- notify.unit-tests --pipeline-id $CI_PIPELINE_ID --pipeline-url $CI_PIPELINE_URL --branch-name $CI_COMMIT_REF_NAME
   needs:

--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -8,6 +8,5 @@ invoke_unit_tests:
   rules:
     - !reference [.on_invoke_tasks_changes]
   script:
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - dda inv -- -e invoke-unit-tests.run

--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -74,8 +74,7 @@ generate_windows_gitlab_runner_bump_pr:
   script:
     # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository
     - !reference [.setup_github_app_agent_platform_auto_pr]
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- -e github.update-windows-runner-version
@@ -94,8 +93,7 @@ generate_windows_gitlab_runner_bump_pr_manual:
   script:
     # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository
     - !reference [.setup_github_app_agent_platform_auto_pr]
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
-    - python3 -m dda self dep sync -f legacy-tasks
+    - dda self dep sync -f legacy-tasks
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- -e github.update-windows-runner-version

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -7,9 +7,7 @@ $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
 if ($Env:TARGET_ARCH -eq "x64") {
     & ridk enable
 }
-$ddaversion = Get-Content -Path ".dda/version" -Raw
-& $Env:Python3_ROOT_DIR\python.exe -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$ddaversion"
-& $Env:Python3_ROOT_DIR\python.exe -m dda self dep sync -f legacy-tasks
+& dda self dep sync -f legacy-tasks
 
 $PROBE_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:PATH"

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -5,9 +5,7 @@ $Env:Python2_ROOT_DIR=$Env:TEST_EMBEDDED_PY2
 $Env:Python3_ROOT_DIR=$Env:TEST_EMBEDDED_PY3
 
 & ridk enable
-$ddaversion = Get-Content -Path ".dda/version" -Raw
-& $Env:Python3_ROOT_DIR\python.exe -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$ddaversion"
-& $Env:Python3_ROOT_DIR\python.exe -m dda self dep sync -f legacy-tasks
+& dda self dep sync -f legacy-tasks
 
 $PROBE_BUILD_ROOT=(Get-Location).Path
 $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:Python3_ROOT_DIR\Scripts;$Env:Python2_ROOT_DIR;$Env:Python2_ROOT_DIR\Scripts;$Env:PATH"


### PR DESCRIPTION
### Motivation

Consistency, and so that new features may be used since the pinned minimum version in this repo rarely gets updated.

### Additional notes

The majority of this PR is merely removing an unnecessary manual installation step since `dda` is already installed in the build images. There are 3 instances where that is not the case:

- GitHub Actions - this reads `.gitlab-ci.yml` to get the current commit of the build images repository in order to fetch the pinned version
- `.gitlab/common/macos.yml` - macOS does not have its own image, this reads an environment variable to find out the current commit
- `.gitlab/benchmarks/benchmarks.yml` - this uses an image that we do not own and does not ship `dda`, now we read an environment variable just like ^