### PR TITLE
WorkloadFilter Lazy Loading

### DIFF
--- a/comp/core/workloadfilter/catalog/common.go
+++ b/comp/core/workloadfilter/catalog/common.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AutodiscoveryAnnotations creates a CEL program for autodiscovery annotations.
-func AutodiscoveryAnnotations() program.AnnotationsProgram {
+func AutodiscoveryAnnotations() program.FilterProgram {
 	return program.AnnotationsProgram{
 		Name:          "AutodiscoveryAnnotation",
 		ExcludePrefix: "",
@@ -21,7 +21,7 @@ func AutodiscoveryAnnotations() program.AnnotationsProgram {
 }
 
 // AutodiscoveryMetricsAnnotations creates a CEL program for autodiscovery metrics annotations.
-func AutodiscoveryMetricsAnnotations() program.AnnotationsProgram {
+func AutodiscoveryMetricsAnnotations() program.FilterProgram {
 	return program.AnnotationsProgram{
 		Name:          "AutodiscoveryMetricsAnnotations",
 		ExcludePrefix: "metrics_",
@@ -29,7 +29,7 @@ func AutodiscoveryMetricsAnnotations() program.AnnotationsProgram {
 }
 
 // AutodiscoveryLogsAnnotations creates a CEL program for autodiscovery logs annotations.
-func AutodiscoveryLogsAnnotations() program.AnnotationsProgram {
+func AutodiscoveryLogsAnnotations() program.FilterProgram {
 	return program.AnnotationsProgram{
 		Name:          "AutodiscoveryLogsAnnotations",
 		ExcludePrefix: "logs_",

--- a/comp/core/workloadfilter/catalog/container.go
+++ b/comp/core/workloadfilter/catalog/container.go
@@ -15,7 +15,7 @@ import (
 )
 
 // LegacyContainerMetricsProgram creates a program for filtering container metrics
-func LegacyContainerMetricsProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerMetricsProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerMetricsProgram"
 	var initErrors []error
 
@@ -40,7 +40,7 @@ func LegacyContainerMetricsProgram(config config.Component, logger log.Component
 }
 
 // LegacyContainerLogsProgram creates a program for filtering container logs
-func LegacyContainerLogsProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerLogsProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerLogsProgram"
 	var initErrors []error
 
@@ -65,7 +65,7 @@ func LegacyContainerLogsProgram(config config.Component, logger log.Component) p
 }
 
 // LegacyContainerACExcludeProgram creates a program for excluding containers via legacy `AC` filters
-func LegacyContainerACExcludeProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerACExcludeProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerACExcludeProgram"
 	var initErrors []error
 
@@ -83,7 +83,7 @@ func LegacyContainerACExcludeProgram(config config.Component, logger log.Compone
 }
 
 // LegacyContainerACIncludeProgram creates a program for including containers via legacy `AC` filters
-func LegacyContainerACIncludeProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerACIncludeProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerACIncludeProgram"
 	var initErrors []error
 
@@ -101,7 +101,7 @@ func LegacyContainerACIncludeProgram(config config.Component, logger log.Compone
 }
 
 // LegacyContainerGlobalProgram creates a program for filtering container globally
-func LegacyContainerGlobalProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerGlobalProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerGlobalProgram"
 	var initErrors []error
 
@@ -126,7 +126,7 @@ func LegacyContainerGlobalProgram(config config.Component, logger log.Component)
 }
 
 // LegacyContainerSBOMProgram creates a program for filtering container SBOMs
-func LegacyContainerSBOMProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyContainerSBOMProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerSBOMProgram"
 	var initErrors []error
 
@@ -162,7 +162,7 @@ func LegacyContainerSBOMProgram(config config.Component, logger log.Component) p
 }
 
 // ContainerPausedProgram creates a program for filtering paused containers
-func ContainerPausedProgram(config config.Component, logger log.Component) program.CELProgram {
+func ContainerPausedProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "ContainerPausedProgram"
 	var initErrors []error
 	var excludeList []string

--- a/comp/core/workloadfilter/catalog/kube_endpoints.go
+++ b/comp/core/workloadfilter/catalog/kube_endpoints.go
@@ -14,7 +14,7 @@ import (
 )
 
 // LegacyEndpointsMetricsProgram creates a program for filtering endpoints metrics
-func LegacyEndpointsMetricsProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyEndpointsMetricsProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyEndpointsMetricsProgram"
 	var initErrors []error
 
@@ -39,7 +39,7 @@ func LegacyEndpointsMetricsProgram(config config.Component, logger log.Component
 }
 
 // LegacyEndpointsGlobalProgram creates a program for filtering endpoints globally
-func LegacyEndpointsGlobalProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyEndpointsGlobalProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyEndpointsGlobalProgram"
 	var initErrors []error
 

--- a/comp/core/workloadfilter/catalog/kube_service.go
+++ b/comp/core/workloadfilter/catalog/kube_service.go
@@ -14,7 +14,7 @@ import (
 )
 
 // LegacyServiceMetricsProgram creates a program for filtering service metrics
-func LegacyServiceMetricsProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyServiceMetricsProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyServiceMetricsProgram"
 	var initErrors []error
 
@@ -39,7 +39,7 @@ func LegacyServiceMetricsProgram(config config.Component, logger log.Component) 
 }
 
 // LegacyServiceGlobalProgram creates a program for filtering services globally
-func LegacyServiceGlobalProgram(config config.Component, logger log.Component) program.CELProgram {
+func LegacyServiceGlobalProgram(config config.Component, logger log.Component) program.FilterProgram {
 	programName := "LegacyServiceGlobalProgram"
 	var initErrors []error
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Migrates the workload filtering component to lazily initialization the filtering programs

### Motivation

Memory efficiency for unused filters and thus now will never be created.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit Tests and CI

### Possible Drawbacks / Trade-offs

Shifts and distributes cost (memory/cpu) related to initialization of filters to the first caller. For example, the first iteration of a container corecheck would be slightly slower, but every iteration after will have the filters compiled and ready to use.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A