### PR TITLE
[CWS] Fix Flaky IOUring Connect Test 

### DIFF
--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -89,6 +89,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fmt.Printf("Listener created on port 4243: %+v\n", listener)
 	defer listener.Close()
 
 	go listener.Accept()
@@ -100,6 +101,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fmt.Printf("Socket created with fd: %d\n", fd)
 	defer unix.Close(fd)
 
 	iour, err := iouring.New(1)
@@ -109,6 +111,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 		}
 		t.Skip("io_uring not supported")
 	}
+	fmt.Printf("io_uring initialized: %+v\n", iour)
 	defer iour.Close()
 
 	sa := unix.SockaddrInet4{
@@ -120,13 +123,14 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	fmt.Printf("Prepared connect request: %+v\n", prepRequest)
 	ch := make(chan iouring.Result, 1)
 
 	test.WaitSignal(t, func() error {
 		if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
 			return err
 		}
+		fmt.Printf("Submitted connect request to io_uring: %+v\n", prepRequest)
 		var result iouring.Result
 		select {
 		case result = <-ch:

--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -32,7 +32,7 @@ func TestConnectEventAFIntetTCP(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet",
-			Expression: `connect.addr.family == AF_INET && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.port == 4242 && connect.addr.family == AF_INET && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -55,7 +55,7 @@ func TestConnectEventAFIntetTCP(t *testing.T) {
 	go listener.Accept()
 
 	test.WaitSignal(t, func() error {
-		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "tcp"); err != nil {
+		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "tcp", "4242"); err != nil {
 			return err
 		}
 		return err
@@ -75,7 +75,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet_io_uring",
-			Expression: `connect.addr.port == 4242 && connect.addr.family == AF_INET && process.file.name == "testsuite"`,
+			Expression: `connect.addr.port == 4243 && connect.addr.family == AF_INET && process.file.name == "testsuite"`,
 		},
 	}
 
@@ -84,7 +84,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
-	listener, err := net.Listen("tcp", ":4242")
+	listener, err := net.Listen("tcp", ":4243")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	defer iour.Close()
 
 	sa := unix.SockaddrInet4{
-		Port: 4242,
+		Port: 4243,
 		Addr: [4]byte(net.IPv4(0, 0, 0, 0)),
 	}
 
@@ -143,7 +143,7 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 		assertTriggeredRule(t, rule, "test_connect_af_inet_io_uring")
 		assert.Equal(t, uint16(unix.AF_INET), event.Connect.AddrFamily, "wrong address family")
 		assert.Equal(t, "testsuite", event.ProcessContext.FileEvent.BasenameStr, "wrong process name")
-		assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
+		assert.Equal(t, uint16(4243), event.Connect.Addr.Port, "wrong address port")
 		assert.Equal(t, string("0.0.0.0/32"), event.Connect.Addr.IPNet.String(), "wrong address")
 		assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Connect.Protocol, "wrong protocol")
 		assert.Contains(t, []int64{0, -int64(syscall.EAGAIN)}, event.Connect.Retval, "wrong retval")
@@ -155,7 +155,7 @@ func TestConnectEventAFInetAnyUDP(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet",
-			Expression: `connect.addr.family == AF_INET && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.port == 4244 && connect.addr.family == AF_INET && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -170,21 +170,21 @@ func TestConnectEventAFInetAnyUDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	conn, err := net.ListenPacket("udp", ":4242")
+	conn, err := net.ListenPacket("udp", ":4244")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer conn.Close()
 
 	test.WaitSignal(t, func() error {
-		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "udp"); err != nil {
+		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET", "any", "udp", "4244"); err != nil {
 			return err
 		}
 		return err
 	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "connect", event.GetType(), "wrong event type")
 		assert.Equal(t, uint16(unix.AF_INET), event.Connect.AddrFamily, "wrong address family")
-		assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
+		assert.Equal(t, uint16(4244), event.Connect.Addr.Port, "wrong address port")
 		assert.Equal(t, string("0.0.0.0/32"), event.Connect.Addr.IPNet.String(), "wrong address")
 		assert.Equal(t, uint16(unix.IPPROTO_UDP), event.Connect.Protocol, "wrong protocol")
 		assert.Equal(t, int64(0), event.Connect.Retval, "wrong retval")
@@ -196,7 +196,7 @@ func TestConnectEventAFInet6AnyTCP(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet6",
-			Expression: `connect.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.port == 4245 && connect.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -215,7 +215,7 @@ func TestConnectEventAFInet6AnyTCP(t *testing.T) {
 		t.Skip("IPv6 is not supported")
 	}
 
-	listener, err := net.Listen("tcp", ":4242")
+	listener, err := net.Listen("tcp", ":4245")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,14 +224,14 @@ func TestConnectEventAFInet6AnyTCP(t *testing.T) {
 	go listener.Accept()
 
 	test.WaitSignal(t, func() error {
-		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "tcp"); err != nil {
+		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "tcp", "4245"); err != nil {
 			return err
 		}
 		return err
 	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "connect", event.GetType(), "wrong event type")
 		assert.Equal(t, uint16(unix.AF_INET6), event.Connect.AddrFamily, "wrong address family")
-		assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
+		assert.Equal(t, uint16(4245), event.Connect.Addr.Port, "wrong address port")
 		assert.Equal(t, string("::/128"), event.Connect.Addr.IPNet.String(), "wrong address")
 		assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Connect.Protocol, "wrong protocol")
 		assert.Equal(t, int64(0), event.Connect.Retval, "wrong retval")
@@ -243,7 +243,7 @@ func TestConnectEventAFInet6AnyUDP(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect_af_inet6",
-			Expression: `connect.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
+			Expression: `connect.addr.port == 4246 && connect.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
 		},
 	}
 
@@ -262,21 +262,21 @@ func TestConnectEventAFInet6AnyUDP(t *testing.T) {
 		t.Skip("IPv6 is not supported")
 	}
 
-	conn, err := net.ListenPacket("udp", ":4242")
+	conn, err := net.ListenPacket("udp", ":4246")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer conn.Close()
 
 	test.WaitSignal(t, func() error {
-		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "udp"); err != nil {
+		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "connect", "AF_INET6", "any", "udp", "4246"); err != nil {
 			return err
 		}
 		return err
 	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "connect", event.GetType(), "wrong event type")
 		assert.Equal(t, uint16(unix.AF_INET6), event.Connect.AddrFamily, "wrong address family")
-		assert.Equal(t, uint16(4242), event.Connect.Addr.Port, "wrong address port")
+		assert.Equal(t, uint16(4246), event.Connect.Addr.Port, "wrong address port")
 		assert.Equal(t, string("::/128"), event.Connect.Addr.IPNet.String(), "wrong address")
 		assert.Equal(t, uint16(unix.IPPROTO_UDP), event.Connect.Protocol, "wrong protocol")
 		assert.Equal(t, int64(0), event.Connect.Retval, "wrong retval")

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -1138,7 +1138,7 @@ func TestFilterConnectAddrFamily(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_connect",
-			Expression: `connect.addr.port == 4242`,
+			Expression: `connect.addr.port == 4241`,
 		},
 	}
 
@@ -1176,6 +1176,7 @@ func TestFilterConnectAddrFamily(t *testing.T) {
 			"AF_UNIX",
 			socketPath,
 			"tcp",
+			"4241",
 		)
 	}, func(event *model.Event) bool {
 		addressFamilyIntf, err := event.GetFieldValue("connect.addr.family")

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -760,10 +760,11 @@ int test_bind(int argc, char** argv) {
 
 int test_connect_af_inet(int argc, char** argv) {
 
-    if (argc != 3) {
+    if (argc != 4) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: an option for the addr in the list: any, custom_ip\n");
         fprintf(stderr, "Arg2: an option for the protocol in the list: tcp, udp\n");
+        fprintf(stderr, "Arg3: the port number to connect to\n");
         return EXIT_FAILURE;
     }
 
@@ -799,7 +800,7 @@ int test_connect_af_inet(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    addr.sin_port = htons(4242);
+    addr.sin_port = htons(atoi(argv[3]));
 
     if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         close(s);
@@ -813,10 +814,11 @@ int test_connect_af_inet(int argc, char** argv) {
 
 int test_connect_af_inet6(int argc, char** argv) {
 
-    if (argc != 3) {
+    if (argc != 4) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: an option for the addr in the list: any, custom_ip\n");
         fprintf(stderr, "Arg2: an option for the protocol in the list: tcp, udp\n");
+        fprintf(stderr, "Arg3: the port number to connect to\n");
         return EXIT_FAILURE;
     }
 
@@ -847,7 +849,7 @@ int test_connect_af_inet6(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    addr.sin6_port = htons(4242);
+    addr.sin6_port = htons(atoi(argv[3]));
     if (connect(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         close(s);
         perror("Failed to connect to port");
@@ -859,10 +861,11 @@ int test_connect_af_inet6(int argc, char** argv) {
 }
 
 int test_connect_af_unix(int argc, char** argv) {
-    if (argc != 3) {
+    if (argc != 4) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: the path of the UNIX socket to connect to\n");
         fprintf(stderr, "Arg2: an option for the protocol in the list: tcp, udp\n");
+        fprintf(stderr, "Note: the UNIX socket must be created before running this command so the port does not matter\n");
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR attempts to fix the flakiness of the `IOUring Connect` test.

- Adds a sleep to ensure that the `accept` call is properly set up before we begin tracking events. This might cause some issues.
- Changes the ports used to prevent overlaps. Previously, the test could fail with the error `listen tcp :4242: bind: address already in use`.  
  While we could have used `setsockopt` with `REUSEPORT` and/or `REUSEADDR`, changing the ports gives us more control over the test environment.

### Motivation

Reduce test flakiness and improve reliability.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->