### PR TITLE
dyninst/irgen: add support for hmap (go1.23 and prior)

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -637,7 +637,12 @@ func fieldType[T ir.Type](st *ir.StructureType, name string) (T, error) {
 	}
 	fieldType, ok := f.Type.(T)
 	if !ok {
-		return *new(T), fmt.Errorf("field %q is not a %T, got %T", name, new(T), f.Type)
+		ret := *new(T)
+		err := fmt.Errorf(
+			"field %q of type %q is not a %T, got %T",
+			name, st.Name, ret, f.Type,
+		)
+		return ret, err
 	}
 	return fieldType, nil
 }
@@ -724,9 +729,47 @@ func completeSwissMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
 	return nil
 }
 
-func completeHMapHeaderType(_ *typeCatalog, _ *ir.StructureType) error {
-	// TODO: Implement this and test it on older versions of Go.
-	return fmt.Errorf("hmap support is not implemented")
+func completeHMapHeaderType(tc *typeCatalog, st *ir.StructureType) error {
+	bucketsField, err := field(st, "buckets")
+	if err != nil {
+		return err
+	}
+	bucketsStructType, err := pointeeType[*ir.StructureType](bucketsField.Type)
+	if err != nil {
+		return err
+	}
+	keysArrayType, err := fieldType[*ir.ArrayType](bucketsStructType, "keys")
+	if err != nil {
+		return err
+	}
+	keyType := keysArrayType.Element
+	valuesArrayType, err := fieldType[*ir.ArrayType](bucketsStructType, "values")
+	if err != nil {
+		return err
+	}
+	valueType := valuesArrayType.Element
+	bucketsType := &ir.GoHMapBucketType{
+		StructureType: bucketsStructType,
+		KeyType:       keyType,
+		ValueType:     valueType,
+	}
+	bucketsSliceDataType := &ir.GoSliceDataType{
+		TypeCommon: ir.TypeCommon{
+			ID:       tc.idAlloc.next(),
+			Name:     fmt.Sprintf("[]%s.array", bucketsType.GetName()),
+			ByteSize: tc.maxDynamicTypeSize,
+		},
+		Element: bucketsType,
+	}
+	headerType := &ir.GoHMapHeaderType{
+		StructureType: st,
+		BucketType:    bucketsType,
+		BucketsType:   bucketsSliceDataType,
+	}
+	tc.typesByID[bucketsSliceDataType.ID] = bucketsSliceDataType
+	tc.typesByID[headerType.ID] = headerType
+	tc.typesByID[bucketsType.ID] = bucketsType
+	return nil
 }
 
 func completeGoStringType(tc *typeCatalog, st *ir.StructureType) error {


### PR DESCRIPTION
Prior to this change, we hard failed in ir generation for older go binaries. Tests will come in a follow-up to
avoid conflicts and team review dependencies.

Relates to [DEBUG-4185](https://datadoghq.atlassian.net/browse/DEBUG-4185).


[DEBUG-4185]: https://datadoghq.atlassian.net/browse/DEBUG-4185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ