### PR TITLE
Do not rely on Github API to download protoc

### DIFF
--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -4,10 +4,10 @@ import shutil
 import sys
 import zipfile
 from pathlib import Path
+from urllib.request import urlretrieve
 
 from invoke import Context, Exit, task
 
-from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.go import download_go_dependencies
 from tasks.libs.common.retry import run_command_with_retry
@@ -138,9 +138,8 @@ def install_protoc(ctx, version=None):
     zip_name = "protoc"
     zip_file = os.path.join(zip_path, f"{zip_name}.zip")
 
-    gh = GithubAPI(public_repo=True)
     # the download_from_url expect to have the path and the name of the file separated and without the extension
-    gh.download_from_url(artifact_url, zip_path, zip_name)
+    urlretrieve(artifact_url, zip_file)
 
     # Unzip it in the target destination
     destination = os.path.join(Path.home(), ".local")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Relying on Github API exposes us to Github rate limit, that can be an issue since it is IP based.
By downloading the file directly with `urlretrieve` we are less exposed to that rate limit

### Motivation

Make sure the setup tasks work

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->