### PR TITLE
dyninst/ebpf: use correct length for variable sized types

### DIFF
--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -244,7 +244,7 @@ sm_chase_pointer(global_ctx_t* ctx, pointers_queue_item_t item) {
   // Recurse if there is more to capture object of this type.
   sm->pointer_chasing_ttl = item.ttl;
   sm->di_0 = item.di;
-  sm->di_0.length = info->byte_len;
+  sm->di_0.length = item.di.length;
   if (!info->enqueue_pc) {
     return false;
   }


### PR DESCRIPTION
Before this change, if we had a slice or something variable sized, we'd assume that the number of bytes we'd read the right amount but then try to enqueue on the scratch buffer the maximum number of bytes. This had a fun side-effect of only surfacing issues in the test that runs all the probes because in all the other tests, the scratch buf is zeroed. Elsewhere we should assert on some other behaviorial statistics of probes like the number of pointers we chased and we should also really mess with the initial contents of the scratch buffer.
