### PR TITLE
Fix secrets tests no longer being run

### DIFF
--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -81,11 +81,13 @@ func getBackendCommandBinary(t *testing.T) (string, func()) {
 
 // TestMain runs before other tests in this package. It hooks the getDDAgentUserSID
 // function to make it work for Windows tests
-func TestMain(_ *testing.M) {
+func TestMain(m *testing.M) {
 	// Windows-only fix for running on CI. Instead of checking the registry for
 	// permissions (the agent wasn't installed, so that wouldn't work), use a stub
 	// function that gets permissions info directly from the current User
 	testCheckRightsStub()
+
+	os.Exit(m.Run())
 }
 
 func TestExecCommandError(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The `m.Run()` is required to run any tests