### PR TITLE
[SMP] Adjust quality_gate_metrics_logs memory limit to 1.1 GiB

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -30,7 +30,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total collector memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: 5 GiB
+      upper_bound: 1.1 GiB
 
   - name: cpu_usage
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit adjusts the memory limit down to a loose cap. We are
    observing ~1.07 GiB in practice.
