### PR TITLE
Add more tests to orchestrator check processor

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/ecs/task.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/ecs/task.go
@@ -11,6 +11,8 @@ package ecs
 import (
 	"fmt"
 
+	"github.com/benbjohnson/clock"
+
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
@@ -75,6 +77,7 @@ func (t *TaskCollector) Process(rcfg *collectors.CollectorRunConfig, list interf
 			ClusterID:        rcfg.ClusterID,
 			CollectorTags:    nil,
 			AgentVersion:     rcfg.AgentVersion,
+			Clock:            clock.New(),
 		},
 		AWSAccountID: rcfg.AWSAccountID,
 		ClusterName:  rcfg.ClusterName,

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
@@ -8,6 +8,7 @@
 package collectors
 
 import (
+	"github.com/benbjohnson/clock"
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	vpai "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -73,6 +74,7 @@ func NewK8sProcessorContext(rcfg *CollectorRunConfig, metadata *CollectorMetadat
 			CollectorTags:       metadata.CollectorTags(),
 			TerminatedResources: rcfg.TerminatedResources,
 			AgentVersion:        rcfg.AgentVersion,
+			Clock:               clock.New(),
 		},
 		APIClient:         rcfg.APIClient,
 		LabelsAsTags:      metadata.LabelsAsTags,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster.go
@@ -58,6 +58,11 @@ func NewClusterProcessor() *ClusterProcessor {
 func (p *ClusterProcessor) Process(ctx processors.ProcessorContext, list interface{}) (processResult processors.ProcessResult, processed int, err error) {
 	processed = -1
 
+	processResult = processors.ProcessResult{
+		MetadataMessages: []model.MessageBody{},
+		ManifestMessages: []model.MessageBody{},
+	}
+
 	defer processors.RecoverOnPanic()
 
 	// Cluster information is an aggregation of node list data.

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cluster_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -85,6 +86,7 @@ func TestClusterProcessor_Process_Success(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -194,6 +196,7 @@ func TestClusterProcessor_ExtendedResources(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func TestClusterRoleHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -72,6 +74,7 @@ func TestClusterRoleHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -137,6 +140,7 @@ func TestClusterRoleHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -174,6 +178,7 @@ func TestClusterRoleHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -207,6 +212,7 @@ func TestClusterRoleHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -288,6 +294,7 @@ func TestClusterRoleProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrolebinding_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func TestClusterRoleBindingHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -72,6 +74,7 @@ func TestClusterRoleBindingHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -137,6 +140,7 @@ func TestClusterRoleBindingHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -174,6 +178,7 @@ func TestClusterRoleBindingHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -207,6 +212,7 @@ func TestClusterRoleBindingHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -285,6 +291,7 @@ func TestClusterRoleBindingProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cr_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ func TestCRHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -115,6 +117,7 @@ func TestCRHandlers_BuildManifestMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -165,6 +168,7 @@ func TestCRHandlers_BuildManifestMessageBody_GenericResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -208,6 +212,7 @@ func TestCRHandlers_ScrubBeforeExtraction(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -249,6 +254,7 @@ func TestCRProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/crd_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,6 +39,7 @@ func TestCRDHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -115,6 +117,7 @@ func TestCRDHandlers_BuildManifestMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -147,6 +150,7 @@ func TestCRDHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestCRDHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -204,6 +209,7 @@ func TestCRDHandlers_ScrubBeforeExtraction(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -243,6 +249,7 @@ func TestCRDProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ func TestCronJobV1Handlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestCronJobV1Handlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestCronJobV1Handlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestCronJobV1Handlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestCronJobV1Handlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -279,6 +285,7 @@ func TestCronJobV1Processor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob_v1beta1_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -42,6 +43,7 @@ func TestCronJobV1Beta1Handlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestCronJobV1Beta1Handlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -140,6 +143,7 @@ func TestCronJobV1Beta1Handlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -177,6 +181,7 @@ func TestCronJobV1Beta1Handlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -210,6 +215,7 @@ func TestCronJobV1Beta1Handlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -280,6 +286,7 @@ func TestCronJobV1Beta1Processor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ func TestDaemonSetHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestDaemonSetHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestDaemonSetHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestDaemonSetHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestDaemonSetHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestDaemonSetProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ func TestDeploymentHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestDeploymentHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestDeploymentHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestDeploymentHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestDeploymentHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestDeploymentProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	v2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ func TestHorizontalPodAutoscalerHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestHorizontalPodAutoscalerHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestHorizontalPodAutoscalerHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestHorizontalPodAutoscalerHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestHorizontalPodAutoscalerHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestHorizontalPodAutoscalerProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/ingress_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -41,6 +42,7 @@ func TestIngressHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestIngressHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestIngressHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestIngressHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestIngressHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestIngressProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +43,7 @@ func TestJobHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestJobHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -140,6 +143,7 @@ func TestJobHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -177,6 +181,7 @@ func TestJobHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -210,6 +215,7 @@ func TestJobHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -278,6 +284,7 @@ func TestJobProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/limitrange_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -40,6 +41,7 @@ func TestLimitRangeHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestLimitRangeHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -140,6 +143,7 @@ func TestLimitRangeHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -177,6 +181,7 @@ func TestLimitRangeHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -212,6 +217,7 @@ func TestLimitRangeHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -279,6 +285,7 @@ func TestLimitRangeProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/namespace_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func TestNamespaceHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -71,6 +73,7 @@ func TestNamespaceHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -136,6 +139,7 @@ func TestNamespaceHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -173,6 +177,7 @@ func TestNamespaceHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -205,6 +210,7 @@ func TestNamespaceHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -280,6 +286,7 @@ func TestNamespaceProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/networkpolicy_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -42,6 +43,7 @@ func TestNetworkPolicyHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestNetworkPolicyHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -140,6 +143,7 @@ func TestNetworkPolicyHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -177,6 +181,7 @@ func TestNetworkPolicyHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -209,6 +214,7 @@ func TestNetworkPolicyHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -284,6 +290,7 @@ func TestNetworkPolicyProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/node_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,6 +42,7 @@ func TestNodeHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestNodeHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestNodeHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestNodeHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -208,6 +213,7 @@ func TestNodeHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -295,6 +301,7 @@ func TestNodeProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolume_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -40,6 +41,7 @@ func TestPersistentVolumeHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestPersistentVolumeHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -141,6 +144,7 @@ func TestPersistentVolumeHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -178,6 +182,7 @@ func TestPersistentVolumeHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -210,6 +215,7 @@ func TestPersistentVolumeHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -282,6 +288,7 @@ func TestPersistentVolumeProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/persistentvolumeclaim_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,6 +42,7 @@ func TestPersistentVolumeClaimHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -76,6 +78,7 @@ func TestPersistentVolumeClaimHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -142,6 +145,7 @@ func TestPersistentVolumeClaimHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -179,6 +183,7 @@ func TestPersistentVolumeClaimHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -211,6 +216,7 @@ func TestPersistentVolumeClaimHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -283,6 +289,7 @@ func TestPersistentVolumeClaimProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -49,6 +50,7 @@ func TestPodHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -82,6 +84,7 @@ func TestPodHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -150,6 +153,7 @@ func TestPodHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -188,6 +192,7 @@ func TestPodHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -220,6 +225,7 @@ func TestPodHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -282,6 +288,7 @@ func TestPodHandlers_ScrubBeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -318,6 +325,7 @@ func TestPodProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/poddisruptionbudget_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ func TestPodDisruptionBudgetHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -75,6 +77,7 @@ func TestPodDisruptionBudgetHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -138,6 +141,7 @@ func TestPodDisruptionBudgetHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -175,6 +179,7 @@ func TestPodDisruptionBudgetHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -207,6 +212,7 @@ func TestPodDisruptionBudgetHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -275,6 +281,7 @@ func TestPodDisruptionBudgetProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ func TestReplicaSetHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -76,6 +78,7 @@ func TestReplicaSetHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestReplicaSetHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestReplicaSetHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -205,6 +210,7 @@ func TestReplicaSetHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestReplicaSetProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/role_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func TestRoleHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -74,6 +76,7 @@ func TestRoleHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -137,6 +140,7 @@ func TestRoleHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -174,6 +178,7 @@ func TestRoleHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -203,6 +208,7 @@ func TestRoleHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -275,6 +281,7 @@ func TestRoleProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func TestRoleBindingHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -76,6 +78,7 @@ func TestRoleBindingHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -139,6 +142,7 @@ func TestRoleBindingHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -176,6 +180,7 @@ func TestRoleBindingHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -205,6 +210,7 @@ func TestRoleBindingHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -277,6 +283,7 @@ func TestRoleBindingProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/service_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ func TestServiceHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -78,6 +80,7 @@ func TestServiceHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -141,6 +144,7 @@ func TestServiceHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -178,6 +182,7 @@ func TestServiceHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -207,6 +212,7 @@ func TestServiceHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -279,6 +285,7 @@ func TestServiceProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/serviceaccount_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ func TestServiceAccountHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -78,6 +80,7 @@ func TestServiceAccountHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -141,6 +144,7 @@ func TestServiceAccountHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -178,6 +182,7 @@ func TestServiceAccountHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -207,6 +212,7 @@ func TestServiceAccountHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -279,6 +285,7 @@ func TestServiceAccountProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ func TestStatefulSetHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -79,6 +81,7 @@ func TestStatefulSetHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -142,6 +145,7 @@ func TestStatefulSetHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -179,6 +183,7 @@ func TestStatefulSetHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -208,6 +213,7 @@ func TestStatefulSetHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -280,6 +286,7 @@ func TestStatefulSetProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/storageclass_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -43,6 +44,7 @@ func TestStorageClassHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -83,6 +85,7 @@ func TestStorageClassHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -146,6 +149,7 @@ func TestStorageClassHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -183,6 +187,7 @@ func TestStorageClassHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -212,6 +217,7 @@ func TestStorageClassHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -284,6 +290,7 @@ func TestStorageClassProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/verticalpodautoscaler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
@@ -44,6 +45,7 @@ func TestVerticalPodAutoscalerHandlers_ExtractResource(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -83,6 +85,7 @@ func TestVerticalPodAutoscalerHandlers_ResourceList(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -146,6 +149,7 @@ func TestVerticalPodAutoscalerHandlers_BuildMessageBody(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -183,6 +187,7 @@ func TestVerticalPodAutoscalerHandlers_BeforeMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -212,6 +217,7 @@ func TestVerticalPodAutoscalerHandlers_AfterMarshalling(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,
@@ -284,6 +290,7 @@ func TestVerticalPodAutoscalerProcessor_Process(t *testing.T) {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              cfg,
+			Clock:            clock.New(),
 			ClusterID:        "test-cluster-id",
 			MsgGroupID:       1,
 			ManifestProducer: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor_handlers_test.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package processors
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processorstest"
+)
+
+type TestResourceHandlers struct {
+	SkipAfterMarshalling  bool
+	SkipBeforeCacheCheck  bool
+	SkipBeforeMarshalling bool
+	PanicInResourceList   bool
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) AfterMarshalling(ctx ProcessorContext, resource, resourceModel any, yaml []byte) (skip bool) {
+	if rh.SkipAfterMarshalling {
+		return true
+	}
+	resource.(*processorstest.Resource).PropertyToSetAfterMarshalling = "value-after-marshalling"
+	resourceModel.(*processorstest.Resource).PropertyToSetAfterMarshalling = "value-after-marshalling"
+	return false
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) BeforeCacheCheck(ctx ProcessorContext, resource, resourceModel any) (skip bool) {
+	if rh.SkipBeforeCacheCheck {
+		return true
+	}
+	resource.(*processorstest.Resource).PropertyToSetBeforeCacheCheck = "value-before-cache-check"
+	resourceModel.(*processorstest.Resource).PropertyToSetBeforeCacheCheck = "value-before-cache-check"
+	return false
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) BeforeMarshalling(ctx ProcessorContext, resource, resourceModel any) (skip bool) {
+	if rh.SkipBeforeMarshalling {
+		return true
+	}
+	resource.(*processorstest.Resource).PropertyToSetBeforeMarshalling = "value-before-marshalling"
+	resourceModel.(*processorstest.Resource).PropertyToSetBeforeMarshalling = "value-before-marshalling"
+	return false
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) BuildMessageBody(ctx ProcessorContext, resourceModels []any, groupSize int) model.MessageBody {
+	pctx := ctx.(*processorstest.ProcessorContext)
+	models := make([]*model.Manifest, 0, len(resourceModels))
+
+	for _, resourceModel := range resourceModels {
+		models = append(models, &model.Manifest{
+			Content: processorstest.MustMarshalJSON(resourceModel),
+		})
+	}
+
+	return &model.CollectorManifest{
+		AgentVersion: ctx.GetAgentVersion(),
+		ClusterName:  pctx.GetOrchestratorConfig().KubeClusterName,
+		ClusterId:    pctx.GetClusterID(),
+		GroupId:      pctx.GetMsgGroupID(),
+		GroupSize:    int32(groupSize),
+		Manifests:    models,
+	}
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) BuildManifestMessageBody(ctx ProcessorContext, resourceManifests []any, groupSize int) model.MessageBody {
+	pctx := ctx.(*processorstest.ProcessorContext)
+	manifests := make([]*model.Manifest, 0, len(resourceManifests))
+
+	for _, resourceManifest := range resourceManifests {
+		manifests = append(manifests, resourceManifest.(*model.Manifest))
+	}
+
+	return &model.CollectorManifest{
+		AgentVersion: ctx.GetAgentVersion(),
+		ClusterName:  pctx.GetOrchestratorConfig().KubeClusterName,
+		ClusterId:    pctx.GetClusterID(),
+		GroupId:      pctx.GetMsgGroupID(),
+		GroupSize:    int32(groupSize),
+		Manifests:    manifests,
+	}
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ExtractResource(ctx ProcessorContext, resource any) (resourceModel any) {
+	return resource.(*processorstest.Resource).DeepCopy()
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) GetMetadataTags(ctx ProcessorContext, resourceMetadataModel any) []string {
+	return []string{"metadata_tag:metadata_tag_value"}
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) GetNodeName(ctx ProcessorContext, resource any) string {
+	return "node"
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ResourceList(ctx ProcessorContext, list any) (resources []any) {
+	if rh.PanicInResourceList {
+		panic("panicked on purpose")
+	}
+	resources = make([]any, 0, len(list.([]*processorstest.Resource)))
+	for _, resource := range list.([]*processorstest.Resource) {
+		resources = append(resources, resource.DeepCopy())
+	}
+	return resources
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ResourceUID(ctx ProcessorContext, resource any) types.UID {
+	return types.UID(resource.(*processorstest.Resource).ResourceUID)
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ResourceVersion(ctx ProcessorContext, resource, resourceModel any) string {
+	return resource.(*processorstest.Resource).ResourceVersion
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ScrubBeforeExtraction(ctx ProcessorContext, resource any) {
+	resource.(*processorstest.Resource).PropertyToScrubBeforeExtraction = "scrubbed-before-extraction"
+}
+
+//nolint:revive
+func (rh *TestResourceHandlers) ScrubBeforeMarshalling(ctx ProcessorContext, resource any) {
+	resource.(*processorstest.Resource).PropertyToScrubBeforeMarshalling = "scrubbed-before-marshalling"
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor_test.go
@@ -13,11 +13,244 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processorstest"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 )
+
+// ProcessorTestSuite is a test suite for the Processor.
+type ProcessorTestSuite struct {
+	suite.Suite
+}
+
+func (s *ProcessorTestSuite) SetupTest() {
+	orchestrator.KubernetesResourceCache = orchestrator.NewKubernetesResourceCache()
+}
+
+type testProcessScenario struct {
+	inputHandlers          Handlers
+	inputProcessorContext  *processorstest.ProcessorContext
+	inputResource          *processorstest.Resource
+	outputListed           int
+	outputProcessed        int
+	outputResourceMetadata *processorstest.Resource
+	outputResourceManifest *processorstest.Resource
+}
+
+func (s *ProcessorTestSuite) testProcessScenario(scenario testProcessScenario) {
+	processor := Processor{h: scenario.inputHandlers}
+	resource := scenario.inputResource
+	expectedResourceMetadata := scenario.outputResourceMetadata
+	expectedResourceManifest := scenario.outputResourceManifest
+
+	expectedResult := func() ProcessResult {
+		result := ProcessResult{
+			MetadataMessages: []model.MessageBody{},
+			ManifestMessages: []model.MessageBody{},
+		}
+
+		if scenario.outputProcessed <= 0 {
+			return result
+		}
+
+		result.MetadataMessages = []model.MessageBody{
+			&model.CollectorManifest{
+				AgentVersion: scenario.inputProcessorContext.GetAgentVersion(),
+				ClusterName:  scenario.inputProcessorContext.GetOrchestratorConfig().KubeClusterName,
+				ClusterId:    scenario.inputProcessorContext.GetClusterID(),
+				GroupId:      scenario.inputProcessorContext.GetMsgGroupID(),
+				GroupSize:    1,
+				Manifests: []*model.Manifest{
+					{
+						Content: processorstest.MustMarshalJSON(expectedResourceMetadata),
+					},
+				},
+			},
+		}
+
+		if scenario.inputProcessorContext.IsManifestProducer() {
+			result.ManifestMessages = []model.MessageBody{
+				&model.CollectorManifest{
+					AgentVersion: scenario.inputProcessorContext.GetAgentVersion(),
+					ClusterName:  scenario.inputProcessorContext.GetOrchestratorConfig().KubeClusterName,
+					ClusterId:    scenario.inputProcessorContext.GetClusterID(),
+					GroupId:      scenario.inputProcessorContext.GetMsgGroupID(),
+					GroupSize:    1,
+					Manifests: []*model.Manifest{
+						{
+							ApiVersion:      "apiGroup/v1",
+							Kind:            "ResourceKind",
+							Content:         processorstest.MustMarshalJSON(expectedResourceManifest),
+							ContentType:     "json",
+							IsTerminated:    scenario.inputProcessorContext.IsTerminatedResources(),
+							NodeName:        "node",
+							ResourceVersion: expectedResourceManifest.ResourceVersion,
+							Tags:            []string{"collector_tag:collector_tag_value", "metadata_tag:metadata_tag_value"},
+							Type:            1,
+							Uid:             expectedResourceManifest.ResourceUID,
+							Version:         "v1",
+						},
+					},
+				},
+			}
+		}
+
+		return result
+	}
+
+	result, listed, processed := processor.Process(scenario.inputProcessorContext, []*processorstest.Resource{resource})
+	s.Require().Equal(scenario.outputListed, listed)
+	s.Require().Equal(scenario.outputProcessed, processed)
+	s.Equal(expectedResult(), result)
+}
+
+func (s *ProcessorTestSuite) TestProcess() {
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:          &TestResourceHandlers{},
+		inputProcessorContext:  processorstest.NewProcessorContext(),
+		inputResource:          processorstest.NewResource(),
+		outputListed:           1,
+		outputProcessed:        1,
+		outputResourceManifest: processorstest.NewExpectedResourceManifest(),
+		outputResourceMetadata: processorstest.NewExpectedResourceMetadata(),
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_Panic() {
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:         &TestResourceHandlers{PanicInResourceList: true},
+		inputProcessorContext: processorstest.NewProcessorContext(),
+		inputResource:         processorstest.NewResource(),
+		outputProcessed:       -1,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_TerminatedResources_DeletionTimestampMissing() {
+	processorContext := processorstest.NewProcessorContext()
+	processorContext.TerminatedResources = true
+
+	deletionTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	processorContext.Clock.Set(deletionTime)
+
+	outputResourceMetadata := processorstest.NewExpectedResourceMetadata()
+	outputResourceMetadata.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: deletionTime}
+
+	outputResourceManifest := processorstest.NewExpectedResourceManifest()
+	outputResourceManifest.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: deletionTime}
+
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:          &TestResourceHandlers{},
+		inputProcessorContext:  processorContext,
+		inputResource:          processorstest.NewResource(),
+		outputListed:           1,
+		outputProcessed:        1,
+		outputResourceMetadata: outputResourceMetadata,
+		outputResourceManifest: outputResourceManifest,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_TerminatedResources_DeletionTimestampPresent() {
+	processorContext := processorstest.NewProcessorContext()
+	processorContext.TerminatedResources = true
+
+	resource := processorstest.NewResource()
+	resource.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+	expectedResourceMetadata := processorstest.NewExpectedResourceMetadata()
+	expectedResourceMetadata.ObjectMeta.DeletionTimestamp = resource.ObjectMeta.DeletionTimestamp
+
+	expectedResourceManifest := processorstest.NewExpectedResourceManifest()
+	expectedResourceManifest.ObjectMeta.DeletionTimestamp = resource.ObjectMeta.DeletionTimestamp
+
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:          &TestResourceHandlers{},
+		inputProcessorContext:  processorContext,
+		inputResource:          resource,
+		outputListed:           1,
+		outputProcessed:        1,
+		outputResourceMetadata: expectedResourceMetadata,
+		outputResourceManifest: expectedResourceManifest,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_NotManifestProducer() {
+	processorContext := processorstest.NewProcessorContext()
+	processorContext.ManifestProducer = false
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:          &TestResourceHandlers{},
+		inputProcessorContext:  processorContext,
+		inputResource:          processorstest.NewResource(),
+		outputListed:           1,
+		outputProcessed:        1,
+		outputResourceMetadata: processorstest.NewExpectedResourceMetadata(),
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_SkipCacheHit() {
+	resource := processorstest.NewResource()
+	orchestrator.KubernetesResourceCache.Set(resource.ResourceUID, resource.ResourceVersion, 0)
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:         &TestResourceHandlers{},
+		inputProcessorContext: processorstest.NewProcessorContext(),
+		inputResource:         resource,
+		outputListed:          1,
+		outputProcessed:       0,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_SkipBeforeCacheCheck() {
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:         &TestResourceHandlers{SkipBeforeCacheCheck: true},
+		inputProcessorContext: processorstest.NewProcessorContext(),
+		inputResource:         processorstest.NewResource(),
+		outputListed:          1,
+		outputProcessed:       0,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_SkipAfterMarshalling_ManifestCollectionDisabled() {
+	processorContext := processorstest.NewProcessorContext()
+	processorContext.GetOrchestratorConfig().IsManifestCollectionEnabled = false
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:         &TestResourceHandlers{SkipAfterMarshalling: true},
+		inputProcessorContext: processorContext,
+		inputResource:         processorstest.NewResource(),
+		outputListed:          1,
+		outputProcessed:       0,
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_SkipAfterMarshalling_ManifestCollectionEnabled() {
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:          &TestResourceHandlers{},
+		inputProcessorContext:  processorstest.NewProcessorContext(),
+		inputResource:          processorstest.NewResource(),
+		outputListed:           1,
+		outputProcessed:        1,
+		outputResourceManifest: processorstest.NewExpectedResourceManifest(),
+		outputResourceMetadata: processorstest.NewExpectedResourceMetadata(),
+	})
+}
+
+func (s *ProcessorTestSuite) TestProcess_SkipBeforeMarshalling() {
+	s.testProcessScenario(testProcessScenario{
+		inputHandlers:         &TestResourceHandlers{SkipBeforeMarshalling: true},
+		inputProcessorContext: processorstest.NewProcessorContext(),
+		inputResource:         processorstest.NewResource(),
+		outputListed:          1,
+		outputProcessed:       0,
+	})
+}
+
+func TestProcessorTestSuite(t *testing.T) {
+	suite.Run(t, new(ProcessorTestSuite))
+}
 
 func TestSortedMarshal(t *testing.T) {
 	p := corev1.Pod{

--- a/pkg/collector/corechecks/cluster/orchestrator/processorstest/context.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processorstest/context.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+//nolint:revive
+package processorstest
+
+import (
+	"github.com/benbjohnson/clock"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	pkgorchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
+)
+
+// ProcessorContext is a test context for processors.
+type ProcessorContext struct {
+	AgentVersion        *model.AgentVersion
+	APIVersion          string
+	Kind                string
+	Clock               *clock.Mock
+	ClusterID           string
+	CollectorTags       []string
+	MsgGroupID          int32
+	NodeType            pkgorchestratormodel.NodeType
+	OrchestratorConfig  *config.OrchestratorConfig
+	ManifestProducer    bool
+	TerminatedResources bool
+}
+
+// NewProcessorContext creates a new test ProcessorContext.
+func NewProcessorContext() *ProcessorContext {
+	return &ProcessorContext{
+		AgentVersion: &model.AgentVersion{
+			Major:  1,
+			Minor:  0,
+			Patch:  0,
+			Commit: "commit",
+		},
+		APIVersion:    "apiGroup/v1",
+		Kind:          "ResourceKind",
+		Clock:         clock.NewMock(),
+		ClusterID:     "cluster-id",
+		CollectorTags: []string{"collector_tag:collector_tag_value"},
+		MsgGroupID:    1,
+		NodeType:      1,
+		OrchestratorConfig: &config.OrchestratorConfig{
+			ExtraTags:                      []string{"extra_tag:extra_tag_value"},
+			IsManifestCollectionEnabled:    true,
+			KubeClusterName:                "cluster",
+			MaxPerMessage:                  100,
+			OrchestrationCollectionEnabled: true,
+		},
+		ManifestProducer:    true,
+		TerminatedResources: false,
+	}
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetAgentVersion() *model.AgentVersion {
+	return pc.AgentVersion
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetAPIVersion() string {
+	return pc.APIVersion
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetClock() clock.Clock {
+	return pc.Clock
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetClusterID() string {
+	return pc.ClusterID
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetCollectorTags() []string {
+	return pc.CollectorTags
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetKind() string {
+	return pc.Kind
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetMsgGroupID() int32 {
+	return pc.MsgGroupID
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetNodeType() pkgorchestratormodel.NodeType {
+	return pc.NodeType
+}
+
+//nolint:revive
+func (pc *ProcessorContext) GetOrchestratorConfig() *config.OrchestratorConfig {
+	return pc.OrchestratorConfig
+}
+
+//nolint:revive
+func (pc *ProcessorContext) IsManifestProducer() bool {
+	return pc.ManifestProducer
+}
+
+//nolint:revive
+func (pc *ProcessorContext) IsTerminatedResources() bool {
+	return pc.TerminatedResources
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/processorstest/resource.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processorstest/resource.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+//nolint:revive
+package processorstest
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Resource is a test resource for processors.
+type Resource struct {
+	ObjectMeta                       ObjectMeta `json:"object_meta"`
+	Property                         string     `json:"property"`
+	PropertyToSetAfterMarshalling    string     `json:"property_to_set_after_marshalling"`
+	PropertyToSetBeforeMarshalling   string     `json:"property_to_set_before_marshalling"`
+	PropertyToSetBeforeCacheCheck    string     `json:"property_to_set_before_cache_check"`
+	PropertyToScrubBeforeExtraction  string     `json:"property_to_scrub_before_extraction"`
+	PropertyToScrubBeforeMarshalling string     `json:"property_to_scrub_before_marshalling"`
+	ResourceVersion                  string     `json:"resource_version"`
+	ResourceUID                      string     `json:"resource_uid"`
+}
+
+// ObjectMeta is a test object meta for a test resource.
+type ObjectMeta struct {
+	DeletionTimestamp *metav1.Time `json:"deletion_timestamp"`
+}
+
+// DeepCopy creates a deep copy of the resource.
+func (r *Resource) DeepCopy() *Resource {
+	originalResource := MustMarshalJSON(r)
+	resourceCopy := MustUnmarshalJSON[Resource](originalResource)
+	return &resourceCopy
+}
+
+// NewResource creates a new resource to be used as input for processor tests.
+func NewResource() *Resource {
+	return &Resource{
+		Property:                         "value",
+		PropertyToScrubBeforeExtraction:  "secret1",
+		PropertyToScrubBeforeMarshalling: "secret2",
+		ResourceVersion:                  "1",
+		ResourceUID:                      "uid",
+	}
+}
+
+// NewExpectedResourceMetadata returns the expected state of the resource created with [NewResource] after successful metadata processing.
+func NewExpectedResourceMetadata() *Resource {
+	return &Resource{
+		Property:                         "value",
+		PropertyToScrubBeforeExtraction:  "scrubbed-before-extraction",
+		PropertyToScrubBeforeMarshalling: "secret2",
+		ResourceVersion:                  "1",
+		ResourceUID:                      "uid",
+		PropertyToSetBeforeMarshalling:   "value-before-marshalling",
+		PropertyToSetBeforeCacheCheck:    "value-before-cache-check",
+	}
+}
+
+// NewExpectedResourceManifest returns the expected state of the resource created with [NewResource] after successful manifest processing.
+func NewExpectedResourceManifest() *Resource {
+	return &Resource{
+		Property:                         "value",
+		PropertyToScrubBeforeExtraction:  "scrubbed-before-extraction",
+		PropertyToScrubBeforeMarshalling: "scrubbed-before-marshalling",
+		ResourceVersion:                  "1",
+		ResourceUID:                      "uid",
+		PropertyToSetBeforeMarshalling:   "value-before-marshalling",
+		PropertyToSetBeforeCacheCheck:    "value-before-cache-check",
+	}
+}
+
+// MustMarshalJSON marshals a resource to JSON and panics if the marshalling fails.
+// Only to be used in tests.
+func MustMarshalJSON(resource any) []byte {
+	json, err := json.Marshal(resource)
+	if err != nil {
+		panic(err)
+	}
+	return json
+}
+
+// MustUnmarshalJSON unmarshals a resource from JSON and panics if the unmarshalling fails.
+// Only to be used in tests.
+func MustUnmarshalJSON[T any](data []byte) T {
+	var resource T
+
+	if err := json.Unmarshal(data, &resource); err != nil {
+		panic(err)
+	}
+
+	return resource
+}

--- a/pkg/collector/corechecks/orchestrator/pod/pod.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/benbjohnson/clock"
 	"go.uber.org/atomic"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -176,6 +177,7 @@ func (c *Check) Run() error {
 	ctx := &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
 			Cfg:              c.config,
+			Clock:            clock.New(),
 			MsgGroupID:       groupID,
 			NodeType:         orchestrator.K8sPod,
 			ClusterID:        c.clusterID,

--- a/pkg/orchestrator/cache.go
+++ b/pkg/orchestrator/cache.go
@@ -35,7 +35,7 @@ var (
 	cacheMiss   = map[pkgorchestratormodel.NodeType]*expvar.Int{}
 
 	// KubernetesResourceCache provides an in-memory key:value store similar to memcached for kubernetes resources.
-	KubernetesResourceCache = cache.New(defaultExpire, defaultPurge)
+	KubernetesResourceCache = NewKubernetesResourceCache()
 
 	// Telemetry
 	tlmCacheHits   = telemetry.NewCounter("orchestrator", "cache_hits", []string{"orchestrator", "resource"}, "Number of cache hits")
@@ -49,6 +49,12 @@ func init() {
 		cacheExpVars.Set(nodeType.String(), cacheHits[nodeType])
 		sendExpVars.Set(nodeType.String(), cacheMiss[nodeType])
 	}
+}
+
+// NewKubernetesResourceCache creates a new in-memory cache for kubernetes resources.
+// This is used for testing purposes.
+func NewKubernetesResourceCache() *cache.Cache {
+	return cache.New(defaultExpire, defaultPurge)
 }
 
 // SkipKubernetesResource checks with a global kubernetes cache whether the resource was already reported.


### PR DESCRIPTION
Add tests to the processor component.
In order to allow testing time-dependent logic, it changes the processor context contract to accept a clock interface.