### PR TITLE
[EBPF-770] gpu: fix concurrency issues in handling kernel spans

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -438,7 +438,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ring_buffer_pages_per_device"), 32) // 32 pages = 128KB by default per device
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_kernel_launches_per_stream"), 1000)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_mem_alloc_events_per_stream"), 1000)
-	cfg.BindEnvAndSetDefault(join(gpuNS, "max_pending_spans_per_stream"), 1000)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "max_pending_kernel_spans_per_stream"), 1000)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "max_pending_memory_spans_per_stream"), 1000)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_streams"), 100)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_stream_inactivity_seconds"), 30) // 30 seconds by default, includes two checks at the default interval of 15 seconds
 

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -438,6 +438,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ring_buffer_pages_per_device"), 32) // 32 pages = 128KB by default per device
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_kernel_launches_per_stream"), 1000)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_mem_alloc_events_per_stream"), 1000)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "max_pending_spans_per_stream"), 1000)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_streams"), 100)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "max_stream_inactivity_seconds"), 30) // 30 seconds by default, includes two checks at the default interval of 15 seconds
 

--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -30,10 +30,10 @@ type aggregator struct {
 	measuredIntervalNs int64
 
 	// currentAllocs is the list of current (active) memory allocations
-	currentAllocs []*memoryAllocation
+	currentAllocs []*memorySpan
 
 	// pastAllocs is the list of past (freed) memory allocations
-	pastAllocs []*memoryAllocation
+	pastAllocs []*memorySpan
 
 	// deviceMaxThreads is the maximum number of threads the GPU can run in parallel, for utilization calculations
 	deviceMaxThreads uint64
@@ -83,8 +83,8 @@ func (agg *aggregator) processKernelSpan(span *kernelSpan) {
 }
 
 // processPastData takes spans/allocations that have already been closed
-func (agg *aggregator) processPastData(data *streamData) {
-	for _, span := range data.spans {
+func (agg *aggregator) processPastData(data *streamSpans) {
+	for _, span := range data.kernels {
 		agg.processKernelSpan(span)
 	}
 
@@ -92,8 +92,8 @@ func (agg *aggregator) processPastData(data *streamData) {
 }
 
 // processCurrentData takes spans/allocations that are active (e.g., unfreed allocations, running kernels)
-func (agg *aggregator) processCurrentData(data *streamData) {
-	for _, span := range data.spans {
+func (agg *aggregator) processCurrentData(data *streamSpans) {
+	for _, span := range data.kernels {
 		agg.processKernelSpan(span)
 	}
 

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -40,8 +40,10 @@ type Config struct {
 	MaxKernelLaunchesPerStream int
 	// MaxMemAllocEventsPerStream is the maximum number of memory allocation events to process per stream before evicting the oldest events.
 	MaxMemAllocEventsPerStream int
-	// MaxPendingSpans is the maximum number of pending spans (kernel spans and memory allocations) to keep in each stream handler.
-	MaxPendingSpans int
+	// MaxPendingKernelSpans is the maximum number of pending kernel spans to keep in each stream handler.
+	MaxPendingKernelSpans int
+	// MaxPendingMemorySpans is the maximum number of pending memory allocation spans to keep in each stream handler.
+	MaxPendingMemorySpans int
 	// MaxStreams is the maximum number of streams that can be processed concurrently.
 	MaxStreams int
 	// MaxStreamInactivity is the maximum time to wait for a stream to be inactive before flushing it.
@@ -62,7 +64,8 @@ func New() *Config {
 		RingBufferSizePagesPerDevice: spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "ring_buffer_pages_per_device")),
 		MaxKernelLaunchesPerStream:   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_kernel_launches_per_stream")),
 		MaxMemAllocEventsPerStream:   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_mem_alloc_events_per_stream")),
-		MaxPendingSpans:              spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_pending_spans_per_stream")),
+		MaxPendingKernelSpans:        spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_pending_kernel_spans_per_stream")),
+		MaxPendingMemorySpans:        spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_pending_memory_spans_per_stream")),
 		MaxStreams:                   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_streams")),
 		MaxStreamInactivity:          time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_stream_inactivity_seconds"))) * time.Second,
 	}

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	MaxKernelLaunchesPerStream int
 	// MaxMemAllocEventsPerStream is the maximum number of memory allocation events to process per stream before evicting the oldest events.
 	MaxMemAllocEventsPerStream int
+	// MaxPendingSpans is the maximum number of pending spans (kernel spans and memory allocations) to keep in each stream handler.
+	MaxPendingSpans int
 	// MaxStreams is the maximum number of streams that can be processed concurrently.
 	MaxStreams int
 	// MaxStreamInactivity is the maximum time to wait for a stream to be inactive before flushing it.
@@ -60,6 +62,7 @@ func New() *Config {
 		RingBufferSizePagesPerDevice: spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "ring_buffer_pages_per_device")),
 		MaxKernelLaunchesPerStream:   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_kernel_launches_per_stream")),
 		MaxMemAllocEventsPerStream:   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_mem_alloc_events_per_stream")),
+		MaxPendingSpans:              spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_pending_spans_per_stream")),
 		MaxStreams:                   spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_streams")),
 		MaxStreamInactivity:          time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "max_stream_inactivity_seconds"))) * time.Second,
 	}

--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -23,18 +23,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-func getTestSystemContext(t *testing.T, extraOpts ...systemContextOption) *systemContext {
+func getTestSystemContext(tb testing.TB, extraOpts ...systemContextOption) *systemContext {
 	opts := []systemContextOption{
 		withProcRoot(kernel.ProcFSRoot()),
-		withWorkloadMeta(testutil.GetWorkloadMetaMock(t)),
-		withTelemetry(testutil.GetTelemetryMock(t)),
+		withWorkloadMeta(testutil.GetWorkloadMetaMock(tb)),
+		withTelemetry(testutil.GetTelemetryMock(tb)),
 	}
 
 	opts = append(opts, extraOpts...) // Allow overriding the default options
 
 	sysCtx, err := getSystemContext(opts...)
-	require.NoError(t, err)
-	require.NotNil(t, sysCtx)
+	require.NoError(tb, err)
+	require.NotNil(tb, sysCtx)
 	return sysCtx
 }
 

--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -60,7 +60,8 @@ func TestPytorchBatchedKernels(t *testing.T) {
 	// actually having the consumers running.
 	cfg.MaxKernelLaunchesPerStream = len(events.Events)
 	cfg.MaxMemAllocEventsPerStream = len(events.Events)
-	cfg.MaxPendingSpans = len(events.Events)
+	cfg.MaxPendingKernelSpans = len(events.Events)
+	cfg.MaxPendingMemorySpans = len(events.Events)
 
 	handlers := newStreamCollection(ctx, telemetryMock, cfg)
 	consumer := newCudaEventConsumer(ctx, handlers, nil, cfg, telemetryMock)

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -93,7 +93,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 			}
 		}
 
-		return len(probe.streamHandlers.globalStreams) == 1 && len(probe.streamHandlers.streams) == 1 && handlerStream != nil && handlerGlobal != nil && len(handlerStream.kernelSpans) > 0 && len(handlerGlobal.allocations) > 0
+		return len(probe.streamHandlers.globalStreams) == 1 && len(probe.streamHandlers.streams) == 1 && handlerStream != nil && handlerGlobal != nil && len(handlerStream.pendingKernelSpans) > 0 && len(handlerGlobal.pendingMemorySpans) > 0
 	}, 3*time.Second, 100*time.Millisecond, "stream and global handlers not found: existing is %v", probe.consumer.streamHandlers)
 
 	// Check that we're receiving the events we expect

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -131,14 +131,18 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	require.Len(t, tidMap, 1)
 	require.ElementsMatch(t, []int{cmd.Process.Pid}, maps.Keys(tidMap))
 
-	require.Equal(t, 1, len(handlerStream.kernelSpans))
-	span := handlerStream.kernelSpans[0]
+	streamPastData := handlerStream.getPastData()
+	require.NotNil(t, streamPastData)
+	require.Equal(t, 1, len(streamPastData.kernels))
+	span := streamPastData.kernels[0]
 	require.Equal(t, uint64(1), span.numKernels)
 	require.Equal(t, uint64(1*2*3*4*5*6), span.avgThreadCount)
 	require.Greater(t, span.endKtime, span.startKtime)
 
-	require.Equal(t, 1, len(handlerGlobal.allocations))
-	alloc := handlerGlobal.allocations[0]
+	globalPastData := handlerGlobal.getPastData()
+	require.NotNil(t, globalPastData)
+	require.Equal(t, 1, len(globalPastData.allocations))
+	alloc := globalPastData.allocations[0]
 	require.Equal(t, uint64(100), alloc.size)
 	require.False(t, alloc.isLeaked)
 	require.Greater(t, alloc.endKtime, alloc.startKtime)

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -69,7 +69,7 @@ func (g *statsGenerator) getStats(nowKtime int64) (*model.GPUStats, error) {
 		}
 
 		currData := handler.getCurrentData(uint64(nowKtime))
-		pastData := handler.getPastData(true)
+		pastData := handler.getPastData()
 
 		if currData != nil {
 			aggr.processCurrentData(currData)

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -153,7 +153,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
-	stream.allocations = []*memoryAllocation{
+	stream.allocations = []*memorySpan{
 		{
 			startKtime: uint64(startKtime),
 			endKtime:   uint64(endKtime),
@@ -218,7 +218,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
-	stream.allocations = []*memoryAllocation{
+	stream.allocations = []*memorySpan{
 		{
 			startKtime: uint64(startKtime),
 			endKtime:   uint64(endKtime),
@@ -368,7 +368,7 @@ func TestGetStatsNormalization(t *testing.T) {
 		// Add memory allocations
 		globalStream := addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 		globalStream.ended = false
-		globalStream.allocations = []*memoryAllocation{
+		globalStream.allocations = []*memorySpan{
 			{
 				startKtime: uint64(startKtime),
 				endKtime:   uint64(endKtime),

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -141,26 +141,24 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	numThreads := uint64(5)
 	stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
 	stream.ended = false
-	stream.kernelSpans = []*kernelSpan{
-		{
-			startKtime:     uint64(startKtime),
-			endKtime:       uint64(endKtime),
-			avgThreadCount: numThreads,
-			numKernels:     10,
-		},
+	// Send kernel span to the channel
+	stream.kernelSpans <- &kernelSpan{
+		startKtime:     uint64(startKtime),
+		endKtime:       uint64(endKtime),
+		avgThreadCount: numThreads,
+		numKernels:     10,
 	}
 
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
-	stream.allocations = []*memorySpan{
-		{
-			startKtime: uint64(startKtime),
-			endKtime:   uint64(endKtime),
-			size:       allocSize,
-			isLeaked:   false,
-			allocType:  globalMemAlloc,
-		},
+	// Send allocation to the channel
+	stream.allocations <- &memorySpan{
+		startKtime: uint64(startKtime),
+		endKtime:   uint64(endKtime),
+		size:       allocSize,
+		isLeaked:   false,
+		allocType:  globalMemAlloc,
 	}
 
 	checkDuration := 10 * time.Second
@@ -206,26 +204,24 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 		},
 	}
 
-	stream.kernelSpans = []*kernelSpan{
-		{
-			startKtime:     uint64(startKtime),
-			endKtime:       uint64(endKtime),
-			avgThreadCount: numThreads,
-			numKernels:     10,
-		},
+	// Send kernel span to the channel
+	stream.kernelSpans <- &kernelSpan{
+		startKtime:     uint64(startKtime),
+		endKtime:       uint64(endKtime),
+		avgThreadCount: numThreads,
+		numKernels:     10,
 	}
 
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
-	stream.allocations = []*memorySpan{
-		{
-			startKtime: uint64(startKtime),
-			endKtime:   uint64(endKtime),
-			size:       allocSize,
-			isLeaked:   false,
-			allocType:  globalMemAlloc,
-		},
+	// Send allocation to the channel
+	stream.allocations <- &memorySpan{
+		startKtime: uint64(startKtime),
+		endKtime:   uint64(endKtime),
+		size:       allocSize,
+		isLeaked:   false,
+		allocType:  globalMemAlloc,
 	}
 
 	stream.memAllocEvents.Add(0, gpuebpf.CudaMemEvent{
@@ -268,13 +264,12 @@ func TestGetStatsMultiGPU(t *testing.T) {
 		streamID := uint64(i)
 		stream := addStream(t, streamHandlers, pid, streamID, uuid, "")
 		stream.ended = false
-		stream.kernelSpans = []*kernelSpan{
-			{
-				startKtime:     uint64(startKtime),
-				endKtime:       uint64(endKtime),
-				avgThreadCount: numThreads,
-				numKernels:     10,
-			},
+		// Send kernel span to the channel
+		stream.kernelSpans <- &kernelSpan{
+			startKtime:     uint64(startKtime),
+			endKtime:       uint64(endKtime),
+			avgThreadCount: numThreads,
+			numKernels:     10,
 		}
 	}
 
@@ -356,26 +351,24 @@ func TestGetStatsNormalization(t *testing.T) {
 		streamID := uint64(pid)
 		stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
 		stream.ended = false
-		stream.kernelSpans = []*kernelSpan{
-			{
-				startKtime:     uint64(startKtime),
-				endKtime:       uint64(endKtime),
-				avgThreadCount: numThreads,
-				numKernels:     10,
-			},
+		// Send kernel span to the channel
+		stream.kernelSpans <- &kernelSpan{
+			startKtime:     uint64(startKtime),
+			endKtime:       uint64(endKtime),
+			avgThreadCount: numThreads,
+			numKernels:     10,
 		}
 
 		// Add memory allocations
 		globalStream := addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 		globalStream.ended = false
-		globalStream.allocations = []*memorySpan{
-			{
-				startKtime: uint64(startKtime),
-				endKtime:   uint64(endKtime),
-				size:       memSize,
-				isLeaked:   false,
-				allocType:  globalMemAlloc,
-			},
+		// Send allocation to the channel
+		globalStream.allocations <- &memorySpan{
+			startKtime: uint64(startKtime),
+			endKtime:   uint64(endKtime),
+			size:       memSize,
+			isLeaked:   false,
+			allocType:  globalMemAlloc,
 		}
 	}
 

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -142,7 +142,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
 	stream.ended = false
 	// Send kernel span to the channel
-	stream.kernelSpans <- &kernelSpan{
+	stream.pendingKernelSpans <- &kernelSpan{
 		startKtime:     uint64(startKtime),
 		endKtime:       uint64(endKtime),
 		avgThreadCount: numThreads,
@@ -153,7 +153,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
 	// Send allocation to the channel
-	stream.allocations <- &memorySpan{
+	stream.pendingMemorySpans <- &memorySpan{
 		startKtime: uint64(startKtime),
 		endKtime:   uint64(endKtime),
 		size:       allocSize,
@@ -205,7 +205,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	}
 
 	// Send kernel span to the channel
-	stream.kernelSpans <- &kernelSpan{
+	stream.pendingKernelSpans <- &kernelSpan{
 		startKtime:     uint64(startKtime),
 		endKtime:       uint64(endKtime),
 		avgThreadCount: numThreads,
@@ -216,7 +216,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 	stream.ended = false
 	// Send allocation to the channel
-	stream.allocations <- &memorySpan{
+	stream.pendingMemorySpans <- &memorySpan{
 		startKtime: uint64(startKtime),
 		endKtime:   uint64(endKtime),
 		size:       allocSize,
@@ -265,7 +265,7 @@ func TestGetStatsMultiGPU(t *testing.T) {
 		stream := addStream(t, streamHandlers, pid, streamID, uuid, "")
 		stream.ended = false
 		// Send kernel span to the channel
-		stream.kernelSpans <- &kernelSpan{
+		stream.pendingKernelSpans <- &kernelSpan{
 			startKtime:     uint64(startKtime),
 			endKtime:       uint64(endKtime),
 			avgThreadCount: numThreads,
@@ -352,7 +352,7 @@ func TestGetStatsNormalization(t *testing.T) {
 		stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
 		stream.ended = false
 		// Send kernel span to the channel
-		stream.kernelSpans <- &kernelSpan{
+		stream.pendingKernelSpans <- &kernelSpan{
 			startKtime:     uint64(startKtime),
 			endKtime:       uint64(endKtime),
 			avgThreadCount: numThreads,
@@ -363,7 +363,7 @@ func TestGetStatsNormalization(t *testing.T) {
 		globalStream := addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
 		globalStream.ended = false
 		// Send allocation to the channel
-		globalStream.allocations <- &memorySpan{
+		globalStream.pendingMemorySpans <- &memorySpan{
 			startKtime: uint64(startKtime),
 			endKtime:   uint64(endKtime),
 			size:       memSize,

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -62,12 +62,14 @@ type streamTelemetry struct {
 	forcedSyncOnKernelLaunch telemetry.Counter
 	allocEvicted             telemetry.Counter
 	invalidFreeEvents        telemetry.Counter
+	rejectedSpans            telemetry.Counter
 }
 
 func getStreamLimits(config *config.Config) streamLimits {
 	return streamLimits{
 		maxKernelLaunches: config.MaxKernelLaunchesPerStream,
 		maxAllocEvents:    config.MaxMemAllocEventsPerStream,
+		maxPendingSpans:   config.MaxPendingSpans,
 	}
 }
 
@@ -96,6 +98,7 @@ func newStreamTelemetry(tm telemetry.Component) *streamTelemetry {
 		activeHandlers:           tm.NewGauge(subsystem, "active_handlers", nil, "Number of active stream handlers"),
 		removedHandlers:          tm.NewCounter(subsystem, "removed_handlers", []string{"device", "reason"}, "Number of removed stream handlers and why"),
 		rejectedStreams:          tm.NewCounter(subsystem, "rejected_streams_due_to_limit", nil, "Number of rejected streams due to the max stream limit"),
+		rejectedSpans:            tm.NewCounter(subsystem, "rejected_spans_due_to_limit", nil, "Number of rejected spans due to the max span limit"),
 	}
 }
 

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -67,9 +67,10 @@ type streamTelemetry struct {
 
 func getStreamLimits(config *config.Config) streamLimits {
 	return streamLimits{
-		maxKernelLaunches: config.MaxKernelLaunchesPerStream,
-		maxAllocEvents:    config.MaxMemAllocEventsPerStream,
-		maxPendingSpans:   config.MaxPendingSpans,
+		maxKernelLaunches:     config.MaxKernelLaunchesPerStream,
+		maxAllocEvents:        config.MaxMemAllocEventsPerStream,
+		maxPendingKernelSpans: config.MaxPendingKernelSpans,
+		maxPendingMemorySpans: config.MaxPendingMemorySpans,
 	}
 }
 

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -887,11 +887,6 @@ func TestGetPastDataConcurrency(t *testing.T) {
 	require.GreaterOrEqual(t, len(data.allocations), int(beforeGetDataSyncs))
 }
 
-// before
-// BenchmarkHandleEvents-8           604144              1901 ns/op            1146 B/op          2 allocs/op
-// after
-// BenchmarkHandleEvents-8           525607              2126 ns/op            1144 B/op          2 allocs/op
-
 func BenchmarkHandleEvents(b *testing.B) {
 	ddnvml.WithMockNVML(b, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -57,9 +57,9 @@ func TestKernelLaunchesHandled(t *testing.T) {
 	currTime := uint64(100)
 	currData := stream.getCurrentData(currTime)
 	require.NotNil(t, currData)
-	require.Len(t, currData.spans, 1)
+	require.Len(t, currData.kernels, 1)
 
-	span := currData.spans[0]
+	span := currData.kernels[0]
 	require.Equal(t, kernStartTime, span.startKtime)
 	require.Equal(t, currTime, span.endKtime)
 	require.Equal(t, uint64(numLaunches), span.numKernels)
@@ -73,8 +73,8 @@ func TestKernelLaunchesHandled(t *testing.T) {
 	pastData := stream.getPastData(true)
 	require.NotNil(t, pastData)
 
-	require.Len(t, pastData.spans, 1)
-	span = pastData.spans[0]
+	require.Len(t, pastData.kernels, 1)
+	span = pastData.kernels[0]
 	require.Equal(t, kernStartTime, span.startKtime)
 	require.Equal(t, syncTime, span.endKtime)
 	require.Equal(t, uint64(numLaunches), span.numKernels)
@@ -424,9 +424,9 @@ func TestKernelLaunchEnrichment(t *testing.T) {
 			currTime := uint64(100)
 			currData := stream.getCurrentData(currTime)
 			require.NotNil(t, currData)
-			require.Len(t, currData.spans, 1)
+			require.Len(t, currData.kernels, 1)
 
-			span := currData.spans[0]
+			span := currData.kernels[0]
 			require.Equal(t, kernStartTime, span.startKtime)
 			require.Equal(t, currTime, span.endKtime)
 			require.Equal(t, uint64(numLaunches), span.numKernels)
@@ -450,8 +450,8 @@ func TestKernelLaunchEnrichment(t *testing.T) {
 			pastData := stream.getPastData(true)
 			require.NotNil(t, pastData)
 
-			require.Len(t, pastData.spans, 1)
-			span = pastData.spans[0]
+			require.Len(t, pastData.kernels, 1)
+			span = pastData.kernels[0]
 			require.Equal(t, kernStartTime, span.startKtime)
 			require.Equal(t, syncTime, span.endKtime)
 			require.Equal(t, uint64(numLaunches), span.numKernels)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the data structure used to store pending kernel/memory spans in the stream handlers, from a list to a channel. It also changes the naming of kernelSpans/allocations to have a more uniform naming using "span" for consistency.

### Motivation

Avoid panics due to race conditions, where one goroutine can be clearing the pending kernel spans/allocations while another writes into the array. 

I used a channel with non-blocking reads/writes instead of a mutex, as the implementation was simpler and channels are faster than the mutex locking.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests. Added a specific test with concurrent consumer/producer to reproduce the original issue with the race detector enabled.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->