### PR TITLE
[CODEX-1454] migrating to the 22.04 based pr-commenter image

### DIFF
--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -24,7 +24,7 @@ golang_deps_diff:
 
 golang_deps_commenter:
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2-jammy
   tags: ["arch:amd64"]
   rules:
     - !reference [.on_dev_branches]


### PR DESCRIPTION
Ubuntu 20.04 is EOL and a new pr-commenter image is available