### PR TITLE
dyninst: add testing for go1.23.11

### DIFF
--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -1,0 +1,301 @@
+// Stack machine code
+	Illegal 
+// 0x1: ChasePointers
+	ChasePointers 
+	Return 
+// 0x3: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 03 00 00 00 // ProcessType[*****int]
+	Return 
+// 0x24: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
+	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
+	Return 
+// 0x33: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 33 00 00 00 // ProcessType[**int]
+	Return 
+// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
+	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
+	Return 
+// 0x63: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 23 00 00 00 
+	Return 
+// 0x69: ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Return 
+// 0x84: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
+	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
+	Return 
+// 0x93: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xa9: ProcessEvent[Probe[main.inlined]@4a63ca]
+	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
+	Return 
+// 0xb8: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xc8: ProcessEvent[Probe[main.inlined]@4a5dce]
+	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
+	Return 
+// 0xd7: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xed: ProcessEvent[Probe[main.intArg]@4a60aa]
+	PrepareEventRoot 34 00 00 00 09 00 00 00 
+	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
+	Return 
+// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Return 
+// 0x118: ProcessEvent[Probe[main.intArrayArg]@4a622a]
+	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
+	Return 
+// 0x127: ProcessType[string]
+	ProcessString 2a 00 00 00 
+	Return 
+// 0x12d: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call 2d 01 00 00 // ProcessType[[3]string]
+	Return 
+// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
+	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
+	Return 
+// 0x16d: ProcessType[[]int]
+	ProcessSlice 2c 00 00 00 08 00 00 00 
+	Return 
+// 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 6d 01 00 00 // ProcessType[[]int]
+	Return 
+// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
+	PrepareEventRoot 36 00 00 00 19 00 00 00 
+	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
+	Return 
+// 0x1af: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x1b5: ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call af 01 00 00 // ProcessType[map[string]int]
+	Return 
+// 0x1d0: ProcessEvent[Probe[main.mapArg]@4a648a]
+	PrepareEventRoot 3b 00 00 00 09 00 00 00 
+	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
+	Return 
+// 0x1df: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	Return 
+// 0x201: ProcessEvent[Probe[main.stringArg]@4a612a]
+	PrepareEventRoot 35 00 00 00 11 00 00 00 
+	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
+	Return 
+// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call 2d 01 00 00 // ProcessType[[3]string]
+	Return 
+// 0x231: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
+	PrepareEventRoot 39 00 00 00 31 00 00 00 
+	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
+	Return 
+// 0x240: ProcessType[[]string]
+	ProcessSlice 2e 00 00 00 10 00 00 00 
+	Return 
+// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 40 02 00 00 // ProcessType[[]string]
+	Return 
+// 0x273: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
+	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
+	Return 
+// 0x282: ProcessType[****int]
+	ProcessPointer 04 00 00 00 
+	Return 
+// 0x288: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x28e: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 33 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x29c: ProcessType[hash<string,int>]
+	ProcessGoHmap 30 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2aa: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2b6: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x2bc: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2cc: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x2d2: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call cc 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e2: ProcessType[*bucket<string,main.bigStruct>]
+	ProcessPointer 25 00 00 00 
+	Return 
+// 0x2e8: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call bc 02 00 00 // ProcessType[[]key<string>]
+	Call d2 02 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call e2 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x2fd: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call e8 02 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x309: ProcessType[*bucket<string,int>]
+	ProcessPointer 15 00 00 00 
+	Return 
+// 0x30f: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call bc 02 00 00 // ProcessType[[]key<string>]
+	IncrementOutputOffset 40 00 00 00 
+	Call 09 03 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x324: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 0f 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// Extra illegal ops to simplify code bound checks
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+// Types
+ID: 1 Len: 8 Enqueue: 0
+ID: 2 Len: 8 Enqueue: 3
+ID: 3 Len: 8 Enqueue: 642
+ID: 4 Len: 8 Enqueue: 694
+ID: 5 Len: 8 Enqueue: 51
+ID: 6 Len: 8 Enqueue: 648
+ID: 7 Len: 16 Enqueue: 295
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 1 Enqueue: 0
+ID: 10 Len: 24 Enqueue: 365
+ID: 11 Len: 24 Enqueue: 0
+ID: 12 Len: 24 Enqueue: 576
+ID: 13 Len: 8 Enqueue: 0
+ID: 14 Len: 48 Enqueue: 301
+ID: 15 Len: 8 Enqueue: 431
+ID: 16 Len: 8 Enqueue: 0
+ID: 17 Len: 48 Enqueue: 668
+ID: 18 Len: 2 Enqueue: 0
+ID: 19 Len: 4 Enqueue: 0
+ID: 20 Len: 8 Enqueue: 777
+ID: 21 Len: 208 Enqueue: 783
+ID: 22 Len: 8 Enqueue: 0
+ID: 23 Len: 128 Enqueue: 700
+ID: 24 Len: 64 Enqueue: 0
+ID: 25 Len: 8 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 0
+ID: 27 Len: 24 Enqueue: 0
+ID: 28 Len: 8 Enqueue: 0
+ID: 29 Len: 24 Enqueue: 0
+ID: 30 Len: 8 Enqueue: 0
+ID: 31 Len: 8 Enqueue: 0
+ID: 32 Len: 8 Enqueue: 0
+ID: 33 Len: 8 Enqueue: 99
+ID: 34 Len: 8 Enqueue: 0
+ID: 35 Len: 48 Enqueue: 654
+ID: 36 Len: 8 Enqueue: 738
+ID: 37 Len: 208 Enqueue: 744
+ID: 38 Len: 64 Enqueue: 722
+ID: 39 Len: 8 Enqueue: 716
+ID: 40 Len: 184 Enqueue: 0
+ID: 41 Len: 128 Enqueue: 0
+ID: 42 Len: 2048 Enqueue: 0
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 2048 Enqueue: 0
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 2048 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 0
+ID: 48 Len: 2048 Enqueue: 804
+ID: 49 Len: 2048 Enqueue: 0
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 2048 Enqueue: 765
+ID: 52 Len: 9 Enqueue: 0
+ID: 53 Len: 17 Enqueue: 0
+ID: 54 Len: 25 Enqueue: 0
+ID: 55 Len: 25 Enqueue: 0
+ID: 56 Len: 25 Enqueue: 0
+ID: 57 Len: 49 Enqueue: 0
+ID: 58 Len: 49 Enqueue: 0
+ID: 59 Len: 9 Enqueue: 0
+ID: 60 Len: 9 Enqueue: 0
+ID: 61 Len: 9 Enqueue: 0
+ID: 62 Len: 9 Enqueue: 0
+ID: 63 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -1,0 +1,301 @@
+// Stack machine code
+	Illegal 
+// 0x1: ChasePointers
+	ChasePointers 
+	Return 
+// 0x3: ProcessType[*****int]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x9: ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 03 00 00 00 // ProcessType[*****int]
+	Return 
+// 0x24: ProcessEvent[Probe[main.PointerChainArg]@b5338]
+	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
+	Return 
+// 0x33: ProcessType[**int]
+	ProcessPointer 06 00 00 00 
+	Return 
+// 0x39: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 33 00 00 00 // ProcessType[**int]
+	Return 
+// 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
+	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
+	Return 
+// 0x63: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 23 00 00 00 
+	Return 
+// 0x69: ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
+	Return 
+// 0x84: ProcessEvent[Probe[main.bigMapArg]@b5820]
+	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
+	Return 
+// 0x93: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xa9: ProcessEvent[Probe[main.inlined]@b56ec]
+	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
+	Return 
+// 0xb8: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xc8: ProcessEvent[Probe[main.inlined]@b514c]
+	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
+	Return 
+// 0xd7: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0xed: ProcessEvent[Probe[main.intArg]@b53cc]
+	PrepareEventRoot 34 00 00 00 09 00 00 00 
+	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
+	Return 
+// 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Return 
+// 0x118: ProcessEvent[Probe[main.intArrayArg]@b554c]
+	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
+	Return 
+// 0x127: ProcessType[string]
+	ProcessString 2a 00 00 00 
+	Return 
+// 0x12d: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call 2d 01 00 00 // ProcessType[[3]string]
+	Return 
+// 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
+	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
+	Return 
+// 0x16d: ProcessType[[]int]
+	ProcessSlice 2c 00 00 00 08 00 00 00 
+	Return 
+// 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 6d 01 00 00 // ProcessType[[]int]
+	Return 
+// 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b54bc]
+	PrepareEventRoot 36 00 00 00 19 00 00 00 
+	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
+	Return 
+// 0x1af: ProcessType[map[string]int]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x1b5: ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call af 01 00 00 // ProcessType[map[string]int]
+	Return 
+// 0x1d0: ProcessEvent[Probe[main.mapArg]@b57ac]
+	PrepareEventRoot 3b 00 00 00 09 00 00 00 
+	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
+	Return 
+// 0x1df: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	Return 
+// 0x201: ProcessEvent[Probe[main.stringArg]@b543c]
+	PrepareEventRoot 35 00 00 00 11 00 00 00 
+	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
+	Return 
+// 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call 2d 01 00 00 // ProcessType[[3]string]
+	Return 
+// 0x231: ProcessEvent[Probe[main.stringArrayArg]@b565c]
+	PrepareEventRoot 39 00 00 00 31 00 00 00 
+	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
+	Return 
+// 0x240: ProcessType[[]string]
+	ProcessSlice 2e 00 00 00 10 00 00 00 
+	Return 
+// 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 40 02 00 00 // ProcessType[[]string]
+	Return 
+// 0x273: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
+	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
+	Return 
+// 0x282: ProcessType[****int]
+	ProcessPointer 04 00 00 00 
+	Return 
+// 0x288: ProcessType[*int]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x28e: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 33 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x29c: ProcessType[hash<string,int>]
+	ProcessGoHmap 30 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2aa: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2b6: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x2bc: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 27 01 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x2cc: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x2d2: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call cc 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2e2: ProcessType[*bucket<string,main.bigStruct>]
+	ProcessPointer 25 00 00 00 
+	Return 
+// 0x2e8: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call bc 02 00 00 // ProcessType[[]key<string>]
+	Call d2 02 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call e2 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x2fd: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call e8 02 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x309: ProcessType[*bucket<string,int>]
+	ProcessPointer 15 00 00 00 
+	Return 
+// 0x30f: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call bc 02 00 00 // ProcessType[[]key<string>]
+	IncrementOutputOffset 40 00 00 00 
+	Call 09 03 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x324: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 0f 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// Extra illegal ops to simplify code bound checks
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+	Illegal 
+// Types
+ID: 1 Len: 8 Enqueue: 0
+ID: 2 Len: 8 Enqueue: 3
+ID: 3 Len: 8 Enqueue: 642
+ID: 4 Len: 8 Enqueue: 694
+ID: 5 Len: 8 Enqueue: 51
+ID: 6 Len: 8 Enqueue: 648
+ID: 7 Len: 16 Enqueue: 295
+ID: 8 Len: 8 Enqueue: 0
+ID: 9 Len: 1 Enqueue: 0
+ID: 10 Len: 24 Enqueue: 365
+ID: 11 Len: 24 Enqueue: 0
+ID: 12 Len: 24 Enqueue: 576
+ID: 13 Len: 8 Enqueue: 0
+ID: 14 Len: 48 Enqueue: 301
+ID: 15 Len: 8 Enqueue: 431
+ID: 16 Len: 8 Enqueue: 0
+ID: 17 Len: 48 Enqueue: 668
+ID: 18 Len: 2 Enqueue: 0
+ID: 19 Len: 4 Enqueue: 0
+ID: 20 Len: 8 Enqueue: 777
+ID: 21 Len: 208 Enqueue: 783
+ID: 22 Len: 8 Enqueue: 0
+ID: 23 Len: 128 Enqueue: 700
+ID: 24 Len: 64 Enqueue: 0
+ID: 25 Len: 8 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 0
+ID: 27 Len: 24 Enqueue: 0
+ID: 28 Len: 8 Enqueue: 0
+ID: 29 Len: 24 Enqueue: 0
+ID: 30 Len: 8 Enqueue: 0
+ID: 31 Len: 8 Enqueue: 0
+ID: 32 Len: 8 Enqueue: 0
+ID: 33 Len: 8 Enqueue: 99
+ID: 34 Len: 8 Enqueue: 0
+ID: 35 Len: 48 Enqueue: 654
+ID: 36 Len: 8 Enqueue: 738
+ID: 37 Len: 208 Enqueue: 744
+ID: 38 Len: 64 Enqueue: 722
+ID: 39 Len: 8 Enqueue: 716
+ID: 40 Len: 184 Enqueue: 0
+ID: 41 Len: 128 Enqueue: 0
+ID: 42 Len: 2048 Enqueue: 0
+ID: 43 Len: 8 Enqueue: 0
+ID: 44 Len: 2048 Enqueue: 0
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 2048 Enqueue: 682
+ID: 47 Len: 8 Enqueue: 0
+ID: 48 Len: 2048 Enqueue: 804
+ID: 49 Len: 2048 Enqueue: 0
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 2048 Enqueue: 765
+ID: 52 Len: 9 Enqueue: 0
+ID: 53 Len: 17 Enqueue: 0
+ID: 54 Len: 25 Enqueue: 0
+ID: 55 Len: 25 Enqueue: 0
+ID: 56 Len: 25 Enqueue: 0
+ID: 57 Len: 49 Enqueue: 0
+ID: 58 Len: 49 Enqueue: 0
+ID: 59 Len: 9 Enqueue: 0
+ID: 60 Len: 9 Enqueue: 0
+ID: 61 Len: 9 Enqueue: 0
+ID: 62 Len: 9 Enqueue: 0
+ID: 63 Len: 9 Enqueue: 0

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -544,6 +544,14 @@ func (h *goHMapHeaderType) encodeValueFields(
 	if err := writeTokens(enc, jsontext.EndArray); err != nil {
 		return err
 	}
+	if uint64(encodedItems) < count {
+		if err := writeTokens(enc,
+			tokenNotCapturedReason,
+			tokenNotCapturedReasonPruned,
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,105 @@
+LocatePC: 0x4a60a0
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
+LocatePC: 0x4a60d1
+	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+LocatePC: 0x4a6120
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+LocatePC: 0x4a6158
+	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+LocatePC: 0x4a61a0
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+LocatePC: 0x4a61dd
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+LocatePC: 0x4a6220
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+LocatePC: 0x4a6253
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+LocatePC: 0x4a62a0
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+LocatePC: 0x4a62dd
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+LocatePC: 0x4a6320
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+LocatePC: 0x4a6353
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+LocatePC: 0x4a63a0
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+LocatePC: 0x4a63a0
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+LocatePC: 0x4a6480
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+LocatePC: 0x4a64ab
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0x4a64e0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+LocatePC: 0x4a653d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
+LocatePC: 0x4a63c0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+LocatePC: 0x4a63f1
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0x4a5dce
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0x4a5df6
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0x4a6006
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0x4a6025
+	fmt.Println@fmt/print.go:314
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0x4a6050
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+LocatePC: 0x4a606d
+	fmt.Println@fmt/print.go:314
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+FunctionLines: 0x4a6050
+	fmt.Println
+		[0x4a5dfc, 0x4a5e1f) fmt.Println@fmt/print.go:314
+		[0x4a601d, 0x4a6045) fmt.Println@fmt/print.go:314
+		[0x4a6067, 0x4a608a) fmt.Println@fmt/print.go:314
+	fmt.Scanln
+		[0x4a5c5d, 0x4a5c64) fmt.Scanln@fmt/scan.go:70
+		[0x4a5c65, 0x4a5c78) fmt.Scanln@fmt/scan.go:70
+	main.PointerChainArg
+		[0x4a6006, 0x4a601d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerSmallChainArg
+		[0x4a6050, 0x4a6067) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.inlined
+		[0x4a5dce, 0x4a5dfc) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main
+		[0x4a5c40, 0x4a5c5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a5c64, 0x4a5c65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0x4a5c78, 0x4a5c7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0x4a5c7d, 0x4a5cbd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0x4a5cbd, 0x4a5ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0x4a5ccc, 0x4a5cdd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0x4a5cdd, 0x4a5d0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0x4a5d0d, 0x4a5d2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0x4a5d2c, 0x4a5d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0x4a5d7d, 0x4a5da5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0x4a5da5, 0x4a5dcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0x4a5dcd, 0x4a5dce) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0x4a5e1f, 0x4a5e2b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0x4a5e2b, 0x4a5e67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0x4a5e67, 0x4a5f05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0x4a5f05, 0x4a5f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0x4a5f20, 0x4a5f5b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0x4a5f5b, 0x4a5f95) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0x4a5f95, 0x4a5fd3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0x4a5fd3, 0x4a6005) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0x4a6005, 0x4a6006) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0x4a6045, 0x4a6050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0x4a608a, 0x4a6093) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0x4a6093, 0x4a609d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,108 @@
+LocatePC: 0xb53c0
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:42
+LocatePC: 0xb53f8
+	fmt.Println@fmt/print.go:314
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:43
+LocatePC: 0xb5430
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+LocatePC: 0xb5470
+	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+LocatePC: 0xb54b0
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+LocatePC: 0xb54f8
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+LocatePC: 0xb5540
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+LocatePC: 0xb5580
+	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+LocatePC: 0xb55c0
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+LocatePC: 0xb5608
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+LocatePC: 0xb5650
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+LocatePC: 0xb5690
+	fmt.Println@fmt/print.go:314
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+LocatePC: 0xb56d0
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+LocatePC: 0xb56d8
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+LocatePC: 0xb57a0
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+LocatePC: 0xb57d8
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+LocatePC: 0xb5810
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+LocatePC: 0xb5870
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:107
+LocatePC: 0xb56e0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:75
+LocatePC: 0xb5718
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+LocatePC: 0xb514c
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0xb516c
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+LocatePC: 0xb5338
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb5350
+	fmt.Println@fmt/print.go:314
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+LocatePC: 0xb5370
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+LocatePC: 0xb5388
+	fmt.Println@fmt/print.go:314
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+FunctionLines: 0xb5370
+	fmt.Println
+		[0xb5168, 0xb518c) fmt.Println@fmt/print.go:314
+		[0xb5348, 0xb5368) fmt.Println@fmt/print.go:314
+		[0xb5380, 0xb53a0) fmt.Println@fmt/print.go:314
+	fmt.Scanln
+		[0xb4fd0, 0xb4fd8) fmt.Scanln@fmt/scan.go:70
+		[0xb4fdc, 0xb4ff4) fmt.Scanln@fmt/scan.go:70
+	main.PointerChainArg
+		[0xb5338, 0xb5348) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+	main.PointerSmallChainArg
+		[0xb5370, 0xb5380) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+	main.inlined
+		[0xb514c, 0xb5168) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:76
+	main.main
+		[0xb4fb0, 0xb4fd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb4fd8, 0xb4fdc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
+		[0xb4ff4, 0xb4ff8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:16
+		[0xb4ff8, 0xb5028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:17
+		[0xb5028, 0xb503c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:19
+		[0xb503c, 0xb504c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:20
+		[0xb504c, 0xb5078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:21
+		[0xb5078, 0xb5094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:22
+		[0xb5094, 0xb50e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:23
+		[0xb50e0, 0xb5114) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
+		[0xb5114, 0xb5148) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
+		[0xb5148, 0xb514c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
+		[0xb518c, 0xb5198) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb5198, 0xb51cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb51cc, 0xb5250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb5250, 0xb5268) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb5268, 0xb529c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb529c, 0xb52d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb52d0, 0xb5304) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb5304, 0xb5334) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5334, 0xb5338) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb5368, 0xb5370) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb53a0, 0xb53ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb53ac, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -90,11 +90,9 @@ func TestDyninst(t *testing.T) {
 			t.Logf("%s is not used in integration tests", svc)
 			continue
 		}
-		for _, cfg := range cfgs {
-			t.Run(fmt.Sprintf("%s-%s", svc, cfg), func(t *testing.T) {
-				runIntegrationTestSuite(t, svc, cfg, rewrite, sem)
-			})
-		}
+		t.Run(svc, func(t *testing.T) {
+			runIntegrationTestSuite(t, svc, rewrite, sem, cfgs...)
+		})
 	}
 }
 
@@ -315,14 +313,10 @@ type probeOutputs map[string][]json.RawMessage
 func runIntegrationTestSuite(
 	t *testing.T,
 	service string,
-	cfg testprogs.Config,
 	rewrite bool,
 	sem dyninsttest.Semaphore,
+	cfgs ...testprogs.Config,
 ) {
-	if cfg.GOARCH != runtime.GOARCH {
-		t.Skipf("cross-execution is not supported, running on %s, skipping %s", runtime.GOARCH, cfg.GOARCH)
-		return
-	}
 	var outputs = struct {
 		sync.Mutex
 		byTest map[string]probeOutputs // testName -> probeID -> [redacted JSON]
@@ -344,33 +338,42 @@ func runIntegrationTestSuite(
 		expectedOutput, err = getExpectedDecodedOutputOfProbes(service)
 		require.NoError(t, err)
 	}
-	bin := testprogs.MustGetBinary(t, service, cfg)
-	for _, debug := range []bool{false, true} {
-		runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) {
-			t.Parallel()
-			actual := testDyninst(
-				t, service, bin, probeSlice, rewrite, expectedOutput, debug, sem,
-			)
-			if t.Failed() {
+	for _, cfg := range cfgs {
+		t.Run(cfg.String(), func(t *testing.T) {
+			if cfg.GOARCH != runtime.GOARCH {
+				t.Skipf("cross-execution is not supported, running on %s, skipping %s", runtime.GOARCH, cfg.GOARCH)
 				return
 			}
-			outputs.Lock()
-			defer outputs.Unlock()
-			outputs.byTest[t.Name()] = actual
-		}
-		t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
-			if debug && testing.Short() {
-				t.Skip("skipping debug with short")
-			}
 			t.Parallel()
-			t.Run("all-probes", func(t *testing.T) { runTest(t, probes) })
-			for i := range probes {
-				probeID := probes[i].GetID()
-				t.Run(probeID, func(t *testing.T) {
-					if testing.Short() {
-						t.Skip("skipping individual probe with short")
+			bin := testprogs.MustGetBinary(t, service, cfg)
+			for _, debug := range []bool{false, true} {
+				runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) {
+					t.Parallel()
+					actual := testDyninst(
+						t, service, bin, probeSlice, rewrite, expectedOutput, debug, sem,
+					)
+					if t.Failed() {
+						return
 					}
-					runTest(t, probes[i:i+1])
+					outputs.Lock()
+					defer outputs.Unlock()
+					outputs.byTest[t.Name()] = actual
+				}
+				t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
+					if debug && testing.Short() {
+						t.Skip("skipping debug with short")
+					}
+					t.Parallel()
+					t.Run("all-probes", func(t *testing.T) { runTest(t, probes) })
+					for i := range probes {
+						probeID := probes[i].GetID()
+						t.Run(probeID, func(t *testing.T) {
+							if testing.Short() {
+								t.Skip("skipping individual probe with short")
+							}
+							runTest(t, probes[i:i+1])
+						})
+					}
 				})
 			}
 		})

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,0 +1,27 @@
+ID: 1
+Probes:
+    - id: a
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.noop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 1 EventRootType Probe[main.noop]
+          InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.noop
+      OutOfLinePCRanges: [0x4a5f60..0x4a5f61]
+      InlinePCRanges: []
+      Variables: []
+Types:
+    - __kind: EventRootType
+      ID: 1
+      Name: Probe[main.noop]
+MaxTypeID: 1
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,0 +1,27 @@
+ID: 1
+Probes:
+    - id: a
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.noop}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 1 EventRootType Probe[main.noop]
+          InjectionPoints: [{PC: 742032, Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.noop
+      OutOfLinePCRanges: [0xb5290..0xb52a0]
+      InlinePCRanges: []
+      Variables: []
+Types:
+    - __kind: EventRootType
+      ID: 1
+      Name: Probe[main.noop]
+MaxTypeID: 1
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,0 +1,3179 @@
+ID: 1
+Probes:
+    - id: http_handler
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.HandleHTTP}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 268 EventRootType Probe[main.HandleHTTP]
+          InjectionPoints: [{PC: "0xd59413", Frameless: false}]
+          Condition: null
+    - id: look_at_the_request
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.LookAtTheRequest}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 2
+          Type: 269 EventRootType Probe[main.LookAtTheRequest]
+          InjectionPoints: [{PC: "0xd5976e", Frameless: false}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.HandleHTTP
+      OutOfLinePCRanges: [0xd59400..0xd5969c]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Locations:
+            - Range: 0xd59400..0xd5946c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd5946c..0xd5946f
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd5946f..0xd5969c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: r
+          Type: 25 PointerType *net/http.Request
+          Locations:
+            - Range: 0xd59400..0xd59476
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd59476..0xd5969c
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: span
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0xd59488..0xd594c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 197 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd59598..0xd595ba
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd595ba..0xd5969c
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: .autotmp_14
+          Type: 200 StructureType context.backgroundCtx
+          Locations:
+            - Range: 0xd59400..0xd5969c
+              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 2
+      Name: main.LookAtTheRequest
+      OutOfLinePCRanges: [0xd59760..0xd59825]
+      InlinePCRanges: []
+      Variables:
+        - Name: path
+          Type: 27 GoStringHeaderType string
+          Locations:
+            - Range: 0xd59760..0xd59785
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.125344e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 2
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 3 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 3
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 397536
+      GoKind: 22
+      Pointee: 4 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 4
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.677216e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 5 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 22 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 23 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 5
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.118464e+06
+      GoKind: 22
+      Pointee: 6 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 6
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.480928e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 7 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 17 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 18 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 7
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 2.042848e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 8 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 8 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 10 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 11 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 11 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 12 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 14 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 8
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 542976
+      GoKind: 12
+    - __kind: BaseType
+      ID: 9
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542656
+      GoKind: 10
+    - __kind: BaseType
+      ID: 10
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 545600
+      GoKind: 8
+    - __kind: BaseType
+      ID: 11
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542400
+      GoKind: 8
+    - __kind: BaseType
+      ID: 12
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 780448
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 13
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 797664
+      GoKind: 19
+    - __kind: PointerType
+      ID: 14
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376096
+      GoKind: 22
+      Pointee: 11 BaseType uint8
+    - __kind: BaseType
+      ID: 15
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 545664
+      GoKind: 5
+    - __kind: BaseType
+      ID: 16
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 545728
+      GoKind: 5
+    - __kind: StructureType
+      ID: 17
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.8848e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 14 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 18
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 484800
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 19 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 202 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 19
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 397472
+      GoKind: 22
+      Pointee: 20 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 20
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.335552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 21
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 542848
+      GoKind: 2
+    - __kind: PointerType
+      ID: 22
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.118912e+06
+      GoKind: 22
+      Pointee: 7 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 23
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 636416
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 8 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 24
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 543360
+      GoKind: 26
+    - __kind: PointerType
+      ID: 25
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.219328e+06
+      GoKind: 22
+      Pointee: 26 StructureType net/http.Request
+    - __kind: StructureType
+      ID: 26
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.255648e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 28 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 32 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 54 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 54 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 55 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 33 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 27 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 27 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 70 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 129 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 130 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 27 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 133 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 42 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 138 GoMapType map[string]string
+    - __kind: GoStringHeaderType
+      ID: 27
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 542272
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 205 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+      Data: 204 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 28
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.001856e+06
+      GoKind: 22
+      Pointee: 29 StructureType net/url.URL
+    - __kind: StructureType
+      ID: 29
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.040928e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 30 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 32 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 27 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 27 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 30
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.141472e+06
+      GoKind: 22
+      Pointee: 31 StructureType net/url.Userinfo
+    - __kind: StructureType
+      ID: 31
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.469216e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 32
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 543296
+      GoKind: 1
+    - __kind: GoMapType
+      ID: 33
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.963648e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 38 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 216 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: BaseType
+      ID: 36
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 542528
+      GoKind: 9
+    - __kind: PointerType
+      ID: 37
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 38
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 41 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 37 PointerType *bucket<string,[]string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 42 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 39
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 632576
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: ArrayType
+      ID: 40
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 41
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 42 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 42
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 468896
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 43 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 207 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 375968
+      GoKind: 22
+      Pointee: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 44
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 379872
+      GoKind: 22
+      Pointee: 45 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 45
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.465184e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 46
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 470560
+      GoKind: 22
+      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 470496
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 209 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 48
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 49
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.13712e+06
+      GoKind: 22
+      Pointee: 50 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 50
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.136992e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+    - __kind: GoInterfaceType
+      ID: 51
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.09296e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 52
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 645248
+      GoKind: 19
+    - __kind: BaseType
+      ID: 53
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 542720
+      GoKind: 6
+    - __kind: GoMapType
+      ID: 54
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.711808e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 55
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 853696
+      GoKind: 22
+      Pointee: 56 StructureType mime/multipart.Form
+    - __kind: StructureType
+      ID: 56
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.325792e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 57 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoMapType
+      ID: 57
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 899200
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 904000
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 213 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: PointerType
+      ID: 61
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<string,[]*mime/multipart.FileHeader>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+        - Name: overflow
+          Offset: 328
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 63
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 461472
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 65
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 66
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 853600
+      GoKind: 22
+      Pointee: 67 StructureType mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 67
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.881056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 68 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 53 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 53 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 68
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.637312e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 467744
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 217 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 852160
+      GoKind: 22
+      Pointee: 71 StructureType crypto/tls.ConnectionState
+    - __kind: StructureType
+      ID: 71
+      Name: crypto/tls.ConnectionState
+      ByteSize: 192
+      GoRuntimeType: 2.16032e+06
+      GoKind: 25
+      RawFields:
+        - Name: Version
+          Offset: 0
+          Type: 36 BaseType uint16
+        - Name: HandshakeComplete
+          Offset: 2
+          Type: 32 BaseType bool
+        - Name: DidResume
+          Offset: 3
+          Type: 32 BaseType bool
+        - Name: CipherSuite
+          Offset: 4
+          Type: 36 BaseType uint16
+        - Name: NegotiatedProtocol
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: NegotiatedProtocolIsMutual
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: ServerName
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: PeerCertificates
+          Offset: 48
+          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+        - Name: VerifiedChains
+          Offset: 72
+          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+        - Name: SignedCertificateTimestamps
+          Offset: 96
+          Type: 125 GoSliceHeaderType [][]uint8
+        - Name: OCSPResponse
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: TLSUnique
+          Offset: 144
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: ECHAccepted
+          Offset: 168
+          Type: 32 BaseType bool
+        - Name: ekm
+          Offset: 176
+          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+        - Name: testingOnlyDidHRR
+          Offset: 184
+          Type: 32 BaseType bool
+        - Name: testingOnlyCurveID
+          Offset: 186
+          Type: 128 BaseType crypto/tls.CurveID
+    - __kind: GoSliceHeaderType
+      ID: 72
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 473664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 73 PointerType **crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 219 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 73
+      Name: '**crypto/x509.Certificate'
+      ByteSize: 8
+      Pointee: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 74
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.9528e+06
+      GoKind: 22
+      Pointee: 75 StructureType crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 75
+      Name: crypto/x509.Certificate
+      ByteSize: 1352
+      GoRuntimeType: 2.300352e+06
+      GoKind: 25
+      RawFields:
+        - Name: Raw
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawTBSCertificate
+          Offset: 24
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubjectPublicKeyInfo
+          Offset: 48
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubject
+          Offset: 72
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawIssuer
+          Offset: 96
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: Signature
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: SignatureAlgorithm
+          Offset: 144
+          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+        - Name: PublicKeyAlgorithm
+          Offset: 152
+          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+        - Name: PublicKey
+          Offset: 160
+          Type: 78 GoEmptyInterfaceType interface {}
+        - Name: Version
+          Offset: 176
+          Type: 21 BaseType int
+        - Name: SerialNumber
+          Offset: 184
+          Type: 80 PointerType *math/big.Int
+        - Name: Issuer
+          Offset: 192
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: Subject
+          Offset: 440
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: NotBefore
+          Offset: 688
+          Type: 91 StructureType time.Time
+        - Name: NotAfter
+          Offset: 712
+          Type: 91 StructureType time.Time
+        - Name: KeyUsage
+          Offset: 736
+          Type: 101 BaseType crypto/x509.KeyUsage
+        - Name: Extensions
+          Offset: 744
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: ExtraExtensions
+          Offset: 768
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: UnhandledCriticalExtensions
+          Offset: 792
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: ExtKeyUsage
+          Offset: 816
+          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+        - Name: UnknownExtKeyUsage
+          Offset: 840
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: BasicConstraintsValid
+          Offset: 864
+          Type: 32 BaseType bool
+        - Name: IsCA
+          Offset: 865
+          Type: 32 BaseType bool
+        - Name: MaxPathLen
+          Offset: 872
+          Type: 21 BaseType int
+        - Name: MaxPathLenZero
+          Offset: 880
+          Type: 32 BaseType bool
+        - Name: SubjectKeyId
+          Offset: 888
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: AuthorityKeyId
+          Offset: 912
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: OCSPServer
+          Offset: 936
+          Type: 42 GoSliceHeaderType []string
+        - Name: IssuingCertificateURL
+          Offset: 960
+          Type: 42 GoSliceHeaderType []string
+        - Name: DNSNames
+          Offset: 984
+          Type: 42 GoSliceHeaderType []string
+        - Name: EmailAddresses
+          Offset: 1008
+          Type: 42 GoSliceHeaderType []string
+        - Name: IPAddresses
+          Offset: 1032
+          Type: 110 GoSliceHeaderType []net.IP
+        - Name: URIs
+          Offset: 1056
+          Type: 113 GoSliceHeaderType []*net/url.URL
+        - Name: PermittedDNSDomainsCritical
+          Offset: 1080
+          Type: 32 BaseType bool
+        - Name: PermittedDNSDomains
+          Offset: 1088
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedDNSDomains
+          Offset: 1112
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedIPRanges
+          Offset: 1136
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: ExcludedIPRanges
+          Offset: 1160
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: PermittedEmailAddresses
+          Offset: 1184
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedEmailAddresses
+          Offset: 1208
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedURIDomains
+          Offset: 1232
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedURIDomains
+          Offset: 1256
+          Type: 42 GoSliceHeaderType []string
+        - Name: CRLDistributionPoints
+          Offset: 1280
+          Type: 42 GoSliceHeaderType []string
+        - Name: PolicyIdentifiers
+          Offset: 1304
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: Policies
+          Offset: 1328
+          Type: 120 GoSliceHeaderType []crypto/x509.OID
+    - __kind: BaseType
+      ID: 76
+      Name: crypto/x509.SignatureAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 1.097184e+06
+      GoKind: 2
+    - __kind: BaseType
+      ID: 77
+      Name: crypto/x509.PublicKeyAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 780640
+      GoKind: 2
+    - __kind: GoEmptyInterfaceType
+      ID: 78
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 797856
+      GoKind: 20
+      UnderlyingStructure: 79 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 79
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 22 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 80
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.2968e+06
+      GoKind: 22
+      Pointee: 81 StructureType math/big.Int
+    - __kind: StructureType
+      ID: 81
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.339552e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 82 GoSliceHeaderType math/big.nat
+    - __kind: GoSliceHeaderType
+      ID: 82
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.279904e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 83 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 221 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 83
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 401952
+      GoKind: 22
+      Pointee: 84 BaseType math/big.Word
+    - __kind: BaseType
+      ID: 84
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 546368
+      GoKind: 7
+    - __kind: StructureType
+      ID: 85
+      Name: crypto/x509/pkix.Name
+      ByteSize: 248
+      GoRuntimeType: 2.105056e+06
+      GoKind: 25
+      RawFields:
+        - Name: Country
+          Offset: 0
+          Type: 42 GoSliceHeaderType []string
+        - Name: Organization
+          Offset: 24
+          Type: 42 GoSliceHeaderType []string
+        - Name: OrganizationalUnit
+          Offset: 48
+          Type: 42 GoSliceHeaderType []string
+        - Name: Locality
+          Offset: 72
+          Type: 42 GoSliceHeaderType []string
+        - Name: Province
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: StreetAddress
+          Offset: 120
+          Type: 42 GoSliceHeaderType []string
+        - Name: PostalCode
+          Offset: 144
+          Type: 42 GoSliceHeaderType []string
+        - Name: SerialNumber
+          Offset: 168
+          Type: 27 GoStringHeaderType string
+        - Name: CommonName
+          Offset: 184
+          Type: 27 GoStringHeaderType string
+        - Name: Names
+          Offset: 200
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+        - Name: ExtraNames
+          Offset: 224
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 86
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 485824
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 87
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 414432
+      GoKind: 22
+      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: StructureType
+      ID: 88
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.347072e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: encoding/asn1.ObjectIdentifier
+      ByteSize: 24
+      GoRuntimeType: 1.03504e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 90
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 376544
+      GoKind: 22
+      Pointee: 21 BaseType int
+    - __kind: StructureType
+      ID: 91
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.280832e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 53 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 93 PointerType *time.Location
+    - __kind: BaseType
+      ID: 92
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 542784
+      GoKind: 11
+    - __kind: PointerType
+      ID: 93
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.45808e+06
+      GoKind: 22
+      Pointee: 94 StructureType time.Location
+    - __kind: StructureType
+      ID: 94
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.877312e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 95 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 98 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 27 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 96 PointerType *time.zone
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 463072
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 227 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 96
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 370848
+      GoKind: 22
+      Pointee: 97 StructureType time.zone
+    - __kind: StructureType
+      ID: 97
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.457888e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 32 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 463136
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 99 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 229 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 370912
+      GoKind: 22
+      Pointee: 100 StructureType time.zoneTrans
+    - __kind: StructureType
+      ID: 100
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.663584e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 53 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 32 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 101
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546048
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 485312
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 414624
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.49168e+06
+      GoKind: 25
+      RawFields:
+        - Name: Id
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 485376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 106
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.034912e+06
+      GoKind: 22
+      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 474944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 399136
+      GoKind: 22
+      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: BaseType
+      ID: 109
+      Name: crypto/x509.ExtKeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546112
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 458208
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 237 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 2.02848e+06
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 112
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.0008e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 239 GoSliceDataType net.IP.array
+    - __kind: GoSliceHeaderType
+      ID: 113
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 485440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 114 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 241 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 114
+      Name: '**net/url.URL'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 28 PointerType *net/url.URL
+    - __kind: GoSliceHeaderType
+      ID: 115
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 485504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 116 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 243 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 116
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 117
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.122784e+06
+      GoKind: 22
+      Pointee: 118 StructureType net.IPNet
+    - __kind: StructureType
+      ID: 118
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.306912e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 112 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 119 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceHeaderType
+      ID: 119
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 999200
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 245 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 485568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 247 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.76128e+06
+      GoKind: 22
+      Pointee: 122 StructureType crypto/x509.OID
+    - __kind: StructureType
+      ID: 122
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.761504e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 123
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 473792
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 124 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 124
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 125
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 456992
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 126 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 251 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 126
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 456736
+      GoKind: 22
+      Pointee: 69 GoSliceHeaderType []uint8
+    - __kind: GoSubroutineType
+      ID: 127
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 982944
+      GoKind: 19
+    - __kind: BaseType
+      ID: 128
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 778432
+      GoKind: 9
+    - __kind: GoChannelType
+      ID: 129
+      Name: <-chan struct {}
+      GoRuntimeType: 555264
+      GoKind: 18
+    - __kind: PointerType
+      ID: 130
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.632128e+06
+      GoKind: 22
+      Pointee: 131 StructureType net/http.Response
+    - __kind: StructureType
+      ID: 131
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.123392e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 32 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 32 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 33 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 25 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 70 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 132
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.215648e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: PointerType
+      ID: 133
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.453088e+06
+      GoKind: 22
+      Pointee: 134 StructureType net/http.pattern
+    - __kind: StructureType
+      ID: 134
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.745152e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 135 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 135
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 458976
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 136 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 253 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 136
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 367776
+      GoKind: 22
+      Pointee: 137 StructureType net/http.segment
+    - __kind: StructureType
+      ID: 137
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.452896e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 32 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 138
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 900832
+      GoKind: 21
+      HeaderType: 140 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 139
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 140 GoHMapHeaderType hash<string,string>
+    - __kind: GoHMapHeaderType
+      ID: 140
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 141 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 141 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<string,string>
+      BucketsType: 255 GoSliceDataType []bucket<string,string>.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoHMapBucketType
+      ID: 142
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 143 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 141 PointerType *bucket<string,string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 143
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 144
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.18704e+06
+      GoKind: 22
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: StructureType
+      ID: 145
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.25136e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 146 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 53 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 138 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 151 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 157 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 92 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 92 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 92 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 148 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 32 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 32 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 32 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 27 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 32 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 132 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 196 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 146
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.750752e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 147 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 9 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 149 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 149 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 147
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.313952e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 148 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 9 BaseType uint32
+    - __kind: BaseType
+      ID: 148
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 542592
+      GoKind: 5
+    - __kind: StructureType
+      ID: 149
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315392e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 150 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 148 BaseType int32
+    - __kind: StructureType
+      ID: 150
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 965760
+      GoKind: 25
+      RawFields: []
+    - __kind: GoMapType
+      ID: 151
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.007264e+06
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 152
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoHMapHeaderType
+      ID: 153
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 154 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 154 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 155 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 265 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: PointerType
+      ID: 154
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoHMapBucketType
+      ID: 155
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 156 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 154 PointerType *bucket<string,interface {}>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 78 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 156
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoMapType
+      ID: 157
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 904864
+      GoKind: 21
+      HeaderType: 159 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 158
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 159 GoHMapHeaderType hash<string,float64>
+    - __kind: GoHMapHeaderType
+      ID: 159
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 160 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 160 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 161 GoHMapBucketType bucket<string,float64>
+      BucketsType: 257 GoSliceDataType []bucket<string,float64>.array
+    - __kind: PointerType
+      ID: 160
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 161 GoHMapBucketType bucket<string,float64>
+    - __kind: GoHMapBucketType
+      ID: 161
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 162 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 160 PointerType *bucket<string,float64>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 163 BaseType float64
+    - __kind: ArrayType
+      ID: 162
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 163 BaseType float64
+    - __kind: BaseType
+      ID: 163
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 543232
+      GoKind: 14
+    - __kind: GoSliceHeaderType
+      ID: 164
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463392
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 165
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.129312e+06
+      GoKind: 22
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: StructureType
+      ID: 166
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.821952e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 92 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 92 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 138 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 9 BaseType uint32
+    - __kind: GoSliceHeaderType
+      ID: 167
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 168
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.12944e+06
+      GoKind: 22
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: StructureType
+      ID: 169
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.663776e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 92 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 170 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 186 GoMapType map[string]interface {}
+    - __kind: GoMapType
+      ID: 170
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 904960
+      GoKind: 21
+      HeaderType: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 171
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoHMapHeaderType
+      ID: 172
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 262 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: PointerType
+      ID: 173
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoHMapBucketType
+      ID: 174
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 175 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 175
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 176
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130208e+06
+      GoKind: 22
+      Pointee: 177 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 177
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.822208e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 178 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 53 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 163 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 178
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 964992
+      GoKind: 5
+    - __kind: PointerType
+      ID: 179
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.13008e+06
+      GoKind: 22
+      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: StructureType
+      ID: 180
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.129952e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 181 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: GoSliceHeaderType
+      ID: 181
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 463456
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 182 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 182
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 183
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.129824e+06
+      GoKind: 22
+      Pointee: 184 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 184
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.748064e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 185 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 53 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 163 BaseType float64
+    - __kind: BaseType
+      ID: 185
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 965088
+      GoKind: 5
+    - __kind: GoMapType
+      ID: 186
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896320
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 187
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.91664e+06
+      GoKind: 22
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: StructureType
+      ID: 188
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 168
+      GoRuntimeType: 2.124736e+06
+      GoKind: 25
+      RawFields:
+        - Name: updated
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: trace
+          Offset: 8
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+        - Name: span
+          Offset: 16
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: errors
+          Offset: 24
+          Type: 149 StructureType sync/atomic.Int32
+        - Name: reparentID
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: isRemote
+          Offset: 48
+          Type: 32 BaseType bool
+        - Name: traceID
+          Offset: 49
+          Type: 195 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+        - Name: spanID
+          Offset: 72
+          Type: 92 BaseType uint64
+        - Name: mu
+          Offset: 80
+          Type: 146 StructureType sync.RWMutex
+        - Name: baggage
+          Offset: 104
+          Type: 138 GoMapType map[string]string
+        - Name: hasBaggage
+          Offset: 112
+          Type: 9 BaseType uint32
+        - Name: origin
+          Offset: 120
+          Type: 27 GoStringHeaderType string
+        - Name: spanLinks
+          Offset: 136
+          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: baggageOnly
+          Offset: 160
+          Type: 32 BaseType bool
+    - __kind: PointerType
+      ID: 189
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.131904e+06
+      GoKind: 22
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: StructureType
+      ID: 190
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      ByteSize: 104
+      GoRuntimeType: 2.016896e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 146 StructureType sync.RWMutex
+        - Name: spans
+          Offset: 24
+          Type: 191 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: tags
+          Offset: 48
+          Type: 138 GoMapType map[string]string
+        - Name: propagatingTags
+          Offset: 56
+          Type: 138 GoMapType map[string]string
+        - Name: finished
+          Offset: 64
+          Type: 21 BaseType int
+        - Name: full
+          Offset: 72
+          Type: 32 BaseType bool
+        - Name: priority
+          Offset: 80
+          Type: 193 PointerType *float64
+        - Name: locked
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: samplingDecision
+          Offset: 92
+          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+        - Name: root
+          Offset: 96
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 191
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 463840
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 192 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 192
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 193
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 376928
+      GoKind: 22
+      Pointee: 163 BaseType float64
+    - __kind: BaseType
+      ID: 194
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 542080
+      GoKind: 10
+    - __kind: ArrayType
+      ID: 195
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+      ByteSize: 16
+      GoRuntimeType: 847552
+      GoKind: 17
+      Count: 16
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: GoSubroutineType
+      ID: 196
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 455328
+      GoKind: 19
+    - __kind: PointerType
+      ID: 197
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.176256e+06
+      GoKind: 22
+      Pointee: 198 StructureType bytes.Buffer
+    - __kind: StructureType
+      ID: 198
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.450784e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 21 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 199 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 199
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541504
+      GoKind: 3
+    - __kind: StructureType
+      ID: 200
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.708224e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 201 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 201
+      Name: context.emptyCtx
+      GoRuntimeType: 1.434688e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 20 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 203
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 202 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoStringDataType
+      ID: 204
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 205
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 204 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 208
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 210
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 215
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 217
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 218
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 217 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 221
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 84 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 222
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 221 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 223
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 224
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 225
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 21 BaseType int
+    - __kind: PointerType
+      ID: 226
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 97 StructureType time.zone
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 229
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 100 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 230
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 229 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 232
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 112 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 240
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 28 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 246
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 122 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 248
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 250
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 69 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 252
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 137 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 254
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 257
+      Name: '[]bucket<string,float64>.array'
+      ByteSize: 2048
+      Element: 161 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 261
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 2048
+      Element: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 267
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 8
+      Pointee: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 25 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 269
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 27 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+MaxTypeID: 269
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,0 +1,3178 @@
+ID: 1
+Probes:
+    - id: http_handler
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.HandleHTTP}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 268 EventRootType Probe[main.HandleHTTP]
+          InjectionPoints: [{PC: "0x8dfb70", Frameless: true}]
+          Condition: null
+    - id: look_at_the_request
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.LookAtTheRequest}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 2
+          Type: 269 EventRootType Probe[main.LookAtTheRequest]
+          InjectionPoints: [{PC: "0x8dfe8c", Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.HandleHTTP
+      OutOfLinePCRanges: [0x8dfb60..0x8dfda0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Locations:
+            - Range: 0x8dfb60..0x8dfbb8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8dfbb8..0x8dfbbc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8dfbbc..0x8dfda0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          IsParameter: true
+          IsReturn: false
+        - Name: r
+          Type: 25 PointerType *net/http.Request
+          Locations:
+            - Range: 0x8dfb60..0x8dfbc4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x8dfbc4..0x8dfda0
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: span
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0x8dfbd8..0x8dfc08
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 197 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x8dfcac..0x8dfcc8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8dfcc8..0x8dfda0
+              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: .autotmp_14
+          Type: 200 StructureType context.backgroundCtx
+          Locations:
+            - Range: 0x8dfb60..0x8dfda0
+              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 2
+      Name: main.LookAtTheRequest
+      OutOfLinePCRanges: [0x8dfe80..0x8dff40]
+      InlinePCRanges: []
+      Variables:
+        - Name: path
+          Type: 27 GoStringHeaderType string
+          Locations:
+            - Range: 0x8dfe80..0x8dfea4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.125568e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 2
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 3 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 3
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 397632
+      GoKind: 22
+      Pointee: 4 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 4
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.677792e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 5 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 22 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 23 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 5
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.11904e+06
+      GoKind: 22
+      Pointee: 6 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 6
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.481312e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 7 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 17 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 18 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 7
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 2.043424e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 8 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 8 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 10 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 11 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 11 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 12 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 14 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 8
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 543200
+      GoKind: 12
+    - __kind: BaseType
+      ID: 9
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542880
+      GoKind: 10
+    - __kind: BaseType
+      ID: 10
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 545824
+      GoKind: 8
+    - __kind: BaseType
+      ID: 11
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542624
+      GoKind: 8
+    - __kind: BaseType
+      ID: 12
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 780576
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 13
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 797792
+      GoKind: 19
+    - __kind: PointerType
+      ID: 14
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376192
+      GoKind: 22
+      Pointee: 11 BaseType uint8
+    - __kind: BaseType
+      ID: 15
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 545888
+      GoKind: 5
+    - __kind: BaseType
+      ID: 16
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 545952
+      GoKind: 5
+    - __kind: StructureType
+      ID: 17
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.885376e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 14 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 18
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 484960
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 19 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 202 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 19
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 397568
+      GoKind: 22
+      Pointee: 20 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 20
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.335776e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 21
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 543072
+      GoKind: 2
+    - __kind: PointerType
+      ID: 22
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.119488e+06
+      GoKind: 22
+      Pointee: 7 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 23
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 636736
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 8 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 24
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 543584
+      GoKind: 26
+    - __kind: PointerType
+      ID: 25
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.219904e+06
+      GoKind: 22
+      Pointee: 26 StructureType net/http.Request
+    - __kind: StructureType
+      ID: 26
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.256224e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 28 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 32 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 54 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 54 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 55 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 33 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 27 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 27 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 70 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 129 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 130 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 27 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 133 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 42 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 138 GoMapType map[string]string
+    - __kind: GoStringHeaderType
+      ID: 27
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 542496
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 205 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+      Data: 204 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 28
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 2.002432e+06
+      GoKind: 22
+      Pointee: 29 StructureType net/url.URL
+    - __kind: StructureType
+      ID: 29
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 2.041504e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 30 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 32 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 27 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 27 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 30
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.141696e+06
+      GoKind: 22
+      Pointee: 31 StructureType net/url.Userinfo
+    - __kind: StructureType
+      ID: 31
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.4696e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 32
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 543520
+      GoKind: 1
+    - __kind: GoMapType
+      ID: 33
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.964224e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 38 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 216 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: BaseType
+      ID: 36
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 542752
+      GoKind: 9
+    - __kind: PointerType
+      ID: 37
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 38
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 41 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 37 PointerType *bucket<string,[]string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 42 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 39
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 632800
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: ArrayType
+      ID: 40
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 41
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 42 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 42
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 469056
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 43 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 207 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 376064
+      GoKind: 22
+      Pointee: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 44
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 379968
+      GoKind: 22
+      Pointee: 45 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 45
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.465568e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 46
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 470720
+      GoKind: 22
+      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 470656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 209 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 48
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 49
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.137344e+06
+      GoKind: 22
+      Pointee: 50 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 50
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.137216e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+    - __kind: GoInterfaceType
+      ID: 51
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.093184e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 52
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 645568
+      GoKind: 19
+    - __kind: BaseType
+      ID: 53
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 542944
+      GoKind: 6
+    - __kind: GoMapType
+      ID: 54
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.712384e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 55
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 853824
+      GoKind: 22
+      Pointee: 56 StructureType mime/multipart.Form
+    - __kind: StructureType
+      ID: 56
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.326016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 57 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoMapType
+      ID: 57
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 899328
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 904128
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 213 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: PointerType
+      ID: 61
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<string,[]*mime/multipart.FileHeader>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+        - Name: overflow
+          Offset: 328
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 63
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 461632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 65
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 66
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 853728
+      GoKind: 22
+      Pointee: 67 StructureType mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 67
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.881632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 68 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 53 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 53 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 68
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.637888e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 467904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 217 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 852288
+      GoKind: 22
+      Pointee: 71 StructureType crypto/tls.ConnectionState
+    - __kind: StructureType
+      ID: 71
+      Name: crypto/tls.ConnectionState
+      ByteSize: 192
+      GoRuntimeType: 2.160896e+06
+      GoKind: 25
+      RawFields:
+        - Name: Version
+          Offset: 0
+          Type: 36 BaseType uint16
+        - Name: HandshakeComplete
+          Offset: 2
+          Type: 32 BaseType bool
+        - Name: DidResume
+          Offset: 3
+          Type: 32 BaseType bool
+        - Name: CipherSuite
+          Offset: 4
+          Type: 36 BaseType uint16
+        - Name: NegotiatedProtocol
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: NegotiatedProtocolIsMutual
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: ServerName
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: PeerCertificates
+          Offset: 48
+          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+        - Name: VerifiedChains
+          Offset: 72
+          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+        - Name: SignedCertificateTimestamps
+          Offset: 96
+          Type: 125 GoSliceHeaderType [][]uint8
+        - Name: OCSPResponse
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: TLSUnique
+          Offset: 144
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: ECHAccepted
+          Offset: 168
+          Type: 32 BaseType bool
+        - Name: ekm
+          Offset: 176
+          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+        - Name: testingOnlyDidHRR
+          Offset: 184
+          Type: 32 BaseType bool
+        - Name: testingOnlyCurveID
+          Offset: 186
+          Type: 128 BaseType crypto/tls.CurveID
+    - __kind: GoSliceHeaderType
+      ID: 72
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 473824
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 73 PointerType **crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 219 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 73
+      Name: '**crypto/x509.Certificate'
+      ByteSize: 8
+      Pointee: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 74
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.953376e+06
+      GoKind: 22
+      Pointee: 75 StructureType crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 75
+      Name: crypto/x509.Certificate
+      ByteSize: 1352
+      GoRuntimeType: 2.300928e+06
+      GoKind: 25
+      RawFields:
+        - Name: Raw
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawTBSCertificate
+          Offset: 24
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubjectPublicKeyInfo
+          Offset: 48
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubject
+          Offset: 72
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawIssuer
+          Offset: 96
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: Signature
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: SignatureAlgorithm
+          Offset: 144
+          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+        - Name: PublicKeyAlgorithm
+          Offset: 152
+          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+        - Name: PublicKey
+          Offset: 160
+          Type: 78 GoEmptyInterfaceType interface {}
+        - Name: Version
+          Offset: 176
+          Type: 21 BaseType int
+        - Name: SerialNumber
+          Offset: 184
+          Type: 80 PointerType *math/big.Int
+        - Name: Issuer
+          Offset: 192
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: Subject
+          Offset: 440
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: NotBefore
+          Offset: 688
+          Type: 91 StructureType time.Time
+        - Name: NotAfter
+          Offset: 712
+          Type: 91 StructureType time.Time
+        - Name: KeyUsage
+          Offset: 736
+          Type: 101 BaseType crypto/x509.KeyUsage
+        - Name: Extensions
+          Offset: 744
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: ExtraExtensions
+          Offset: 768
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: UnhandledCriticalExtensions
+          Offset: 792
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: ExtKeyUsage
+          Offset: 816
+          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+        - Name: UnknownExtKeyUsage
+          Offset: 840
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: BasicConstraintsValid
+          Offset: 864
+          Type: 32 BaseType bool
+        - Name: IsCA
+          Offset: 865
+          Type: 32 BaseType bool
+        - Name: MaxPathLen
+          Offset: 872
+          Type: 21 BaseType int
+        - Name: MaxPathLenZero
+          Offset: 880
+          Type: 32 BaseType bool
+        - Name: SubjectKeyId
+          Offset: 888
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: AuthorityKeyId
+          Offset: 912
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: OCSPServer
+          Offset: 936
+          Type: 42 GoSliceHeaderType []string
+        - Name: IssuingCertificateURL
+          Offset: 960
+          Type: 42 GoSliceHeaderType []string
+        - Name: DNSNames
+          Offset: 984
+          Type: 42 GoSliceHeaderType []string
+        - Name: EmailAddresses
+          Offset: 1008
+          Type: 42 GoSliceHeaderType []string
+        - Name: IPAddresses
+          Offset: 1032
+          Type: 110 GoSliceHeaderType []net.IP
+        - Name: URIs
+          Offset: 1056
+          Type: 113 GoSliceHeaderType []*net/url.URL
+        - Name: PermittedDNSDomainsCritical
+          Offset: 1080
+          Type: 32 BaseType bool
+        - Name: PermittedDNSDomains
+          Offset: 1088
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedDNSDomains
+          Offset: 1112
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedIPRanges
+          Offset: 1136
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: ExcludedIPRanges
+          Offset: 1160
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: PermittedEmailAddresses
+          Offset: 1184
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedEmailAddresses
+          Offset: 1208
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedURIDomains
+          Offset: 1232
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedURIDomains
+          Offset: 1256
+          Type: 42 GoSliceHeaderType []string
+        - Name: CRLDistributionPoints
+          Offset: 1280
+          Type: 42 GoSliceHeaderType []string
+        - Name: PolicyIdentifiers
+          Offset: 1304
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: Policies
+          Offset: 1328
+          Type: 120 GoSliceHeaderType []crypto/x509.OID
+    - __kind: BaseType
+      ID: 76
+      Name: crypto/x509.SignatureAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 1.097408e+06
+      GoKind: 2
+    - __kind: BaseType
+      ID: 77
+      Name: crypto/x509.PublicKeyAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 780768
+      GoKind: 2
+    - __kind: GoEmptyInterfaceType
+      ID: 78
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 797984
+      GoKind: 20
+      UnderlyingStructure: 79 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 79
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 22 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 80
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.297376e+06
+      GoKind: 22
+      Pointee: 81 StructureType math/big.Int
+    - __kind: StructureType
+      ID: 81
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.339776e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 82 GoSliceHeaderType math/big.nat
+    - __kind: GoSliceHeaderType
+      ID: 82
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.28048e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 83 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 221 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 83
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 402048
+      GoKind: 22
+      Pointee: 84 BaseType math/big.Word
+    - __kind: BaseType
+      ID: 84
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 546592
+      GoKind: 7
+    - __kind: StructureType
+      ID: 85
+      Name: crypto/x509/pkix.Name
+      ByteSize: 248
+      GoRuntimeType: 2.105632e+06
+      GoKind: 25
+      RawFields:
+        - Name: Country
+          Offset: 0
+          Type: 42 GoSliceHeaderType []string
+        - Name: Organization
+          Offset: 24
+          Type: 42 GoSliceHeaderType []string
+        - Name: OrganizationalUnit
+          Offset: 48
+          Type: 42 GoSliceHeaderType []string
+        - Name: Locality
+          Offset: 72
+          Type: 42 GoSliceHeaderType []string
+        - Name: Province
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: StreetAddress
+          Offset: 120
+          Type: 42 GoSliceHeaderType []string
+        - Name: PostalCode
+          Offset: 144
+          Type: 42 GoSliceHeaderType []string
+        - Name: SerialNumber
+          Offset: 168
+          Type: 27 GoStringHeaderType string
+        - Name: CommonName
+          Offset: 184
+          Type: 27 GoStringHeaderType string
+        - Name: Names
+          Offset: 200
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+        - Name: ExtraNames
+          Offset: 224
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 86
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 485984
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 87
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 414592
+      GoKind: 22
+      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: StructureType
+      ID: 88
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.347456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: encoding/asn1.ObjectIdentifier
+      ByteSize: 24
+      GoRuntimeType: 1.035264e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 90
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 376640
+      GoKind: 22
+      Pointee: 21 BaseType int
+    - __kind: StructureType
+      ID: 91
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.281408e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 53 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 93 PointerType *time.Location
+    - __kind: BaseType
+      ID: 92
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 543008
+      GoKind: 11
+    - __kind: PointerType
+      ID: 93
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.458464e+06
+      GoKind: 22
+      Pointee: 94 StructureType time.Location
+    - __kind: StructureType
+      ID: 94
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.877888e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 95 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 98 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 27 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 96 PointerType *time.zone
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 463232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 227 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 96
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 370944
+      GoKind: 22
+      Pointee: 97 StructureType time.zone
+    - __kind: StructureType
+      ID: 97
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.458272e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 32 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 463296
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 99 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 229 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 371008
+      GoKind: 22
+      Pointee: 100 StructureType time.zoneTrans
+    - __kind: StructureType
+      ID: 100
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.66416e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 53 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 32 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 101
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546272
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 485472
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 414784
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.492064e+06
+      GoKind: 25
+      RawFields:
+        - Name: Id
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 485536
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 106
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.035136e+06
+      GoKind: 22
+      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 475104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 399232
+      GoKind: 22
+      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: BaseType
+      ID: 109
+      Name: crypto/x509.ExtKeyUsage
+      ByteSize: 8
+      GoRuntimeType: 546336
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 458368
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 237 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 2.029056e+06
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 112
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 2.001376e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 239 GoSliceDataType net.IP.array
+    - __kind: GoSliceHeaderType
+      ID: 113
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 485600
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 114 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 241 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 114
+      Name: '**net/url.URL'
+      ByteSize: 8
+      Pointee: 28 PointerType *net/url.URL
+    - __kind: GoSliceHeaderType
+      ID: 115
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 485664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 116 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 243 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 116
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 117
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.123008e+06
+      GoKind: 22
+      Pointee: 118 StructureType net.IPNet
+    - __kind: StructureType
+      ID: 118
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.307136e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 112 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 119 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceHeaderType
+      ID: 119
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 999424
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 245 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 485728
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 247 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.761856e+06
+      GoKind: 22
+      Pointee: 122 StructureType crypto/x509.OID
+    - __kind: StructureType
+      ID: 122
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.76208e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 123
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 473952
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 124 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 124
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 125
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 457152
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 126 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 251 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 126
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 456896
+      GoKind: 22
+      Pointee: 69 GoSliceHeaderType []uint8
+    - __kind: GoSubroutineType
+      ID: 127
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 983168
+      GoKind: 19
+    - __kind: BaseType
+      ID: 128
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 778560
+      GoKind: 9
+    - __kind: GoChannelType
+      ID: 129
+      Name: <-chan struct {}
+      GoRuntimeType: 555488
+      GoKind: 18
+    - __kind: PointerType
+      ID: 130
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.632704e+06
+      GoKind: 22
+      Pointee: 131 StructureType net/http.Response
+    - __kind: StructureType
+      ID: 131
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.123968e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 32 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 32 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 33 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 25 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 70 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 132
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.215872e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: PointerType
+      ID: 133
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.453472e+06
+      GoKind: 22
+      Pointee: 134 StructureType net/http.pattern
+    - __kind: StructureType
+      ID: 134
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.745728e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 135 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 135
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 459136
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 136 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 253 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 136
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 367872
+      GoKind: 22
+      Pointee: 137 StructureType net/http.segment
+    - __kind: StructureType
+      ID: 137
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.45328e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 32 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 138
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 900960
+      GoKind: 21
+      HeaderType: 140 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 139
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 140 GoHMapHeaderType hash<string,string>
+    - __kind: GoHMapHeaderType
+      ID: 140
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 141 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 141 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<string,string>
+      BucketsType: 255 GoSliceDataType []bucket<string,string>.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoHMapBucketType
+      ID: 142
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 143 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 141 PointerType *bucket<string,string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 143
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 144
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.187616e+06
+      GoKind: 22
+      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: StructureType
+      ID: 145
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.251936e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 146 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 53 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 138 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 151 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 157 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 92 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 92 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 92 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 148 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 32 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 32 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 32 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 27 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 32 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 132 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 196 GoSubroutineType func()
+    - __kind: StructureType
+      ID: 146
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.751328e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 147 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 9 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 149 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 149 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 147
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.314176e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 148 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 9 BaseType uint32
+    - __kind: BaseType
+      ID: 148
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 542816
+      GoKind: 5
+    - __kind: StructureType
+      ID: 149
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315616e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 150 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 148 BaseType int32
+    - __kind: StructureType
+      ID: 150
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 965984
+      GoKind: 25
+      RawFields: []
+    - __kind: GoMapType
+      ID: 151
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.007488e+06
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 152
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoHMapHeaderType
+      ID: 153
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 154 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 154 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 155 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 265 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: PointerType
+      ID: 154
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoHMapBucketType
+      ID: 155
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 156 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 154 PointerType *bucket<string,interface {}>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 78 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 156
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoMapType
+      ID: 157
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 904992
+      GoKind: 21
+      HeaderType: 159 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 158
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 159 GoHMapHeaderType hash<string,float64>
+    - __kind: GoHMapHeaderType
+      ID: 159
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 160 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 160 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 161 GoHMapBucketType bucket<string,float64>
+      BucketsType: 257 GoSliceDataType []bucket<string,float64>.array
+    - __kind: PointerType
+      ID: 160
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 161 GoHMapBucketType bucket<string,float64>
+    - __kind: GoHMapBucketType
+      ID: 161
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 162 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 160 PointerType *bucket<string,float64>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 163 BaseType float64
+    - __kind: ArrayType
+      ID: 162
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 163 BaseType float64
+    - __kind: BaseType
+      ID: 163
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 543456
+      GoKind: 14
+    - __kind: GoSliceHeaderType
+      ID: 164
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463552
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 165
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.129536e+06
+      GoKind: 22
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: StructureType
+      ID: 166
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.822528e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 92 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 92 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 138 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 9 BaseType uint32
+    - __kind: GoSliceHeaderType
+      ID: 167
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463744
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
+      ID: 168
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.129664e+06
+      GoKind: 22
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: StructureType
+      ID: 169
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.664352e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 92 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 170 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 186 GoMapType map[string]interface {}
+    - __kind: GoMapType
+      ID: 170
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 905088
+      GoKind: 21
+      HeaderType: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 171
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoHMapHeaderType
+      ID: 172
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 262 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: PointerType
+      ID: 173
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoHMapBucketType
+      ID: 174
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 175 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 175
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 176
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130432e+06
+      GoKind: 22
+      Pointee: 177 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 177
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 56
+      GoRuntimeType: 1.822784e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 178 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+        - Name: StringValue
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 53 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 163 BaseType float64
+        - Name: ArrayValue
+          Offset: 48
+          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: BaseType
+      ID: 178
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+      ByteSize: 4
+      GoRuntimeType: 965216
+      GoKind: 5
+    - __kind: PointerType
+      ID: 179
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130304e+06
+      GoKind: 22
+      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+    - __kind: StructureType
+      ID: 180
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      ByteSize: 24
+      GoRuntimeType: 1.130176e+06
+      GoKind: 25
+      RawFields:
+        - Name: Values
+          Offset: 0
+          Type: 181 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: GoSliceHeaderType
+      ID: 181
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 24
+      GoRuntimeType: 463616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 182 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: PointerType
+      ID: 182
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 183
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
+      ByteSize: 8
+      GoRuntimeType: 1.130048e+06
+      GoKind: 22
+      Pointee: 184 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: StructureType
+      ID: 184
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      ByteSize: 48
+      GoRuntimeType: 1.74864e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 185 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+        - Name: StringValue
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: BoolValue
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: IntValue
+          Offset: 32
+          Type: 53 BaseType int64
+        - Name: DoubleValue
+          Offset: 40
+          Type: 163 BaseType float64
+    - __kind: BaseType
+      ID: 185
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+      ByteSize: 4
+      GoRuntimeType: 965312
+      GoKind: 5
+    - __kind: GoMapType
+      ID: 186
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896448
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 187
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.917216e+06
+      GoKind: 22
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: StructureType
+      ID: 188
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 168
+      GoRuntimeType: 2.125312e+06
+      GoKind: 25
+      RawFields:
+        - Name: updated
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: trace
+          Offset: 8
+          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+        - Name: span
+          Offset: 16
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: errors
+          Offset: 24
+          Type: 149 StructureType sync/atomic.Int32
+        - Name: reparentID
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: isRemote
+          Offset: 48
+          Type: 32 BaseType bool
+        - Name: traceID
+          Offset: 49
+          Type: 195 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+        - Name: spanID
+          Offset: 72
+          Type: 92 BaseType uint64
+        - Name: mu
+          Offset: 80
+          Type: 146 StructureType sync.RWMutex
+        - Name: baggage
+          Offset: 104
+          Type: 138 GoMapType map[string]string
+        - Name: hasBaggage
+          Offset: 112
+          Type: 9 BaseType uint32
+        - Name: origin
+          Offset: 120
+          Type: 27 GoStringHeaderType string
+        - Name: spanLinks
+          Offset: 136
+          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: baggageOnly
+          Offset: 160
+          Type: 32 BaseType bool
+    - __kind: PointerType
+      ID: 189
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
+      ByteSize: 8
+      GoRuntimeType: 2.13248e+06
+      GoKind: 22
+      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+    - __kind: StructureType
+      ID: 190
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      ByteSize: 104
+      GoRuntimeType: 2.017472e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 146 StructureType sync.RWMutex
+        - Name: spans
+          Offset: 24
+          Type: 191 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: tags
+          Offset: 48
+          Type: 138 GoMapType map[string]string
+        - Name: propagatingTags
+          Offset: 56
+          Type: 138 GoMapType map[string]string
+        - Name: finished
+          Offset: 64
+          Type: 21 BaseType int
+        - Name: full
+          Offset: 72
+          Type: 32 BaseType bool
+        - Name: priority
+          Offset: 80
+          Type: 193 PointerType *float64
+        - Name: locked
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: samplingDecision
+          Offset: 92
+          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+        - Name: root
+          Offset: 96
+          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: GoSliceHeaderType
+      ID: 191
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 24
+      GoRuntimeType: 464000
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 192 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: PointerType
+      ID: 192
+      Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 193
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 377024
+      GoKind: 22
+      Pointee: 163 BaseType float64
+    - __kind: BaseType
+      ID: 194
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+      ByteSize: 4
+      GoRuntimeType: 542304
+      GoKind: 10
+    - __kind: ArrayType
+      ID: 195
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+      ByteSize: 16
+      GoRuntimeType: 847680
+      GoKind: 17
+      Count: 16
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: GoSubroutineType
+      ID: 196
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 455488
+      GoKind: 19
+    - __kind: PointerType
+      ID: 197
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.176832e+06
+      GoKind: 22
+      Pointee: 198 StructureType bytes.Buffer
+    - __kind: StructureType
+      ID: 198
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.451168e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 21 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 199 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 199
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541728
+      GoKind: 3
+    - __kind: StructureType
+      ID: 200
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.7088e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 201 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 201
+      Name: context.emptyCtx
+      GoRuntimeType: 1.435072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 20 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 203
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 202 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoStringDataType
+      ID: 204
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 205
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 204 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 208
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 207 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 209
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 210
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 209 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 215
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 217
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 218
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 217 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 220
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 221
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 84 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 222
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 221 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 223
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 224
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 225
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 21 BaseType int
+    - __kind: PointerType
+      ID: 226
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 97 StructureType time.zone
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 229
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 100 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 230
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 229 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 231
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 232
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 233
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 234
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 235
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 236
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 112 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 238
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 237 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 239
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 240
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 239 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 28 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 242
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 241 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 243
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 244
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 243 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 245
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 246
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 245 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 247
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 122 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 248
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 247 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 249
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 250
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 251
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 69 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 252
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 253
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 137 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 254
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 253 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 255
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceDataType
+      ID: 256
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 257
+      Name: '[]bucket<string,float64>.array'
+      ByteSize: 2048
+      Element: 161 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 258
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 2048
+      Element: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 259
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 260
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 2048
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 261
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 262
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      ByteSize: 2048
+      Element: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 263
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 2048
+      Element: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+    - __kind: PointerType
+      ID: 264
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
+      ByteSize: 8
+      Pointee: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]bucket<string,interface {}>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 266
+      Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 2048
+      Element: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 267
+      Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
+      ByteSize: 8
+      Pointee: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 25 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 269
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 27 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+MaxTypeID: 269
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,0 +1,2393 @@
+ID: 1
+Probes:
+    - id: http_handler
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.HandleHTTP}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 204 EventRootType Probe[main.HandleHTTP]
+          InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
+          Condition: null
+    - id: look_at_the_request
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.LookAtTheRequest}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 2
+          Type: 205 EventRootType Probe[main.LookAtTheRequest]
+          InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.HandleHTTP
+      OutOfLinePCRanges: [0xd289e0..0xd28c90]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Locations:
+            - Range: 0xd289e0..0xd28a4c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd28a4c..0xd28a4f
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd28a4f..0xd28c90
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: r
+          Type: 25 PointerType *net/http.Request
+          Locations:
+            - Range: 0xd289e0..0xd28a56
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd28a56..0xd28c90
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: '&buf'
+          Type: 144 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd28b8f..0xd28bb1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd28bb1..0xd28c90
+              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 147 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0xd28a68..0xd28a68
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd28a68..0xd28aa8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd28aa8..0xd28aac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: false
+          IsReturn: false
+        - Name: .autotmp_14
+          Type: 148 StructureType context.backgroundCtx
+          Locations:
+            - Range: 0xd289e0..0xd28c90
+              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 2
+      Name: main.LookAtTheRequest
+      OutOfLinePCRanges: [0xd28d60..0xd28e25]
+      InlinePCRanges: []
+      Variables:
+        - Name: path
+          Type: 27 GoStringHeaderType string
+          Locations:
+            - Range: 0xd28d60..0xd28d85
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.098336e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 2
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 3 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 3
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 393440
+      GoKind: 22
+      Pointee: 4 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 4
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.636192e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 5 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 22 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 23 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 5
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.059904e+06
+      GoKind: 22
+      Pointee: 6 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 6
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.444448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 7 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 17 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 18 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 7
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 1.988576e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 8 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 8 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 10 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 11 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 11 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 12 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 14 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 8
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 534272
+      GoKind: 12
+    - __kind: BaseType
+      ID: 9
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 533952
+      GoKind: 10
+    - __kind: BaseType
+      ID: 10
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 536768
+      GoKind: 8
+    - __kind: BaseType
+      ID: 11
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533696
+      GoKind: 8
+    - __kind: BaseType
+      ID: 12
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 768256
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 13
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 785184
+      GoKind: 19
+    - __kind: PointerType
+      ID: 14
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371744
+      GoKind: 22
+      Pointee: 11 BaseType uint8
+    - __kind: BaseType
+      ID: 15
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 536832
+      GoKind: 5
+    - __kind: BaseType
+      ID: 16
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 536896
+      GoKind: 5
+    - __kind: StructureType
+      ID: 17
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.842048e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 14 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 18
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 480864
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 19 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 150 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 19
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 393376
+      GoKind: 22
+      Pointee: 20 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 20
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.304416e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 21
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 534144
+      GoKind: 2
+    - __kind: PointerType
+      ID: 22
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.060352e+06
+      GoKind: 22
+      Pointee: 7 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 23
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 625280
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 8 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 24
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 534656
+      GoKind: 26
+    - __kind: PointerType
+      ID: 25
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.154176e+06
+      GoKind: 22
+      Pointee: 26 StructureType net/http.Request
+    - __kind: StructureType
+      ID: 26
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.189984e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 28 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 32 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 54 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 54 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 55 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 33 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 27 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 27 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 70 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 129 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 130 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 27 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 133 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 42 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 138 GoMapType map[string]string
+    - __kind: GoStringHeaderType
+      ID: 27
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 533568
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 153 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+      Data: 152 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 28
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 1.949216e+06
+      GoKind: 22
+      Pointee: 29 StructureType net/url.URL
+    - __kind: StructureType
+      ID: 29
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 1.986272e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 30 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 32 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 27 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 27 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 30
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.114208e+06
+      GoKind: 22
+      Pointee: 31 StructureType net/url.Userinfo
+    - __kind: StructureType
+      ID: 31
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.432736e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 32
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 534592
+      GoKind: 1
+    - __kind: GoMapType
+      ID: 33
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.91744e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 38 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 164 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: BaseType
+      ID: 36
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 533824
+      GoKind: 9
+    - __kind: PointerType
+      ID: 37
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 38
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 41 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 37 PointerType *bucket<string,[]string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 42 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 39
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 621728
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: ArrayType
+      ID: 40
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 41
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 42 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 42
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 464704
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 43 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 155 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 371616
+      GoKind: 22
+      Pointee: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 44
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 375520
+      GoKind: 22
+      Pointee: 45 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 45
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.428704e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 46
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 466432
+      GoKind: 22
+      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 466368
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 157 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 48
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 49
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.109856e+06
+      GoKind: 22
+      Pointee: 50 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 50
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.109728e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+    - __kind: GoInterfaceType
+      ID: 51
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.067136e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 52
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 634112
+      GoKind: 19
+    - __kind: BaseType
+      ID: 53
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 534016
+      GoKind: 6
+    - __kind: GoMapType
+      ID: 54
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.670784e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 55
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 837472
+      GoKind: 22
+      Pointee: 56 StructureType mime/multipart.Form
+    - __kind: StructureType
+      ID: 56
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.294336e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 57 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoMapType
+      ID: 57
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 882496
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 887296
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: PointerType
+      ID: 61
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<string,[]*mime/multipart.FileHeader>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+        - Name: overflow
+          Offset: 328
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 63
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 457376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 65
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 66
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 837376
+      GoKind: 22
+      Pointee: 67 StructureType mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 67
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.838016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 68 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 53 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 53 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 68
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.595904e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 463552
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 165 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 835936
+      GoKind: 22
+      Pointee: 71 StructureType crypto/tls.ConnectionState
+    - __kind: StructureType
+      ID: 71
+      Name: crypto/tls.ConnectionState
+      ByteSize: 192
+      GoRuntimeType: 2.1e+06
+      GoKind: 25
+      RawFields:
+        - Name: Version
+          Offset: 0
+          Type: 36 BaseType uint16
+        - Name: HandshakeComplete
+          Offset: 2
+          Type: 32 BaseType bool
+        - Name: DidResume
+          Offset: 3
+          Type: 32 BaseType bool
+        - Name: CipherSuite
+          Offset: 4
+          Type: 36 BaseType uint16
+        - Name: NegotiatedProtocol
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: NegotiatedProtocolIsMutual
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: ServerName
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: PeerCertificates
+          Offset: 48
+          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+        - Name: VerifiedChains
+          Offset: 72
+          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+        - Name: SignedCertificateTimestamps
+          Offset: 96
+          Type: 125 GoSliceHeaderType [][]uint8
+        - Name: OCSPResponse
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: TLSUnique
+          Offset: 144
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: ECHAccepted
+          Offset: 168
+          Type: 32 BaseType bool
+        - Name: ekm
+          Offset: 176
+          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+        - Name: testingOnlyDidHRR
+          Offset: 184
+          Type: 32 BaseType bool
+        - Name: testingOnlyCurveID
+          Offset: 186
+          Type: 128 BaseType crypto/tls.CurveID
+    - __kind: GoSliceHeaderType
+      ID: 72
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469536
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 73 PointerType **crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 73
+      Name: '**crypto/x509.Certificate'
+      ByteSize: 8
+      Pointee: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 74
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.90528e+06
+      GoKind: 22
+      Pointee: 75 StructureType crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 75
+      Name: crypto/x509.Certificate
+      ByteSize: 1352
+      GoRuntimeType: 2.234656e+06
+      GoKind: 25
+      RawFields:
+        - Name: Raw
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawTBSCertificate
+          Offset: 24
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubjectPublicKeyInfo
+          Offset: 48
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubject
+          Offset: 72
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawIssuer
+          Offset: 96
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: Signature
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: SignatureAlgorithm
+          Offset: 144
+          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+        - Name: PublicKeyAlgorithm
+          Offset: 152
+          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+        - Name: PublicKey
+          Offset: 160
+          Type: 78 GoEmptyInterfaceType interface {}
+        - Name: Version
+          Offset: 176
+          Type: 21 BaseType int
+        - Name: SerialNumber
+          Offset: 184
+          Type: 80 PointerType *math/big.Int
+        - Name: Issuer
+          Offset: 192
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: Subject
+          Offset: 440
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: NotBefore
+          Offset: 688
+          Type: 91 StructureType time.Time
+        - Name: NotAfter
+          Offset: 712
+          Type: 91 StructureType time.Time
+        - Name: KeyUsage
+          Offset: 736
+          Type: 101 BaseType crypto/x509.KeyUsage
+        - Name: Extensions
+          Offset: 744
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: ExtraExtensions
+          Offset: 768
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: UnhandledCriticalExtensions
+          Offset: 792
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: ExtKeyUsage
+          Offset: 816
+          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+        - Name: UnknownExtKeyUsage
+          Offset: 840
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: BasicConstraintsValid
+          Offset: 864
+          Type: 32 BaseType bool
+        - Name: IsCA
+          Offset: 865
+          Type: 32 BaseType bool
+        - Name: MaxPathLen
+          Offset: 872
+          Type: 21 BaseType int
+        - Name: MaxPathLenZero
+          Offset: 880
+          Type: 32 BaseType bool
+        - Name: SubjectKeyId
+          Offset: 888
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: AuthorityKeyId
+          Offset: 912
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: OCSPServer
+          Offset: 936
+          Type: 42 GoSliceHeaderType []string
+        - Name: IssuingCertificateURL
+          Offset: 960
+          Type: 42 GoSliceHeaderType []string
+        - Name: DNSNames
+          Offset: 984
+          Type: 42 GoSliceHeaderType []string
+        - Name: EmailAddresses
+          Offset: 1008
+          Type: 42 GoSliceHeaderType []string
+        - Name: IPAddresses
+          Offset: 1032
+          Type: 110 GoSliceHeaderType []net.IP
+        - Name: URIs
+          Offset: 1056
+          Type: 113 GoSliceHeaderType []*net/url.URL
+        - Name: PermittedDNSDomainsCritical
+          Offset: 1080
+          Type: 32 BaseType bool
+        - Name: PermittedDNSDomains
+          Offset: 1088
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedDNSDomains
+          Offset: 1112
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedIPRanges
+          Offset: 1136
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: ExcludedIPRanges
+          Offset: 1160
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: PermittedEmailAddresses
+          Offset: 1184
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedEmailAddresses
+          Offset: 1208
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedURIDomains
+          Offset: 1232
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedURIDomains
+          Offset: 1256
+          Type: 42 GoSliceHeaderType []string
+        - Name: CRLDistributionPoints
+          Offset: 1280
+          Type: 42 GoSliceHeaderType []string
+        - Name: PolicyIdentifiers
+          Offset: 1304
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: Policies
+          Offset: 1328
+          Type: 120 GoSliceHeaderType []crypto/x509.OID
+    - __kind: BaseType
+      ID: 76
+      Name: crypto/x509.SignatureAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 1.070976e+06
+      GoKind: 2
+    - __kind: BaseType
+      ID: 77
+      Name: crypto/x509.PublicKeyAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 768448
+      GoKind: 2
+    - __kind: GoEmptyInterfaceType
+      ID: 78
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 785376
+      GoKind: 20
+      UnderlyingStructure: 79 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 79
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 22 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 80
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.231104e+06
+      GoKind: 22
+      Pointee: 81 StructureType math/big.Int
+    - __kind: StructureType
+      ID: 81
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.308416e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 82 GoSliceHeaderType math/big.nat
+    - __kind: GoSliceHeaderType
+      ID: 82
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.21424e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 83 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 169 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 83
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 397856
+      GoKind: 22
+      Pointee: 84 BaseType math/big.Word
+    - __kind: BaseType
+      ID: 84
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 537536
+      GoKind: 7
+    - __kind: StructureType
+      ID: 85
+      Name: crypto/x509/pkix.Name
+      ByteSize: 248
+      GoRuntimeType: 2.046944e+06
+      GoKind: 25
+      RawFields:
+        - Name: Country
+          Offset: 0
+          Type: 42 GoSliceHeaderType []string
+        - Name: Organization
+          Offset: 24
+          Type: 42 GoSliceHeaderType []string
+        - Name: OrganizationalUnit
+          Offset: 48
+          Type: 42 GoSliceHeaderType []string
+        - Name: Locality
+          Offset: 72
+          Type: 42 GoSliceHeaderType []string
+        - Name: Province
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: StreetAddress
+          Offset: 120
+          Type: 42 GoSliceHeaderType []string
+        - Name: PostalCode
+          Offset: 144
+          Type: 42 GoSliceHeaderType []string
+        - Name: SerialNumber
+          Offset: 168
+          Type: 27 GoStringHeaderType string
+        - Name: CommonName
+          Offset: 184
+          Type: 27 GoStringHeaderType string
+        - Name: Names
+          Offset: 200
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+        - Name: ExtraNames
+          Offset: 224
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 86
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 481888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 87
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 408800
+      GoKind: 22
+      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: StructureType
+      ID: 88
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.316256e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: encoding/asn1.ObjectIdentifier
+      ByteSize: 24
+      GoRuntimeType: 1.009856e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 90
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 372192
+      GoKind: 22
+      Pointee: 21 BaseType int
+    - __kind: StructureType
+      ID: 91
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.215168e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 53 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 93 PointerType *time.Location
+    - __kind: BaseType
+      ID: 92
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 534080
+      GoKind: 11
+    - __kind: PointerType
+      ID: 93
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.421216e+06
+      GoKind: 22
+      Pointee: 94 StructureType time.Location
+    - __kind: StructureType
+      ID: 94
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.833984e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 95 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 98 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 27 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 96 PointerType *time.zone
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 459040
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 175 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 96
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 367072
+      GoKind: 22
+      Pointee: 97 StructureType time.zone
+    - __kind: StructureType
+      ID: 97
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.421024e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 32 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 459104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 99 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 177 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 367136
+      GoKind: 22
+      Pointee: 100 StructureType time.zoneTrans
+    - __kind: StructureType
+      ID: 100
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.623328e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 53 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 32 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 101
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537216
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 481376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 408992
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.455008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Id
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 481440
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 106
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.009728e+06
+      GoKind: 22
+      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 470816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 395040
+      GoKind: 22
+      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: BaseType
+      ID: 109
+      Name: crypto/x509.ExtKeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537280
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 454048
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 185 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 1.974144e+06
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 112
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 1.94816e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 187 GoSliceDataType net.IP.array
+    - __kind: GoSliceHeaderType
+      ID: 113
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 481504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 114 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 189 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 114
+      Name: '**net/url.URL'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 28 PointerType *net/url.URL
+    - __kind: GoSliceHeaderType
+      ID: 115
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 481568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 116 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 191 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 116
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 117
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.095776e+06
+      GoKind: 22
+      Pointee: 118 StructureType net.IPNet
+    - __kind: StructureType
+      ID: 118
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.275936e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 112 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 119 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceHeaderType
+      ID: 119
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 975808
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 193 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 481632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 195 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.717248e+06
+      GoKind: 22
+      Pointee: 122 StructureType crypto/x509.OID
+    - __kind: StructureType
+      ID: 122
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.717472e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 123
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 124 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 124
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 125
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 452832
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 126 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 199 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 126
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 452512
+      GoKind: 22
+      Pointee: 69 GoSliceHeaderType []uint8
+    - __kind: GoSubroutineType
+      ID: 127
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 960256
+      GoKind: 19
+    - __kind: BaseType
+      ID: 128
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 766048
+      GoKind: 9
+    - __kind: GoChannelType
+      ID: 129
+      Name: <-chan struct {}
+      GoRuntimeType: 546752
+      GoKind: 18
+    - __kind: PointerType
+      ID: 130
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.590912e+06
+      GoKind: 22
+      Pointee: 131 StructureType net/http.Response
+    - __kind: StructureType
+      ID: 131
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.064832e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 32 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 32 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 33 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 25 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 70 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 132
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.187104e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: PointerType
+      ID: 133
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.416224e+06
+      GoKind: 22
+      Pointee: 134 StructureType net/http.pattern
+    - __kind: StructureType
+      ID: 134
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.701568e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 135 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 135
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 454816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 136 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 201 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 136
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 364000
+      GoKind: 22
+      Pointee: 137 StructureType net/http.segment
+    - __kind: StructureType
+      ID: 137
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.416032e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 32 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 138
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 884128
+      GoKind: 21
+      HeaderType: 140 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 139
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 140 GoHMapHeaderType hash<string,string>
+    - __kind: GoHMapHeaderType
+      ID: 140
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 141 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 141 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<string,string>
+      BucketsType: 203 GoSliceDataType []bucket<string,string>.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoHMapBucketType
+      ID: 142
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 143 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 141 PointerType *bucket<string,string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 143
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 144
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.114976e+06
+      GoKind: 22
+      Pointee: 145 StructureType bytes.Buffer
+    - __kind: StructureType
+      ID: 145
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.41392e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 21 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 146 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 146
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532800
+      GoKind: 3
+    - __kind: GoInterfaceType
+      ID: 147
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.295936e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 148
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.6672e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 149 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 149
+      Name: context.emptyCtx
+      GoRuntimeType: 1.399456e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: GoSliceDataType
+      ID: 150
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 20 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 151
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 150 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoStringDataType
+      ID: 152
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 153
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 152 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 154
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 155
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 156
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 155 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 157
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 158
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 157 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 159
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 160
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 161
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 162
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 163
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 166
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 165 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 167
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 168
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 84 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 170
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 169 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 172
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 173
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 21 BaseType int
+    - __kind: PointerType
+      ID: 174
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 175
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 97 StructureType time.zone
+    - __kind: PointerType
+      ID: 176
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 175 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 177
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 100 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 178
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 182
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 183
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 184
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 185
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 112 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 187
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 188
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 28 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 194
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 193 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 122 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 196
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 195 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 198
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 69 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 200
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 137 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 202
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 201 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 142 GoHMapBucketType bucket<string,string>
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 25 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 205
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 27 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+MaxTypeID: 205
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,0 +1,2392 @@
+ID: 1
+Probes:
+    - id: http_handler
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.HandleHTTP}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 1
+          Type: 204 EventRootType Probe[main.HandleHTTP]
+          InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
+          Condition: null
+    - id: look_at_the_request
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.LookAtTheRequest}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 2
+          Type: 205 EventRootType Probe[main.LookAtTheRequest]
+          InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 1
+      Name: main.HandleHTTP
+      OutOfLinePCRanges: [0x8ad860..0x8adab0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 1 GoInterfaceType net/http.ResponseWriter
+          Locations:
+            - Range: 0x8ad860..0x8ad8b8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8ad8b8..0x8ad8bc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8ad8bc..0x8adab0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          IsParameter: true
+          IsReturn: false
+        - Name: r
+          Type: 25 PointerType *net/http.Request
+          Locations:
+            - Range: 0x8ad860..0x8ad8c4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x8ad8c4..0x8adab0
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: '&buf'
+          Type: 144 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x8ad9b4..0x8ad9d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8ad9d0..0x8adab0
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 147 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0x8ad8d8..0x8ad8d8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x8ad8d8..0x8ad910
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8ad910..0x8ad914
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: false
+          IsReturn: false
+        - Name: .autotmp_14
+          Type: 148 StructureType context.backgroundCtx
+          Locations:
+            - Range: 0x8ad860..0x8adab0
+              Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 2
+      Name: main.LookAtTheRequest
+      OutOfLinePCRanges: [0x8adb90..0x8adc50]
+      InlinePCRanges: []
+      Variables:
+        - Name: path
+          Type: 27 GoStringHeaderType string
+          Locations:
+            - Range: 0x8adb90..0x8adbb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: GoInterfaceType
+      ID: 1
+      Name: net/http.ResponseWriter
+      ByteSize: 16
+      GoRuntimeType: 1.098528e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 2
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 3 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 3
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 393504
+      GoKind: 22
+      Pointee: 4 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 4
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.636736e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 5 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 22 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 23 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 5
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.060448e+06
+      GoKind: 22
+      Pointee: 6 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 6
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.4448e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 7 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 17 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 18 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 7
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 1.98912e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 8 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 8 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 9 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 10 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 11 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 11 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 12 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 14 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 8
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 534464
+      GoKind: 12
+    - __kind: BaseType
+      ID: 9
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 534144
+      GoKind: 10
+    - __kind: BaseType
+      ID: 10
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 536960
+      GoKind: 8
+    - __kind: BaseType
+      ID: 11
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533888
+      GoKind: 8
+    - __kind: BaseType
+      ID: 12
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 768352
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 13
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 785280
+      GoKind: 19
+    - __kind: PointerType
+      ID: 14
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371808
+      GoKind: 22
+      Pointee: 11 BaseType uint8
+    - __kind: BaseType
+      ID: 15
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 537024
+      GoKind: 5
+    - __kind: BaseType
+      ID: 16
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 537088
+      GoKind: 5
+    - __kind: StructureType
+      ID: 17
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.842592e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 14 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 18
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 480992
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 19 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 150 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 19
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 393440
+      GoKind: 22
+      Pointee: 20 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 20
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.304608e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 15 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 16 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 21
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 534336
+      GoKind: 2
+    - __kind: PointerType
+      ID: 22
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.060896e+06
+      GoKind: 22
+      Pointee: 7 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 23
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 625568
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 8 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 24
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 534848
+      GoKind: 26
+    - __kind: PointerType
+      ID: 25
+      Name: '*net/http.Request'
+      ByteSize: 8
+      GoRuntimeType: 2.15472e+06
+      GoKind: 22
+      Pointee: 26 StructureType net/http.Request
+    - __kind: StructureType
+      ID: 26
+      Name: net/http.Request
+      ByteSize: 304
+      GoRuntimeType: 2.190528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Method
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: URL
+          Offset: 16
+          Type: 28 PointerType *net/url.URL
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: GetBody
+          Offset: 80
+          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+        - Name: ContentLength
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 120
+          Type: 32 BaseType bool
+        - Name: Host
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+        - Name: Form
+          Offset: 144
+          Type: 54 GoMapType net/url.Values
+        - Name: PostForm
+          Offset: 152
+          Type: 54 GoMapType net/url.Values
+        - Name: MultipartForm
+          Offset: 160
+          Type: 55 PointerType *mime/multipart.Form
+        - Name: Trailer
+          Offset: 168
+          Type: 33 GoMapType net/http.Header
+        - Name: RemoteAddr
+          Offset: 176
+          Type: 27 GoStringHeaderType string
+        - Name: RequestURI
+          Offset: 192
+          Type: 27 GoStringHeaderType string
+        - Name: TLS
+          Offset: 208
+          Type: 70 PointerType *crypto/tls.ConnectionState
+        - Name: Cancel
+          Offset: 216
+          Type: 129 GoChannelType <-chan struct {}
+        - Name: Response
+          Offset: 224
+          Type: 130 PointerType *net/http.Response
+        - Name: Pattern
+          Offset: 232
+          Type: 27 GoStringHeaderType string
+        - Name: ctx
+          Offset: 248
+          Type: 132 GoInterfaceType context.Context
+        - Name: pat
+          Offset: 264
+          Type: 133 PointerType *net/http.pattern
+        - Name: matches
+          Offset: 272
+          Type: 42 GoSliceHeaderType []string
+        - Name: otherValues
+          Offset: 296
+          Type: 138 GoMapType map[string]string
+    - __kind: GoStringHeaderType
+      ID: 27
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 533760
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 153 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+      Data: 152 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 28
+      Name: '*net/url.URL'
+      ByteSize: 8
+      GoRuntimeType: 1.94976e+06
+      GoKind: 22
+      Pointee: 29 StructureType net/url.URL
+    - __kind: StructureType
+      ID: 29
+      Name: net/url.URL
+      ByteSize: 144
+      GoRuntimeType: 1.986816e+06
+      GoKind: 25
+      RawFields:
+        - Name: Scheme
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Opaque
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: User
+          Offset: 32
+          Type: 30 PointerType *net/url.Userinfo
+        - Name: Host
+          Offset: 40
+          Type: 27 GoStringHeaderType string
+        - Name: Path
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: RawPath
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+        - Name: OmitHost
+          Offset: 88
+          Type: 32 BaseType bool
+        - Name: ForceQuery
+          Offset: 89
+          Type: 32 BaseType bool
+        - Name: RawQuery
+          Offset: 96
+          Type: 27 GoStringHeaderType string
+        - Name: Fragment
+          Offset: 112
+          Type: 27 GoStringHeaderType string
+        - Name: RawFragment
+          Offset: 128
+          Type: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 30
+      Name: '*net/url.Userinfo'
+      ByteSize: 8
+      GoRuntimeType: 1.1144e+06
+      GoKind: 22
+      Pointee: 31 StructureType net/url.Userinfo
+    - __kind: StructureType
+      ID: 31
+      Name: net/url.Userinfo
+      ByteSize: 40
+      GoRuntimeType: 1.433088e+06
+      GoKind: 25
+      RawFields:
+        - Name: username
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: password
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: passwordSet
+          Offset: 32
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 32
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 534784
+      GoKind: 1
+    - __kind: GoMapType
+      ID: 33
+      Name: net/http.Header
+      ByteSize: 8
+      GoRuntimeType: 1.917984e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 37 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 38 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 164 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: BaseType
+      ID: 36
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 534016
+      GoKind: 9
+    - __kind: PointerType
+      ID: 37
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 38
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 41 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 37 PointerType *bucket<string,[]string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 42 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 39
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 621920
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType uint8
+    - __kind: ArrayType
+      ID: 40
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 41
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 42 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 42
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 464768
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 43 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 155 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 43
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 371680
+      GoKind: 22
+      Pointee: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 44
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 375584
+      GoKind: 22
+      Pointee: 45 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 45
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.429056e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 46 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 46
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 466496
+      GoKind: 22
+      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 47
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 466432
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 48 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 157 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 48
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 49
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.110048e+06
+      GoKind: 22
+      Pointee: 50 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 50
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.10992e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+    - __kind: GoInterfaceType
+      ID: 51
+      Name: io.ReadCloser
+      ByteSize: 16
+      GoRuntimeType: 1.067328e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 52
+      Name: func() (io.ReadCloser, error)
+      ByteSize: 8
+      GoRuntimeType: 634400
+      GoKind: 19
+    - __kind: BaseType
+      ID: 53
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 534208
+      GoKind: 6
+    - __kind: GoMapType
+      ID: 54
+      Name: net/url.Values
+      ByteSize: 8
+      GoRuntimeType: 1.671328e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 55
+      Name: '*mime/multipart.Form'
+      ByteSize: 8
+      GoRuntimeType: 837568
+      GoKind: 22
+      Pointee: 56 StructureType mime/multipart.Form
+    - __kind: StructureType
+      ID: 56
+      Name: mime/multipart.Form
+      ByteSize: 16
+      GoRuntimeType: 1.294528e+06
+      GoKind: 25
+      RawFields:
+        - Name: Value
+          Offset: 0
+          Type: 57 GoMapType map[string][]string
+        - Name: File
+          Offset: 8
+          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+    - __kind: GoMapType
+      ID: 57
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 882592
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoMapType
+      ID: 58
+      Name: map[string][]*mime/multipart.FileHeader
+      ByteSize: 8
+      GoRuntimeType: 887392
+      GoKind: 21
+      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: PointerType
+      ID: 59
+      Name: '*hash<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapHeaderType
+      ID: 60
+      Name: hash<string,[]*mime/multipart.FileHeader>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+    - __kind: PointerType
+      ID: 61
+      Name: '*bucket<string,[]*mime/multipart.FileHeader>'
+      ByteSize: 8
+      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoHMapBucketType
+      ID: 62
+      Name: bucket<string,[]*mime/multipart.FileHeader>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+        - Name: overflow
+          Offset: 328
+          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: ArrayType
+      ID: 63
+      Name: '[]val<[]*mime/multipart.FileHeader>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+    - __kind: GoSliceHeaderType
+      ID: 64
+      Name: '[]*mime/multipart.FileHeader'
+      ByteSize: 24
+      GoRuntimeType: 457504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 65 PointerType **mime/multipart.FileHeader
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: PointerType
+      ID: 65
+      Name: '**mime/multipart.FileHeader'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 66
+      Name: '*mime/multipart.FileHeader'
+      ByteSize: 8
+      GoRuntimeType: 837472
+      GoKind: 22
+      Pointee: 67 StructureType mime/multipart.FileHeader
+    - __kind: StructureType
+      ID: 67
+      Name: mime/multipart.FileHeader
+      ByteSize: 88
+      GoRuntimeType: 1.83856e+06
+      GoKind: 25
+      RawFields:
+        - Name: Filename
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: Header
+          Offset: 16
+          Type: 68 GoMapType net/textproto.MIMEHeader
+        - Name: Size
+          Offset: 24
+          Type: 53 BaseType int64
+        - Name: content
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: tmpfile
+          Offset: 56
+          Type: 27 GoStringHeaderType string
+        - Name: tmpoff
+          Offset: 72
+          Type: 53 BaseType int64
+        - Name: tmpshared
+          Offset: 80
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 68
+      Name: net/textproto.MIMEHeader
+      ByteSize: 8
+      GoRuntimeType: 1.596448e+06
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoSliceHeaderType
+      ID: 69
+      Name: '[]uint8'
+      ByteSize: 24
+      GoRuntimeType: 463616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 165 GoSliceDataType []uint8.array
+    - __kind: PointerType
+      ID: 70
+      Name: '*crypto/tls.ConnectionState'
+      ByteSize: 8
+      GoRuntimeType: 836032
+      GoKind: 22
+      Pointee: 71 StructureType crypto/tls.ConnectionState
+    - __kind: StructureType
+      ID: 71
+      Name: crypto/tls.ConnectionState
+      ByteSize: 192
+      GoRuntimeType: 2.100544e+06
+      GoKind: 25
+      RawFields:
+        - Name: Version
+          Offset: 0
+          Type: 36 BaseType uint16
+        - Name: HandshakeComplete
+          Offset: 2
+          Type: 32 BaseType bool
+        - Name: DidResume
+          Offset: 3
+          Type: 32 BaseType bool
+        - Name: CipherSuite
+          Offset: 4
+          Type: 36 BaseType uint16
+        - Name: NegotiatedProtocol
+          Offset: 8
+          Type: 27 GoStringHeaderType string
+        - Name: NegotiatedProtocolIsMutual
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: ServerName
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: PeerCertificates
+          Offset: 48
+          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+        - Name: VerifiedChains
+          Offset: 72
+          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+        - Name: SignedCertificateTimestamps
+          Offset: 96
+          Type: 125 GoSliceHeaderType [][]uint8
+        - Name: OCSPResponse
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: TLSUnique
+          Offset: 144
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: ECHAccepted
+          Offset: 168
+          Type: 32 BaseType bool
+        - Name: ekm
+          Offset: 176
+          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+        - Name: testingOnlyDidHRR
+          Offset: 184
+          Type: 32 BaseType bool
+        - Name: testingOnlyCurveID
+          Offset: 186
+          Type: 128 BaseType crypto/tls.CurveID
+    - __kind: GoSliceHeaderType
+      ID: 72
+      Name: '[]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469664
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 73 PointerType **crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 73
+      Name: '**crypto/x509.Certificate'
+      ByteSize: 8
+      Pointee: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 74
+      Name: '*crypto/x509.Certificate'
+      ByteSize: 8
+      GoRuntimeType: 1.905824e+06
+      GoKind: 22
+      Pointee: 75 StructureType crypto/x509.Certificate
+    - __kind: StructureType
+      ID: 75
+      Name: crypto/x509.Certificate
+      ByteSize: 1352
+      GoRuntimeType: 2.2352e+06
+      GoKind: 25
+      RawFields:
+        - Name: Raw
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawTBSCertificate
+          Offset: 24
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubjectPublicKeyInfo
+          Offset: 48
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawSubject
+          Offset: 72
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: RawIssuer
+          Offset: 96
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: Signature
+          Offset: 120
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: SignatureAlgorithm
+          Offset: 144
+          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+        - Name: PublicKeyAlgorithm
+          Offset: 152
+          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+        - Name: PublicKey
+          Offset: 160
+          Type: 78 GoEmptyInterfaceType interface {}
+        - Name: Version
+          Offset: 176
+          Type: 21 BaseType int
+        - Name: SerialNumber
+          Offset: 184
+          Type: 80 PointerType *math/big.Int
+        - Name: Issuer
+          Offset: 192
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: Subject
+          Offset: 440
+          Type: 85 StructureType crypto/x509/pkix.Name
+        - Name: NotBefore
+          Offset: 688
+          Type: 91 StructureType time.Time
+        - Name: NotAfter
+          Offset: 712
+          Type: 91 StructureType time.Time
+        - Name: KeyUsage
+          Offset: 736
+          Type: 101 BaseType crypto/x509.KeyUsage
+        - Name: Extensions
+          Offset: 744
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: ExtraExtensions
+          Offset: 768
+          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+        - Name: UnhandledCriticalExtensions
+          Offset: 792
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: ExtKeyUsage
+          Offset: 816
+          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+        - Name: UnknownExtKeyUsage
+          Offset: 840
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: BasicConstraintsValid
+          Offset: 864
+          Type: 32 BaseType bool
+        - Name: IsCA
+          Offset: 865
+          Type: 32 BaseType bool
+        - Name: MaxPathLen
+          Offset: 872
+          Type: 21 BaseType int
+        - Name: MaxPathLenZero
+          Offset: 880
+          Type: 32 BaseType bool
+        - Name: SubjectKeyId
+          Offset: 888
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: AuthorityKeyId
+          Offset: 912
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: OCSPServer
+          Offset: 936
+          Type: 42 GoSliceHeaderType []string
+        - Name: IssuingCertificateURL
+          Offset: 960
+          Type: 42 GoSliceHeaderType []string
+        - Name: DNSNames
+          Offset: 984
+          Type: 42 GoSliceHeaderType []string
+        - Name: EmailAddresses
+          Offset: 1008
+          Type: 42 GoSliceHeaderType []string
+        - Name: IPAddresses
+          Offset: 1032
+          Type: 110 GoSliceHeaderType []net.IP
+        - Name: URIs
+          Offset: 1056
+          Type: 113 GoSliceHeaderType []*net/url.URL
+        - Name: PermittedDNSDomainsCritical
+          Offset: 1080
+          Type: 32 BaseType bool
+        - Name: PermittedDNSDomains
+          Offset: 1088
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedDNSDomains
+          Offset: 1112
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedIPRanges
+          Offset: 1136
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: ExcludedIPRanges
+          Offset: 1160
+          Type: 115 GoSliceHeaderType []*net.IPNet
+        - Name: PermittedEmailAddresses
+          Offset: 1184
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedEmailAddresses
+          Offset: 1208
+          Type: 42 GoSliceHeaderType []string
+        - Name: PermittedURIDomains
+          Offset: 1232
+          Type: 42 GoSliceHeaderType []string
+        - Name: ExcludedURIDomains
+          Offset: 1256
+          Type: 42 GoSliceHeaderType []string
+        - Name: CRLDistributionPoints
+          Offset: 1280
+          Type: 42 GoSliceHeaderType []string
+        - Name: PolicyIdentifiers
+          Offset: 1304
+          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+        - Name: Policies
+          Offset: 1328
+          Type: 120 GoSliceHeaderType []crypto/x509.OID
+    - __kind: BaseType
+      ID: 76
+      Name: crypto/x509.SignatureAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 1.071168e+06
+      GoKind: 2
+    - __kind: BaseType
+      ID: 77
+      Name: crypto/x509.PublicKeyAlgorithm
+      ByteSize: 8
+      GoRuntimeType: 768544
+      GoKind: 2
+    - __kind: GoEmptyInterfaceType
+      ID: 78
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 785472
+      GoKind: 20
+      UnderlyingStructure: 79 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 79
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 22 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 24 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 80
+      Name: '*math/big.Int'
+      ByteSize: 8
+      GoRuntimeType: 2.231648e+06
+      GoKind: 22
+      Pointee: 81 StructureType math/big.Int
+    - __kind: StructureType
+      ID: 81
+      Name: math/big.Int
+      ByteSize: 32
+      GoRuntimeType: 1.308608e+06
+      GoKind: 25
+      RawFields:
+        - Name: neg
+          Offset: 0
+          Type: 32 BaseType bool
+        - Name: abs
+          Offset: 8
+          Type: 82 GoSliceHeaderType math/big.nat
+    - __kind: GoSliceHeaderType
+      ID: 82
+      Name: math/big.nat
+      ByteSize: 24
+      GoRuntimeType: 2.214784e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 83 PointerType *math/big.Word
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 169 GoSliceDataType math/big.nat.array
+    - __kind: PointerType
+      ID: 83
+      Name: '*math/big.Word'
+      ByteSize: 8
+      GoRuntimeType: 397920
+      GoKind: 22
+      Pointee: 84 BaseType math/big.Word
+    - __kind: BaseType
+      ID: 84
+      Name: math/big.Word
+      ByteSize: 8
+      GoRuntimeType: 537728
+      GoKind: 7
+    - __kind: StructureType
+      ID: 85
+      Name: crypto/x509/pkix.Name
+      ByteSize: 248
+      GoRuntimeType: 2.047488e+06
+      GoKind: 25
+      RawFields:
+        - Name: Country
+          Offset: 0
+          Type: 42 GoSliceHeaderType []string
+        - Name: Organization
+          Offset: 24
+          Type: 42 GoSliceHeaderType []string
+        - Name: OrganizationalUnit
+          Offset: 48
+          Type: 42 GoSliceHeaderType []string
+        - Name: Locality
+          Offset: 72
+          Type: 42 GoSliceHeaderType []string
+        - Name: Province
+          Offset: 96
+          Type: 42 GoSliceHeaderType []string
+        - Name: StreetAddress
+          Offset: 120
+          Type: 42 GoSliceHeaderType []string
+        - Name: PostalCode
+          Offset: 144
+          Type: 42 GoSliceHeaderType []string
+        - Name: SerialNumber
+          Offset: 168
+          Type: 27 GoStringHeaderType string
+        - Name: CommonName
+          Offset: 184
+          Type: 27 GoStringHeaderType string
+        - Name: Names
+          Offset: 200
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+        - Name: ExtraNames
+          Offset: 224
+          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: GoSliceHeaderType
+      ID: 86
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 24
+      GoRuntimeType: 482016
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: PointerType
+      ID: 87
+      Name: '*crypto/x509/pkix.AttributeTypeAndValue'
+      ByteSize: 8
+      GoRuntimeType: 408928
+      GoKind: 22
+      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: StructureType
+      ID: 88
+      Name: crypto/x509/pkix.AttributeTypeAndValue
+      ByteSize: 40
+      GoRuntimeType: 1.316608e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Value
+          Offset: 24
+          Type: 78 GoEmptyInterfaceType interface {}
+    - __kind: GoSliceHeaderType
+      ID: 89
+      Name: encoding/asn1.ObjectIdentifier
+      ByteSize: 24
+      GoRuntimeType: 1.010048e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 90 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 90
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 372256
+      GoKind: 22
+      Pointee: 21 BaseType int
+    - __kind: StructureType
+      ID: 91
+      Name: time.Time
+      ByteSize: 24
+      GoRuntimeType: 2.215712e+06
+      GoKind: 25
+      RawFields:
+        - Name: wall
+          Offset: 0
+          Type: 92 BaseType uint64
+        - Name: ext
+          Offset: 8
+          Type: 53 BaseType int64
+        - Name: loc
+          Offset: 16
+          Type: 93 PointerType *time.Location
+    - __kind: BaseType
+      ID: 92
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 534272
+      GoKind: 11
+    - __kind: PointerType
+      ID: 93
+      Name: '*time.Location'
+      ByteSize: 8
+      GoRuntimeType: 1.421568e+06
+      GoKind: 22
+      Pointee: 94 StructureType time.Location
+    - __kind: StructureType
+      ID: 94
+      Name: time.Location
+      ByteSize: 104
+      GoRuntimeType: 1.834528e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: zone
+          Offset: 16
+          Type: 95 GoSliceHeaderType []time.zone
+        - Name: tx
+          Offset: 40
+          Type: 98 GoSliceHeaderType []time.zoneTrans
+        - Name: extend
+          Offset: 64
+          Type: 27 GoStringHeaderType string
+        - Name: cacheStart
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: cacheEnd
+          Offset: 88
+          Type: 53 BaseType int64
+        - Name: cacheZone
+          Offset: 96
+          Type: 96 PointerType *time.zone
+    - __kind: GoSliceHeaderType
+      ID: 95
+      Name: '[]time.zone'
+      ByteSize: 24
+      GoRuntimeType: 459168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 96 PointerType *time.zone
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 175 GoSliceDataType []time.zone.array
+    - __kind: PointerType
+      ID: 96
+      Name: '*time.zone'
+      ByteSize: 8
+      GoRuntimeType: 367136
+      GoKind: 22
+      Pointee: 97 StructureType time.zone
+    - __kind: StructureType
+      ID: 97
+      Name: time.zone
+      ByteSize: 32
+      GoRuntimeType: 1.421376e+06
+      GoKind: 25
+      RawFields:
+        - Name: name
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: offset
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: isDST
+          Offset: 24
+          Type: 32 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 98
+      Name: '[]time.zoneTrans'
+      ByteSize: 24
+      GoRuntimeType: 459232
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 99 PointerType *time.zoneTrans
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 177 GoSliceDataType []time.zoneTrans.array
+    - __kind: PointerType
+      ID: 99
+      Name: '*time.zoneTrans'
+      ByteSize: 8
+      GoRuntimeType: 367200
+      GoKind: 22
+      Pointee: 100 StructureType time.zoneTrans
+    - __kind: StructureType
+      ID: 100
+      Name: time.zoneTrans
+      ByteSize: 16
+      GoRuntimeType: 1.623872e+06
+      GoKind: 25
+      RawFields:
+        - Name: when
+          Offset: 0
+          Type: 53 BaseType int64
+        - Name: index
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: isstd
+          Offset: 9
+          Type: 32 BaseType bool
+        - Name: isutc
+          Offset: 10
+          Type: 32 BaseType bool
+    - __kind: BaseType
+      ID: 101
+      Name: crypto/x509.KeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537408
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 102
+      Name: '[]crypto/x509/pkix.Extension'
+      ByteSize: 24
+      GoRuntimeType: 481504
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 103 PointerType *crypto/x509/pkix.Extension
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*crypto/x509/pkix.Extension'
+      ByteSize: 8
+      GoRuntimeType: 409120
+      GoKind: 22
+      Pointee: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: StructureType
+      ID: 104
+      Name: crypto/x509/pkix.Extension
+      ByteSize: 56
+      GoRuntimeType: 1.45536e+06
+      GoKind: 25
+      RawFields:
+        - Name: Id
+          Offset: 0
+          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+        - Name: Critical
+          Offset: 24
+          Type: 32 BaseType bool
+        - Name: Value
+          Offset: 32
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 105
+      Name: '[]encoding/asn1.ObjectIdentifier'
+      ByteSize: 24
+      GoRuntimeType: 481568
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: PointerType
+      ID: 106
+      Name: '*encoding/asn1.ObjectIdentifier'
+      ByteSize: 8
+      GoRuntimeType: 1.00992e+06
+      GoKind: 22
+      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: GoSliceHeaderType
+      ID: 107
+      Name: '[]crypto/x509.ExtKeyUsage'
+      ByteSize: 24
+      GoRuntimeType: 470944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*crypto/x509.ExtKeyUsage'
+      ByteSize: 8
+      GoRuntimeType: 395104
+      GoKind: 22
+      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: BaseType
+      ID: 109
+      Name: crypto/x509.ExtKeyUsage
+      ByteSize: 8
+      GoRuntimeType: 537472
+      GoKind: 2
+    - __kind: GoSliceHeaderType
+      ID: 110
+      Name: '[]net.IP'
+      ByteSize: 24
+      GoRuntimeType: 454176
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 111 PointerType *net.IP
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 185 GoSliceDataType []net.IP.array
+    - __kind: PointerType
+      ID: 111
+      Name: '*net.IP'
+      ByteSize: 8
+      GoRuntimeType: 1.974688e+06
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType net.IP
+    - __kind: GoSliceHeaderType
+      ID: 112
+      Name: net.IP
+      ByteSize: 24
+      GoRuntimeType: 1.948704e+06
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 187 GoSliceDataType net.IP.array
+    - __kind: GoSliceHeaderType
+      ID: 113
+      Name: '[]*net/url.URL'
+      ByteSize: 24
+      GoRuntimeType: 481632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 114 PointerType **net/url.URL
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 189 GoSliceDataType []*net/url.URL.array
+    - __kind: PointerType
+      ID: 114
+      Name: '**net/url.URL'
+      ByteSize: 8
+      Pointee: 28 PointerType *net/url.URL
+    - __kind: GoSliceHeaderType
+      ID: 115
+      Name: '[]*net.IPNet'
+      ByteSize: 24
+      GoRuntimeType: 481696
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 116 PointerType **net.IPNet
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 191 GoSliceDataType []*net.IPNet.array
+    - __kind: PointerType
+      ID: 116
+      Name: '**net.IPNet'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 117
+      Name: '*net.IPNet'
+      ByteSize: 8
+      GoRuntimeType: 1.095968e+06
+      GoKind: 22
+      Pointee: 118 StructureType net.IPNet
+    - __kind: StructureType
+      ID: 118
+      Name: net.IPNet
+      ByteSize: 48
+      GoRuntimeType: 1.276128e+06
+      GoKind: 25
+      RawFields:
+        - Name: IP
+          Offset: 0
+          Type: 112 GoSliceHeaderType net.IP
+        - Name: Mask
+          Offset: 24
+          Type: 119 GoSliceHeaderType net.IPMask
+    - __kind: GoSliceHeaderType
+      ID: 119
+      Name: net.IPMask
+      ByteSize: 24
+      GoRuntimeType: 976000
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 14 PointerType *uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 193 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceHeaderType
+      ID: 120
+      Name: '[]crypto/x509.OID'
+      ByteSize: 24
+      GoRuntimeType: 481760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 121 PointerType *crypto/x509.OID
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 195 GoSliceDataType []crypto/x509.OID.array
+    - __kind: PointerType
+      ID: 121
+      Name: '*crypto/x509.OID'
+      ByteSize: 8
+      GoRuntimeType: 1.717792e+06
+      GoKind: 22
+      Pointee: 122 StructureType crypto/x509.OID
+    - __kind: StructureType
+      ID: 122
+      Name: crypto/x509.OID
+      ByteSize: 24
+      GoRuntimeType: 1.718016e+06
+      GoKind: 25
+      RawFields:
+        - Name: der
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+    - __kind: GoSliceHeaderType
+      ID: 123
+      Name: '[][]*crypto/x509.Certificate'
+      ByteSize: 24
+      GoRuntimeType: 469792
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 124 PointerType *[]*crypto/x509.Certificate
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: PointerType
+      ID: 124
+      Name: '*[]*crypto/x509.Certificate'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: GoSliceHeaderType
+      ID: 125
+      Name: '[][]uint8'
+      ByteSize: 24
+      GoRuntimeType: 452960
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 126 PointerType *[]uint8
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 199 GoSliceDataType [][]uint8.array
+    - __kind: PointerType
+      ID: 126
+      Name: '*[]uint8'
+      ByteSize: 8
+      GoRuntimeType: 452640
+      GoKind: 22
+      Pointee: 69 GoSliceHeaderType []uint8
+    - __kind: GoSubroutineType
+      ID: 127
+      Name: func(string, []uint8, int) ([]uint8, error)
+      ByteSize: 8
+      GoRuntimeType: 960448
+      GoKind: 19
+    - __kind: BaseType
+      ID: 128
+      Name: crypto/tls.CurveID
+      ByteSize: 2
+      GoRuntimeType: 766144
+      GoKind: 9
+    - __kind: GoChannelType
+      ID: 129
+      Name: <-chan struct {}
+      GoRuntimeType: 546944
+      GoKind: 18
+    - __kind: PointerType
+      ID: 130
+      Name: '*net/http.Response'
+      ByteSize: 8
+      GoRuntimeType: 1.591456e+06
+      GoKind: 22
+      Pointee: 131 StructureType net/http.Response
+    - __kind: StructureType
+      ID: 131
+      Name: net/http.Response
+      ByteSize: 144
+      GoRuntimeType: 2.065376e+06
+      GoKind: 25
+      RawFields:
+        - Name: Status
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: StatusCode
+          Offset: 16
+          Type: 21 BaseType int
+        - Name: Proto
+          Offset: 24
+          Type: 27 GoStringHeaderType string
+        - Name: ProtoMajor
+          Offset: 40
+          Type: 21 BaseType int
+        - Name: ProtoMinor
+          Offset: 48
+          Type: 21 BaseType int
+        - Name: Header
+          Offset: 56
+          Type: 33 GoMapType net/http.Header
+        - Name: Body
+          Offset: 64
+          Type: 51 GoInterfaceType io.ReadCloser
+        - Name: ContentLength
+          Offset: 80
+          Type: 53 BaseType int64
+        - Name: TransferEncoding
+          Offset: 88
+          Type: 42 GoSliceHeaderType []string
+        - Name: Close
+          Offset: 112
+          Type: 32 BaseType bool
+        - Name: Uncompressed
+          Offset: 113
+          Type: 32 BaseType bool
+        - Name: Trailer
+          Offset: 120
+          Type: 33 GoMapType net/http.Header
+        - Name: Request
+          Offset: 128
+          Type: 25 PointerType *net/http.Request
+        - Name: TLS
+          Offset: 136
+          Type: 70 PointerType *crypto/tls.ConnectionState
+    - __kind: GoInterfaceType
+      ID: 132
+      Name: context.Context
+      ByteSize: 16
+      GoRuntimeType: 1.187296e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: PointerType
+      ID: 133
+      Name: '*net/http.pattern'
+      ByteSize: 8
+      GoRuntimeType: 1.416576e+06
+      GoKind: 22
+      Pointee: 134 StructureType net/http.pattern
+    - __kind: StructureType
+      ID: 134
+      Name: net/http.pattern
+      ByteSize: 88
+      GoRuntimeType: 1.702112e+06
+      GoKind: 25
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: method
+          Offset: 16
+          Type: 27 GoStringHeaderType string
+        - Name: host
+          Offset: 32
+          Type: 27 GoStringHeaderType string
+        - Name: segments
+          Offset: 48
+          Type: 135 GoSliceHeaderType []net/http.segment
+        - Name: loc
+          Offset: 72
+          Type: 27 GoStringHeaderType string
+    - __kind: GoSliceHeaderType
+      ID: 135
+      Name: '[]net/http.segment'
+      ByteSize: 24
+      GoRuntimeType: 454944
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 136 PointerType *net/http.segment
+        - Name: len
+          Offset: 8
+          Type: 21 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 21 BaseType int
+      Data: 201 GoSliceDataType []net/http.segment.array
+    - __kind: PointerType
+      ID: 136
+      Name: '*net/http.segment'
+      ByteSize: 8
+      GoRuntimeType: 364064
+      GoKind: 22
+      Pointee: 137 StructureType net/http.segment
+    - __kind: StructureType
+      ID: 137
+      Name: net/http.segment
+      ByteSize: 24
+      GoRuntimeType: 1.416384e+06
+      GoKind: 25
+      RawFields:
+        - Name: s
+          Offset: 0
+          Type: 27 GoStringHeaderType string
+        - Name: wild
+          Offset: 16
+          Type: 32 BaseType bool
+        - Name: multi
+          Offset: 17
+          Type: 32 BaseType bool
+    - __kind: GoMapType
+      ID: 138
+      Name: map[string]string
+      ByteSize: 8
+      GoRuntimeType: 884224
+      GoKind: 21
+      HeaderType: 140 GoHMapHeaderType hash<string,string>
+    - __kind: PointerType
+      ID: 139
+      Name: '*hash<string,string>'
+      ByteSize: 8
+      Pointee: 140 GoHMapHeaderType hash<string,string>
+    - __kind: GoHMapHeaderType
+      ID: 140
+      Name: hash<string,string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 21 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 11 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 11 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 36 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 9 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 141 PointerType *bucket<string,string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 141 PointerType *bucket<string,string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 8 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 44 PointerType *runtime.mapextra
+      BucketType: 142 GoHMapBucketType bucket<string,string>
+      BucketsType: 203 GoSliceDataType []bucket<string,string>.array
+    - __kind: PointerType
+      ID: 141
+      Name: '*bucket<string,string>'
+      ByteSize: 8
+      Pointee: 142 GoHMapBucketType bucket<string,string>
+    - __kind: GoHMapBucketType
+      ID: 142
+      Name: bucket<string,string>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 39 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 40 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 143 ArrayType []val<string>
+        - Name: overflow
+          Offset: 264
+          Type: 141 PointerType *bucket<string,string>
+      KeyType: 27 GoStringHeaderType string
+      ValueType: 27 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 143
+      Name: '[]val<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 144
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.11552e+06
+      GoKind: 22
+      Pointee: 145 StructureType bytes.Buffer
+    - __kind: StructureType
+      ID: 145
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.414272e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 69 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 21 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 146 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 146
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532992
+      GoKind: 3
+    - __kind: GoInterfaceType
+      ID: 147
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.296128e+06
+      GoKind: 20
+      UnderlyingStructure: 2 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 148
+      Name: context.backgroundCtx
+      GoRuntimeType: 1.667744e+06
+      GoKind: 25
+      RawFields:
+        - Name: emptyCtx
+          Offset: 0
+          Type: 149 StructureType context.emptyCtx
+    - __kind: StructureType
+      ID: 149
+      Name: context.emptyCtx
+      GoRuntimeType: 1.399808e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: GoSliceDataType
+      ID: 150
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 20 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 151
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 150 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoStringDataType
+      ID: 152
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 153
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 152 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 154
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 155
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 27 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 156
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 155 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 157
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 49 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 158
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 157 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 159
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 160
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 161
+      Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
+      ByteSize: 2048
+      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+    - __kind: GoSliceDataType
+      ID: 162
+      Name: '[]*mime/multipart.FileHeader.array'
+      ByteSize: 2048
+      Element: 66 PointerType *mime/multipart.FileHeader
+    - __kind: PointerType
+      ID: 163
+      Name: '*[]*mime/multipart.FileHeader.array'
+      ByteSize: 8
+      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+    - __kind: GoSliceDataType
+      ID: 164
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 38 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 165
+      Name: '[]uint8.array'
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 166
+      Name: '*[]uint8.array'
+      ByteSize: 8
+      Pointee: 165 GoSliceDataType []uint8.array
+    - __kind: GoSliceDataType
+      ID: 167
+      Name: '[]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 74 PointerType *crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 168
+      Name: '*[]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 169
+      Name: math/big.nat.array
+      ByteSize: 2048
+      Element: 84 BaseType math/big.Word
+    - __kind: PointerType
+      ID: 170
+      Name: '*math/big.nat.array'
+      ByteSize: 8
+      Pointee: 169 GoSliceDataType math/big.nat.array
+    - __kind: GoSliceDataType
+      ID: 171
+      Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 2048
+      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+    - __kind: PointerType
+      ID: 172
+      Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
+      ByteSize: 8
+      Pointee: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+    - __kind: GoSliceDataType
+      ID: 173
+      Name: encoding/asn1.ObjectIdentifier.array
+      ByteSize: 2048
+      Element: 21 BaseType int
+    - __kind: PointerType
+      ID: 174
+      Name: '*encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 175
+      Name: '[]time.zone.array'
+      ByteSize: 2048
+      Element: 97 StructureType time.zone
+    - __kind: PointerType
+      ID: 176
+      Name: '*[]time.zone.array'
+      ByteSize: 8
+      Pointee: 175 GoSliceDataType []time.zone.array
+    - __kind: GoSliceDataType
+      ID: 177
+      Name: '[]time.zoneTrans.array'
+      ByteSize: 2048
+      Element: 100 StructureType time.zoneTrans
+    - __kind: PointerType
+      ID: 178
+      Name: '*[]time.zoneTrans.array'
+      ByteSize: 8
+      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+    - __kind: GoSliceDataType
+      ID: 179
+      Name: '[]crypto/x509/pkix.Extension.array'
+      ByteSize: 2048
+      Element: 104 StructureType crypto/x509/pkix.Extension
+    - __kind: PointerType
+      ID: 180
+      Name: '*[]crypto/x509/pkix.Extension.array'
+      ByteSize: 8
+      Pointee: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+    - __kind: GoSliceDataType
+      ID: 181
+      Name: '[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 2048
+      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+    - __kind: PointerType
+      ID: 182
+      Name: '*[]encoding/asn1.ObjectIdentifier.array'
+      ByteSize: 8
+      Pointee: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+    - __kind: GoSliceDataType
+      ID: 183
+      Name: '[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 2048
+      Element: 109 BaseType crypto/x509.ExtKeyUsage
+    - __kind: PointerType
+      ID: 184
+      Name: '*[]crypto/x509.ExtKeyUsage.array'
+      ByteSize: 8
+      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+    - __kind: GoSliceDataType
+      ID: 185
+      Name: '[]net.IP.array'
+      ByteSize: 2048
+      Element: 112 GoSliceHeaderType net.IP
+    - __kind: PointerType
+      ID: 186
+      Name: '*[]net.IP.array'
+      ByteSize: 8
+      Pointee: 185 GoSliceDataType []net.IP.array
+    - __kind: GoSliceDataType
+      ID: 187
+      Name: net.IP.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 188
+      Name: '*net.IP.array'
+      ByteSize: 8
+      Pointee: 187 GoSliceDataType net.IP.array
+    - __kind: GoSliceDataType
+      ID: 189
+      Name: '[]*net/url.URL.array'
+      ByteSize: 2048
+      Element: 28 PointerType *net/url.URL
+    - __kind: PointerType
+      ID: 190
+      Name: '*[]*net/url.URL.array'
+      ByteSize: 8
+      Pointee: 189 GoSliceDataType []*net/url.URL.array
+    - __kind: GoSliceDataType
+      ID: 191
+      Name: '[]*net.IPNet.array'
+      ByteSize: 2048
+      Element: 117 PointerType *net.IPNet
+    - __kind: PointerType
+      ID: 192
+      Name: '*[]*net.IPNet.array'
+      ByteSize: 8
+      Pointee: 191 GoSliceDataType []*net.IPNet.array
+    - __kind: GoSliceDataType
+      ID: 193
+      Name: net.IPMask.array
+      ByteSize: 2048
+      Element: 11 BaseType uint8
+    - __kind: PointerType
+      ID: 194
+      Name: '*net.IPMask.array'
+      ByteSize: 8
+      Pointee: 193 GoSliceDataType net.IPMask.array
+    - __kind: GoSliceDataType
+      ID: 195
+      Name: '[]crypto/x509.OID.array'
+      ByteSize: 2048
+      Element: 122 StructureType crypto/x509.OID
+    - __kind: PointerType
+      ID: 196
+      Name: '*[]crypto/x509.OID.array'
+      ByteSize: 8
+      Pointee: 195 GoSliceDataType []crypto/x509.OID.array
+    - __kind: GoSliceDataType
+      ID: 197
+      Name: '[][]*crypto/x509.Certificate.array'
+      ByteSize: 2048
+      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+    - __kind: PointerType
+      ID: 198
+      Name: '*[][]*crypto/x509.Certificate.array'
+      ByteSize: 8
+      Pointee: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[][]uint8.array'
+      ByteSize: 2048
+      Element: 69 GoSliceHeaderType []uint8
+    - __kind: PointerType
+      ID: 200
+      Name: '*[][]uint8.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType [][]uint8.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]net/http.segment.array'
+      ByteSize: 2048
+      Element: 137 StructureType net/http.segment
+    - __kind: PointerType
+      ID: 202
+      Name: '*[]net/http.segment.array'
+      ByteSize: 8
+      Pointee: 201 GoSliceDataType []net/http.segment.array
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<string,string>.array'
+      ByteSize: 2048
+      Element: 142 GoHMapBucketType bucket<string,string>
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.HandleHTTP]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 1 GoInterfaceType net/http.ResponseWriter
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: r
+          Offset: 17
+          Expression:
+            Type: 25 PointerType *net/http.Request
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 1, name: r}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 205
+      Name: Probe[main.LookAtTheRequest]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: path
+          Offset: 1
+          Expression:
+            Type: 27 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: path}
+                  Offset: 0
+                  ByteSize: 16
+MaxTypeID: 205
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,0 +1,7045 @@
+ID: 1
+Probes:
+    - id: stackC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stackC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 93}
+      events:
+        - ID: 87
+          Type: 314 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd06b0a", Frameless: false}]
+          Condition: null
+    - id: testArrayOfArrays
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfArrays}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 21}
+      events:
+        - ID: 15
+          Type: 242 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0xd02720", Frameless: true}]
+          Condition: null
+    - id: testArrayOfArraysOfArrays
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfArraysOfArrays}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 23}
+      events:
+        - ID: 17
+          Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0xd02760", Frameless: true}]
+          Condition: null
+    - id: testArrayOfMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfMaps}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 58}
+      events:
+        - ID: 52
+          Type: 279 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd04280", Frameless: true}]
+          Condition: null
+    - id: testArrayOfStrings
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfStrings}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 22}
+      events:
+        - ID: 16
+          Type: 243 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0xd02740", Frameless: true}]
+          Condition: null
+    - id: testBigStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testBigStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 35
+          Type: 262 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
+          Condition: null
+    - id: testBoolArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testBoolArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 4
+          Type: 231 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0xd025c0", Frameless: true}]
+          Condition: null
+    - id: testByteArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testByteArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 7}
+      events:
+        - ID: 1
+          Type: 228 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0xd02560", Frameless: true}]
+          Condition: null
+    - id: testChannel
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testChannel}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 74}
+      events:
+        - ID: 68
+          Type: 295 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd05dc0", Frameless: true}]
+          Condition: null
+    - id: testCombinedByte
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedByte}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 72}
+      events:
+        - ID: 66
+          Type: 293 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd059e0", Frameless: true}]
+          Condition: null
+    - id: testCycle
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCycle}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 82}
+      events:
+        - ID: 76
+          Type: 303 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd06180", Frameless: true}]
+          Condition: null
+    - id: testEmptySlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptySlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 84}
+      events:
+        - ID: 78
+          Type: 305 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd066c0", Frameless: true}]
+          Condition: null
+    - id: testEmptySliceOfStructs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptySliceOfStructs}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 87}
+      events:
+        - ID: 81
+          Type: 308 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd06720", Frameless: true}]
+          Condition: null
+    - id: testEmptyString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptyString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 95
+          Type: 322 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd06c40", Frameless: true}]
+          Condition: null
+    - id: testEmptyStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptyStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 103}
+      events:
+        - ID: 97
+          Type: 324 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
+          Condition: null
+    - id: testError
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testError}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 272 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xd03f20", Frameless: true}]
+          Condition: null
+    - id: testEsotericHeap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEsotericHeap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 37
+          Type: 264 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xd0322a", Frameless: false}]
+          Condition: null
+    - id: testEsotericStack
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEsotericStack}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 36
+          Type: 263 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xd0310e", Frameless: false}]
+          Condition: null
+    - id: testFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFrameless}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 48}
+      events:
+        - ID: 42
+          Type: 269 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xd03980", Frameless: true}]
+          Condition: null
+    - id: testFramelessArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFramelessArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 49}
+      events:
+        - ID: 43
+          Type: 270 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xd039a4", Frameless: false}]
+          Condition: null
+    - id: testInlinedBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 38
+          Type: 265 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xd0366a", Frameless: false}]
+          Condition: null
+    - id: testInlinedBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 45}
+      events:
+        - ID: 39
+          Type: 266 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xd0370e", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 46}
+      events:
+        - ID: 40
+          Type: 267 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xd037ea", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 99
+          Type: 326 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xd03766", Frameless: false}]
+          Condition: null
+    - id: testInlinedBC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 47}
+      events:
+        - ID: 41
+          Type: 268 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xd0386e", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 100
+          Type: 327 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xd03873", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 101
+          Type: 328 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xd03926", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrint
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedPrint}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 98
+          Type: 325 EventRootType Probe[main.testInlinedPrint]
+          InjectionPoints:
+            - PC: "0xd034ca"
+              Frameless: false
+            - PC: "0xd03551"
+              Frameless: false
+            - PC: "0xd03692"
+              Frameless: false
+            - PC: "0xd0371c"
+              Frameless: false
+            - PC: "0xd037ef"
+              Frameless: false
+          Condition: null
+    - id: testInlinedSq
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSq}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 102
+          Type: 329 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xd03981", Frameless: true}]
+          Condition: null
+    - id: testInlinedSumArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSumArray}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 103
+          Type: 330 EventRootType Probe[main.testInlinedSumArray]
+          InjectionPoints:
+            - PC: "0xd039c5"
+              Frameless: false
+            - PC: "0xd03a65"
+              Frameless: false
+          Condition: null
+    - id: testInt16Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt16Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 13}
+      events:
+        - ID: 7
+          Type: 234 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0xd02620", Frameless: true}]
+          Condition: null
+    - id: testInt32Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt32Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 14}
+      events:
+        - ID: 8
+          Type: 235 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0xd02640", Frameless: true}]
+          Condition: null
+    - id: testInt64Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt64Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 15}
+      events:
+        - ID: 9
+          Type: 236 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0xd02660", Frameless: true}]
+          Condition: null
+    - id: testInt8Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt8Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 12}
+      events:
+        - ID: 6
+          Type: 233 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0xd02600", Frameless: true}]
+          Condition: null
+    - id: testIntArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testIntArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 5
+          Type: 232 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0xd025e0", Frameless: true}]
+          Condition: null
+    - id: testInterface
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInterface}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 50}
+      events:
+        - ID: 44
+          Type: 271 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
+          Condition: null
+    - id: testLinkedList
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLinkedList}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 76}
+      events:
+        - ID: 70
+          Type: 297 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd05fa0", Frameless: true}]
+          Condition: null
+    - id: testMapArrayToArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapArrayToArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 50
+          Type: 277 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd04240", Frameless: true}]
+          Condition: null
+    - id: testMapEmbeddedMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapEmbeddedMaps}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 62}
+      events:
+        - ID: 56
+          Type: 283 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd04300", Frameless: true}]
+          Condition: null
+    - id: testMapIntToInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapIntToInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 60}
+      events:
+        - ID: 54
+          Type: 281 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd042c0", Frameless: true}]
+          Condition: null
+    - id: testMapLargeKeyLargeValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapLargeKeyLargeValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 71}
+      events:
+        - ID: 65
+          Type: 292 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd04420", Frameless: true}]
+          Condition: null
+    - id: testMapLargeKeySmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapLargeKeySmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 70}
+      events:
+        - ID: 64
+          Type: 291 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd04400", Frameless: true}]
+          Condition: null
+    - id: testMapMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 61}
+      events:
+        - ID: 55
+          Type: 282 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd042e0", Frameless: true}]
+          Condition: null
+    - id: testMapSmallKeyLargeValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapSmallKeyLargeValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 69}
+      events:
+        - ID: 63
+          Type: 290 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd043e0", Frameless: true}]
+          Condition: null
+    - id: testMapSmallKeySmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapSmallKeySmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 68}
+      events:
+        - ID: 62
+          Type: 289 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd043c0", Frameless: true}]
+          Condition: null
+    - id: testMapStringToInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 54}
+      events:
+        - ID: 48
+          Type: 275 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd04200", Frameless: true}]
+          Condition: null
+    - id: testMapStringToSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 49
+          Type: 276 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd04220", Frameless: true}]
+          Condition: null
+    - id: testMapStringToStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 53}
+      events:
+        - ID: 47
+          Type: 274 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd041e0", Frameless: true}]
+          Condition: null
+    - id: testMapWithLinkedList
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithLinkedList}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 63}
+      events:
+        - ID: 57
+          Type: 284 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd04320", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallKeyAndValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallKeyAndValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 66}
+      events:
+        - ID: 60
+          Type: 287 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd04380", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallKeyAndValueMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallKeyAndValueMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 67}
+      events:
+        - ID: 61
+          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd043a0", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 64}
+      events:
+        - ID: 58
+          Type: 285 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd04340", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallValueMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallValueMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 65}
+      events:
+        - ID: 59
+          Type: 286 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd04360", Frameless: true}]
+          Condition: null
+    - id: testMassiveString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMassiveString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 99}
+      events:
+        - ID: 93
+          Type: 320 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd06c00", Frameless: true}]
+          Condition: null
+    - id: testMultipleSimpleParams
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleSimpleParams}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 73}
+      events:
+        - ID: 67
+          Type: 294 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd05ba0", Frameless: true}]
+          Condition: null
+    - id: testNilPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 81}
+      events:
+        - ID: 75
+          Type: 302 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd06140", Frameless: true}]
+          Condition: null
+    - id: testNilSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 91}
+      events:
+        - ID: 85
+          Type: 312 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd067a0", Frameless: true}]
+          Condition: null
+    - id: testNilSliceOfStructs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSliceOfStructs}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 88}
+      events:
+        - ID: 82
+          Type: 309 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd06740", Frameless: true}]
+          Condition: null
+    - id: testNilSliceWithOtherParams
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSliceWithOtherParams}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 90}
+      events:
+        - ID: 84
+          Type: 311 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd06780", Frameless: true}]
+          Condition: null
+    - id: testOneStringInStructPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testOneStringInStructPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 98}
+      events:
+        - ID: 92
+          Type: 319 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
+          Condition: null
+    - id: testPointerLoop
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerLoop}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 77}
+      events:
+        - ID: 71
+          Type: 298 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
+          Condition: null
+    - id: testPointerToMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerToMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 59}
+      events:
+        - ID: 53
+          Type: 280 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd042a0", Frameless: true}]
+          Condition: null
+    - id: testPointerToSimpleStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerToSimpleStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 75}
+      events:
+        - ID: 69
+          Type: 296 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd05f80", Frameless: true}]
+          Condition: null
+    - id: testRuneArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testRuneArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 8}
+      events:
+        - ID: 2
+          Type: 229 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0xd02580", Frameless: true}]
+          Condition: null
+    - id: testSingleBool
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleBool}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 27}
+      events:
+        - ID: 21
+          Type: 248 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
+          Condition: null
+    - id: testSingleByte
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleByte}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 25}
+      events:
+        - ID: 19
+          Type: 246 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
+          Condition: null
+    - id: testSingleFloat32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleFloat32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 32
+          Type: 259 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0xd02ce0", Frameless: true}]
+          Condition: null
+    - id: testSingleFloat64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleFloat64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 33
+          Type: 260 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0xd02d00", Frameless: true}]
+          Condition: null
+    - id: testSingleInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 28}
+      events:
+        - ID: 22
+          Type: 249 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0xd02ba0", Frameless: true}]
+          Condition: null
+    - id: testSingleInt16
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt16}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 30}
+      events:
+        - ID: 24
+          Type: 251 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
+          Condition: null
+    - id: testSingleInt32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 31}
+      events:
+        - ID: 25
+          Type: 252 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0xd02c00", Frameless: true}]
+          Condition: null
+    - id: testSingleInt64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - ID: 26
+          Type: 253 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0xd02c20", Frameless: true}]
+          Condition: null
+    - id: testSingleInt8
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt8}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 29}
+      events:
+        - ID: 23
+          Type: 250 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0xd02bc0", Frameless: true}]
+          Condition: null
+    - id: testSingleRune
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleRune}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 26}
+      events:
+        - ID: 20
+          Type: 247 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
+          Condition: null
+    - id: testSingleString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 94}
+      events:
+        - ID: 88
+          Type: 315 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
+          Condition: null
+    - id: testSingleUint
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - ID: 27
+          Type: 254 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0xd02c40", Frameless: true}]
+          Condition: null
+    - id: testSingleUint16
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint16}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - ID: 29
+          Type: 256 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0xd02c80", Frameless: true}]
+          Condition: null
+    - id: testSingleUint32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 30
+          Type: 257 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0xd02ca0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 31
+          Type: 258 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0xd02cc0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint8
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint8}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - ID: 28
+          Type: 255 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0xd02c60", Frameless: true}]
+          Condition: null
+    - id: testSliceOfSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSliceOfSlices}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - ID: 79
+          Type: 306 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd066e0", Frameless: true}]
+          Condition: null
+    - id: testSmallMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSmallMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 57}
+      events:
+        - ID: 51
+          Type: 278 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd04260", Frameless: true}]
+          Condition: null
+    - id: testStringArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 9}
+      events:
+        - ID: 3
+          Type: 230 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0xd025a0", Frameless: true}]
+          Condition: null
+    - id: testStringPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 80}
+      events:
+        - ID: 74
+          Type: 301 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd06100", Frameless: true}]
+          Condition: null
+    - id: testStringSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 89}
+      events:
+        - ID: 83
+          Type: 310 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd06760", Frameless: true}]
+          Condition: null
+    - id: testStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - ID: 96
+          Type: 323 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd06ec0", Frameless: true}]
+          Condition: null
+    - id: testStructSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 86}
+      events:
+        - ID: 80
+          Type: 307 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd06700", Frameless: true}]
+          Condition: null
+    - id: testStructWithMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 46
+          Type: 273 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd041c0", Frameless: true}]
+          Condition: null
+    - id: testThreeStrings
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStrings}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 95}
+      events:
+        - ID: 89
+          Type: 316 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
+          Condition: null
+    - id: testThreeStringsInStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStringsInStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 96}
+      events:
+        - ID: 90
+          Type: 317 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
+          Condition: null
+    - id: testThreeStringsInStructPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStringsInStructPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 97}
+      events:
+        - ID: 91
+          Type: 318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
+          Condition: null
+    - id: testTypeAlias
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTypeAlias}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 34
+          Type: 261 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0xd02d20", Frameless: true}]
+          Condition: null
+    - id: testUint16Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint16Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 18}
+      events:
+        - ID: 12
+          Type: 239 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0xd026c0", Frameless: true}]
+          Condition: null
+    - id: testUint32Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint32Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 19}
+      events:
+        - ID: 13
+          Type: 240 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0xd026e0", Frameless: true}]
+          Condition: null
+    - id: testUint64Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint64Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 20}
+      events:
+        - ID: 14
+          Type: 241 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0xd02700", Frameless: true}]
+          Condition: null
+    - id: testUint8Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint8Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 17}
+      events:
+        - ID: 11
+          Type: 238 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0xd026a0", Frameless: true}]
+          Condition: null
+    - id: testUintArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 16}
+      events:
+        - ID: 10
+          Type: 237 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0xd02680", Frameless: true}]
+          Condition: null
+    - id: testUintPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 79}
+      events:
+        - ID: 73
+          Type: 300 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd06020", Frameless: true}]
+          Condition: null
+    - id: testUintSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 83}
+      events:
+        - ID: 77
+          Type: 304 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd066a0", Frameless: true}]
+          Condition: null
+    - id: testUnitializedString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUnitializedString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 100}
+      events:
+        - ID: 94
+          Type: 321 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd06c20", Frameless: true}]
+          Condition: null
+    - id: testUnsafePointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUnsafePointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 78}
+      events:
+        - ID: 72
+          Type: 299 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd05fe0", Frameless: true}]
+          Condition: null
+    - id: testVeryLargeArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testVeryLargeArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 24}
+      events:
+        - ID: 18
+          Type: 245 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0xd027c0", Frameless: true}]
+          Condition: null
+    - id: testVeryLargeSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testVeryLargeSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 92}
+      events:
+        - ID: 86
+          Type: 313 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd067c0", Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 7
+      Name: main.testByteArray
+      OutOfLinePCRanges: [0xd02560..0xd02561]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 ArrayType [2]uint8
+          Locations:
+            - Range: 0xd02560..0xd02561
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 8
+      Name: main.testRuneArray
+      OutOfLinePCRanges: [0xd02580..0xd02581]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0xd02580..0xd02581
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.testStringArray
+      OutOfLinePCRanges: [0xd025a0..0xd025a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0xd025a0..0xd025a1
+              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.testBoolArray
+      OutOfLinePCRanges: [0xd025c0..0xd025c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 ArrayType [2]bool
+          Locations:
+            - Range: 0xd025c0..0xd025c1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.testIntArray
+      OutOfLinePCRanges: [0xd025e0..0xd025e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 ArrayType [2]int
+          Locations:
+            - Range: 0xd025e0..0xd025e1
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xd02600..0xd02601]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 13 ArrayType [2]int8
+          Locations:
+            - Range: 0xd02600..0xd02601
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xd02620..0xd02621]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 ArrayType [2]int16
+          Locations:
+            - Range: 0xd02620..0xd02621
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 14
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xd02640..0xd02641]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0xd02640..0xd02641
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 15
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0xd02660..0xd02661]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 ArrayType [2]int64
+          Locations:
+            - Range: 0xd02660..0xd02661
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 16
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0xd02680..0xd02681]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 19 ArrayType [2]uint
+          Locations:
+            - Range: 0xd02680..0xd02681
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 17
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0xd026a0..0xd026a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 ArrayType [2]uint8
+          Locations:
+            - Range: 0xd026a0..0xd026a1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 18
+      Name: main.testUint16Array
+      OutOfLinePCRanges: [0xd026c0..0xd026c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 21 ArrayType [2]uint16
+          Locations:
+            - Range: 0xd026c0..0xd026c1
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 19
+      Name: main.testUint32Array
+      OutOfLinePCRanges: [0xd026e0..0xd026e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 23 ArrayType [2]uint32
+          Locations:
+            - Range: 0xd026e0..0xd026e1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 20
+      Name: main.testUint64Array
+      OutOfLinePCRanges: [0xd02700..0xd02701]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 25 ArrayType [2]uint64
+          Locations:
+            - Range: 0xd02700..0xd02701
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 21
+      Name: main.testArrayOfArrays
+      OutOfLinePCRanges: [0xd02720..0xd02721]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 27 ArrayType [2][2]int
+          Locations:
+            - Range: 0xd02720..0xd02721
+              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 22
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0xd02740..0xd02741]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0xd02740..0xd02741
+              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 23
+      Name: main.testArrayOfArraysOfArrays
+      OutOfLinePCRanges: [0xd02760..0xd02761]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 28 ArrayType [2][2][2]int
+          Locations:
+            - Range: 0xd02760..0xd02761
+              Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 24
+      Name: main.testVeryLargeArray
+      OutOfLinePCRanges: [0xd027c0..0xd027c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 29 ArrayType [100]uint
+          Locations:
+            - Range: 0xd027c0..0xd027c1
+              Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 25
+      Name: main.testSingleByte
+      OutOfLinePCRanges: [0xd02b40..0xd02b41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xd02b40..0xd02b41
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 26
+      Name: main.testSingleRune
+      OutOfLinePCRanges: [0xd02b60..0xd02b61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0xd02b60..0xd02b61
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 27
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0xd02b80..0xd02b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 BaseType bool
+          Locations:
+            - Range: 0xd02b80..0xd02b81
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 28
+      Name: main.testSingleInt
+      OutOfLinePCRanges: [0xd02ba0..0xd02ba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd02ba0..0xd02ba1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 29
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0xd02bc0..0xd02bc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd02bc0..0xd02bc1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 30
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0xd02be0..0xd02be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType int16
+          Locations:
+            - Range: 0xd02be0..0xd02be1
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 31
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0xd02c00..0xd02c01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0xd02c00..0xd02c01
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 32
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0xd02c20..0xd02c21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 18 BaseType int64
+          Locations:
+            - Range: 0xd02c20..0xd02c21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 33
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0xd02c40..0xd02c41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xd02c40..0xd02c41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 34
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0xd02c60..0xd02c61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xd02c60..0xd02c61
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 35
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0xd02c80..0xd02c81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 22 BaseType uint16
+          Locations:
+            - Range: 0xd02c80..0xd02c81
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 36
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0xd02ca0..0xd02ca1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 24 BaseType uint32
+          Locations:
+            - Range: 0xd02ca0..0xd02ca1
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0xd02cc0..0xd02cc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 26 BaseType uint64
+          Locations:
+            - Range: 0xd02cc0..0xd02cc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testSingleFloat32
+      OutOfLinePCRanges: [0xd02ce0..0xd02ce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0xd02ce0..0xd02ce1
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testSingleFloat64
+      OutOfLinePCRanges: [0xd02d00..0xd02d01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 31 BaseType float64
+          Locations:
+            - Range: 0xd02d00..0xd02d01
+              Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testTypeAlias
+      OutOfLinePCRanges: [0xd02d20..0xd02d21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 32 BaseType main.typeAlias
+          Locations:
+            - Range: 0xd02d20..0xd02d21
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testBigStruct
+      OutOfLinePCRanges: [0xd02e80..0xd02e9f]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 33 StructureType main.bigStruct
+          Locations:
+            - Range: 0xd02e80..0xd02e9f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testEsotericStack
+      OutOfLinePCRanges: [0xd03100..0xd03205]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 57 StructureType main.esotericStack
+          Locations:
+            - Range: 0xd03100..0xd03153
+              Pieces:
+                - Size: 4
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 4
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 11, Shift: 0}
+            - Range: 0xd03153..0xd03158
+              Pieces:
+                - Size: 4
+                  Op: null
+                - Size: 4
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 11, Shift: 0}
+            - Range: 0xd03158..0xd0315d
+              Pieces:
+                - Size: 4
+                  Op: null
+                - Size: 4
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 11, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testEsotericHeap
+      OutOfLinePCRanges: [0xd03220..0xd03283]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 63 PointerType *main.esotericHeap
+          Locations:
+            - Range: 0xd03220..0xd0324d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xd03660..0xd036e8]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03660..0xd03675
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 45
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xd03700..0xd037c5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03700..0xd03716
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03700..0xd03727
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03716..0xd03727
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03727..0xd037c5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 46
+      Name: main.testInlinedBBA
+      OutOfLinePCRanges: [0xd037e0..0xd03842]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd037e0..0xd037fa
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 47
+      Name: main.testInlinedBC
+      OutOfLinePCRanges: [0xd03860..0xd0396e]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd038bb..0xd038c5
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xd038c5..0xd038e0
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xd038e0..0xd038f4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd038b6..0xd038c0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xd038c0..0xd038e0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xd038e0..0xd038ef
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 48
+      Name: main.testFrameless
+      OutOfLinePCRanges: [0xd03980..0xd03986]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03980..0xd03985
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0xd03980..0xd03986, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 49
+      Name: main.testFramelessArray
+      OutOfLinePCRanges: [0xd039a0..0xd039e3]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0xd039a0..0xd039e3
+              Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0xd039a0..0xd039e3, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 50
+      Name: main.testInterface
+      OutOfLinePCRanges: [0xd03c80..0xd03f0d]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 74 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xd03c80..0xd03cbe
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd03cbe..0xd03cc5
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xd03c80..0xd03f0d, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: hash
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd03cfd..0xd03d02
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd03d02..0xd03d1e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd03d1e..0xd03d25
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {CfaOffset: -136}
+            - Range: 0xd03d25..0xd03f0d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {CfaOffset: -136}
+          IsParameter: false
+          IsReturn: false
+        - Name: inter
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd03d5d..0xd03d62
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd03d62..0xd03d7f
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -128}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd03d7f..0xd03d85
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -128}
+                - Size: 8
+                  Op: {CfaOffset: -160}
+            - Range: 0xd03d85..0xd03f0d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -128}
+                - Size: 8
+                  Op: {CfaOffset: -160}
+          IsParameter: false
+          IsReturn: false
+        - Name: iType
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd03dbd..0xd03dc2
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd03dc2..0xd03ddf
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd03ddf..0xd03de5
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {CfaOffset: -152}
+            - Range: 0xd03de5..0xd03f0d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {CfaOffset: -152}
+          IsParameter: false
+          IsReturn: false
+        - Name: iFun
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd03e1d..0xd03e22
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd03e22..0xd03e4a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd03e4a..0xd03e4f
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {CfaOffset: -144}
+            - Range: 0xd03e4f..0xd03f0d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {CfaOffset: -144}
+          IsParameter: false
+          IsReturn: false
+    - ID: 51
+      Name: main.testError
+      OutOfLinePCRanges: [0xd03f20..0xd03f21]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 75 GoInterfaceType error
+          Locations:
+            - Range: 0xd03f20..0xd03f21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 52
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0xd041c0..0xd041c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 76 StructureType main.structWithMap
+          Locations:
+            - Range: 0xd041c0..0xd041c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 53
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0xd041e0..0xd041e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 92 GoMapType map[string]main.nestedStruct
+          Locations:
+            - Range: 0xd041e0..0xd041e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 54
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0xd04200..0xd04201]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 100 GoMapType map[string]int
+          Locations:
+            - Range: 0xd04200..0xd04201
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 55
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0xd04220..0xd04221]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 105 GoMapType map[string][]string
+          Locations:
+            - Range: 0xd04220..0xd04221
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 56
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0xd04240..0xd04241]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 112 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0xd04240..0xd04241
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 57
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xd04260..0xd04261]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 100 GoMapType map[string]int
+          Locations:
+            - Range: 0xd04260..0xd04261
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 58
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0xd04280..0xd04281]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 120 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0xd04280..0xd04281
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 59
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0xd042a0..0xd042a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 121 PointerType *map[string]int
+          Locations:
+            - Range: 0xd042a0..0xd042a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 60
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xd042c0..0xd042c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 77 GoMapType map[int]int
+          Locations:
+            - Range: 0xd042c0..0xd042c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 61
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xd042e0..0xd042e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd042e0..0xd042e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 62
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xd04300..0xd04301]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xd04300..0xd04301
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xd04320..0xd04321]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 130 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0xd04320..0xd04321
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 64
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xd04340..0xd04341]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd04340..0xd04341
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xd04360..0xd04361]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0xd04360..0xd04361
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd04380..0xd04381]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd04380..0xd04381
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd043a0..0xd043a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd043a0..0xd043a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd043c0..0xd043c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd043c0..0xd043c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd043e0..0xd043e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 151 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd043e0..0xd043e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd04400..0xd04401]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 158 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd04400..0xd04401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd04420..0xd04421]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd04420..0xd04421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testCombinedByte
+      OutOfLinePCRanges: [0xd059e0..0xd059e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xd059e0..0xd059e1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xd059e0..0xd059e1
+              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0xd059e0..0xd059e1
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMultipleSimpleParams
+      OutOfLinePCRanges: [0xd05ba0..0xd05ba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 BaseType bool
+          Locations:
+            - Range: 0xd05ba0..0xd05ba1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xd05ba0..0xd05ba1
+              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0xd05ba0..0xd05ba1
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xd05ba0..0xd05ba1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd05ba0..0xd05ba1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testChannel
+      OutOfLinePCRanges: [0xd05dc0..0xd05dc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: c
+          Type: 169 GoChannelType chan bool
+          Locations:
+            - Range: 0xd05dc0..0xd05dc1
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testPointerToSimpleStruct
+      OutOfLinePCRanges: [0xd05f80..0xd05f81]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.structWithTwoValues
+          Locations:
+            - Range: 0xd05f80..0xd05f81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
+      Name: main.testLinkedList
+      OutOfLinePCRanges: [0xd05fa0..0xd05fa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 137 StructureType main.node
+          Locations:
+            - Range: 0xd05fa0..0xd05fa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
+      Name: main.testPointerLoop
+      OutOfLinePCRanges: [0xd05fc0..0xd05fc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 138 PointerType *main.node
+          Locations:
+            - Range: 0xd05fc0..0xd05fc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 78
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xd05fe0..0xd05fe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 56 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xd05fe0..0xd05fe1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 79
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xd06020..0xd06021]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 PointerType *uint
+          Locations:
+            - Range: 0xd06020..0xd06021
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 80
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xd06100..0xd06101]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 36 PointerType *string
+          Locations:
+            - Range: 0xd06100..0xd06101
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 81
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xd06140..0xd06141]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 173 PointerType *bool
+          Locations:
+            - Range: 0xd06140..0xd06141
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xd06140..0xd06141
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 82
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xd06180..0xd06181]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 174 PointerType *main.t
+          Locations:
+            - Range: 0xd06180..0xd06181
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 83
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd066a0..0xd066a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd066a0..0xd066a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 84
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd066c0..0xd066c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd066c0..0xd066c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 85
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd066e0..0xd066e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 178 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd066e0..0xd066e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 86
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd06700..0xd06701]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd06700..0xd06701
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06700..0xd06701
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd06720..0xd06721]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd06720..0xd06721
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06720..0xd06721
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd06740..0xd06741]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd06740..0xd06741
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06740..0xd06741
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd06760..0xd06761]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 111 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd06760..0xd06761
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd06780..0xd06781]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0xd06780..0xd06781
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 183 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0xd06780..0xd06781
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xd06780..0xd06781
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0xd067a0..0xd067a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 184 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0xd067a0..0xd067a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd067c0..0xd067c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd067c0..0xd067c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.stackC
+      OutOfLinePCRanges: [0xd06b00..0xd06b52]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xd06b00..0xd06b52, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 94
+      Name: main.testSingleString
+      OutOfLinePCRanges: [0xd06b60..0xd06b61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06b60..0xd06b61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0xd06b80..0xd06b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06b80..0xd06b81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06b80..0xd06b81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06b80..0xd06b81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0xd06ba0..0xd06bbf]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0xd06ba0..0xd06bbf
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 187 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0xd06bc0..0xd06bc1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0xd06be0..0xd06be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 188 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0xd06be0..0xd06be1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 99
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd06c00..0xd06c01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06c00..0xd06c01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 100
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd06c20..0xd06c21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06c20..0xd06c21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd06c40..0xd06c41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06c40..0xd06c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testStruct
+      OutOfLinePCRanges: [0xd06ec0..0xd06ee3]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 190 StructureType main.aStruct
+          Locations:
+            - Range: 0xd06ec0..0xd06ee3
+              Pieces:
+                - Size: 1
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0xd07040..0xd07041]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 191 StructureType main.emptyStruct
+          Locations: [{Range: 0xd07040..0xd07041, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 1
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xd034c0..0xd03522]
+      InlinePCRanges:
+        - Ranges: [0xd03551..0xd0358d]
+          RootRanges: [0xd03540..0xd035b1]
+        - Ranges: [0xd03692..0xd036ce]
+          RootRanges: [0xd03660..0xd036e8]
+        - Ranges: [0xd0371c..0xd03758]
+          RootRanges: [0xd03700..0xd037c5]
+        - Ranges: [0xd037ef..0xd0382b]
+          RootRanges: [0xd037e0..0xd03842]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd034c0..0xd034d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03551..0xd0355c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03692..0xd0369d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03716..0xd03727
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03727..0xd037c5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xd037e0..0xd037fa
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd03766..0xd0379e]
+          RootRanges: [0xd03700..0xd037c5]
+      Variables: []
+    - ID: 3
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd03873..0xd038b1]
+          RootRanges: [0xd03860..0xd0396e]
+      Variables: []
+    - ID: 4
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd03926..0xd0395e]
+          RootRanges: [0xd03860..0xd0396e]
+      Variables: []
+    - ID: 5
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd03981..0xd03985]
+          RootRanges: [0xd03980..0xd03986]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd03980..0xd03985
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.testInlinedSumArray
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd039c5..0xd039dd]
+          RootRanges: [0xd039a0..0xd039e3]
+        - Ranges: [0xd03a65..0xd03a83]
+          RootRanges: [0xd03a00..0xd03b85]
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0xd039ad..0xd039e3
+              Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
+            - Range: 0xd03a4c..0xd03b85
+              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 527360
+      GoKind: 2
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 618720
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 526912
+      GoKind: 8
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 618816
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 527104
+      GoKind: 5
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 618912
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 526784
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 193 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 192 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 359264
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 527808
+      GoKind: 1
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 617856
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 526848
+      GoKind: 3
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 526976
+      GoKind: 4
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 527232
+      GoKind: 6
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 527424
+      GoKind: 7
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 527040
+      GoKind: 9
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 527168
+      GoKind: 10
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 619008
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 527296
+      GoKind: 11
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 527680
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 527744
+      GoKind: 14
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 443168
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 194 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 35
+      Name: '**string'
+      ByteSize: 8
+      GoRuntimeType: 484288
+      GoKind: 22
+      Pointee: 36 PointerType *string
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 359136
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 973440
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 38
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 39 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 56 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 39
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 381792
+      GoKind: 22
+      Pointee: 40 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 40
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.625696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 41 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 54 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 24 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 55 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 41
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.053952e+06
+      GoKind: 22
+      Pointee: 42 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 42
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.435168e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 43 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 50 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 51 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 43
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 1.979616e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 44 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 44 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 24 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 45 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 4 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 4 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 46 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 9 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 48 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 49 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 44
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527488
+      GoKind: 12
+    - __kind: BaseType
+      ID: 45
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 530240
+      GoKind: 8
+    - __kind: BaseType
+      ID: 46
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 759008
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 47
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 773120
+      GoKind: 19
+    - __kind: BaseType
+      ID: 48
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 530304
+      GoKind: 5
+    - __kind: BaseType
+      ID: 49
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 530368
+      GoKind: 5
+    - __kind: StructureType
+      ID: 50
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.827456e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 9 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 51
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 466976
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 52 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 196 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 52
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 381728
+      GoKind: 22
+      Pointee: 53 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 53
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.294816e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 48 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 49 BaseType internal/abi.TypeOff
+    - __kind: PointerType
+      ID: 54
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.0544e+06
+      GoKind: 22
+      Pointee: 43 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 55
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 616896
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 44 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 56
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 527872
+      GoKind: 26
+    - __kind: StructureType
+      ID: 57
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.818528e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 58 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 59 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 61 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 62 GoSubroutineType func()
+    - __kind: GoChannelType
+      ID: 58
+      Name: chan struct {}
+      GoRuntimeType: 537984
+      GoKind: 18
+    - __kind: GoEmptyInterfaceType
+      ID: 59
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 772256
+      GoKind: 20
+      UnderlyingStructure: 60 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 60
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 54 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 56 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 61
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 973184
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 62
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 441760
+      GoKind: 19
+    - __kind: PointerType
+      ID: 63
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 354080
+      GoKind: 22
+      Pointee: 64 StructureType main.esotericHeap
+    - __kind: StructureType
+      ID: 64
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.692288e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 57 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 65 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 66 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 69 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 73 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 65
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.270976e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 66
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.272096e+06
+      GoKind: 25
+      RawFields:
+        - Name: done
+          Offset: 0
+          Type: 67 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 65 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 67
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.272576e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 68
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 940384
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 69
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.410784e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 70 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 71 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 70
+      Name: sync.noCopy
+      GoRuntimeType: 940288
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 71
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.411168e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 72 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 72
+      Name: sync/atomic.align64
+      GoRuntimeType: 940480
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 73
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.272416e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: GoInterfaceType
+      ID: 74
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 973056
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: GoInterfaceType
+      ID: 75
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 977536
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 76
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.092256e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 77 GoMapType map[int]int
+    - __kind: GoMapType
+      ID: 77
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 872672
+      GoKind: 21
+      HeaderType: 79 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 78
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 79 GoHMapHeaderType hash<int,int>
+    - __kind: GoHMapHeaderType
+      ID: 79
+      Name: hash<int,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 80 PointerType *bucket<int,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 80 PointerType *bucket<int,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 81 GoHMapBucketType bucket<int,int>
+      BucketsType: 198 GoSliceDataType []bucket<int,int>.array
+    - __kind: PointerType
+      ID: 80
+      Name: '*bucket<int,int>'
+      ByteSize: 8
+      Pointee: 81 GoHMapBucketType bucket<int,int>
+    - __kind: GoHMapBucketType
+      ID: 81
+      Name: bucket<int,int>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 83 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 84 ArrayType []val<int>
+        - Name: overflow
+          Offset: 136
+          Type: 80 PointerType *bucket<int,int>
+      KeyType: 1 BaseType int
+      ValueType: 1 BaseType int
+    - __kind: ArrayType
+      ID: 82
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 615360
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 83
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 84
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: PointerType
+      ID: 85
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 363040
+      GoKind: 22
+      Pointee: 86 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 86
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.416736e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 87 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 87 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 87
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 451552
+      GoKind: 22
+      Pointee: 88 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 451488
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 199 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 89
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 90
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.100704e+06
+      GoKind: 22
+      Pointee: 91 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 91
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.100576e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+    - __kind: GoMapType
+      ID: 92
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 874400
+      GoKind: 21
+      HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 93
+      Name: '*hash<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: GoHMapHeaderType
+      ID: 94
+      Name: hash<string,main.nestedStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 201 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: PointerType
+      ID: 95
+      Name: '*bucket<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoHMapBucketType
+      ID: 96
+      Name: bucket<string,main.nestedStruct>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 98 ArrayType []val<main.nestedStruct>
+        - Name: overflow
+          Offset: 328
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 99 StructureType main.nestedStruct
+    - __kind: ArrayType
+      ID: 97
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 98
+      Name: '[]val<main.nestedStruct>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 99 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 99
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.269696e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 100
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 874304
+      GoKind: 21
+      HeaderType: 102 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 101
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 102 GoHMapHeaderType hash<string,int>
+    - __kind: GoHMapHeaderType
+      ID: 102
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 103 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 103 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 104 GoHMapBucketType bucket<string,int>
+      BucketsType: 202 GoSliceDataType []bucket<string,int>.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 104 GoHMapBucketType bucket<string,int>
+    - __kind: GoHMapBucketType
+      ID: 104
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 84 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 103 PointerType *bucket<string,int>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoMapType
+      ID: 105
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 874208
+      GoKind: 21
+      HeaderType: 107 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 106
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 107 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 107
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 108 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 108 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 203 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 109 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 109
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 110 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 108 PointerType *bucket<string,[]string>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 111 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 110
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 111 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 449760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 204 GoSliceDataType []string.array
+    - __kind: GoMapType
+      ID: 112
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 873824
+      GoKind: 21
+      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 113
+      Name: '*hash<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: GoHMapHeaderType
+      ID: 114
+      Name: hash<[4]string,[2]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 206 GoSliceDataType []bucket<[4]string,[2]int>.array
+    - __kind: PointerType
+      ID: 115
+      Name: '*bucket<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoHMapBucketType
+      ID: 116
+      Name: bucket<[4]string,[2]int>
+      ByteSize: 656
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 117 ArrayType []key<[4]string>
+        - Name: values
+          Offset: 520
+          Type: 119 ArrayType []val<[2]int>
+        - Name: overflow
+          Offset: 648
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+      KeyType: 118 ArrayType [4]string
+      ValueType: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[]key<[4]string>'
+      ByteSize: 512
+      Count: 8
+      HasCount: true
+      Element: 118 ArrayType [4]string
+    - __kind: ArrayType
+      ID: 118
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 617760
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 119
+      Name: '[]val<[2]int>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 120
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 100 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 121
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 100 GoMapType map[string]int
+    - __kind: GoMapType
+      ID: 122
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 874112
+      GoKind: 21
+      HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 123
+      Name: '*hash<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: GoHMapHeaderType
+      ID: 124
+      Name: hash<string,[]main.structWithMap>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+    - __kind: PointerType
+      ID: 125
+      Name: '*bucket<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoHMapBucketType
+      ID: 126
+      Name: bucket<string,[]main.structWithMap>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 127 ArrayType []val<[]main.structWithMap>
+        - Name: overflow
+          Offset: 328
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 128 GoSliceHeaderType []main.structWithMap
+    - __kind: ArrayType
+      ID: 127
+      Name: '[]val<[]main.structWithMap>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 128 GoSliceHeaderType []main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 128
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 442656
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 129 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 208 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 129
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 354016
+      GoKind: 22
+      Pointee: 76 StructureType main.structWithMap
+    - __kind: GoMapType
+      ID: 130
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 873920
+      GoKind: 21
+      HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 131
+      Name: '*hash<bool,main.node>'
+      ByteSize: 8
+      Pointee: 132 GoHMapHeaderType hash<bool,main.node>
+    - __kind: GoHMapHeaderType
+      ID: 132
+      Name: hash<bool,main.node>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 133 PointerType *bucket<bool,main.node>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 133 PointerType *bucket<bool,main.node>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 134 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+    - __kind: PointerType
+      ID: 133
+      Name: '*bucket<bool,main.node>'
+      ByteSize: 8
+      Pointee: 134 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoHMapBucketType
+      ID: 134
+      Name: bucket<bool,main.node>
+      ByteSize: 152
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 135 ArrayType []key<bool>
+        - Name: values
+          Offset: 16
+          Type: 136 ArrayType []val<main.node>
+        - Name: overflow
+          Offset: 144
+          Type: 133 PointerType *bucket<bool,main.node>
+      KeyType: 11 BaseType bool
+      ValueType: 137 StructureType main.node
+    - __kind: ArrayType
+      ID: 135
+      Name: '[]key<bool>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 136
+      Name: '[]val<main.node>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 137 StructureType main.node
+    - __kind: StructureType
+      ID: 137
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.269536e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 138 PointerType *main.node
+    - __kind: PointerType
+      ID: 138
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 354144
+      GoKind: 22
+      Pointee: 137 StructureType main.node
+    - __kind: GoMapType
+      ID: 139
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 874016
+      GoKind: 21
+      HeaderType: 141 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 140
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 141 GoHMapHeaderType hash<int,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 141
+      Name: hash<int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 142 PointerType *bucket<int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 142 PointerType *bucket<int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+    - __kind: PointerType
+      ID: 142
+      Name: '*bucket<int,uint8>'
+      ByteSize: 8
+      Pointee: 143 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoHMapBucketType
+      ID: 143
+      Name: bucket<int,uint8>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 83 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 80
+          Type: 142 PointerType *bucket<int,uint8>
+      KeyType: 1 BaseType int
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 144
+      Name: '[]val<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoMapType
+      ID: 145
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 874592
+      GoKind: 21
+      HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 146
+      Name: '*hash<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 147 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 147
+      Name: hash<uint8,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 148 PointerType *bucket<uint8,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 148 PointerType *bucket<uint8,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 149 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: PointerType
+      ID: 148
+      Name: '*bucket<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 149 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoHMapBucketType
+      ID: 149
+      Name: bucket<uint8,uint8>
+      ByteSize: 32
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 150 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 24
+          Type: 148 PointerType *bucket<uint8,uint8>
+      KeyType: 4 BaseType uint8
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 150
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoMapType
+      ID: 151
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 874496
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: PointerType
+      ID: 152
+      Name: '*hash<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 153 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: GoHMapHeaderType
+      ID: 153
+      Name: hash<uint8,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 154 PointerType *bucket<uint8,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 154 PointerType *bucket<uint8,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 155 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 213 GoSliceDataType []bucket<uint8,[4]int>.array
+    - __kind: PointerType
+      ID: 154
+      Name: '*bucket<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 155 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoHMapBucketType
+      ID: 155
+      Name: bucket<uint8,[4]int>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 150 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 156 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 272
+          Type: 154 PointerType *bucket<uint8,[4]int>
+      KeyType: 4 BaseType uint8
+      ValueType: 157 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 156
+      Name: '[]val<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 157 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 157
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 617472
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoMapType
+      ID: 158
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 873728
+      GoKind: 21
+      HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: PointerType
+      ID: 159
+      Name: '*hash<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 160 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 160
+      Name: hash<[4]int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 161 PointerType *bucket<[4]int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 161 PointerType *bucket<[4]int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 162 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 214 GoSliceDataType []bucket<[4]int,uint8>.array
+    - __kind: PointerType
+      ID: 161
+      Name: '*bucket<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 162 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoHMapBucketType
+      ID: 162
+      Name: bucket<[4]int,uint8>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 163 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 272
+          Type: 161 PointerType *bucket<[4]int,uint8>
+      KeyType: 157 ArrayType [4]int
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 163
+      Name: '[]key<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 157 ArrayType [4]int
+    - __kind: GoMapType
+      ID: 164
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 873632
+      GoKind: 21
+      HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 165
+      Name: '*hash<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 166 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: GoHMapHeaderType
+      ID: 166
+      Name: hash<[4]int,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 215 GoSliceDataType []bucket<[4]int,[4]int>.array
+    - __kind: PointerType
+      ID: 167
+      Name: '*bucket<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 168 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoHMapBucketType
+      ID: 168
+      Name: bucket<[4]int,[4]int>
+      ByteSize: 528
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 163 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 156 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 520
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+      KeyType: 157 ArrayType [4]int
+      ValueType: 157 ArrayType [4]int
+    - __kind: GoChannelType
+      ID: 169
+      Name: chan bool
+      GoRuntimeType: 539072
+      GoKind: 18
+    - __kind: PointerType
+      ID: 170
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 171 StructureType main.structWithTwoValues
+    - __kind: StructureType
+      ID: 171
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: PointerType
+      ID: 172
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 359776
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 173
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 360160
+      GoKind: 22
+      Pointee: 11 BaseType bool
+    - __kind: PointerType
+      ID: 174
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 175 GoSliceHeaderType main.t
+    - __kind: GoSliceHeaderType
+      ID: 175
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 176 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 216 GoSliceDataType main.t.array
+    - __kind: PointerType
+      ID: 176
+      Name: '**main.t'
+      ByteSize: 8
+      Pointee: 174 PointerType *main.t
+    - __kind: GoSliceHeaderType
+      ID: 177
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 449248
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 172 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 218 GoSliceDataType []uint.array
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 220 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 177 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 222 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 182 StructureType main.structWithNoStrings
+    - __kind: StructureType
+      ID: 182
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 183
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 449632
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 173 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 224 GoSliceDataType []bool.array
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 448608
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 226 GoSliceDataType []uint16.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 359392
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: StructureType
+      ID: 186
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.threeStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 186 StructureType main.threeStringStruct
+    - __kind: PointerType
+      ID: 188
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 189 StructureType main.oneStringStruct
+    - __kind: StructureType
+      ID: 189
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 190
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 99 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 191
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: GoStringDataType
+      ID: 192
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 193
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 192 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: PointerType
+      ID: 195
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 194 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 53 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 197
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[]bucket<int,int>.array'
+      ByteSize: 2048
+      Element: 81 GoHMapBucketType bucket<int,int>
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]bucket<string,main.nestedStruct>.array'
+      ByteSize: 2048
+      Element: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 104 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 109 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 205
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 204 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<[4]string,[2]int>.array'
+      ByteSize: 2048
+      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]bucket<string,[]main.structWithMap>.array'
+      ByteSize: 2048
+      Element: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 76 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 209
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]bucket<bool,main.node>.array'
+      ByteSize: 2048
+      Element: 134 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]bucket<int,uint8>.array'
+      ByteSize: 2048
+      Element: 143 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]bucket<uint8,uint8>.array'
+      ByteSize: 2048
+      Element: 149 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]bucket<uint8,[4]int>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]bucket<[4]int,uint8>.array'
+      ByteSize: 2048
+      Element: 162 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]bucket<[4]int,[4]int>.array'
+      ByteSize: 2048
+      Element: 168 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 174 PointerType *main.t
+    - __kind: PointerType
+      ID: 217
+      Name: '*main.t.array'
+      ByteSize: 8
+      Pointee: 216 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 218
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: PointerType
+      ID: 219
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 218 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 220
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 177 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 221
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 220 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 222
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 182 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 223
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 224
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: PointerType
+      ID: 225
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 224 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 226
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 226 GoSliceDataType []uint16.array
+    - __kind: EventRootType
+      ID: 228
+      Name: Probe[main.testByteArray]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 229
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 230
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.testBoolArray]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 10 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 232
+      Name: Probe[main.testIntArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 12 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 233
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 234
+      Name: Probe[main.testInt16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 15 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 235
+      Name: Probe[main.testInt32Array]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 236
+      Name: Probe[main.testInt64Array]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 17 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 237
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 238
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.testUint32Array]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 23 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.testUint64Array]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 25 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 242
+      Name: Probe[main.testArrayOfArrays]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 28 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 29 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 246
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 247
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 250
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 251
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 252
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 253
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 254
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 255
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 256
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 32 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 264
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 63 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 269
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 271
+      Name: Probe[main.testInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 74 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 75 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 76 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 92 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 100 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 105 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.testMapArrayToArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 112 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 278
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 100 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 121 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 77 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 282
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 122 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 122 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 130 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.testMapWithSmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 139 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 139 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.testMapWithSmallKeyAndValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 151 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 158 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 164 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 169 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 170 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 137 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 138 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.testUnsafePointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 56 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 172 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testNilPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 173 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 174 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 178 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 111 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testNilSliceWithOtherParams]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 2
+          Expression:
+            Type: 183 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: x
+          Offset: 26
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testNilSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 184 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.testSingleString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 17
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 33
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 187 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 188 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testUnitializedString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 190 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 191 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+MaxTypeID: 330
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,0 +1,7045 @@
+ID: 1
+Probes:
+    - id: stackC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stackC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 93}
+      events:
+        - ID: 87
+          Type: 314 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x88f12c", Frameless: true}]
+          Condition: null
+    - id: testArrayOfArrays
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfArrays}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 21}
+      events:
+        - ID: 15
+          Type: 242 EventRootType Probe[main.testArrayOfArrays]
+          InjectionPoints: [{PC: "0x88baa0", Frameless: true}]
+          Condition: null
+    - id: testArrayOfArraysOfArrays
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfArraysOfArrays}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 23}
+      events:
+        - ID: 17
+          Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          InjectionPoints: [{PC: "0x88bac0", Frameless: true}]
+          Condition: null
+    - id: testArrayOfMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfMaps}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 58}
+      events:
+        - ID: 52
+          Type: 279 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88d180", Frameless: true}]
+          Condition: null
+    - id: testArrayOfStrings
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayOfStrings}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 22}
+      events:
+        - ID: 16
+          Type: 243 EventRootType Probe[main.testArrayOfStrings]
+          InjectionPoints: [{PC: "0x88bab0", Frameless: true}]
+          Condition: null
+    - id: testBigStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testBigStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 41}
+      events:
+        - ID: 35
+          Type: 262 EventRootType Probe[main.testBigStruct]
+          InjectionPoints: [{PC: "0x88c020", Frameless: true}]
+          Condition: null
+    - id: testBoolArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testBoolArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 4
+          Type: 231 EventRootType Probe[main.testBoolArray]
+          InjectionPoints: [{PC: "0x88b9f0", Frameless: true}]
+          Condition: null
+    - id: testByteArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testByteArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 7}
+      events:
+        - ID: 1
+          Type: 228 EventRootType Probe[main.testByteArray]
+          InjectionPoints: [{PC: "0x88b9c0", Frameless: true}]
+          Condition: null
+    - id: testChannel
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testChannel}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 74}
+      events:
+        - ID: 68
+          Type: 295 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88e730", Frameless: true}]
+          Condition: null
+    - id: testCombinedByte
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedByte}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 72}
+      events:
+        - ID: 66
+          Type: 293 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
+          Condition: null
+    - id: testCycle
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCycle}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 82}
+      events:
+        - ID: 76
+          Type: 303 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88e9d0", Frameless: true}]
+          Condition: null
+    - id: testEmptySlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptySlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 84}
+      events:
+        - ID: 78
+          Type: 305 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
+          Condition: null
+    - id: testEmptySliceOfStructs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptySliceOfStructs}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 87}
+      events:
+        - ID: 81
+          Type: 308 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x88ee00", Frameless: true}]
+          Condition: null
+    - id: testEmptyString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptyString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 101}
+      events:
+        - ID: 95
+          Type: 322 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x88f210", Frameless: true}]
+          Condition: null
+    - id: testEmptyStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEmptyStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 103}
+      events:
+        - ID: 97
+          Type: 324 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x88f520", Frameless: true}]
+          Condition: null
+    - id: testError
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testError}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 272 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x88cec0", Frameless: true}]
+          Condition: null
+    - id: testEsotericHeap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEsotericHeap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 43}
+      events:
+        - ID: 37
+          Type: 264 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x88c2dc", Frameless: true}]
+          Condition: null
+    - id: testEsotericStack
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testEsotericStack}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 42}
+      events:
+        - ID: 36
+          Type: 263 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x88c1ec", Frameless: true}]
+          Condition: null
+    - id: testFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFrameless}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 48}
+      events:
+        - ID: 42
+          Type: 269 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x88ca10", Frameless: true}]
+          Condition: null
+    - id: testFramelessArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFramelessArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 49}
+      events:
+        - ID: 43
+          Type: 270 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x88ca20", Frameless: true}]
+          Condition: null
+    - id: testInlinedBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 38
+          Type: 265 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
+          Condition: null
+    - id: testInlinedBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 45}
+      events:
+        - ID: 39
+          Type: 266 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x88c7ac", Frameless: true}]
+          Condition: null
+    - id: testInlinedBBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 46}
+      events:
+        - ID: 40
+          Type: 267 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x88c87c", Frameless: true}]
+          Condition: null
+    - id: testInlinedBBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 99
+          Type: 326 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x88c808", Frameless: false}]
+          Condition: null
+    - id: testInlinedBC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 47}
+      events:
+        - ID: 41
+          Type: 268 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x88c8fc", Frameless: true}]
+          Condition: null
+    - id: testInlinedBCA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 100
+          Type: 327 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x88c90c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 101
+          Type: 328 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x88c9c0", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrint
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedPrint}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 98
+          Type: 325 EventRootType Probe[main.testInlinedPrint]
+          InjectionPoints:
+            - PC: "0x88c57c"
+              Frameless: true
+            - PC: "0x88c5fc"
+              Frameless: false
+            - PC: "0x88c748"
+              Frameless: false
+            - PC: "0x88c7c4"
+              Frameless: false
+            - PC: "0x88c88c"
+              Frameless: false
+          Condition: null
+    - id: testInlinedSq
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSq}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 102
+          Type: 329 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x88ca14", Frameless: true}]
+          Condition: null
+    - id: testInlinedSumArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSumArray}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 103
+          Type: 330 EventRootType Probe[main.testInlinedSumArray]
+          InjectionPoints:
+            - PC: "0x88ca44"
+              Frameless: false
+            - PC: "0x88cadc"
+              Frameless: false
+          Condition: null
+    - id: testInt16Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt16Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 13}
+      events:
+        - ID: 7
+          Type: 234 EventRootType Probe[main.testInt16Array]
+          InjectionPoints: [{PC: "0x88ba20", Frameless: true}]
+          Condition: null
+    - id: testInt32Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt32Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 14}
+      events:
+        - ID: 8
+          Type: 235 EventRootType Probe[main.testInt32Array]
+          InjectionPoints: [{PC: "0x88ba30", Frameless: true}]
+          Condition: null
+    - id: testInt64Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt64Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 15}
+      events:
+        - ID: 9
+          Type: 236 EventRootType Probe[main.testInt64Array]
+          InjectionPoints: [{PC: "0x88ba40", Frameless: true}]
+          Condition: null
+    - id: testInt8Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInt8Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 12}
+      events:
+        - ID: 6
+          Type: 233 EventRootType Probe[main.testInt8Array]
+          InjectionPoints: [{PC: "0x88ba10", Frameless: true}]
+          Condition: null
+    - id: testIntArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testIntArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 5
+          Type: 232 EventRootType Probe[main.testIntArray]
+          InjectionPoints: [{PC: "0x88ba00", Frameless: true}]
+          Condition: null
+    - id: testInterface
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInterface}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 50}
+      events:
+        - ID: 44
+          Type: 271 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x88ccd0", Frameless: true}]
+          Condition: null
+    - id: testLinkedList
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLinkedList}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 76}
+      events:
+        - ID: 70
+          Type: 297 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88e8e0", Frameless: true}]
+          Condition: null
+    - id: testMapArrayToArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapArrayToArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 56}
+      events:
+        - ID: 50
+          Type: 277 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88d160", Frameless: true}]
+          Condition: null
+    - id: testMapEmbeddedMaps
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapEmbeddedMaps}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 62}
+      events:
+        - ID: 56
+          Type: 283 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88d1c0", Frameless: true}]
+          Condition: null
+    - id: testMapIntToInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapIntToInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 60}
+      events:
+        - ID: 54
+          Type: 281 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88d1a0", Frameless: true}]
+          Condition: null
+    - id: testMapLargeKeyLargeValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapLargeKeyLargeValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 71}
+      events:
+        - ID: 65
+          Type: 292 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88d250", Frameless: true}]
+          Condition: null
+    - id: testMapLargeKeySmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapLargeKeySmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 70}
+      events:
+        - ID: 64
+          Type: 291 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88d240", Frameless: true}]
+          Condition: null
+    - id: testMapMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 61}
+      events:
+        - ID: 55
+          Type: 282 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88d1b0", Frameless: true}]
+          Condition: null
+    - id: testMapSmallKeyLargeValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapSmallKeyLargeValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 69}
+      events:
+        - ID: 63
+          Type: 290 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88d230", Frameless: true}]
+          Condition: null
+    - id: testMapSmallKeySmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapSmallKeySmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 68}
+      events:
+        - ID: 62
+          Type: 289 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88d220", Frameless: true}]
+          Condition: null
+    - id: testMapStringToInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 54}
+      events:
+        - ID: 48
+          Type: 275 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88d140", Frameless: true}]
+          Condition: null
+    - id: testMapStringToSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 55}
+      events:
+        - ID: 49
+          Type: 276 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88d150", Frameless: true}]
+          Condition: null
+    - id: testMapStringToStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapStringToStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 53}
+      events:
+        - ID: 47
+          Type: 274 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88d130", Frameless: true}]
+          Condition: null
+    - id: testMapWithLinkedList
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithLinkedList}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 63}
+      events:
+        - ID: 57
+          Type: 284 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallKeyAndValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallKeyAndValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 66}
+      events:
+        - ID: 60
+          Type: 287 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88d200", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallKeyAndValueMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallKeyAndValueMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 67}
+      events:
+        - ID: 61
+          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88d210", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallValue
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallValue}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 64}
+      events:
+        - ID: 58
+          Type: 285 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88d1e0", Frameless: true}]
+          Condition: null
+    - id: testMapWithSmallValueMassive
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMapWithSmallValueMassive}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 65}
+      events:
+        - ID: 59
+          Type: 286 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88d1f0", Frameless: true}]
+          Condition: null
+    - id: testMassiveString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMassiveString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 99}
+      events:
+        - ID: 93
+          Type: 320 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x88f1f0", Frameless: true}]
+          Condition: null
+    - id: testMultipleSimpleParams
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleSimpleParams}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 73}
+      events:
+        - ID: 67
+          Type: 294 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88e590", Frameless: true}]
+          Condition: null
+    - id: testNilPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 81}
+      events:
+        - ID: 75
+          Type: 302 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88e9b0", Frameless: true}]
+          Condition: null
+    - id: testNilSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 91}
+      events:
+        - ID: 85
+          Type: 312 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x88ee40", Frameless: true}]
+          Condition: null
+    - id: testNilSliceOfStructs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSliceOfStructs}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 88}
+      events:
+        - ID: 82
+          Type: 309 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x88ee10", Frameless: true}]
+          Condition: null
+    - id: testNilSliceWithOtherParams
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testNilSliceWithOtherParams}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 90}
+      events:
+        - ID: 84
+          Type: 311 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x88ee30", Frameless: true}]
+          Condition: null
+    - id: testOneStringInStructPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testOneStringInStructPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 98}
+      events:
+        - ID: 92
+          Type: 319 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x88f1e0", Frameless: true}]
+          Condition: null
+    - id: testPointerLoop
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerLoop}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 77}
+      events:
+        - ID: 71
+          Type: 298 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88e8f0", Frameless: true}]
+          Condition: null
+    - id: testPointerToMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerToMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 59}
+      events:
+        - ID: 53
+          Type: 280 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88d190", Frameless: true}]
+          Condition: null
+    - id: testPointerToSimpleStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testPointerToSimpleStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 75}
+      events:
+        - ID: 69
+          Type: 296 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88e8d0", Frameless: true}]
+          Condition: null
+    - id: testRuneArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testRuneArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 8}
+      events:
+        - ID: 2
+          Type: 229 EventRootType Probe[main.testRuneArray]
+          InjectionPoints: [{PC: "0x88b9d0", Frameless: true}]
+          Condition: null
+    - id: testSingleBool
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleBool}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 27}
+      events:
+        - ID: 21
+          Type: 248 EventRootType Probe[main.testSingleBool]
+          InjectionPoints: [{PC: "0x88be40", Frameless: true}]
+          Condition: null
+    - id: testSingleByte
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleByte}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 25}
+      events:
+        - ID: 19
+          Type: 246 EventRootType Probe[main.testSingleByte]
+          InjectionPoints: [{PC: "0x88be20", Frameless: true}]
+          Condition: null
+    - id: testSingleFloat32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleFloat32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - ID: 32
+          Type: 259 EventRootType Probe[main.testSingleFloat32]
+          InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
+          Condition: null
+    - id: testSingleFloat64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleFloat64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - ID: 33
+          Type: 260 EventRootType Probe[main.testSingleFloat64]
+          InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
+          Condition: null
+    - id: testSingleInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 28}
+      events:
+        - ID: 22
+          Type: 249 EventRootType Probe[main.testSingleInt]
+          InjectionPoints: [{PC: "0x88be50", Frameless: true}]
+          Condition: null
+    - id: testSingleInt16
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt16}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 30}
+      events:
+        - ID: 24
+          Type: 251 EventRootType Probe[main.testSingleInt16]
+          InjectionPoints: [{PC: "0x88be70", Frameless: true}]
+          Condition: null
+    - id: testSingleInt32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 31}
+      events:
+        - ID: 25
+          Type: 252 EventRootType Probe[main.testSingleInt32]
+          InjectionPoints: [{PC: "0x88be80", Frameless: true}]
+          Condition: null
+    - id: testSingleInt64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - ID: 26
+          Type: 253 EventRootType Probe[main.testSingleInt64]
+          InjectionPoints: [{PC: "0x88be90", Frameless: true}]
+          Condition: null
+    - id: testSingleInt8
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleInt8}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 29}
+      events:
+        - ID: 23
+          Type: 250 EventRootType Probe[main.testSingleInt8]
+          InjectionPoints: [{PC: "0x88be60", Frameless: true}]
+          Condition: null
+    - id: testSingleRune
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleRune}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 26}
+      events:
+        - ID: 20
+          Type: 247 EventRootType Probe[main.testSingleRune]
+          InjectionPoints: [{PC: "0x88be30", Frameless: true}]
+          Condition: null
+    - id: testSingleString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 94}
+      events:
+        - ID: 88
+          Type: 315 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x88f190", Frameless: true}]
+          Condition: null
+    - id: testSingleUint
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - ID: 27
+          Type: 254 EventRootType Probe[main.testSingleUint]
+          InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint16
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint16}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - ID: 29
+          Type: 256 EventRootType Probe[main.testSingleUint16]
+          InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint32
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint32}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - ID: 30
+          Type: 257 EventRootType Probe[main.testSingleUint32]
+          InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint64
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint64}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - ID: 31
+          Type: 258 EventRootType Probe[main.testSingleUint64]
+          InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
+          Condition: null
+    - id: testSingleUint8
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSingleUint8}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - ID: 28
+          Type: 255 EventRootType Probe[main.testSingleUint8]
+          InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
+          Condition: null
+    - id: testSliceOfSlices
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSliceOfSlices}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - ID: 79
+          Type: 306 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x88ede0", Frameless: true}]
+          Condition: null
+    - id: testSmallMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testSmallMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 57}
+      events:
+        - ID: 51
+          Type: 278 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88d170", Frameless: true}]
+          Condition: null
+    - id: testStringArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 9}
+      events:
+        - ID: 3
+          Type: 230 EventRootType Probe[main.testStringArray]
+          InjectionPoints: [{PC: "0x88b9e0", Frameless: true}]
+          Condition: null
+    - id: testStringPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 80}
+      events:
+        - ID: 74
+          Type: 301 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88e990", Frameless: true}]
+          Condition: null
+    - id: testStringSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStringSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 89}
+      events:
+        - ID: 83
+          Type: 310 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x88ee20", Frameless: true}]
+          Condition: null
+    - id: testStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 102}
+      events:
+        - ID: 96
+          Type: 323 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x88f420", Frameless: true}]
+          Condition: null
+    - id: testStructSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 86}
+      events:
+        - ID: 80
+          Type: 307 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
+          Condition: null
+    - id: testStructWithMap
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithMap}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 46
+          Type: 273 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88d120", Frameless: true}]
+          Condition: null
+    - id: testThreeStrings
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStrings}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 95}
+      events:
+        - ID: 89
+          Type: 316 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x88f1a0", Frameless: true}]
+          Condition: null
+    - id: testThreeStringsInStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStringsInStruct}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 96}
+      events:
+        - ID: 90
+          Type: 317 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x88f1b0", Frameless: true}]
+          Condition: null
+    - id: testThreeStringsInStructPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testThreeStringsInStructPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 97}
+      events:
+        - ID: 91
+          Type: 318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x88f1d0", Frameless: true}]
+          Condition: null
+    - id: testTypeAlias
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testTypeAlias}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 40}
+      events:
+        - ID: 34
+          Type: 261 EventRootType Probe[main.testTypeAlias]
+          InjectionPoints: [{PC: "0x88bf10", Frameless: true}]
+          Condition: null
+    - id: testUint16Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint16Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 18}
+      events:
+        - ID: 12
+          Type: 239 EventRootType Probe[main.testUint16Array]
+          InjectionPoints: [{PC: "0x88ba70", Frameless: true}]
+          Condition: null
+    - id: testUint32Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint32Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 19}
+      events:
+        - ID: 13
+          Type: 240 EventRootType Probe[main.testUint32Array]
+          InjectionPoints: [{PC: "0x88ba80", Frameless: true}]
+          Condition: null
+    - id: testUint64Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint64Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 20}
+      events:
+        - ID: 14
+          Type: 241 EventRootType Probe[main.testUint64Array]
+          InjectionPoints: [{PC: "0x88ba90", Frameless: true}]
+          Condition: null
+    - id: testUint8Array
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUint8Array}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 17}
+      events:
+        - ID: 11
+          Type: 238 EventRootType Probe[main.testUint8Array]
+          InjectionPoints: [{PC: "0x88ba60", Frameless: true}]
+          Condition: null
+    - id: testUintArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 16}
+      events:
+        - ID: 10
+          Type: 237 EventRootType Probe[main.testUintArray]
+          InjectionPoints: [{PC: "0x88ba50", Frameless: true}]
+          Condition: null
+    - id: testUintPointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintPointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 79}
+      events:
+        - ID: 73
+          Type: 300 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88e920", Frameless: true}]
+          Condition: null
+    - id: testUintSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUintSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 83}
+      events:
+        - ID: 77
+          Type: 304 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
+          Condition: null
+    - id: testUnitializedString
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUnitializedString}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 100}
+      events:
+        - ID: 94
+          Type: 321 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x88f200", Frameless: true}]
+          Condition: null
+    - id: testUnsafePointer
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testUnsafePointer}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 78}
+      events:
+        - ID: 72
+          Type: 299 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88e900", Frameless: true}]
+          Condition: null
+    - id: testVeryLargeArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testVeryLargeArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 24}
+      events:
+        - ID: 18
+          Type: 245 EventRootType Probe[main.testVeryLargeArray]
+          InjectionPoints: [{PC: "0x88baf0", Frameless: true}]
+          Condition: null
+    - id: testVeryLargeSlice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testVeryLargeSlice}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 92}
+      events:
+        - ID: 86
+          Type: 313 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x88ee50", Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 7
+      Name: main.testByteArray
+      OutOfLinePCRanges: [0x88b9c0..0x88b9d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 ArrayType [2]uint8
+          Locations:
+            - Range: 0x88b9c0..0x88b9d0
+              Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 8
+      Name: main.testRuneArray
+      OutOfLinePCRanges: [0x88b9d0..0x88b9e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0x88b9d0..0x88b9e0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.testStringArray
+      OutOfLinePCRanges: [0x88b9e0..0x88b9f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0x88b9e0..0x88b9f0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.testBoolArray
+      OutOfLinePCRanges: [0x88b9f0..0x88ba00]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 ArrayType [2]bool
+          Locations:
+            - Range: 0x88b9f0..0x88ba00
+              Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.testIntArray
+      OutOfLinePCRanges: [0x88ba00..0x88ba10]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 ArrayType [2]int
+          Locations:
+            - Range: 0x88ba00..0x88ba10
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0x88ba10..0x88ba20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 13 ArrayType [2]int8
+          Locations:
+            - Range: 0x88ba10..0x88ba20
+              Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0x88ba20..0x88ba30]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 ArrayType [2]int16
+          Locations:
+            - Range: 0x88ba20..0x88ba30
+              Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 14
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0x88ba30..0x88ba40]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0x88ba30..0x88ba40
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 15
+      Name: main.testInt64Array
+      OutOfLinePCRanges: [0x88ba40..0x88ba50]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 17 ArrayType [2]int64
+          Locations:
+            - Range: 0x88ba40..0x88ba50
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 16
+      Name: main.testUintArray
+      OutOfLinePCRanges: [0x88ba50..0x88ba60]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 19 ArrayType [2]uint
+          Locations:
+            - Range: 0x88ba50..0x88ba60
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 17
+      Name: main.testUint8Array
+      OutOfLinePCRanges: [0x88ba60..0x88ba70]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 3 ArrayType [2]uint8
+          Locations:
+            - Range: 0x88ba60..0x88ba70
+              Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 18
+      Name: main.testUint16Array
+      OutOfLinePCRanges: [0x88ba70..0x88ba80]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 21 ArrayType [2]uint16
+          Locations:
+            - Range: 0x88ba70..0x88ba80
+              Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 19
+      Name: main.testUint32Array
+      OutOfLinePCRanges: [0x88ba80..0x88ba90]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 23 ArrayType [2]uint32
+          Locations:
+            - Range: 0x88ba80..0x88ba90
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 20
+      Name: main.testUint64Array
+      OutOfLinePCRanges: [0x88ba90..0x88baa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 25 ArrayType [2]uint64
+          Locations:
+            - Range: 0x88ba90..0x88baa0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 21
+      Name: main.testArrayOfArrays
+      OutOfLinePCRanges: [0x88baa0..0x88bab0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 27 ArrayType [2][2]int
+          Locations:
+            - Range: 0x88baa0..0x88bab0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 22
+      Name: main.testArrayOfStrings
+      OutOfLinePCRanges: [0x88bab0..0x88bac0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0x88bab0..0x88bac0
+              Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 23
+      Name: main.testArrayOfArraysOfArrays
+      OutOfLinePCRanges: [0x88bac0..0x88bad0]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 28 ArrayType [2][2][2]int
+          Locations:
+            - Range: 0x88bac0..0x88bad0
+              Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 24
+      Name: main.testVeryLargeArray
+      OutOfLinePCRanges: [0x88baf0..0x88bb00]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 29 ArrayType [100]uint
+          Locations:
+            - Range: 0x88baf0..0x88bb00
+              Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 25
+      Name: main.testSingleByte
+      OutOfLinePCRanges: [0x88be20..0x88be30]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x88be20..0x88be30
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 26
+      Name: main.testSingleRune
+      OutOfLinePCRanges: [0x88be30..0x88be40]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0x88be30..0x88be40
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 27
+      Name: main.testSingleBool
+      OutOfLinePCRanges: [0x88be40..0x88be50]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 BaseType bool
+          Locations:
+            - Range: 0x88be40..0x88be50
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 28
+      Name: main.testSingleInt
+      OutOfLinePCRanges: [0x88be50..0x88be60]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88be50..0x88be60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 29
+      Name: main.testSingleInt8
+      OutOfLinePCRanges: [0x88be60..0x88be70]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0x88be60..0x88be70
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 30
+      Name: main.testSingleInt16
+      OutOfLinePCRanges: [0x88be70..0x88be80]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 16 BaseType int16
+          Locations:
+            - Range: 0x88be70..0x88be80
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 31
+      Name: main.testSingleInt32
+      OutOfLinePCRanges: [0x88be80..0x88be90]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0x88be80..0x88be90
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 32
+      Name: main.testSingleInt64
+      OutOfLinePCRanges: [0x88be90..0x88bea0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 18 BaseType int64
+          Locations:
+            - Range: 0x88be90..0x88bea0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 33
+      Name: main.testSingleUint
+      OutOfLinePCRanges: [0x88bea0..0x88beb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x88bea0..0x88beb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 34
+      Name: main.testSingleUint8
+      OutOfLinePCRanges: [0x88beb0..0x88bec0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x88beb0..0x88bec0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 35
+      Name: main.testSingleUint16
+      OutOfLinePCRanges: [0x88bec0..0x88bed0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 22 BaseType uint16
+          Locations:
+            - Range: 0x88bec0..0x88bed0
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 36
+      Name: main.testSingleUint32
+      OutOfLinePCRanges: [0x88bed0..0x88bee0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 24 BaseType uint32
+          Locations:
+            - Range: 0x88bed0..0x88bee0
+              Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 37
+      Name: main.testSingleUint64
+      OutOfLinePCRanges: [0x88bee0..0x88bef0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 26 BaseType uint64
+          Locations:
+            - Range: 0x88bee0..0x88bef0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 38
+      Name: main.testSingleFloat32
+      OutOfLinePCRanges: [0x88bef0..0x88bf00]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0x88bef0..0x88bf00
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 39
+      Name: main.testSingleFloat64
+      OutOfLinePCRanges: [0x88bf00..0x88bf10]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 31 BaseType float64
+          Locations:
+            - Range: 0x88bf00..0x88bf10
+              Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 40
+      Name: main.testTypeAlias
+      OutOfLinePCRanges: [0x88bf10..0x88bf20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 32 BaseType main.typeAlias
+          Locations:
+            - Range: 0x88bf10..0x88bf20
+              Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 41
+      Name: main.testBigStruct
+      OutOfLinePCRanges: [0x88c020..0x88c040]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 33 StructureType main.bigStruct
+          Locations:
+            - Range: 0x88c020..0x88c040
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 42
+      Name: main.testEsotericStack
+      OutOfLinePCRanges: [0x88c1e0..0x88c2d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 57 StructureType main.esotericStack
+          Locations:
+            - Range: 0x88c1e0..0x88c228
+              Pieces:
+                - Size: 4
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 4
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+            - Range: 0x88c228..0x88c22c
+              Pieces:
+                - Size: 4
+                  Op: null
+                - Size: 4
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+            - Range: 0x88c22c..0x88c230
+              Pieces:
+                - Size: 4
+                  Op: null
+                - Size: 4
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 43
+      Name: main.testEsotericHeap
+      OutOfLinePCRanges: [0x88c2d0..0x88c350]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 63 PointerType *main.esotericHeap
+          Locations:
+            - Range: 0x88c2d0..0x88c308
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 44
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x88c710..0x88c7a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c710..0x88c748
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 45
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x88c7a0..0x88c870]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c7a0..0x88c7bc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c7a0..0x88c7cc
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c7bc..0x88c7cc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88c7cc..0x88c870
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 46
+      Name: main.testInlinedBBA
+      OutOfLinePCRanges: [0x88c870..0x88c8f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c870..0x88c894
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 47
+      Name: main.testInlinedBC
+      OutOfLinePCRanges: [0x88c8f0..0x88ca10]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c958..0x88c960
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x88c960..0x88c978
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x88c978..0x88c98c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c954..0x88c95c
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x88c95c..0x88c978
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x88c978..0x88c988
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 48
+      Name: main.testFrameless
+      OutOfLinePCRanges: [0x88ca10..0x88ca20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88ca10..0x88ca18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0x88ca10..0x88ca20, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 49
+      Name: main.testFramelessArray
+      OutOfLinePCRanges: [0x88ca20..0x88ca80]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0x88ca20..0x88ca80
+              Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0x88ca20..0x88ca80, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 50
+      Name: main.testInterface
+      OutOfLinePCRanges: [0x88ccc0..0x88cec0]
+      InlinePCRanges: []
+      Variables:
+        - Name: b
+          Type: 74 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0x88ccc0..0x88ccec
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88ccec..0x88ccf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x88ccc0..0x88cec0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: hash
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88cd20..0x88cd24
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x88cd24..0x88cd38
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -96}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88cd38..0x88cd3c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -96}
+                - Size: 8
+                  Op: {CfaOffset: -136}
+            - Range: 0x88cd3c..0x88cec0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -96}
+                - Size: 8
+                  Op: {CfaOffset: -136}
+          IsParameter: false
+          IsReturn: false
+        - Name: inter
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88cd68..0x88cd6c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x88cd6c..0x88cd80
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88cd80..0x88cd84
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {CfaOffset: -160}
+            - Range: 0x88cd84..0x88cec0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -120}
+                - Size: 8
+                  Op: {CfaOffset: -160}
+          IsParameter: false
+          IsReturn: false
+        - Name: iType
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88cdb0..0x88cdb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x88cdb4..0x88cdd0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88cdd0..0x88cdd4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {CfaOffset: -152}
+            - Range: 0x88cdd4..0x88cec0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -112}
+                - Size: 8
+                  Op: {CfaOffset: -152}
+          IsParameter: false
+          IsReturn: false
+        - Name: iFun
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88ce00..0x88ce04
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x88ce04..0x88ce1c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88ce1c..0x88ce20
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {CfaOffset: -144}
+            - Range: 0x88ce20..0x88cec0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -104}
+                - Size: 8
+                  Op: {CfaOffset: -144}
+          IsParameter: false
+          IsReturn: false
+    - ID: 51
+      Name: main.testError
+      OutOfLinePCRanges: [0x88cec0..0x88ced0]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 75 GoInterfaceType error
+          Locations:
+            - Range: 0x88cec0..0x88ced0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 52
+      Name: main.testStructWithMap
+      OutOfLinePCRanges: [0x88d120..0x88d130]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 76 StructureType main.structWithMap
+          Locations:
+            - Range: 0x88d120..0x88d130
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 53
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x88d130..0x88d140]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 92 GoMapType map[string]main.nestedStruct
+          Locations:
+            - Range: 0x88d130..0x88d140
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 54
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x88d140..0x88d150]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 100 GoMapType map[string]int
+          Locations:
+            - Range: 0x88d140..0x88d150
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 55
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x88d150..0x88d160]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 105 GoMapType map[string][]string
+          Locations:
+            - Range: 0x88d150..0x88d160
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 56
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x88d160..0x88d170]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 112 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x88d160..0x88d170
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 57
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x88d170..0x88d180]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 100 GoMapType map[string]int
+          Locations:
+            - Range: 0x88d170..0x88d180
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 58
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x88d180..0x88d190]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 120 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x88d180..0x88d190
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 59
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x88d190..0x88d1a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 121 PointerType *map[string]int
+          Locations:
+            - Range: 0x88d190..0x88d1a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 60
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x88d1a0..0x88d1b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 77 GoMapType map[int]int
+          Locations:
+            - Range: 0x88d1a0..0x88d1b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 61
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x88d1b0..0x88d1c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x88d1b0..0x88d1c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 62
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x88d1c0..0x88d1d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x88d1c0..0x88d1d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x88d1d0..0x88d1e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 130 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x88d1d0..0x88d1e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 64
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x88d1e0..0x88d1f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88d1e0..0x88d1f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x88d1f0..0x88d200]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88d1f0..0x88d200
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88d200..0x88d210]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d200..0x88d210
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88d210..0x88d220]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d210..0x88d220
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88d220..0x88d230]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d220..0x88d230
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x88d230..0x88d240]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 151 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x88d230..0x88d240
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x88d240..0x88d250]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 158 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x88d240..0x88d250
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x88d250..0x88d260]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x88d250..0x88d260
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 72
+      Name: main.testCombinedByte
+      OutOfLinePCRanges: [0x88e4b0..0x88e4c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x88e4b0..0x88e4c0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x88e4b0..0x88e4c0
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0x88e4b0..0x88e4c0
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
+      Name: main.testMultipleSimpleParams
+      OutOfLinePCRanges: [0x88e590..0x88e5a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 BaseType bool
+          Locations:
+            - Range: 0x88e590..0x88e5a0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x88e590..0x88e5a0
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0x88e590..0x88e5a0
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x88e590..0x88e5a0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88e590..0x88e5a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 74
+      Name: main.testChannel
+      OutOfLinePCRanges: [0x88e730..0x88e740]
+      InlinePCRanges: []
+      Variables:
+        - Name: c
+          Type: 169 GoChannelType chan bool
+          Locations:
+            - Range: 0x88e730..0x88e740
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
+      Name: main.testPointerToSimpleStruct
+      OutOfLinePCRanges: [0x88e8d0..0x88e8e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 170 PointerType *main.structWithTwoValues
+          Locations:
+            - Range: 0x88e8d0..0x88e8e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 76
+      Name: main.testLinkedList
+      OutOfLinePCRanges: [0x88e8e0..0x88e8f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 137 StructureType main.node
+          Locations:
+            - Range: 0x88e8e0..0x88e8f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 77
+      Name: main.testPointerLoop
+      OutOfLinePCRanges: [0x88e8f0..0x88e900]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 138 PointerType *main.node
+          Locations:
+            - Range: 0x88e8f0..0x88e900
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 78
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x88e900..0x88e910]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 56 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x88e900..0x88e910
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 79
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x88e920..0x88e930]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 172 PointerType *uint
+          Locations:
+            - Range: 0x88e920..0x88e930
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 80
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0x88e990..0x88e9a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 36 PointerType *string
+          Locations:
+            - Range: 0x88e990..0x88e9a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 81
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0x88e9b0..0x88e9c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 173 PointerType *bool
+          Locations:
+            - Range: 0x88e9b0..0x88e9c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x88e9b0..0x88e9c0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 82
+      Name: main.testCycle
+      OutOfLinePCRanges: [0x88e9d0..0x88e9e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 174 PointerType *main.t
+          Locations:
+            - Range: 0x88e9d0..0x88e9e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 83
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x88edc0..0x88edd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88edc0..0x88edd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 84
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x88edd0..0x88ede0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88edd0..0x88ede0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 85
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x88ede0..0x88edf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 178 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x88ede0..0x88edf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 86
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x88edf0..0x88ee00]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88edf0..0x88ee00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88edf0..0x88ee00
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x88ee00..0x88ee10]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88ee00..0x88ee10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88ee00..0x88ee10
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x88ee10..0x88ee20]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88ee10..0x88ee20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88ee10..0x88ee20
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x88ee20..0x88ee30]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 111 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x88ee20..0x88ee30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x88ee30..0x88ee40]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 14 BaseType int8
+          Locations:
+            - Range: 0x88ee30..0x88ee40
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 183 GoSliceHeaderType []bool
+          Locations:
+            - Range: 0x88ee30..0x88ee40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x88ee30..0x88ee40
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSlice
+      OutOfLinePCRanges: [0x88ee40..0x88ee50]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 184 GoSliceHeaderType []uint16
+          Locations:
+            - Range: 0x88ee40..0x88ee50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 92
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x88ee50..0x88ee60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88ee50..0x88ee60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 93
+      Name: main.stackC
+      OutOfLinePCRanges: [0x88f120..0x88f190]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x88f120..0x88f190, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 94
+      Name: main.testSingleString
+      OutOfLinePCRanges: [0x88f190..0x88f1a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f190..0x88f1a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 95
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x88f1a0..0x88f1b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f1a0..0x88f1b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f1a0..0x88f1b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f1a0..0x88f1b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 96
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0x88f1b0..0x88f1d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 186 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x88f1b0..0x88f1d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 97
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x88f1d0..0x88f1e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 187 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x88f1d0..0x88f1e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 98
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x88f1e0..0x88f1f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 188 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x88f1e0..0x88f1f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 99
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x88f1f0..0x88f200]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f1f0..0x88f200
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 100
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x88f200..0x88f210]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f200..0x88f210
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 101
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x88f210..0x88f220]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f210..0x88f220
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 102
+      Name: main.testStruct
+      OutOfLinePCRanges: [0x88f420..0x88f440]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 190 StructureType main.aStruct
+          Locations:
+            - Range: 0x88f420..0x88f440
+              Pieces:
+                - Size: 1
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
+      Name: main.testEmptyStruct
+      OutOfLinePCRanges: [0x88f520..0x88f530]
+      InlinePCRanges: []
+      Variables:
+        - Name: e
+          Type: 191 StructureType main.emptyStruct
+          Locations: [{Range: 0x88f520..0x88f530, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 1
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x88c570..0x88c5e0]
+      InlinePCRanges:
+        - Ranges: [0x88c5fc..0x88c634]
+          RootRanges: [0x88c5e0..0x88c660]
+        - Ranges: [0x88c748..0x88c780]
+          RootRanges: [0x88c710..0x88c7a0]
+        - Ranges: [0x88c7c4..0x88c7fc]
+          RootRanges: [0x88c7a0..0x88c870]
+        - Ranges: [0x88c88c..0x88c8c4]
+          RootRanges: [0x88c870..0x88c8f0]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88c570..0x88c590
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88c5fc..0x88c604
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88c748..0x88c750
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88c7bc..0x88c7cc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88c7cc..0x88c870
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x88c870..0x88c894
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88c808..0x88c840]
+          RootRanges: [0x88c7a0..0x88c870]
+      Variables: []
+    - ID: 3
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88c90c..0x88c950]
+          RootRanges: [0x88c8f0..0x88ca10]
+      Variables: []
+    - ID: 4
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88c9c0..0x88c9f8]
+          RootRanges: [0x88c8f0..0x88ca10]
+      Variables: []
+    - ID: 5
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88ca14..0x88ca18]
+          RootRanges: [0x88ca10..0x88ca20]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88ca10..0x88ca18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.testInlinedSumArray
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88ca44..0x88ca68]
+          RootRanges: [0x88ca20..0x88ca80]
+        - Ranges: [0x88cadc..0x88cb04]
+          RootRanges: [0x88ca80..0x88cbd0]
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0x88ca30..0x88ca80
+              Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
+            - Range: 0x88cac8..0x88cbd0
+              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 527552
+      GoKind: 2
+    - __kind: ArrayType
+      ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 3
+      Name: '[2]uint8'
+      ByteSize: 2
+      GoRuntimeType: 618912
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: BaseType
+      ID: 4
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 527104
+      GoKind: 8
+    - __kind: ArrayType
+      ID: 5
+      Name: '[2]int32'
+      ByteSize: 8
+      GoRuntimeType: 619008
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 6 BaseType int32
+    - __kind: BaseType
+      ID: 6
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 527296
+      GoKind: 5
+    - __kind: ArrayType
+      ID: 7
+      Name: '[2]string'
+      ByteSize: 32
+      GoRuntimeType: 619104
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: GoStringHeaderType
+      ID: 8
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 526976
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 193 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 192 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 9
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 359328
+      GoKind: 22
+      Pointee: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 10
+      Name: '[2]bool'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: BaseType
+      ID: 11
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 528000
+      GoKind: 1
+    - __kind: ArrayType
+      ID: 12
+      Name: '[2]int'
+      ByteSize: 16
+      GoRuntimeType: 618048
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 13
+      Name: '[2]int8'
+      ByteSize: 2
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 14 BaseType int8
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 527040
+      GoKind: 3
+    - __kind: ArrayType
+      ID: 15
+      Name: '[2]int16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 16 BaseType int16
+    - __kind: BaseType
+      ID: 16
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 527168
+      GoKind: 4
+    - __kind: ArrayType
+      ID: 17
+      Name: '[2]int64'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 18 BaseType int64
+    - __kind: BaseType
+      ID: 18
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 527424
+      GoKind: 6
+    - __kind: ArrayType
+      ID: 19
+      Name: '[2]uint'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: BaseType
+      ID: 20
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 527616
+      GoKind: 7
+    - __kind: ArrayType
+      ID: 21
+      Name: '[2]uint16'
+      ByteSize: 4
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 22 BaseType uint16
+    - __kind: BaseType
+      ID: 22
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 527232
+      GoKind: 9
+    - __kind: ArrayType
+      ID: 23
+      Name: '[2]uint32'
+      ByteSize: 8
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 24
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 527360
+      GoKind: 10
+    - __kind: ArrayType
+      ID: 25
+      Name: '[2]uint64'
+      ByteSize: 16
+      GoRuntimeType: 619200
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 26 BaseType uint64
+    - __kind: BaseType
+      ID: 26
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 527488
+      GoKind: 11
+    - __kind: ArrayType
+      ID: 27
+      Name: '[2][2]int'
+      ByteSize: 32
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 28
+      Name: '[2][2][2]int'
+      ByteSize: 64
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 27 ArrayType [2][2]int
+    - __kind: ArrayType
+      ID: 29
+      Name: '[100]uint'
+      ByteSize: 800
+      GoKind: 17
+      Count: 100
+      HasCount: true
+      Element: 20 BaseType uint
+    - __kind: BaseType
+      ID: 30
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 527872
+      GoKind: 13
+    - __kind: BaseType
+      ID: 31
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 527936
+      GoKind: 14
+    - __kind: BaseType
+      ID: 32
+      Name: main.typeAlias
+      ByteSize: 2
+      GoKind: 9
+    - __kind: StructureType
+      ID: 33
+      Name: main.bigStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: x
+          Offset: 0
+          Type: 34 GoSliceHeaderType []*string
+        - Name: z
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: writer
+          Offset: 32
+          Type: 37 GoInterfaceType io.Writer
+    - __kind: GoSliceHeaderType
+      ID: 34
+      Name: '[]*string'
+      ByteSize: 24
+      GoRuntimeType: 443296
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 35 PointerType **string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 194 GoSliceDataType []*string.array
+    - __kind: PointerType
+      ID: 35
+      Name: '**string'
+      ByteSize: 8
+      GoRuntimeType: 484416
+      GoKind: 22
+      Pointee: 36 PointerType *string
+    - __kind: PointerType
+      ID: 36
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 359200
+      GoKind: 22
+      Pointee: 8 GoStringHeaderType string
+    - __kind: GoInterfaceType
+      ID: 37
+      Name: io.Writer
+      ByteSize: 16
+      GoRuntimeType: 973632
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 38
+      Name: runtime.iface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 39 PointerType *internal/abi.ITab
+        - Name: data
+          Offset: 8
+          Type: 56 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 39
+      Name: '*internal/abi.ITab'
+      ByteSize: 8
+      GoRuntimeType: 381856
+      GoKind: 22
+      Pointee: 40 StructureType internal/abi.ITab
+    - __kind: StructureType
+      ID: 40
+      Name: internal/abi.ITab
+      ByteSize: 32
+      GoRuntimeType: 1.62624e+06
+      GoKind: 25
+      RawFields:
+        - Name: Inter
+          Offset: 0
+          Type: 41 PointerType *internal/abi.InterfaceType
+        - Name: Type
+          Offset: 8
+          Type: 54 PointerType *internal/abi.Type
+        - Name: Hash
+          Offset: 16
+          Type: 24 BaseType uint32
+        - Name: Fun
+          Offset: 24
+          Type: 55 ArrayType [1]uintptr
+    - __kind: PointerType
+      ID: 41
+      Name: '*internal/abi.InterfaceType'
+      ByteSize: 8
+      GoRuntimeType: 2.054496e+06
+      GoKind: 22
+      Pointee: 42 StructureType internal/abi.InterfaceType
+    - __kind: StructureType
+      ID: 42
+      Name: internal/abi.InterfaceType
+      ByteSize: 80
+      GoRuntimeType: 1.43552e+06
+      GoKind: 25
+      RawFields:
+        - Name: Type
+          Offset: 0
+          Type: 43 StructureType internal/abi.Type
+        - Name: PkgPath
+          Offset: 48
+          Type: 50 StructureType internal/abi.Name
+        - Name: Methods
+          Offset: 56
+          Type: 51 GoSliceHeaderType []internal/abi.Imethod
+    - __kind: StructureType
+      ID: 43
+      Name: internal/abi.Type
+      ByteSize: 48
+      GoRuntimeType: 1.98016e+06
+      GoKind: 25
+      RawFields:
+        - Name: Size_
+          Offset: 0
+          Type: 44 BaseType uintptr
+        - Name: PtrBytes
+          Offset: 8
+          Type: 44 BaseType uintptr
+        - Name: Hash
+          Offset: 16
+          Type: 24 BaseType uint32
+        - Name: TFlag
+          Offset: 20
+          Type: 45 BaseType internal/abi.TFlag
+        - Name: Align_
+          Offset: 21
+          Type: 4 BaseType uint8
+        - Name: FieldAlign_
+          Offset: 22
+          Type: 4 BaseType uint8
+        - Name: Kind_
+          Offset: 23
+          Type: 46 BaseType internal/abi.Kind
+        - Name: Equal
+          Offset: 24
+          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+        - Name: GCData
+          Offset: 32
+          Type: 9 PointerType *uint8
+        - Name: Str
+          Offset: 40
+          Type: 48 BaseType internal/abi.NameOff
+        - Name: PtrToThis
+          Offset: 44
+          Type: 49 BaseType internal/abi.TypeOff
+    - __kind: BaseType
+      ID: 44
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527680
+      GoKind: 12
+    - __kind: BaseType
+      ID: 45
+      Name: internal/abi.TFlag
+      ByteSize: 1
+      GoRuntimeType: 530432
+      GoKind: 8
+    - __kind: BaseType
+      ID: 46
+      Name: internal/abi.Kind
+      ByteSize: 1
+      GoRuntimeType: 759104
+      GoKind: 8
+    - __kind: GoSubroutineType
+      ID: 47
+      Name: func(unsafe.Pointer, unsafe.Pointer) bool
+      ByteSize: 8
+      GoRuntimeType: 773216
+      GoKind: 19
+    - __kind: BaseType
+      ID: 48
+      Name: internal/abi.NameOff
+      ByteSize: 4
+      GoRuntimeType: 530496
+      GoKind: 5
+    - __kind: BaseType
+      ID: 49
+      Name: internal/abi.TypeOff
+      ByteSize: 4
+      GoRuntimeType: 530560
+      GoKind: 5
+    - __kind: StructureType
+      ID: 50
+      Name: internal/abi.Name
+      ByteSize: 8
+      GoRuntimeType: 1.828e+06
+      GoKind: 25
+      RawFields:
+        - Name: Bytes
+          Offset: 0
+          Type: 9 PointerType *uint8
+    - __kind: GoSliceHeaderType
+      ID: 51
+      Name: '[]internal/abi.Imethod'
+      ByteSize: 24
+      GoRuntimeType: 467104
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 52 PointerType *internal/abi.Imethod
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 196 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: PointerType
+      ID: 52
+      Name: '*internal/abi.Imethod'
+      ByteSize: 8
+      GoRuntimeType: 381792
+      GoKind: 22
+      Pointee: 53 StructureType internal/abi.Imethod
+    - __kind: StructureType
+      ID: 53
+      Name: internal/abi.Imethod
+      ByteSize: 8
+      GoRuntimeType: 1.295008e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 48 BaseType internal/abi.NameOff
+        - Name: Typ
+          Offset: 4
+          Type: 49 BaseType internal/abi.TypeOff
+    - __kind: PointerType
+      ID: 54
+      Name: '*internal/abi.Type'
+      ByteSize: 8
+      GoRuntimeType: 2.054944e+06
+      GoKind: 22
+      Pointee: 43 StructureType internal/abi.Type
+    - __kind: ArrayType
+      ID: 55
+      Name: '[1]uintptr'
+      ByteSize: 8
+      GoRuntimeType: 617088
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 44 BaseType uintptr
+    - __kind: VoidPointerType
+      ID: 56
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 528064
+      GoKind: 26
+    - __kind: StructureType
+      ID: 57
+      Name: main.esotericStack
+      ByteSize: 64
+      GoRuntimeType: 1.819072e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: _valid
+          Offset: 4
+          Type: 6 BaseType int32
+        - Name: c
+          Offset: 8
+          Type: 58 GoChannelType chan struct {}
+        - Name: val
+          Offset: 16
+          Type: 59 GoEmptyInterfaceType interface {}
+        - Name: _
+          Offset: 32
+          Type: 26 BaseType uint64
+        - Name: work
+          Offset: 40
+          Type: 61 GoInterfaceType main.something
+        - Name: foo
+          Offset: 56
+          Type: 62 GoSubroutineType func()
+    - __kind: GoChannelType
+      ID: 58
+      Name: chan struct {}
+      GoRuntimeType: 538176
+      GoKind: 18
+    - __kind: GoEmptyInterfaceType
+      ID: 59
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 772352
+      GoKind: 20
+      UnderlyingStructure: 60 StructureType runtime.eface
+    - __kind: StructureType
+      ID: 60
+      Name: runtime.eface
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 54 PointerType *internal/abi.Type
+        - Name: data
+          Offset: 8
+          Type: 56 VoidPointerType unsafe.Pointer
+    - __kind: GoInterfaceType
+      ID: 61
+      Name: main.something
+      ByteSize: 16
+      GoRuntimeType: 973376
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: GoSubroutineType
+      ID: 62
+      Name: func()
+      ByteSize: 8
+      GoRuntimeType: 441888
+      GoKind: 19
+    - __kind: PointerType
+      ID: 63
+      Name: '*main.esotericHeap'
+      ByteSize: 8
+      GoRuntimeType: 354144
+      GoKind: 22
+      Pointee: 64 StructureType main.esotericHeap
+    - __kind: StructureType
+      ID: 64
+      Name: main.esotericHeap
+      ByteSize: 112
+      GoRuntimeType: 1.692832e+06
+      GoKind: 25
+      RawFields:
+        - Name: esotericStack
+          Offset: 0
+          Type: 57 StructureType main.esotericStack
+        - Name: mu
+          Offset: 64
+          Type: 65 StructureType sync.Mutex
+        - Name: once
+          Offset: 72
+          Type: 66 StructureType sync.Once
+        - Name: wg
+          Offset: 88
+          Type: 69 StructureType sync.WaitGroup
+        - Name: a
+          Offset: 104
+          Type: 73 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 65
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.271168e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 6 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 66
+      Name: sync.Once
+      ByteSize: 12
+      GoRuntimeType: 1.272288e+06
+      GoKind: 25
+      RawFields:
+        - Name: done
+          Offset: 0
+          Type: 67 StructureType sync/atomic.Uint32
+        - Name: m
+          Offset: 4
+          Type: 65 StructureType sync.Mutex
+    - __kind: StructureType
+      ID: 67
+      Name: sync/atomic.Uint32
+      ByteSize: 4
+      GoRuntimeType: 1.272768e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 68
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 940576
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 69
+      Name: sync.WaitGroup
+      ByteSize: 16
+      GoRuntimeType: 1.411136e+06
+      GoKind: 25
+      RawFields:
+        - Name: noCopy
+          Offset: 0
+          Type: 70 StructureType sync.noCopy
+        - Name: state
+          Offset: 0
+          Type: 71 StructureType sync/atomic.Uint64
+        - Name: sema
+          Offset: 8
+          Type: 24 BaseType uint32
+    - __kind: StructureType
+      ID: 70
+      Name: sync.noCopy
+      GoRuntimeType: 940480
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 71
+      Name: sync/atomic.Uint64
+      ByteSize: 8
+      GoRuntimeType: 1.41152e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: _
+          Offset: 0
+          Type: 72 StructureType sync/atomic.align64
+        - Name: v
+          Offset: 0
+          Type: 26 BaseType uint64
+    - __kind: StructureType
+      ID: 72
+      Name: sync/atomic.align64
+      GoRuntimeType: 940672
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 73
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.272608e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 68 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 6 BaseType int32
+    - __kind: GoInterfaceType
+      ID: 74
+      Name: main.behavior
+      ByteSize: 16
+      GoRuntimeType: 973248
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: GoInterfaceType
+      ID: 75
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 977728
+      GoKind: 20
+      UnderlyingStructure: 38 StructureType runtime.iface
+    - __kind: StructureType
+      ID: 76
+      Name: main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 1.092448e+06
+      GoKind: 25
+      RawFields:
+        - Name: m
+          Offset: 0
+          Type: 77 GoMapType map[int]int
+    - __kind: GoMapType
+      ID: 77
+      Name: map[int]int
+      ByteSize: 8
+      GoRuntimeType: 872768
+      GoKind: 21
+      HeaderType: 79 GoHMapHeaderType hash<int,int>
+    - __kind: PointerType
+      ID: 78
+      Name: '*hash<int,int>'
+      ByteSize: 8
+      Pointee: 79 GoHMapHeaderType hash<int,int>
+    - __kind: GoHMapHeaderType
+      ID: 79
+      Name: hash<int,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 80 PointerType *bucket<int,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 80 PointerType *bucket<int,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 81 GoHMapBucketType bucket<int,int>
+      BucketsType: 198 GoSliceDataType []bucket<int,int>.array
+    - __kind: PointerType
+      ID: 80
+      Name: '*bucket<int,int>'
+      ByteSize: 8
+      Pointee: 81 GoHMapBucketType bucket<int,int>
+    - __kind: GoHMapBucketType
+      ID: 81
+      Name: bucket<int,int>
+      ByteSize: 144
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 83 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 84 ArrayType []val<int>
+        - Name: overflow
+          Offset: 136
+          Type: 80 PointerType *bucket<int,int>
+      KeyType: 1 BaseType int
+      ValueType: 1 BaseType int
+    - __kind: ArrayType
+      ID: 82
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 615552
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 83
+      Name: '[]key<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 84
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: PointerType
+      ID: 85
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 363104
+      GoKind: 22
+      Pointee: 86 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 86
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 1.417088e+06
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 87 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 87 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 87
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 451680
+      GoKind: 22
+      Pointee: 88 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 88
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 451616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 89 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 199 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 89
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 90
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 1.100896e+06
+      GoKind: 22
+      Pointee: 91 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 91
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 1.100768e+06
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+    - __kind: GoMapType
+      ID: 92
+      Name: map[string]main.nestedStruct
+      ByteSize: 8
+      GoRuntimeType: 874496
+      GoKind: 21
+      HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 93
+      Name: '*hash<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+    - __kind: GoHMapHeaderType
+      ID: 94
+      Name: hash<string,main.nestedStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 201 GoSliceDataType []bucket<string,main.nestedStruct>.array
+    - __kind: PointerType
+      ID: 95
+      Name: '*bucket<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoHMapBucketType
+      ID: 96
+      Name: bucket<string,main.nestedStruct>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 98 ArrayType []val<main.nestedStruct>
+        - Name: overflow
+          Offset: 328
+          Type: 95 PointerType *bucket<string,main.nestedStruct>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 99 StructureType main.nestedStruct
+    - __kind: ArrayType
+      ID: 97
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 98
+      Name: '[]val<main.nestedStruct>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 99 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 99
+      Name: main.nestedStruct
+      ByteSize: 24
+      GoRuntimeType: 1.269888e+06
+      GoKind: 25
+      RawFields:
+        - Name: anotherInt
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: anotherString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 100
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 874400
+      GoKind: 21
+      HeaderType: 102 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 101
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 102 GoHMapHeaderType hash<string,int>
+    - __kind: GoHMapHeaderType
+      ID: 102
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 103 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 103 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 104 GoHMapBucketType bucket<string,int>
+      BucketsType: 202 GoSliceDataType []bucket<string,int>.array
+    - __kind: PointerType
+      ID: 103
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 104 GoHMapBucketType bucket<string,int>
+    - __kind: GoHMapBucketType
+      ID: 104
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 84 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 103 PointerType *bucket<string,int>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: GoMapType
+      ID: 105
+      Name: map[string][]string
+      ByteSize: 8
+      GoRuntimeType: 874304
+      GoKind: 21
+      HeaderType: 107 GoHMapHeaderType hash<string,[]string>
+    - __kind: PointerType
+      ID: 106
+      Name: '*hash<string,[]string>'
+      ByteSize: 8
+      Pointee: 107 GoHMapHeaderType hash<string,[]string>
+    - __kind: GoHMapHeaderType
+      ID: 107
+      Name: hash<string,[]string>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 108 PointerType *bucket<string,[]string>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 108 PointerType *bucket<string,[]string>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 109 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 203 GoSliceDataType []bucket<string,[]string>.array
+    - __kind: PointerType
+      ID: 108
+      Name: '*bucket<string,[]string>'
+      ByteSize: 8
+      Pointee: 109 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoHMapBucketType
+      ID: 109
+      Name: bucket<string,[]string>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 110 ArrayType []val<[]string>
+        - Name: overflow
+          Offset: 328
+          Type: 108 PointerType *bucket<string,[]string>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 111 GoSliceHeaderType []string
+    - __kind: ArrayType
+      ID: 110
+      Name: '[]val<[]string>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 111 GoSliceHeaderType []string
+    - __kind: GoSliceHeaderType
+      ID: 111
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 449888
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 36 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 204 GoSliceDataType []string.array
+    - __kind: GoMapType
+      ID: 112
+      Name: map[[4]string][2]int
+      ByteSize: 8
+      GoRuntimeType: 873920
+      GoKind: 21
+      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 113
+      Name: '*hash<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+    - __kind: GoHMapHeaderType
+      ID: 114
+      Name: hash<[4]string,[2]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 206 GoSliceDataType []bucket<[4]string,[2]int>.array
+    - __kind: PointerType
+      ID: 115
+      Name: '*bucket<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoHMapBucketType
+      ID: 116
+      Name: bucket<[4]string,[2]int>
+      ByteSize: 656
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 117 ArrayType []key<[4]string>
+        - Name: values
+          Offset: 520
+          Type: 119 ArrayType []val<[2]int>
+        - Name: overflow
+          Offset: 648
+          Type: 115 PointerType *bucket<[4]string,[2]int>
+      KeyType: 118 ArrayType [4]string
+      ValueType: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 117
+      Name: '[]key<[4]string>'
+      ByteSize: 512
+      Count: 8
+      HasCount: true
+      Element: 118 ArrayType [4]string
+    - __kind: ArrayType
+      ID: 118
+      Name: '[4]string'
+      ByteSize: 64
+      GoRuntimeType: 617952
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 8 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 119
+      Name: '[]val<[2]int>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 12 ArrayType [2]int
+    - __kind: ArrayType
+      ID: 120
+      Name: '[2]map[string]int'
+      ByteSize: 16
+      GoKind: 17
+      Count: 2
+      HasCount: true
+      Element: 100 GoMapType map[string]int
+    - __kind: PointerType
+      ID: 121
+      Name: '*map[string]int'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 100 GoMapType map[string]int
+    - __kind: GoMapType
+      ID: 122
+      Name: map[string][]main.structWithMap
+      ByteSize: 8
+      GoRuntimeType: 874208
+      GoKind: 21
+      HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 123
+      Name: '*hash<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+    - __kind: GoHMapHeaderType
+      ID: 124
+      Name: hash<string,[]main.structWithMap>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+    - __kind: PointerType
+      ID: 125
+      Name: '*bucket<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoHMapBucketType
+      ID: 126
+      Name: bucket<string,[]main.structWithMap>
+      ByteSize: 336
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 97 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 127 ArrayType []val<[]main.structWithMap>
+        - Name: overflow
+          Offset: 328
+          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+      KeyType: 8 GoStringHeaderType string
+      ValueType: 128 GoSliceHeaderType []main.structWithMap
+    - __kind: ArrayType
+      ID: 127
+      Name: '[]val<[]main.structWithMap>'
+      ByteSize: 192
+      Count: 8
+      HasCount: true
+      Element: 128 GoSliceHeaderType []main.structWithMap
+    - __kind: GoSliceHeaderType
+      ID: 128
+      Name: '[]main.structWithMap'
+      ByteSize: 24
+      GoRuntimeType: 442784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 129 PointerType *main.structWithMap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 208 GoSliceDataType []main.structWithMap.array
+    - __kind: PointerType
+      ID: 129
+      Name: '*main.structWithMap'
+      ByteSize: 8
+      GoRuntimeType: 354080
+      GoKind: 22
+      Pointee: 76 StructureType main.structWithMap
+    - __kind: GoMapType
+      ID: 130
+      Name: map[bool]main.node
+      ByteSize: 8
+      GoRuntimeType: 874016
+      GoKind: 21
+      HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
+    - __kind: PointerType
+      ID: 131
+      Name: '*hash<bool,main.node>'
+      ByteSize: 8
+      Pointee: 132 GoHMapHeaderType hash<bool,main.node>
+    - __kind: GoHMapHeaderType
+      ID: 132
+      Name: hash<bool,main.node>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 133 PointerType *bucket<bool,main.node>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 133 PointerType *bucket<bool,main.node>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 134 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+    - __kind: PointerType
+      ID: 133
+      Name: '*bucket<bool,main.node>'
+      ByteSize: 8
+      Pointee: 134 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoHMapBucketType
+      ID: 134
+      Name: bucket<bool,main.node>
+      ByteSize: 152
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 135 ArrayType []key<bool>
+        - Name: values
+          Offset: 16
+          Type: 136 ArrayType []val<main.node>
+        - Name: overflow
+          Offset: 144
+          Type: 133 PointerType *bucket<bool,main.node>
+      KeyType: 11 BaseType bool
+      ValueType: 137 StructureType main.node
+    - __kind: ArrayType
+      ID: 135
+      Name: '[]key<bool>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 11 BaseType bool
+    - __kind: ArrayType
+      ID: 136
+      Name: '[]val<main.node>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 137 StructureType main.node
+    - __kind: StructureType
+      ID: 137
+      Name: main.node
+      ByteSize: 16
+      GoRuntimeType: 1.269728e+06
+      GoKind: 25
+      RawFields:
+        - Name: val
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 138 PointerType *main.node
+    - __kind: PointerType
+      ID: 138
+      Name: '*main.node'
+      ByteSize: 8
+      GoRuntimeType: 354208
+      GoKind: 22
+      Pointee: 137 StructureType main.node
+    - __kind: GoMapType
+      ID: 139
+      Name: map[int]uint8
+      ByteSize: 8
+      GoRuntimeType: 874112
+      GoKind: 21
+      HeaderType: 141 GoHMapHeaderType hash<int,uint8>
+    - __kind: PointerType
+      ID: 140
+      Name: '*hash<int,uint8>'
+      ByteSize: 8
+      Pointee: 141 GoHMapHeaderType hash<int,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 141
+      Name: hash<int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 142 PointerType *bucket<int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 142 PointerType *bucket<int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+    - __kind: PointerType
+      ID: 142
+      Name: '*bucket<int,uint8>'
+      ByteSize: 8
+      Pointee: 143 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoHMapBucketType
+      ID: 143
+      Name: bucket<int,uint8>
+      ByteSize: 88
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 83 ArrayType []key<int>
+        - Name: values
+          Offset: 72
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 80
+          Type: 142 PointerType *bucket<int,uint8>
+      KeyType: 1 BaseType int
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 144
+      Name: '[]val<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoMapType
+      ID: 145
+      Name: map[uint8]uint8
+      ByteSize: 8
+      GoRuntimeType: 874688
+      GoKind: 21
+      HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: PointerType
+      ID: 146
+      Name: '*hash<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 147 GoHMapHeaderType hash<uint8,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 147
+      Name: hash<uint8,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 148 PointerType *bucket<uint8,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 148 PointerType *bucket<uint8,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 149 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+    - __kind: PointerType
+      ID: 148
+      Name: '*bucket<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 149 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoHMapBucketType
+      ID: 149
+      Name: bucket<uint8,uint8>
+      ByteSize: 32
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 150 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 24
+          Type: 148 PointerType *bucket<uint8,uint8>
+      KeyType: 4 BaseType uint8
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 150
+      Name: '[]key<uint8>'
+      ByteSize: 8
+      Count: 8
+      HasCount: true
+      Element: 4 BaseType uint8
+    - __kind: GoMapType
+      ID: 151
+      Name: map[uint8][4]int
+      ByteSize: 8
+      GoRuntimeType: 874592
+      GoKind: 21
+      HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: PointerType
+      ID: 152
+      Name: '*hash<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 153 GoHMapHeaderType hash<uint8,[4]int>
+    - __kind: GoHMapHeaderType
+      ID: 153
+      Name: hash<uint8,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 154 PointerType *bucket<uint8,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 154 PointerType *bucket<uint8,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 155 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 213 GoSliceDataType []bucket<uint8,[4]int>.array
+    - __kind: PointerType
+      ID: 154
+      Name: '*bucket<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 155 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoHMapBucketType
+      ID: 155
+      Name: bucket<uint8,[4]int>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 150 ArrayType []key<uint8>
+        - Name: values
+          Offset: 16
+          Type: 156 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 272
+          Type: 154 PointerType *bucket<uint8,[4]int>
+      KeyType: 4 BaseType uint8
+      ValueType: 157 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 156
+      Name: '[]val<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 157 ArrayType [4]int
+    - __kind: ArrayType
+      ID: 157
+      Name: '[4]int'
+      ByteSize: 32
+      GoRuntimeType: 617664
+      GoKind: 17
+      Count: 4
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoMapType
+      ID: 158
+      Name: map[[4]int]uint8
+      ByteSize: 8
+      GoRuntimeType: 873824
+      GoKind: 21
+      HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: PointerType
+      ID: 159
+      Name: '*hash<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 160 GoHMapHeaderType hash<[4]int,uint8>
+    - __kind: GoHMapHeaderType
+      ID: 160
+      Name: hash<[4]int,uint8>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 161 PointerType *bucket<[4]int,uint8>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 161 PointerType *bucket<[4]int,uint8>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 162 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 214 GoSliceDataType []bucket<[4]int,uint8>.array
+    - __kind: PointerType
+      ID: 161
+      Name: '*bucket<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 162 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoHMapBucketType
+      ID: 162
+      Name: bucket<[4]int,uint8>
+      ByteSize: 280
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 163 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 144 ArrayType []val<uint8>
+        - Name: overflow
+          Offset: 272
+          Type: 161 PointerType *bucket<[4]int,uint8>
+      KeyType: 157 ArrayType [4]int
+      ValueType: 4 BaseType uint8
+    - __kind: ArrayType
+      ID: 163
+      Name: '[]key<[4]int>'
+      ByteSize: 256
+      Count: 8
+      HasCount: true
+      Element: 157 ArrayType [4]int
+    - __kind: GoMapType
+      ID: 164
+      Name: map[[4]int][4]int
+      ByteSize: 8
+      GoRuntimeType: 873728
+      GoKind: 21
+      HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 165
+      Name: '*hash<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 166 GoHMapHeaderType hash<[4]int,[4]int>
+    - __kind: GoHMapHeaderType
+      ID: 166
+      Name: hash<[4]int,[4]int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 4 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 4 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 22 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 24 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 44 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 85 PointerType *runtime.mapextra
+      BucketType: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 215 GoSliceDataType []bucket<[4]int,[4]int>.array
+    - __kind: PointerType
+      ID: 167
+      Name: '*bucket<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 168 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoHMapBucketType
+      ID: 168
+      Name: bucket<[4]int,[4]int>
+      ByteSize: 528
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 82 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 163 ArrayType []key<[4]int>
+        - Name: values
+          Offset: 264
+          Type: 156 ArrayType []val<[4]int>
+        - Name: overflow
+          Offset: 520
+          Type: 167 PointerType *bucket<[4]int,[4]int>
+      KeyType: 157 ArrayType [4]int
+      ValueType: 157 ArrayType [4]int
+    - __kind: GoChannelType
+      ID: 169
+      Name: chan bool
+      GoRuntimeType: 539264
+      GoKind: 18
+    - __kind: PointerType
+      ID: 170
+      Name: '*main.structWithTwoValues'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 171 StructureType main.structWithTwoValues
+    - __kind: StructureType
+      ID: 171
+      Name: main.structWithTwoValues
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 20 BaseType uint
+        - Name: b
+          Offset: 8
+          Type: 11 BaseType bool
+    - __kind: PointerType
+      ID: 172
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 359840
+      GoKind: 22
+      Pointee: 20 BaseType uint
+    - __kind: PointerType
+      ID: 173
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 360224
+      GoKind: 22
+      Pointee: 11 BaseType bool
+    - __kind: PointerType
+      ID: 174
+      Name: '*main.t'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 175 GoSliceHeaderType main.t
+    - __kind: GoSliceHeaderType
+      ID: 175
+      Name: main.t
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 176 PointerType **main.t
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 216 GoSliceDataType main.t.array
+    - __kind: PointerType
+      ID: 176
+      Name: '**main.t'
+      ByteSize: 8
+      Pointee: 174 PointerType *main.t
+    - __kind: GoSliceHeaderType
+      ID: 177
+      Name: '[]uint'
+      ByteSize: 24
+      GoRuntimeType: 449376
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 172 PointerType *uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 218 GoSliceDataType []uint.array
+    - __kind: GoSliceHeaderType
+      ID: 178
+      Name: '[][]uint'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 179 PointerType *[]uint
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 220 GoSliceDataType [][]uint.array
+    - __kind: PointerType
+      ID: 179
+      Name: '*[]uint'
+      ByteSize: 8
+      Pointee: 177 GoSliceHeaderType []uint
+    - __kind: GoSliceHeaderType
+      ID: 180
+      Name: '[]main.structWithNoStrings'
+      ByteSize: 24
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 181 PointerType *main.structWithNoStrings
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 222 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: PointerType
+      ID: 181
+      Name: '*main.structWithNoStrings'
+      ByteSize: 8
+      Pointee: 182 StructureType main.structWithNoStrings
+    - __kind: StructureType
+      ID: 182
+      Name: main.structWithNoStrings
+      ByteSize: 2
+      GoKind: 25
+      RawFields:
+        - Name: aUint8
+          Offset: 0
+          Type: 4 BaseType uint8
+        - Name: aBool
+          Offset: 1
+          Type: 11 BaseType bool
+    - __kind: GoSliceHeaderType
+      ID: 183
+      Name: '[]bool'
+      ByteSize: 24
+      GoRuntimeType: 449760
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 173 PointerType *bool
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 224 GoSliceDataType []bool.array
+    - __kind: GoSliceHeaderType
+      ID: 184
+      Name: '[]uint16'
+      ByteSize: 24
+      GoRuntimeType: 448736
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 185 PointerType *uint16
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 226 GoSliceDataType []uint16.array
+    - __kind: PointerType
+      ID: 185
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 359456
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: StructureType
+      ID: 186
+      Name: main.threeStringStruct
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+        - Name: b
+          Offset: 16
+          Type: 8 GoStringHeaderType string
+        - Name: c
+          Offset: 32
+          Type: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 187
+      Name: '*main.threeStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 186 StructureType main.threeStringStruct
+    - __kind: PointerType
+      ID: 188
+      Name: '*main.oneStringStruct'
+      ByteSize: 8
+      GoKind: 22
+      Pointee: 189 StructureType main.oneStringStruct
+    - __kind: StructureType
+      ID: 189
+      Name: main.oneStringStruct
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 8 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 190
+      Name: main.aStruct
+      ByteSize: 56
+      GoKind: 25
+      RawFields:
+        - Name: aBool
+          Offset: 0
+          Type: 11 BaseType bool
+        - Name: aString
+          Offset: 8
+          Type: 8 GoStringHeaderType string
+        - Name: aNumber
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: nested
+          Offset: 32
+          Type: 99 StructureType main.nestedStruct
+    - __kind: StructureType
+      ID: 191
+      Name: main.emptyStruct
+      GoKind: 25
+      RawFields: []
+    - __kind: GoStringDataType
+      ID: 192
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 193
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 192 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 194
+      Name: '[]*string.array'
+      ByteSize: 2048
+      Element: 36 PointerType *string
+    - __kind: PointerType
+      ID: 195
+      Name: '*[]*string.array'
+      ByteSize: 8
+      Pointee: 194 GoSliceDataType []*string.array
+    - __kind: GoSliceDataType
+      ID: 196
+      Name: '[]internal/abi.Imethod.array'
+      ByteSize: 2048
+      Element: 53 StructureType internal/abi.Imethod
+    - __kind: PointerType
+      ID: 197
+      Name: '*[]internal/abi.Imethod.array'
+      ByteSize: 8
+      Pointee: 196 GoSliceDataType []internal/abi.Imethod.array
+    - __kind: GoSliceDataType
+      ID: 198
+      Name: '[]bucket<int,int>.array'
+      ByteSize: 2048
+      Element: 81 GoHMapBucketType bucket<int,int>
+    - __kind: GoSliceDataType
+      ID: 199
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 90 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 200
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 199 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 201
+      Name: '[]bucket<string,main.nestedStruct>.array'
+      ByteSize: 2048
+      Element: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+    - __kind: GoSliceDataType
+      ID: 202
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 104 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 203
+      Name: '[]bucket<string,[]string>.array'
+      ByteSize: 2048
+      Element: 109 GoHMapBucketType bucket<string,[]string>
+    - __kind: GoSliceDataType
+      ID: 204
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 8 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 205
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 204 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 206
+      Name: '[]bucket<[4]string,[2]int>.array'
+      ByteSize: 2048
+      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+    - __kind: GoSliceDataType
+      ID: 207
+      Name: '[]bucket<string,[]main.structWithMap>.array'
+      ByteSize: 2048
+      Element: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+    - __kind: GoSliceDataType
+      ID: 208
+      Name: '[]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 76 StructureType main.structWithMap
+    - __kind: PointerType
+      ID: 209
+      Name: '*[]main.structWithMap.array'
+      ByteSize: 8
+      Pointee: 208 GoSliceDataType []main.structWithMap.array
+    - __kind: GoSliceDataType
+      ID: 210
+      Name: '[]bucket<bool,main.node>.array'
+      ByteSize: 2048
+      Element: 134 GoHMapBucketType bucket<bool,main.node>
+    - __kind: GoSliceDataType
+      ID: 211
+      Name: '[]bucket<int,uint8>.array'
+      ByteSize: 2048
+      Element: 143 GoHMapBucketType bucket<int,uint8>
+    - __kind: GoSliceDataType
+      ID: 212
+      Name: '[]bucket<uint8,uint8>.array'
+      ByteSize: 2048
+      Element: 149 GoHMapBucketType bucket<uint8,uint8>
+    - __kind: GoSliceDataType
+      ID: 213
+      Name: '[]bucket<uint8,[4]int>.array'
+      ByteSize: 2048
+      Element: 155 GoHMapBucketType bucket<uint8,[4]int>
+    - __kind: GoSliceDataType
+      ID: 214
+      Name: '[]bucket<[4]int,uint8>.array'
+      ByteSize: 2048
+      Element: 162 GoHMapBucketType bucket<[4]int,uint8>
+    - __kind: GoSliceDataType
+      ID: 215
+      Name: '[]bucket<[4]int,[4]int>.array'
+      ByteSize: 2048
+      Element: 168 GoHMapBucketType bucket<[4]int,[4]int>
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: main.t.array
+      ByteSize: 2048
+      Element: 174 PointerType *main.t
+    - __kind: PointerType
+      ID: 217
+      Name: '*main.t.array'
+      ByteSize: 8
+      Pointee: 216 GoSliceDataType main.t.array
+    - __kind: GoSliceDataType
+      ID: 218
+      Name: '[]uint.array'
+      ByteSize: 2048
+      Element: 20 BaseType uint
+    - __kind: PointerType
+      ID: 219
+      Name: '*[]uint.array'
+      ByteSize: 8
+      Pointee: 218 GoSliceDataType []uint.array
+    - __kind: GoSliceDataType
+      ID: 220
+      Name: '[][]uint.array'
+      ByteSize: 2048
+      Element: 177 GoSliceHeaderType []uint
+    - __kind: PointerType
+      ID: 221
+      Name: '*[][]uint.array'
+      ByteSize: 8
+      Pointee: 220 GoSliceDataType [][]uint.array
+    - __kind: GoSliceDataType
+      ID: 222
+      Name: '[]main.structWithNoStrings.array'
+      ByteSize: 2048
+      Element: 182 StructureType main.structWithNoStrings
+    - __kind: PointerType
+      ID: 223
+      Name: '*[]main.structWithNoStrings.array'
+      ByteSize: 8
+      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
+    - __kind: GoSliceDataType
+      ID: 224
+      Name: '[]bool.array'
+      ByteSize: 2048
+      Element: 11 BaseType bool
+    - __kind: PointerType
+      ID: 225
+      Name: '*[]bool.array'
+      ByteSize: 8
+      Pointee: 224 GoSliceDataType []bool.array
+    - __kind: GoSliceDataType
+      ID: 226
+      Name: '[]uint16.array'
+      ByteSize: 2048
+      Element: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 227
+      Name: '*[]uint16.array'
+      ByteSize: 8
+      Pointee: 226 GoSliceDataType []uint16.array
+    - __kind: EventRootType
+      ID: 228
+      Name: Probe[main.testByteArray]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 229
+      Name: Probe[main.testRuneArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 230
+      Name: Probe[main.testStringArray]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.testBoolArray]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 10 ArrayType [2]bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 232
+      Name: Probe[main.testIntArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 12 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 233
+      Name: Probe[main.testInt8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 13 ArrayType [2]int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 234
+      Name: Probe[main.testInt16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 15 ArrayType [2]int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 13, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 235
+      Name: Probe[main.testInt32Array]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 5 ArrayType [2]int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 14, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 236
+      Name: Probe[main.testInt64Array]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 17 ArrayType [2]int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 15, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 237
+      Name: Probe[main.testUintArray]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 19 ArrayType [2]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 16, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 238
+      Name: Probe[main.testUint8Array]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 3 ArrayType [2]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 17, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.testUint16Array]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 21 ArrayType [2]uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 18, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.testUint32Array]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 23 ArrayType [2]uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 19, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.testUint64Array]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 25 ArrayType [2]uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 20, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 242
+      Name: Probe[main.testArrayOfArrays]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 27 ArrayType [2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 21, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.testArrayOfStrings]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 7 ArrayType [2]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 32
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.testArrayOfArraysOfArrays]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 28 ArrayType [2][2][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.testVeryLargeArray]
+      ByteSize: 801
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 29 ArrayType [100]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 800
+    - __kind: EventRootType
+      ID: 246
+      Name: Probe[main.testSingleByte]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 25, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 247
+      Name: Probe[main.testSingleRune]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 26, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.testSingleBool]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.testSingleInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 28, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 250
+      Name: Probe[main.testSingleInt8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 29, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 251
+      Name: Probe[main.testSingleInt16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 16 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 30, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 252
+      Name: Probe[main.testSingleInt32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 31, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 253
+      Name: Probe[main.testSingleInt64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 18 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 254
+      Name: Probe[main.testSingleUint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 255
+      Name: Probe[main.testSingleUint8]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 256
+      Name: Probe[main.testSingleUint16]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 22 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.testSingleUint32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 24 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.testSingleUint64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 26 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.testSingleFloat32]
+      ByteSize: 5
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.testSingleFloat64]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 31 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.testTypeAlias]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 32 BaseType main.typeAlias
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 40, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 2
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.testBigStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 33 StructureType main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 41, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.testEsotericStack]
+      ByteSize: 65
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 57 StructureType main.esotericStack
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 42, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 64
+    - __kind: EventRootType
+      ID: 264
+      Name: Probe[main.testEsotericHeap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 63 PointerType *main.esotericHeap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 43, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 269
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 271
+      Name: Probe[main.testInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: b
+          Offset: 1
+          Expression:
+            Type: 74 GoInterfaceType main.behavior
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 50, index: 0, name: b}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.testError]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 75 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.testStructWithMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 76 StructureType main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 92 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 53, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 100 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 54, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 105 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 55, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.testMapArrayToArray]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 112 GoMapType map[[4]string][2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 56, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 278
+      Name: Probe[main.testSmallMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 100 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 57, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.testArrayOfMaps]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 120 ArrayType [2]map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 58, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.testPointerToMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 121 PointerType *map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.testMapIntToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 77 GoMapType map[int]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 282
+      Name: Probe[main.testMapMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 122 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.testMapEmbeddedMaps]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 122 GoMapType map[string][]main.structWithMap
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 62, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 130 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 63, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.testMapWithSmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 139 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 64, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.testMapWithSmallValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: redactMyEntries
+          Offset: 1
+          Expression:
+            Type: 139 GoMapType map[int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.testMapWithSmallKeyAndValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 66, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 67, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 68, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.testMapSmallKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 151 GoMapType map[uint8][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.testMapLargeKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 158 GoMapType map[[4]int]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 70, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.testMapLargeKeyLargeValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 164 GoMapType map[[4]int][4]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 71, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.testCombinedByte]
+      ByteSize: 7
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: w
+          Offset: 1
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: x
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: y
+          Offset: 3
+          Expression:
+            Type: 30 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 72, index: 2, name: y}
+                  Offset: 0
+                  ByteSize: 4
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 11 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Expression:
+            Type: 4 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Expression:
+            Type: 6 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 73, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.testChannel]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: c
+          Offset: 1
+          Expression:
+            Type: 169 GoChannelType chan bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 74, index: 0, name: c}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.testPointerToSimpleStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 170 PointerType *main.structWithTwoValues
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.testLinkedList]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 137 StructureType main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 76, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.testPointerLoop]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 138 PointerType *main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 77, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.testUnsafePointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 56 VoidPointerType unsafe.Pointer
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 78, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.testUintPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 172 PointerType *uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.testStringPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 36 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 80, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.testNilPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: z
+          Offset: 1
+          Expression:
+            Type: 173 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: a
+          Offset: 9
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 81, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.testCycle]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: t
+          Offset: 1
+          Expression:
+            Type: 174 PointerType *main.t
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 82, index: 0, name: t}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.testUintSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 83, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.testSliceOfSlices]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 178 GoSliceHeaderType [][]uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.testStructSlice]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.testEmptySliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 87, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 88, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.testStringSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 111 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.testNilSliceWithOtherParams]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 2
+          Expression:
+            Type: 183 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: x
+          Offset: 26
+          Expression:
+            Type: 20 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.testNilSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 184 GoSliceHeaderType []uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.testVeryLargeSlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.stackC]
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.testSingleString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 17
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: z
+          Offset: 33
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 2, name: z}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testThreeStringsInStruct]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 186 StructureType main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.testThreeStringsInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 187 PointerType *main.threeStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.testOneStringInStructPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 188 PointerType *main.oneStringStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.testMassiveString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.testUnitializedString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.testStruct]
+      ByteSize: 57
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 190 StructureType main.aStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 56
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.testEmptyStruct]
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: e
+          Offset: 1
+          Expression:
+            Type: 191 StructureType main.emptyStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: e}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.testInlinedPrint]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+MaxTypeID: 330
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,0 +1,1005 @@
+ID: 1
+Probes:
+    - id: PointerChainArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.PointerChainArg}
+      capture:
+        maxReferenceDepth: 3
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 11
+          Type: 62 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
+          Condition: null
+    - id: PointerSmallChainArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.PointerSmallChainArg}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 12
+          Type: 63 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
+          Condition: null
+    - id: bigMapArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.bigMapArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 12}
+      events:
+        - ID: 9
+          Type: 60 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: "0x4a64f3", Frameless: false}]
+          Condition: null
+    - id: inlined
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.inlined}
+      sampling: {snapshotsPerSecond: 2}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 10
+          Type: 61 EventRootType Probe[main.inlined]
+          InjectionPoints:
+            - PC: "0x4a63ca"
+              Frameless: false
+            - PC: "0x4a5dce"
+              Frameless: false
+          Condition: null
+    - id: intArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 1
+          Type: 52 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: "0x4a60aa", Frameless: false}]
+          Condition: null
+    - id: intArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 7}
+      events:
+        - ID: 4
+          Type: 55 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: "0x4a622a", Frameless: false}]
+          Condition: null
+    - id: intArrayArgFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArrayArgFrameless}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 7
+          Type: 58 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: "0x4a63a0", Frameless: true}]
+          Condition: null
+    - id: intSliceArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intSliceArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 3
+          Type: 54 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: "0x4a61aa", Frameless: false}]
+          Condition: null
+    - id: mapArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.mapArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 8
+          Type: 59 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: "0x4a648a", Frameless: false}]
+          Condition: null
+    - id: stringArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 2
+          Type: 53 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: "0x4a612a", Frameless: false}]
+          Condition: null
+    - id: stringArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 9}
+      events:
+        - ID: 6
+          Type: 57 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: "0x4a632a", Frameless: false}]
+          Condition: null
+    - id: stringSliceArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringSliceArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 8}
+      events:
+        - ID: 5
+          Type: 56 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: "0x4a62aa", Frameless: false}]
+          Condition: null
+Subprograms:
+    - ID: 4
+      Name: main.intArg
+      OutOfLinePCRanges: [0x4a60a0..0x4a6102]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x4a60a0..0x4a60b9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 5
+      Name: main.stringArg
+      OutOfLinePCRanges: [0x4a6120..0x4a6191]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a6120..0x4a613e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.intSliceArg
+      OutOfLinePCRanges: [0x4a61a0..0x4a621a]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4a61a0..0x4a61be
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 7
+      Name: main.intArrayArg
+      OutOfLinePCRanges: [0x4a6220..0x4a6287]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 11 ArrayType [3]int
+          Locations:
+            - Range: 0x4a6220..0x4a6287
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 8
+      Name: main.stringSliceArg
+      OutOfLinePCRanges: [0x4a62a0..0x4a631a]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 12 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x4a62a0..0x4a62be
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.stringArrayArg
+      OutOfLinePCRanges: [0x4a6320..0x4a6387]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0x4a6320..0x4a6387
+              Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.stringArrayArgFrameless
+      OutOfLinePCRanges: [0x4a63a0..0x4a63a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0x4a63a0..0x4a63a1
+              Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.mapArg
+      OutOfLinePCRanges: [0x4a6480..0x4a64d6]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 15 GoMapType map[string]int
+          Locations:
+            - Range: 0x4a6480..0x4a64ad
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.bigMapArg
+      OutOfLinePCRanges: [0x4a64e0..0x4a659b]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 33 GoMapType map[string]main.bigStruct
+          Locations:
+            - Range: 0x4a64e0..0x4a6513
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a6513..0x4a659b
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 1
+      Name: main.inlined
+      OutOfLinePCRanges: [0x4a63c0..0x4a6422]
+      InlinePCRanges:
+        - Ranges: [0x4a5dce..0x4a5e1f]
+          RootRanges: [0x4a5c40..0x4a609d]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x4a5dce..0x4a5e1f
+              Pieces: []
+            - Range: 0x4a63c0..0x4a63d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x4a6006..0x4a6045]
+          RootRanges: [0x4a5c40..0x4a609d]
+      Variables:
+        - Name: ptr
+          Type: 2 PointerType *****int
+          Locations:
+            - Range: 0x4a5fdf..0x4a602b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 3
+      Name: main.PointerSmallChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x4a6050..0x4a608a]
+          RootRanges: [0x4a5c40..0x4a609d]
+      Variables:
+        - Name: ptr
+          Type: 5 PointerType **int
+          Locations:
+            - Range: 0x4a6050..0x4a608a
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 38016
+      GoKind: 2
+    - __kind: PointerType
+      ID: 2
+      Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 32512
+      GoKind: 22
+      Pointee: 3 PointerType ****int
+    - __kind: PointerType
+      ID: 3
+      Name: '****int'
+      ByteSize: 8
+      GoRuntimeType: 32448
+      GoKind: 22
+      Pointee: 4 PointerType ***int
+    - __kind: PointerType
+      ID: 4
+      Name: '***int'
+      ByteSize: 8
+      GoRuntimeType: 32384
+      GoKind: 22
+      Pointee: 5 PointerType **int
+    - __kind: PointerType
+      ID: 5
+      Name: '**int'
+      ByteSize: 8
+      GoRuntimeType: 32320
+      GoKind: 22
+      Pointee: 6 PointerType *int
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26496
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 37440
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 43 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 42 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 8
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 26048
+      GoKind: 22
+      Pointee: 9 BaseType uint8
+    - __kind: BaseType
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 37568
+      GoKind: 8
+    - __kind: GoSliceHeaderType
+      ID: 10
+      Name: '[]int'
+      ByteSize: 24
+      GoRuntimeType: 33984
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 44 GoSliceDataType []int.array
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 41408
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 12
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 34304
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 13 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 46 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25920
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 41504
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 54656
+      GoKind: 21
+      HeaderType: 17 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 16
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoHMapHeaderType hash<string,int>
+    - __kind: GoHMapHeaderType
+      ID: 17
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 9 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 9 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 18 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 19 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 20 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 20 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 25 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 26 PointerType *runtime.mapextra
+      BucketType: 21 GoHMapBucketType bucket<string,int>
+      BucketsType: 48 GoSliceDataType []bucket<string,int>.array
+    - __kind: BaseType
+      ID: 18
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37696
+      GoKind: 9
+    - __kind: BaseType
+      ID: 19
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37824
+      GoKind: 10
+    - __kind: PointerType
+      ID: 20
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoHMapBucketType
+      ID: 21
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 24 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 20 PointerType *bucket<string,int>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: ArrayType
+      ID: 22
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 41600
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 24
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: BaseType
+      ID: 25
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 38144
+      GoKind: 12
+    - __kind: PointerType
+      ID: 26
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 29760
+      GoKind: 22
+      Pointee: 27 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 27
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 87232
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 28
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 35968
+      GoKind: 22
+      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 29
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 35904
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 30 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 49 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 30
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 31
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 66528
+      GoKind: 22
+      Pointee: 32 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 32
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 66400
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+    - __kind: GoMapType
+      ID: 33
+      Name: map[string]main.bigStruct
+      ByteSize: 8
+      GoRuntimeType: 54752
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,main.bigStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 9 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 9 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 18 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 19 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 25 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 26 PointerType *runtime.mapextra
+      BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      BucketsType: 51 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: PointerType
+      ID: 36
+      Name: '*bucket<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoHMapBucketType
+      ID: 37
+      Name: bucket<string,main.bigStruct>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 38 ArrayType []val<main.bigStruct>
+        - Name: overflow
+          Offset: 200
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 39 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 38
+      Name: '[]val<main.bigStruct>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 39 PointerType *main.bigStruct
+    - __kind: PointerType
+      ID: 39
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 24256
+      GoKind: 22
+      Pointee: 40 StructureType main.bigStruct
+    - __kind: StructureType
+      ID: 40
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 110528
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 41 ArrayType [128]uint8
+    - __kind: ArrayType
+      ID: 41
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 41888
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: GoStringDataType
+      ID: 42
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 43
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 42 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 44
+      Name: '[]int.array'
+      ByteSize: 2048
+      Element: 1 BaseType int
+    - __kind: PointerType
+      ID: 45
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 44 GoSliceDataType []int.array
+    - __kind: GoSliceDataType
+      ID: 46
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 47
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 46 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 48
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 49
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 50
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 49 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 51
+      Name: '[]bucket<string,main.bigStruct>.array'
+      ByteSize: 2048
+      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: EventRootType
+      ID: 52
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 53
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 54
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 55
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 56
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 57
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 58
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 59
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 60
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 33 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 61
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 62
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 63
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 63
+Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,0 +1,1005 @@
+ID: 1
+Probes:
+    - id: PointerChainArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.PointerChainArg}
+      capture:
+        maxReferenceDepth: 3
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 2}
+      events:
+        - ID: 11
+          Type: 62 EventRootType Probe[main.PointerChainArg]
+          InjectionPoints: [{PC: 742200, Frameless: false}]
+          Condition: null
+    - id: PointerSmallChainArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.PointerSmallChainArg}
+      capture:
+        maxReferenceDepth: 5
+        maxFieldCount: 0
+        maxCollectionSize: 0
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 12
+          Type: 63 EventRootType Probe[main.PointerSmallChainArg]
+          InjectionPoints: [{PC: 742256, Frameless: false}]
+          Condition: null
+    - id: bigMapArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.bigMapArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 12}
+      events:
+        - ID: 9
+          Type: 60 EventRootType Probe[main.bigMapArg]
+          InjectionPoints: [{PC: 743456, Frameless: true}]
+          Condition: null
+    - id: inlined
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.inlined}
+      sampling: {snapshotsPerSecond: 2}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 1}
+      events:
+        - ID: 10
+          Type: 61 EventRootType Probe[main.inlined]
+          InjectionPoints:
+            - PC: 743148
+              Frameless: true
+            - PC: 741708
+              Frameless: false
+          Condition: null
+    - id: intArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 1
+          Type: 52 EventRootType Probe[main.intArg]
+          InjectionPoints: [{PC: 742348, Frameless: true}]
+          Condition: null
+    - id: intArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 7}
+      events:
+        - ID: 4
+          Type: 55 EventRootType Probe[main.intArrayArg]
+          InjectionPoints: [{PC: 742732, Frameless: true}]
+          Condition: null
+    - id: intArrayArgFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArrayArgFrameless}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 10}
+      events:
+        - ID: 7
+          Type: 58 EventRootType Probe[main.stringArrayArgFrameless]
+          InjectionPoints: [{PC: 743120, Frameless: true}]
+          Condition: null
+    - id: intSliceArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.intSliceArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 3
+          Type: 54 EventRootType Probe[main.intSliceArg]
+          InjectionPoints: [{PC: 742588, Frameless: true}]
+          Condition: null
+    - id: mapArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.mapArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 11}
+      events:
+        - ID: 8
+          Type: 59 EventRootType Probe[main.mapArg]
+          InjectionPoints: [{PC: 743340, Frameless: true}]
+          Condition: null
+    - id: stringArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 2
+          Type: 53 EventRootType Probe[main.stringArg]
+          InjectionPoints: [{PC: 742460, Frameless: true}]
+          Condition: null
+    - id: stringArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 9}
+      events:
+        - ID: 6
+          Type: 57 EventRootType Probe[main.stringArrayArg]
+          InjectionPoints: [{PC: 743004, Frameless: true}]
+          Condition: null
+    - id: stringSliceArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.stringSliceArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 8}
+      events:
+        - ID: 5
+          Type: 56 EventRootType Probe[main.stringSliceArg]
+          InjectionPoints: [{PC: 742860, Frameless: true}]
+          Condition: null
+Subprograms:
+    - ID: 4
+      Name: main.intArg
+      OutOfLinePCRanges: [0xb53c0..0xb5430]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xb53c0..0xb53e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 5
+      Name: main.stringArg
+      OutOfLinePCRanges: [0xb5430..0xb54b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 GoStringHeaderType string
+          Locations:
+            - Range: 0xb5430..0xb5454
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.intSliceArg
+      OutOfLinePCRanges: [0xb54b0..0xb5540]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb54b0..0xb54d4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 7
+      Name: main.intArrayArg
+      OutOfLinePCRanges: [0xb5540..0xb55c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 11 ArrayType [3]int
+          Locations:
+            - Range: 0xb5540..0xb55c0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 8
+      Name: main.stringSliceArg
+      OutOfLinePCRanges: [0xb55c0..0xb5650]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 12 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xb55c0..0xb55e4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.stringArrayArg
+      OutOfLinePCRanges: [0xb5650..0xb56d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0xb5650..0xb56d0
+              Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.stringArrayArgFrameless
+      OutOfLinePCRanges: [0xb56d0..0xb56e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 14 ArrayType [3]string
+          Locations:
+            - Range: 0xb56d0..0xb56e0
+              Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.mapArg
+      OutOfLinePCRanges: [0xb57a0..0xb5810]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 15 GoMapType map[string]int
+          Locations:
+            - Range: 0xb57a0..0xb57d8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.bigMapArg
+      OutOfLinePCRanges: [0xb5810..0xb58d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 33 GoMapType map[string]main.bigStruct
+          Locations:
+            - Range: 0xb5810..0xb5848
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb5848..0xb58d0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 1
+      Name: main.inlined
+      OutOfLinePCRanges: [0xb56e0..0xb5750]
+      InlinePCRanges:
+        - Ranges: [0xb514c..0xb518c]
+          RootRanges: [0xb4fb0..0xb53c0]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xb514c..0xb518c
+              Pieces: []
+            - Range: 0xb56e0..0xb5700
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 2
+      Name: main.PointerChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xb5338..0xb5368]
+          RootRanges: [0xb4fb0..0xb53c0]
+      Variables:
+        - Name: ptr
+          Type: 2 PointerType *****int
+          Locations:
+            - Range: 0xb5310..0xb5358
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 3
+      Name: main.PointerSmallChainArg
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xb5370..0xb53a0]
+          RootRanges: [0xb4fb0..0xb53c0]
+      Variables:
+        - Name: ptr
+          Type: 5 PointerType **int
+          Locations:
+            - Range: 0xb5370..0xb53a0
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+Types:
+    - __kind: BaseType
+      ID: 1
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 37984
+      GoKind: 2
+    - __kind: PointerType
+      ID: 2
+      Name: '*****int'
+      ByteSize: 8
+      GoRuntimeType: 32480
+      GoKind: 22
+      Pointee: 3 PointerType ****int
+    - __kind: PointerType
+      ID: 3
+      Name: '****int'
+      ByteSize: 8
+      GoRuntimeType: 32416
+      GoKind: 22
+      Pointee: 4 PointerType ***int
+    - __kind: PointerType
+      ID: 4
+      Name: '***int'
+      ByteSize: 8
+      GoRuntimeType: 32352
+      GoKind: 22
+      Pointee: 5 PointerType **int
+    - __kind: PointerType
+      ID: 5
+      Name: '**int'
+      ByteSize: 8
+      GoRuntimeType: 32288
+      GoKind: 22
+      Pointee: 6 PointerType *int
+    - __kind: PointerType
+      ID: 6
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26464
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: GoStringHeaderType
+      ID: 7
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 37408
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 43 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+      Data: 42 GoStringDataType string.str
+    - __kind: PointerType
+      ID: 8
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 26016
+      GoKind: 22
+      Pointee: 9 BaseType uint8
+    - __kind: BaseType
+      ID: 9
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 37536
+      GoKind: 8
+    - __kind: GoSliceHeaderType
+      ID: 10
+      Name: '[]int'
+      ByteSize: 24
+      GoRuntimeType: 33952
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 6 PointerType *int
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 44 GoSliceDataType []int.array
+    - __kind: ArrayType
+      ID: 11
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 41376
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: GoSliceHeaderType
+      ID: 12
+      Name: '[]string'
+      ByteSize: 24
+      GoRuntimeType: 34272
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 13 PointerType *string
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 46 GoSliceDataType []string.array
+    - __kind: PointerType
+      ID: 13
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25888
+      GoKind: 22
+      Pointee: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 14
+      Name: '[3]string'
+      ByteSize: 48
+      GoRuntimeType: 41472
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: GoMapType
+      ID: 15
+      Name: map[string]int
+      ByteSize: 8
+      GoRuntimeType: 54528
+      GoKind: 21
+      HeaderType: 17 GoHMapHeaderType hash<string,int>
+    - __kind: PointerType
+      ID: 16
+      Name: '*hash<string,int>'
+      ByteSize: 8
+      Pointee: 17 GoHMapHeaderType hash<string,int>
+    - __kind: GoHMapHeaderType
+      ID: 17
+      Name: hash<string,int>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 9 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 9 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 18 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 19 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 20 PointerType *bucket<string,int>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 20 PointerType *bucket<string,int>
+        - Name: nevacuate
+          Offset: 32
+          Type: 25 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 26 PointerType *runtime.mapextra
+      BucketType: 21 GoHMapBucketType bucket<string,int>
+      BucketsType: 48 GoSliceDataType []bucket<string,int>.array
+    - __kind: BaseType
+      ID: 18
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37664
+      GoKind: 9
+    - __kind: BaseType
+      ID: 19
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37792
+      GoKind: 10
+    - __kind: PointerType
+      ID: 20
+      Name: '*bucket<string,int>'
+      ByteSize: 8
+      Pointee: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoHMapBucketType
+      ID: 21
+      Name: bucket<string,int>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 24 ArrayType []val<int>
+        - Name: overflow
+          Offset: 200
+          Type: 20 PointerType *bucket<string,int>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 1 BaseType int
+    - __kind: ArrayType
+      ID: 22
+      Name: '[8]uint8'
+      ByteSize: 8
+      GoRuntimeType: 41568
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: ArrayType
+      ID: 23
+      Name: '[]key<string>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 7 GoStringHeaderType string
+    - __kind: ArrayType
+      ID: 24
+      Name: '[]val<int>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: BaseType
+      ID: 25
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 38112
+      GoKind: 12
+    - __kind: PointerType
+      ID: 26
+      Name: '*runtime.mapextra'
+      ByteSize: 8
+      GoRuntimeType: 29728
+      GoKind: 22
+      Pointee: 27 StructureType runtime.mapextra
+    - __kind: StructureType
+      ID: 27
+      Name: runtime.mapextra
+      ByteSize: 24
+      GoRuntimeType: 87104
+      GoKind: 25
+      RawFields:
+        - Name: overflow
+          Offset: 0
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: oldoverflow
+          Offset: 8
+          Type: 28 PointerType *[]*runtime.bmap
+        - Name: nextOverflow
+          Offset: 16
+          Type: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 28
+      Name: '*[]*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 35936
+      GoKind: 22
+      Pointee: 29 GoSliceHeaderType []*runtime.bmap
+    - __kind: GoSliceHeaderType
+      ID: 29
+      Name: '[]*runtime.bmap'
+      ByteSize: 24
+      GoRuntimeType: 35872
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 30 PointerType **runtime.bmap
+        - Name: len
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 1 BaseType int
+      Data: 49 GoSliceDataType []*runtime.bmap.array
+    - __kind: PointerType
+      ID: 30
+      Name: '**runtime.bmap'
+      ByteSize: 8
+      Pointee: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 31
+      Name: '*runtime.bmap'
+      ByteSize: 8
+      GoRuntimeType: 66400
+      GoKind: 22
+      Pointee: 32 StructureType runtime.bmap
+    - __kind: StructureType
+      ID: 32
+      Name: runtime.bmap
+      ByteSize: 8
+      GoRuntimeType: 66272
+      GoKind: 25
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+    - __kind: GoMapType
+      ID: 33
+      Name: map[string]main.bigStruct
+      ByteSize: 8
+      GoRuntimeType: 54624
+      GoKind: 21
+      HeaderType: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 34
+      Name: '*hash<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 35 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoHMapHeaderType
+      ID: 35
+      Name: hash<string,main.bigStruct>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 9 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 9 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 18 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 19 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+        - Name: nevacuate
+          Offset: 32
+          Type: 25 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 26 PointerType *runtime.mapextra
+      BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
+      BucketsType: 51 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: PointerType
+      ID: 36
+      Name: '*bucket<string,main.bigStruct>'
+      ByteSize: 8
+      Pointee: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: GoHMapBucketType
+      ID: 37
+      Name: bucket<string,main.bigStruct>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 22 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 23 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 38 ArrayType []val<main.bigStruct>
+        - Name: overflow
+          Offset: 200
+          Type: 36 PointerType *bucket<string,main.bigStruct>
+      KeyType: 7 GoStringHeaderType string
+      ValueType: 39 PointerType *main.bigStruct
+    - __kind: ArrayType
+      ID: 38
+      Name: '[]val<main.bigStruct>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 39 PointerType *main.bigStruct
+    - __kind: PointerType
+      ID: 39
+      Name: '*main.bigStruct'
+      ByteSize: 8
+      GoRuntimeType: 24224
+      GoKind: 22
+      Pointee: 40 StructureType main.bigStruct
+    - __kind: StructureType
+      ID: 40
+      Name: main.bigStruct
+      ByteSize: 184
+      GoRuntimeType: 110400
+      GoKind: 25
+      RawFields:
+        - Name: Field1
+          Offset: 0
+          Type: 1 BaseType int
+        - Name: Field2
+          Offset: 8
+          Type: 1 BaseType int
+        - Name: Field3
+          Offset: 16
+          Type: 1 BaseType int
+        - Name: Field4
+          Offset: 24
+          Type: 1 BaseType int
+        - Name: Field5
+          Offset: 32
+          Type: 1 BaseType int
+        - Name: Field6
+          Offset: 40
+          Type: 1 BaseType int
+        - Name: Field7
+          Offset: 48
+          Type: 1 BaseType int
+        - Name: data
+          Offset: 56
+          Type: 41 ArrayType [128]uint8
+    - __kind: ArrayType
+      ID: 41
+      Name: '[128]uint8'
+      ByteSize: 128
+      GoRuntimeType: 41856
+      GoKind: 17
+      Count: 128
+      HasCount: true
+      Element: 9 BaseType uint8
+    - __kind: GoStringDataType
+      ID: 42
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 43
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 42 GoStringDataType string.str
+    - __kind: GoSliceDataType
+      ID: 44
+      Name: '[]int.array'
+      ByteSize: 2048
+      Element: 1 BaseType int
+    - __kind: PointerType
+      ID: 45
+      Name: '*[]int.array'
+      ByteSize: 8
+      Pointee: 44 GoSliceDataType []int.array
+    - __kind: GoSliceDataType
+      ID: 46
+      Name: '[]string.array'
+      ByteSize: 2048
+      Element: 7 GoStringHeaderType string
+    - __kind: PointerType
+      ID: 47
+      Name: '*[]string.array'
+      ByteSize: 8
+      Pointee: 46 GoSliceDataType []string.array
+    - __kind: GoSliceDataType
+      ID: 48
+      Name: '[]bucket<string,int>.array'
+      ByteSize: 2048
+      Element: 21 GoHMapBucketType bucket<string,int>
+    - __kind: GoSliceDataType
+      ID: 49
+      Name: '[]*runtime.bmap.array'
+      ByteSize: 2048
+      Element: 31 PointerType *runtime.bmap
+    - __kind: PointerType
+      ID: 50
+      Name: '*[]*runtime.bmap.array'
+      ByteSize: 8
+      Pointee: 49 GoSliceDataType []*runtime.bmap.array
+    - __kind: GoSliceDataType
+      ID: 51
+      Name: '[]bucket<string,main.bigStruct>.array'
+      ByteSize: 2048
+      Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: EventRootType
+      ID: 52
+      Name: Probe[main.intArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 4, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 53
+      Name: Probe[main.stringArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 7 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 54
+      Name: Probe[main.intSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 10 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 55
+      Name: Probe[main.intArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 11 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 7, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 56
+      Name: Probe[main.stringSliceArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 12 GoSliceHeaderType []string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 8, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 57
+      Name: Probe[main.stringArrayArg]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 9, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 58
+      Name: Probe[main.stringArrayArgFrameless]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Expression:
+            Type: 14 ArrayType [3]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 10, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 48
+    - __kind: EventRootType
+      ID: 59
+      Name: Probe[main.mapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 15 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 11, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 60
+      Name: Probe[main.bigMapArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 33 GoMapType map[string]main.bigStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 12, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 61
+      Name: Probe[main.inlined]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 1, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 62
+      Name: Probe[main.PointerChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 2 PointerType *****int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 2, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 63
+      Name: Probe[main.PointerSmallChainArg]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ptr
+          Offset: 1
+          Expression:
+            Type: 5 PointerType **int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 3, index: 0, name: ptr}
+                  Offset: 0
+                  ByteSize: 8
+MaxTypeID: 63
+Issues: []

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -169,10 +169,14 @@ func redactStackFrame(v jsontext.Value) jsontext.Value {
 	if err != nil {
 		return v
 	}
-	if !strings.HasPrefix(f.FileName, "runtime/asm_") {
+	isAsm := strings.HasPrefix(f.FileName, "runtime/asm_")
+	isRuntime := strings.HasPrefix(f.FileName, "runtime/")
+	if !isAsm && !isRuntime {
 		return v
 	}
-	f.FileName = "runtime/asm_[arch].s"
+	if isAsm {
+		f.FileName = "runtime/asm_[arch].s"
+	}
 	f.LineNumber = "[lineNumber]"
 	buf, err := json.Marshal(f)
 	if err != nil {
@@ -210,6 +214,23 @@ var defaultRedactors = []jsonRedactor{
 		prefixSuffixMatcher{"/debugger/snapshot/captures/", "/entries"},
 		entriesSorter{},
 	),
+	redactor(
+		(*reMatcher)(regexp.MustCompile(`^/debugger/snapshot/captures/entry/arguments/.*`)),
+		replacerFunc(redactMutex),
+	),
+}
+
+func redactMutex(v jsontext.Value) jsontext.Value {
+	var t = struct {
+		Type string `json:"type"`
+	}{}
+	if err := json.Unmarshal(v, &t); err != nil {
+		return v
+	}
+	if t.Type != "sync.Mutex" {
+		return v
+	}
+	return jsontext.Value(`"[sync.Mutex (different in different versions)]"`)
 }
 
 func redactJSON(t *testing.T, ptrPrefix jsontext.Pointer, input []byte, redactors []jsonRedactor) []byte {

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 212, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [54-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [54-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [54-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [79-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [54-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [54-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [54-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 212, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 212, available: [79-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,691 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: o: main.outer (declared at line 97, available: )
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: scanner: *bufio.Scanner (declared at line 23, available: )
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: b: *main.node (declared at line 140, available: )
+		Var: current: *main.node (declared at line 141, available: [142-143], [147-147])
+		Var: smallMap: map[int]uint8 (declared at line 160, available: )
+		Var: largeMap: map[int]uint8 (declared at line 161, available: )
+		Var: smallKeyValueMap: map[uint8]uint8 (declared at line 171, available: )
+		Var: largeKeyValueMap: map[uint8]uint8 (declared at line 172, available: )
+		Var: smallKeyLargeValueMap: map[uint8][4]int (declared at line 183, available: )
+		Var: largeKeyLargeValueMap: map[[4]int][4]int (declared at line 189, available: )
+		Var: largeKeySmallValueMap: map[[4]int]uint8 (declared at line 197, available: )
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-199], [200-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: )
+		Arg: k: uint8 (declared at line 16, available: )
+		Arg: l: uint8 (declared at line 16, available: )
+		Arg: m: uint8 (declared at line 16, available: )
+		Arg: n: uint8 (declared at line 16, available: )
+		Arg: o: uint8 (declared at line 17, available: )
+		Arg: p: uint8 (declared at line 17, available: )
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: upp: **int (declared at line 169, available: )
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: swp: main.structWithPointer (declared at line 114, available: )
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: ptrRcvr: *main.receiver (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15]
+		Arg: x: int (declared at line 0, available: [13-14])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75]
+		Arg: x: int (declared at line 0, available: [75-75])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
+		Arg: a: [5]int (declared at line 0, available: [71-71])
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.firstBehavior
+		Field: s: string
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
+			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+	Type: main.secondBehavior
+		Field: i: int
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
+			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,691 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: o: main.outer (declared at line 97, available: )
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: scanner: *bufio.Scanner (declared at line 23, available: )
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: b: *main.node (declared at line 140, available: )
+		Var: current: *main.node (declared at line 141, available: [142-142], [143-143], [147-147])
+		Var: smallMap: map[int]uint8 (declared at line 160, available: )
+		Var: largeMap: map[int]uint8 (declared at line 161, available: )
+		Var: smallKeyValueMap: map[uint8]uint8 (declared at line 171, available: )
+		Var: largeKeyValueMap: map[uint8]uint8 (declared at line 172, available: )
+		Var: smallKeyLargeValueMap: map[uint8][4]int (declared at line 183, available: )
+		Var: largeKeyLargeValueMap: map[[4]int][4]int (declared at line 189, available: )
+		Var: largeKeySmallValueMap: map[[4]int]uint8 (declared at line 197, available: )
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-190], [191-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: [18-18])
+		Arg: k: uint8 (declared at line 16, available: [18-18])
+		Arg: l: uint8 (declared at line 16, available: [18-18])
+		Arg: m: uint8 (declared at line 16, available: [18-18])
+		Arg: n: uint8 (declared at line 16, available: [18-18])
+		Arg: o: uint8 (declared at line 17, available: [18-18])
+		Arg: p: uint8 (declared at line 17, available: [18-18])
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: upp: **int (declared at line 169, available: )
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: swp: main.structWithPointer (declared at line 114, available: )
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: ptrRcvr: *main.receiver (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67]
+	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15]
+		Arg: x: int (declared at line 0, available: [13-14])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75]
+		Arg: x: int (declared at line 0, available: [75-75])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
+		Arg: a: [5]int (declared at line 0, available: [71-71])
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.firstBehavior
+		Field: s: string
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
+			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+	Type: main.secondBehavior
+		Field: i: int
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
+			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,675 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: o: main.outer (declared at line 97, available: )
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: scanner: *bufio.Scanner (declared at line 23, available: )
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: b: *main.node (declared at line 140, available: )
+		Var: current: *main.node (declared at line 141, available: [142-143], [147-147])
+		Var: smallMap: map[int]uint8 (declared at line 160, available: )
+		Var: largeMap: map[int]uint8 (declared at line 161, available: )
+		Var: smallKeyValueMap: map[uint8]uint8 (declared at line 171, available: )
+		Var: largeKeyValueMap: map[uint8]uint8 (declared at line 172, available: )
+		Var: smallKeyLargeValueMap: map[uint8][4]int (declared at line 183, available: )
+		Var: largeKeyLargeValueMap: map[[4]int][4]int (declared at line 189, available: )
+		Var: largeKeySmallValueMap: map[[4]int]uint8 (declared at line 197, available: )
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-199], [200-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: )
+		Arg: k: uint8 (declared at line 16, available: )
+		Arg: l: uint8 (declared at line 16, available: )
+		Arg: m: uint8 (declared at line 16, available: )
+		Arg: n: uint8 (declared at line 16, available: )
+		Arg: o: uint8 (declared at line 17, available: )
+		Arg: p: uint8 (declared at line 17, available: )
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: upp: **int (declared at line 169, available: )
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: swp: main.structWithPointer (declared at line 114, available: )
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: ptrRcvr: *main.receiver (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.t
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,675 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: o: main.outer (declared at line 97, available: )
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: scanner: *bufio.Scanner (declared at line 23, available: )
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: b: *main.node (declared at line 140, available: )
+		Var: current: *main.node (declared at line 141, available: [142-142], [143-143], [147-147])
+		Var: smallMap: map[int]uint8 (declared at line 160, available: )
+		Var: largeMap: map[int]uint8 (declared at line 161, available: )
+		Var: smallKeyValueMap: map[uint8]uint8 (declared at line 171, available: )
+		Var: largeKeyValueMap: map[uint8]uint8 (declared at line 172, available: )
+		Var: smallKeyLargeValueMap: map[uint8][4]int (declared at line 183, available: )
+		Var: largeKeyLargeValueMap: map[[4]int][4]int (declared at line 189, available: )
+		Var: largeKeySmallValueMap: map[[4]int]uint8 (declared at line 197, available: )
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-190], [191-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: [18-18])
+		Arg: k: uint8 (declared at line 16, available: [18-18])
+		Arg: l: uint8 (declared at line 16, available: [18-18])
+		Arg: m: uint8 (declared at line 16, available: [18-18])
+		Arg: n: uint8 (declared at line 16, available: [18-18])
+		Arg: o: uint8 (declared at line 17, available: [18-18])
+		Arg: p: uint8 (declared at line 17, available: [18-18])
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: upp: **int (declared at line 169, available: )
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: swp: main.structWithPointer (declared at line 114, available: )
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: ptrRcvr: *main.receiver (declared at line 167, available: )
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.t
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
+		Arg: ptr: *****int (declared at line 0, available: [111-111])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
+		Arg: ptr: **int (declared at line 0, available: [115-115])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
+		Arg: x: int (declared at line 0, available: [75-76])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [110:111]
+		Arg: ptr: *****int (declared at line 0, available: [111-111])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [114:115]
+		Arg: ptr: **int (declared at line 0, available: [115-115])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [75:77]
+		Arg: x: int (declared at line 0, available: [75-76])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,0 +1,30 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,0 +1,30 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -43,7 +43,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -79,24 +79,7 @@
                       }
                     }
                   },
-                  "mu": {
-                    "type": "sync.Mutex",
-                    "fields": {
-                      "mu": {
-                        "type": "internal/sync.Mutex",
-                        "fields": {
-                          "state": {
-                            "type": "int32",
-                            "value": "0"
-                          },
-                          "sema": {
-                            "type": "uint32",
-                            "value": "0"
-                          }
-                        }
-                      }
-                    }
-                  },
+                  "mu": "[sync.Mutex (different in different versions)]",
                   "once": {
                     "type": "sync.Once",
                     "fields": {
@@ -109,24 +92,7 @@
                           }
                         }
                       },
-                      "m": {
-                        "type": "sync.Mutex",
-                        "fields": {
-                          "mu": {
-                            "type": "internal/sync.Mutex",
-                            "fields": {
-                              "state": {
-                                "type": "int32",
-                                "value": "0"
-                              },
-                              "sema": {
-                                "type": "uint32",
-                                "value": "0"
-                              }
-                            }
-                          }
-                        }
-                      }
+                      "m": "[sync.Mutex (different in different versions)]"
                     }
                   },
                   "wg": {

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -38,7 +38,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -38,7 +38,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -43,7 +43,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -43,7 +43,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -38,7 +38,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -43,7 +43,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -43,7 +43,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -38,7 +38,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -110,7 +110,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -182,7 +182,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -259,7 +259,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -326,7 +326,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -38,7 +38,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -122,7 +122,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -33,7 +33,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",
@@ -90,7 +90,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -28,7 +28,7 @@
           {
             "function": "runtime.main",
             "fileName": "runtime/proc.go",
-            "lineNumber": 283
+            "lineNumber": "[lineNumber]"
           },
           {
             "function": "runtime.goexit",

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -2215,8 +2215,7 @@ def ninja_add_dyninst_test_programs(
             deps = (d for d in deps.split(" ") if d.startswith(progs_prefix))
             pkg_deps[pkg] = {d.removeprefix(progs_prefix) for d in deps}
 
-    # In the future, we may want to support multiple go versions.
-    go_versions = ["go1.24.3"]
+    go_versions = ["go1.23.11", "go1.24.3"]
     archs = ["amd64", "arm64"]
 
     # Avoiding cgo aids in reproducing the build environment. It's less good in


### PR DESCRIPTION
We want to make sure our tool works for supported go versions.

I'll wait to merge this until https://github.com/DataDog/datadog-agent/pull/39312 and https://github.com/DataDog/datadog-agent/pull/39119.


Relates to [DEBUG-3904](https://datadoghq.atlassian.net/browse/DEBUG-3904).

[DEBUG-3904]: https://datadoghq.atlassian.net/browse/DEBUG-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ