### PR TITLE
Fix dangling links within embedded Python and SSL

### DIFF
--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 
@@ -94,6 +94,33 @@ if [ "$SIGN" = "true" ]; then
 else
     dda inv -- -e omnibus.build --skip-sign --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
 fi
+
+#TODO(regis): consider moving the following check to `DataDog/omnibus-ruby` to benefit other OSes
+declare -i dangling=0
+real_install=$(readlink -f "$INSTALL_DIR")
+while read -r link; do
+    target=$(readlink "$link")
+    if [ ! -e "$link" ]; then
+        dangling+=1
+        echo >&2 "Dangling symlink: $link -❌> $target (must resolve to an existing target)"
+        continue
+    fi
+    real_target=$(readlink -f "$link")
+    if [[ ! $real_target = $real_install/* ]]; then
+        dangling+=1
+        echo >&2 "Outbound symlink: $link -❌> $target (must resolve inside install prefix)"
+        continue
+    fi
+    if [[ $target = /* ]]; then
+        dangling+=1
+        echo >&2 "Absolute symlink: $link -❌> $target (must be relative to symlink's directory)"
+        continue
+    fi
+done < <(find "$INSTALL_DIR" -type l)
+if [ $dangling -gt 0 ]; then
+    exit $dangling
+fi
+
 echo Built packages using omnibus
 
 # --- Notarization ---

--- a/omnibus/config/software/cacerts.rb
+++ b/omnibus/config/software/cacerts.rb
@@ -47,9 +47,11 @@ build do
   else
     mkdir "#{install_dir}/embedded/ssl/certs"
     copy "#{project_dir}/cacert.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
-
-    link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
-
-    block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
+    block 'set certificate permissions and relative symlink within embedded SSL configuration' do
+      Dir.chdir "#{install_dir}/embedded/ssl" do
+        File.chmod 0644, 'certs/cacert.pem'
+        File.symlink 'certs/cacert.pem', 'cert.pem'
+      end
+    end
   end
 end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -43,14 +43,15 @@ build do
             # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will
             # default to `pip2` if the default Python runtime is Python 2.
             delete "#{install_dir}/embedded/bin/pip"
-            link "#{install_dir}/embedded/bin/pip3", "#{install_dir}/embedded/bin/pip"
-
+            delete "#{install_dir}/embedded/bin/pip3"
             delete "#{install_dir}/embedded/bin/python"
-            link "#{install_dir}/embedded/bin/python3", "#{install_dir}/embedded/bin/python"
-
-            # Used in https://docs.datadoghq.com/agent/guide/python-3/
-            delete "#{install_dir}/embedded/bin/2to3"
-            link "#{install_dir}/embedded/bin/2to3-3.12", "#{install_dir}/embedded/bin/2to3"
+            block 'create relative symlinks within embedded Python distribution' do
+              Dir.chdir "#{install_dir}/embedded/bin" do
+                File.symlink 'pip3.12', 'pip3'
+                File.symlink 'pip3', 'pip'
+                File.symlink 'python3', 'python'
+              end
+            end
 
             delete "#{install_dir}/embedded/lib/config_guess"
 


### PR DESCRIPTION
### What does this PR do?
The present change fixes dangling symlinks found below the `embedded` directory inside the Agent's installation prefix when the archive is extracted elsewhere than the hardcoded `/tmp/datadog-agent-build/bin` directory:
```diff
--- before	2025-07-31 13:41:38.126097815 +0200
+++ after	2025-07-31 13:41:43.505175057 +0200
@@ -39,11 +39,11 @@
 -rw-r--r--      1508  ./Datadog Agent.app/Contents/Info.plist
 -rw-r--r--       743  ./Datadog Agent.app/Contents/MacOS/agent.png
 -rwxr-xr-x    140992  ./Datadog Agent.app/Contents/MacOS/gui
 -rw-r--r--    602812  ./Datadog Agent.app/Contents/Resources/Agent.icns
 -rwxr-xr-x       129  ./embedded/bin/2to3-3.12
-lrwxrwxrwx        51  ./embedded/bin/2to3 -❌> /tmp/datadog-agent-build/bin/embedded/bin/2to3-3.12
+lrwxrwxrwx         9  ./embedded/bin/2to3 -> 2to3-3.12
 -rwxr-xr-x       260  ./embedded/bin/ddtrace-run
 -rwxr-xr-x       251  ./embedded/bin/echo_supervisord_conf
 -rwxr-xr-x       127  ./embedded/bin/idle3.12
 lrwxrwxrwx         8  ./embedded/bin/idle3 -> idle3.12
 -rwxr-xr-x       254  ./embedded/bin/in-toto-keygen
@@ -65,12 +65,12 @@
 -rwxr-xr-x    934576  ./embedded/bin/openssl
 -rwxr-xr-x       261  ./embedded/bin/openstack-inventory
 -rwxr-xr-x       244  ./embedded/bin/pbr
 -rwxr-xr-x       251  ./embedded/bin/pidproxy
 -rwxr-xr-x       254  ./embedded/bin/pip3.12
--rwxr-xr-x       254  ./embedded/bin/pip3
-lrwxrwxrwx        46  ./embedded/bin/pip -❌> /tmp/datadog-agent-build/bin/embedded/bin/pip3
+lrwxrwxrwx         7  ./embedded/bin/pip3 -> pip3.12
+lrwxrwxrwx         4  ./embedded/bin/pip -> pip3
 -rwxr-xr-x  43376976  ./embedded/bin/process-agent
 -rw-r--r--      3179  ./embedded/bin/__pycache__/jp.cpython-312.pyc
 -rwxr-xr-x       112  ./embedded/bin/pydoc3.12
 lrwxrwxrwx         9  ./embedded/bin/pydoc3 -> pydoc3.12
 -rwxr-xr-x       245  ./embedded/bin/pyrsa-decrypt
@@ -81,11 +81,11 @@
 -rwxr-xr-x       243  ./embedded/bin/pyrsa-verify
 -rwxr-xr-x       242  ./embedded/bin/pysemver
 -rwxr-xr-x       247  ./embedded/bin/pyspnego-parse
 -rwxr-xr-x     68752  ./embedded/bin/python3.12
 lrwxrwxrwx        10  ./embedded/bin/python3 -> python3.12
-lrwxrwxrwx        49  ./embedded/bin/python -❌> /tmp/datadog-agent-build/bin/embedded/bin/python3
+lrwxrwxrwx         7  ./embedded/bin/python -> python3
 -rwxr-xr-x      2071  ./embedded/bin/python3.12-config
 lrwxrwxrwx        17  ./embedded/bin/python3-config -> python3.12-config
 -rwxr-xr-x       247  ./embedded/bin/rethinkdb-dump
 -rwxr-xr-x       249  ./embedded/bin/rethinkdb-export
 -rwxr-xr-x       249  ./embedded/bin/rethinkdb-import
@@ -27290,11 +27290,11 @@
 -rw-r--r--      9841  ./embedded/share/libtool/slist.c
 -rw-r--r--      2897  ./embedded/share/man/man1/libtool.1
 -rw-r--r--      2843  ./embedded/share/man/man1/libtoolize.1
 -rw-r--r--       396  ./embedded/share/pkgconfig/zlib.pc
 -rw-r--r--    222971  ./embedded/ssl/certs/cacert.pem
-lrwxrwxrwx        58  ./embedded/ssl/cert.pem -❌> /tmp/datadog-agent-build/bin/embedded/ssl/certs/cacert.pem
+lrwxrwxrwx        16  ./embedded/ssl/cert.pem -> certs/cacert.pem
 -rw-r--r--       412  ./embedded/ssl/ct_log_list.cnf
 -rw-r--r--       412  ./embedded/ssl/ct_log_list.cnf.dist
 -rwxr-xr-x      8064  ./embedded/ssl/misc/CA.pl
 -rwxr-xr-x      6746  ./embedded/ssl/misc/tsget.pl
 lrwxrwxrwx         8  ./embedded/ssl/misc/tsget -> tsget.pl
```
Credit goes to @chagui for reporting the issue!

In order to prevent dangling symlinks form being shipped again while allowing package relocation, there are now checks on the existence and validity of symlinks within the archive, which must:
1. point to existing targets at creation time ⇒ prevent trivially dangling symlinks,
2. resolve to locations inside the installation prefix ⇒ avoid dangling symlinks relying on potentially missing files on the host system,
3. use relative paths ⇒ ensure symlinks remain valid regardless of the extraction path and depth.

Without fixing the dangling symlinks, [we would get](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1056720820#L929):
```
Absolute symlink: /tmp/datadog-agent-build/bin/embedded/bin/2to3 -❌> /tmp/datadog-agent-build/bin/embedded/bin/2to3-3.12 (must be relative to symlink's directory)
Absolute symlink: /tmp/datadog-agent-build/bin/embedded/bin/pip -❌> /tmp/datadog-agent-build/bin/embedded/bin/pip3 (must be relative to symlink's directory)
Absolute symlink: /tmp/datadog-agent-build/bin/embedded/bin/python -❌> /tmp/datadog-agent-build/bin/embedded/bin/python3 (must be relative to symlink's directory)
Absolute symlink: /tmp/datadog-agent-build/bin/embedded/ssl/cert.pem -❌> /tmp/datadog-agent-build/bin/embedded/ssl/certs/cacert.pem (must be relative to symlink's directory)
```
### Motivation
<img width="1072" height="387" alt="https://dd.slack.com/archives/C078N61DRK9/p1753801375905049" src="https://github.com/user-attachments/assets/cc43bb2c-c1fe-4ed8-9b33-2c1c885ef800" />
Using relative symlinks is especially important in relocatable packages where absolute symlinks break when the installation directory changes

### Possible Drawbacks / Trade-offs
For practical reasons, the checks are for the time being executed as part of the macOS build. We'll later move them upstream (either to [DataDog/omnibus-ruby](https://github.com/DataDog/omnibus-ruby) or as part of the ongoing Bazel migration).