### PR TITLE
dyninst/symdb: flush the logs on exit

### DIFF
--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -101,6 +101,11 @@ func run(binaryPath string) error {
 	log.Infof("Symbol extraction completed in %s.", time.Since(start))
 	stats := statsFromSymbols(symbols)
 	log.Infof("Symbol statistics for %s: %+v", binaryPath, stats)
+	if !*silent {
+		symbols.Serialize(symdbutil.MakePanickingWriter(os.Stdout))
+	} else {
+		log.Infof("--silent specified; symbols not serialized.")
+	}
 
 	return nil
 }
@@ -125,12 +130,5 @@ func statsFromSymbols(s symdb.Symbols) symbolStats {
 		stats.numFunctions += s.NumFunctions
 		stats.numSourceFiles += s.NumSourceFiles
 	}
-
-	if !*silent {
-		s.Serialize(symdbutil.MakePanickingWriter(os.Stdout))
-	} else {
-		log.Infof("--silent specified; symbols not serialized.")
-	}
-
 	return stats
 }

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -49,6 +49,7 @@ The symbols from the specified binary will be extracted and printed to stdout
 		logLevel = "info"
 	}
 	log.SetupLogger(log.Default(), logLevel)
+	defer log.Flush()
 
 	// Start the pprof server.
 	go func() {
@@ -57,6 +58,7 @@ The symbols from the specified binary will be extracted and printed to stdout
 
 	if err := run(*binaryPath); err != nil {
 		log.Errorf("Error: %v", err)
+		log.Flush()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Otherwise we're sometimes missing a tail.
