### PR TITLE
[AMCC-85] dogstatsd: use the config API to restore previous values of the config

### DIFF
--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
@@ -36,6 +37,8 @@ func (s *server) onBlocklistUpdateCallback(updates map[string]state.RawConfig, a
 	// special case: we received a response from RC, but RC didn't have any
 	// configuration for this agent, let's restore the local config and return
 	if len(updates) == 0 {
+		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
+		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreBlocklistFromLocalConfig()
 		return
 	}
@@ -81,10 +84,18 @@ func (s *server) onBlocklistUpdateCallback(updates map[string]state.RawConfig, a
 	metricNames := slices.Collect(maps.Keys(m))
 
 	if len(metricNames) > 0 {
+		// update the runtime config to be consistent
+		// in `agent config` calls.
+		s.config.Set("statsd_metric_blocklist", metricNames, model.SourceRC)
+		s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
+
 		// apply this new blocklist to all the running workers
 		s.SetBlocklist(metricNames, false)
+
 	} else {
 		// special case: if the metric names list is empty, fallback to local
+		s.config.UnsetForSource("statsd_metric_blocklist", model.SourceRC)
+		s.config.UnsetForSource("statsd_metric_blocklist_match_prefix", model.SourceRC)
 		s.restoreBlocklistFromLocalConfig()
 	}
 }

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -514,10 +514,6 @@ func (s *server) SetExtraTags(tags []string) {
 func (s *server) SetBlocklist(metricNames []string, matchPrefix bool) {
 	s.log.Debugf("SetBlocklist with %d metrics", len(metricNames))
 
-	// update the runtime config to be consistent
-	// in `agent config` calls.
-	s.config.Set("statsd_metric_blocklist", metricNames, model.SourceRC)
-
 	// we will use two different blocklists:
 	// - one with all the metrics names, with all values from `metricNames`
 	// - one with only the metric names ending with histogram aggregates suffixes
@@ -610,10 +606,6 @@ func (s *server) handleMessages() {
 
 func (s *server) restoreBlocklistFromLocalConfig() {
 	s.log.Debug("Restoring blocklist with local config.")
-
-	// update the runtime config to be consistent
-	// in `agent config` calls.
-	s.config.Set("statsd_metric_blocklist", s.localBlocklistConfig.metricNames, model.SourceAgentRuntime)
 
 	s.SetBlocklist(
 		s.localBlocklistConfig.metricNames,


### PR DESCRIPTION
### What does this PR do?

* Fix the override of the config source in `SetBlocklist` and 
* Start using `UnsetForSource` to better use the config API.

### Motivation

Better usage of the config API.

### Describe how you validated your changes

* Ran an Agent
* validated the local config was displayed on `agent config`
* remotely sent a new config, validated it was the one used with `agent config`
* deleted that remote config, validated that `agent config` was again showing the local config

Follow up of https://github.com/DataDog/datadog-agent/pull/39232
