### PR TITLE
[USM] Support http2 PRIORITY flag

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -15,7 +15,7 @@
 // Represents the maximum number of frames we'll process in a single tail call in `handle_headers_frames` program.
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 15
 // Represents the maximum number of tail calls to process headers frames.
-// Currently we have up to 240 frames in a packet, thus 15 (15*16 = 240) tail calls is enough.
+// Currently we have up to 240 frames in a packet, thus 16 (15*16 = 240) tail calls is enough.
 #define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 16
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER (HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER)
 // Maximum number of frames to be processed in a single tail call.
@@ -72,6 +72,9 @@
 
 // The flag which will be sent in the PRIORITY field.
 #define HTTP2_PRIORITY_FLAG 0x20
+
+// 5-byte priority section at the start of a HEADERS frame when the PRIORITY flag is set.
+#define HTTP2_PRIORITY_BUFFER_LEN 5
 
 // Http2 max batch size.
 #define HTTP2_BATCH_SIZE (MAX_BATCH_SIZE(http2_event_t))

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -13,10 +13,10 @@
 #define HTTP2_MAX_FRAMES_FOR_EOS_PARSER (HTTP2_MAX_FRAMES_FOR_EOS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_EOS_PARSER)
 
 // Represents the maximum number of frames we'll process in a single tail call in `handle_headers_frames` program.
-#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 16
+#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 15
 // Represents the maximum number of tail calls to process headers frames.
 // Currently we have up to 240 frames in a packet, thus 15 (15*16 = 240) tail calls is enough.
-#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 15
+#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 16
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER (HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER)
 // Maximum number of frames to be processed in a single tail call.
 #define HTTP2_MAX_FRAMES_ITERATIONS 240
@@ -69,6 +69,9 @@
 
 // The flag which will be sent in the data/header frame that indicates end of stream.
 #define HTTP2_END_OF_STREAM 0x1
+
+// The flag which will be sent in the PRIORITY field.
+#define HTTP2_PRIORITY_FLAG 0x20
 
 // Http2 max batch size.
 #define HTTP2_BATCH_SIZE (MAX_BATCH_SIZE(http2_event_t))

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -934,9 +934,9 @@ static __always_inline void headers_parser(pktbuf_t pkt, void *map_key, conn_tup
         // If PRIORITY flag (0x20) set, skip 5-byte priority fields.
         // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2
         if (current_frame.frame.flags & HTTP2_PRIORITY_FLAG) {
-            pktbuf_advance(pkt, 5);
-            if (current_frame.frame.length > 5) {
-                current_frame.frame.length -= 5;
+            pktbuf_advance(pkt, HTTP2_PRIORITY_BUFFER_LEN);
+            if (current_frame.frame.length > HTTP2_PRIORITY_BUFFER_LEN) {
+                current_frame.frame.length -= HTTP2_PRIORITY_BUFFER_LEN;
             } else {
                 continue;
             }

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -931,6 +931,16 @@ static __always_inline void headers_parser(pktbuf_t pkt, void *map_key, conn_tup
         current_stream->tags = tags;
         pktbuf_set_offset(pkt, current_frame.offset);
 
+        // If PRIORITY flag (0x20) set, skip 5-byte priority fields.
+        // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2
+        if (current_frame.frame.flags & HTTP2_PRIORITY_FLAG) {
+            pktbuf_advance(pkt, 5);
+            if (current_frame.frame.length > 5) {
+                current_frame.frame.length -= 5;
+            } else {
+                continue;
+            }
+        }
         interesting_headers = pktbuf_filter_relevant_headers(pkt, global_dynamic_counter, &http2_ctx->dynamic_index, headers_to_process, current_frame.frame.length, http2_tel);
         pktbuf_process_headers(pkt, &http2_ctx->dynamic_index, current_stream, headers_to_process, interesting_headers, http2_tel);
     }

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1319,6 +1319,36 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}: 1,
 			},
 		},
+		{
+			name: "headers frame with PRIORITY flag",
+			messageBuilder: func() [][]byte {
+				fr := newFramer()
+				hdrBlock, err := usmhttp2.NewHeadersFrameMessage(usmhttp2.HeadersFrameOptions{Headers: testHeaders()})
+				require.NoError(t, err, "could not create headers block")
+
+				// Write a HEADERS frame that carries a PRIORITY section (flag 0x20).
+				require.NoError(t, fr.framer.WriteHeaders(http2.HeadersFrameParam{
+					StreamID:      1,
+					BlockFragment: hdrBlock,
+					EndHeaders:    endHeaders,
+					Priority: http2.PriorityParam{
+						StreamDep: 0,
+						Exclusive: false,
+						Weight:    10, // non-zero weight triggers PRIORITY flag
+					},
+				}), "could not write priority headers")
+
+				fr.writeData(t, 1, endStream, emptyBody)
+
+				return [][]byte{fr.bytes()}
+			},
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* This PR adds support for HTTP/2 priority flag.
* Change `HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL` from 16 to 15.
* Change `HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER` from 15 to 16. 

### Motivation

When priority flag is set, the frame includes 5 additional bytes: 4 bytes for the stream dependency field and 1 byte for the weight. Since we weren’t accounting for these extra bytes in our parser, we were misinterpreting the frame structure, which caused the capture logic to fail.

> The HEADERS frame defines the following flags:
> PRIORITY (0x20): When set, the PRIORITY flag indicates that the Exclusive, Stream Dependency, and Weight fields are present.

link to the HTTP/2 RFC that contains documentation about the issue: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2

I reached the instruction count limit, which explains the changes to the constants we use to iterate over the frames. I increased one and decreased another to maintain the same total number of iterations as before.

### Describe how you validated your changes

I added a UT that includes this flag. It failed before the change and passed after applying my fix.
- [x] Load test.
- [x] Staging cluster deployment.


<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
gRPC plain:
<img width="1683" height="590" alt="Screenshot 2025-07-31 at 11 09 04" src="https://github.com/user-attachments/assets/3eb77a05-e6a9-40da-9d06-edd4dd438b36" />


gRPC TLS:
<img width="1692" height="596" alt="Screenshot 2025-07-31 at 11 06 25" src="https://github.com/user-attachments/assets/7a0784f9-2dab-49c3-ba7e-4cb7648ee782" />

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->