### PR TITLE
Add dogstatsd metrics to crossorg telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -206,6 +206,26 @@ var defaultProfiles = `
       metrics:
         - name: dogstatsd.udp_packets_bytes
         - name: dogstatsd.uds_packets_bytes
+        - name: dogstatsd_client.bytes_sent
+          aggregate_tags:
+          - client
+          - client_version
+          - client_transport
+        - name: dogstatsd_client.bytes_dropped
+          aggregate_tags:
+          - client
+          - client_version
+          - client_transport
+        - name: dogstatsd_client.packets_sent
+          aggregate_tags:
+          - client
+          - client_version
+          - client_transport
+        - name: dogstatsd_client.packets_dropped
+          aggregate_tags:
+          - client
+          - client_version
+          - client_transport
         - name: logs.bytes_missed
         - name: logs.bytes_sent
         - name: logs.decoded

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -135,7 +135,7 @@ func tsToFloatForSamples(ts time.Time) float64 {
 	return float64(ts.Unix())
 }
 
-func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, processID uint32, listenerID string, conf enrichConfig, blocklist *utilstrings.Blocklist) []metrics.MetricSample {
+func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, processID uint32, listenerID string, conf enrichConfig, blocklist *utilstrings.FilterList) []metrics.MetricSample {
 	metricName := ddSample.name
 	tags, hostnameFromTags, extractedOrigin, metricSource := extractTagsMetadata(ddSample.tags, origin, processID, ddSample.localData, ddSample.externalData, ddSample.cardinality, conf)
 

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkMetricsExclusion(b *testing.B) {
 	}
 
 	for i := 1; i <= 512; i *= 2 {
-		blocklist := utilstrings.NewBlocklist(list[:i], false)
+		blocklist := utilstrings.NewFilterList(list[:i], false)
 		b.Run(fmt.Sprintf("%d-exact", i),
 			func(b *testing.B) {
 				for i := 0; i < b.N; i++ {

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -991,7 +991,7 @@ func TestConvertNamespaceBlacklist(t *testing.T) {
 
 func TestMetricBlocklistShouldBlock(t *testing.T) {
 	message := []byte("custom.metric.a:21|ms")
-	blocklist := utilstrings.NewBlocklist([]string{"custom.metric.a", "custom.metric.b"}, false)
+	blocklist := utilstrings.NewFilterList([]string{"custom.metric.a", "custom.metric.b"}, false)
 	conf := enrichConfig{
 		defaultHostname: "default",
 	}
@@ -1028,7 +1028,7 @@ func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 
 func TestMetricBlocklistShouldNotBlock(t *testing.T) {
 	message := []byte("custom.metric.a:21|ms")
-	blocklist := utilstrings.NewBlocklist([]string{"custom.metric.b", "custom.metric.c"}, false)
+	blocklist := utilstrings.NewFilterList([]string{"custom.metric.b", "custom.metric.c"}, false)
 	conf := enrichConfig{
 		defaultHostname: "default",
 	}

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -36,8 +36,8 @@ type worker struct {
 
 	packetsTelemetry *packets.TelemetryStore
 
-	BlocklistUpdate chan utilstrings.Blocklist
-	blocklist       utilstrings.Blocklist
+	BlocklistUpdate chan utilstrings.FilterList
+	blocklist       utilstrings.FilterList
 }
 
 func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
@@ -54,7 +54,7 @@ func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Compon
 		parser:           newParser(s.config, s.sharedFloat64List, workerNum, wmeta, stringInternerTelemetry),
 		samples:          make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 		packetsTelemetry: packetsTelemetry,
-		BlocklistUpdate:  make(chan utilstrings.Blocklist),
+		BlocklistUpdate:  make(chan utilstrings.FilterList),
 	}
 }
 

--- a/pkg/aggregator/agent_telemetry.go
+++ b/pkg/aggregator/agent_telemetry.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
+)
+
+// tlmDogstatsd contains metrics that we want to capture from incoming dogstatsd traffic and send as agent telemetry.
+var tlmDogstatsd = map[string]telemetry.Counter{
+	"datadog.dogstatsd.client.bytes_sent": telemetry.NewCounterWithOpts("dogstatsd_client", "bytes_sent",
+		[]string{"client", "client_version", "client_transport"}, "Intercepted from dogstatsd client", telemetry.DefaultOptions),
+	"datadog.dogstatsd.client.bytes_dropped": telemetry.NewCounterWithOpts("dogstatsd_client", "bytes_dropped",
+		[]string{"client", "client_version", "client_transport"}, "Intercepted from dogstatsd client", telemetry.DefaultOptions),
+	"datadog.dogstatsd.client.packets_sent": telemetry.NewCounterWithOpts("dogstatsd_client", "packets_sent",
+		[]string{"client", "client_version", "client_transport"}, "Intercepted from dogstatsd client", telemetry.DefaultOptions),
+	"datadog.dogstatsd.client.packets_dropped": telemetry.NewCounterWithOpts("dogstatsd_client", "packets_dropped",
+		[]string{"client", "client_version", "client_transport"}, "Intercepted from dogstatsd client", telemetry.DefaultOptions),
+}
+
+// newCOATBlocklist creates a block list to capture metrics coming in from dogstatsd that we want to capture.
+func newCOATBlocklist() utilstrings.Blocklist {
+	return utilstrings.NewBlocklist([]string{
+		"datadog.dogstatsd.client.bytes_sent",
+		"datadog.dogstatsd.client.bytes_dropped",
+		"datadog.dogstatsd.client.packets_sent",
+		"datadog.dogstatsd.client.packets_dropped"}, false)
+}
+
+// addToAgentTelemetry converts the given metrics series into an agent metric.
+// Currently all metrics we capturing are counters, so only counters are handled.
+func addToAgentTelemetry(serie *metrics.Serie) {
+	counter, ok := tlmDogstatsd[serie.Name]
+	if ok {
+		tags := []string{"", "", ""}
+		serie.Tags.ForEach(func(tag string) {
+			t := strings.SplitN(tag, ":", 2)
+			switch t[0] {
+			case "client":
+				tags[0] = t[1]
+			case "client_version":
+				tags[1] = t[1]
+			case "client_transport":
+				tags[2] = t[1]
+			}
+		})
+
+		var total float64
+		for point := range serie.Points {
+			total += serie.Points[point].Value
+		}
+
+		counter.Add(total, tags...)
+	}
+}

--- a/pkg/aggregator/agent_telemetry.go
+++ b/pkg/aggregator/agent_telemetry.go
@@ -26,6 +26,7 @@ var tlmDogstatsd = map[string]telemetry.Counter{
 }
 
 // newCOATBlocklist creates a block list to capture metrics coming in from dogstatsd that we want to capture.
+// This currently only works with series.
 func newAgentTelemFilterList() utilstrings.FilterList {
 	return utilstrings.NewFilterList([]string{
 		"datadog.dogstatsd.client.bytes_sent",
@@ -40,13 +41,15 @@ func getDetailsFromSerie(serie *metrics.Serie) (float64, []string) {
 	tags := []string{"", "", ""}
 	serie.Tags.ForEach(func(tag string) {
 		t := strings.SplitN(tag, ":", 2)
-		switch t[0] {
-		case "client":
-			tags[0] = t[1]
-		case "client_version":
-			tags[1] = t[1]
-		case "client_transport":
-			tags[2] = t[1]
+		if len(t) > 1 {
+			switch t[0] {
+			case "client":
+				tags[0] = t[1]
+			case "client_version":
+				tags[1] = t[1]
+			case "client_transport":
+				tags[2] = t[1]
+			}
 		}
 	})
 

--- a/pkg/aggregator/agent_telemetry.go
+++ b/pkg/aggregator/agent_telemetry.go
@@ -26,8 +26,8 @@ var tlmDogstatsd = map[string]telemetry.Counter{
 }
 
 // newCOATBlocklist creates a block list to capture metrics coming in from dogstatsd that we want to capture.
-func newCOATBlocklist() utilstrings.Blocklist {
-	return utilstrings.NewBlocklist([]string{
+func newAgentTelemFilterList() utilstrings.FilterList {
+	return utilstrings.NewFilterList([]string{
 		"datadog.dogstatsd.client.bytes_sent",
 		"datadog.dogstatsd.client.bytes_dropped",
 		"datadog.dogstatsd.client.packets_sent",

--- a/pkg/aggregator/agent_telemetry_test.go
+++ b/pkg/aggregator/agent_telemetry_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDetailsFromSerie(t *testing.T) {
+	serie1 := metrics.Serie{
+		Name:   "datadog.dogstatsd.client.bytes_sent",
+		Points: []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
+		Tags:   tagset.CompositeTagsFromSlice([]string{"client:ruby", "client_version:5.4.2", "client_transport:udp"}),
+		Host:   "",
+		MType:  metrics.APICountType,
+	}
+
+	value, tags := getDetailsFromSerie(&serie1)
+
+	assert.Equal(t, 1.0, value)
+	assert.Equal(t, tags, []string{"ruby", "5.4.2", "udp"})
+}
+
+func TestGetDetailsFromSerieUnorderedTags(t *testing.T) {
+	serie1 := metrics.Serie{
+		Name:   "datadog.dogstatsd.client.bytes_sent",
+		Points: []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
+		Tags:   tagset.CompositeTagsFromSlice([]string{"client_transport:udp", "client_version:5.4.2", "client:ruby"}),
+		Host:   "",
+		MType:  metrics.APICountType,
+	}
+
+	value, tags := getDetailsFromSerie(&serie1)
+
+	assert.Equal(t, 1.0, value)
+	assert.Equal(t, tags, []string{"ruby", "5.4.2", "udp"})
+}
+
+func TestGetDetailsFromSerieMissingTags(t *testing.T) {
+	serie1 := metrics.Serie{
+		Name:   "datadog.dogstatsd.client.bytes_sent",
+		Points: []metrics.Point{{Ts: 12340.0, Value: float64(543)}},
+		Tags:   tagset.CompositeTagsFromSlice([]string{"client:ruby", "zork:32", "client_transport:udp"}),
+		Host:   "",
+		MType:  metrics.APICountType,
+	}
+
+	value, tags := getDetailsFromSerie(&serie1)
+
+	assert.Equal(t, 543.0, value)
+	assert.Equal(t, tags, []string{"ruby", "", "udp"})
+}
+
+func TestGetDetailsFromSerieMultiplePoints(t *testing.T) {
+	serie1 := metrics.Serie{
+		Name: "datadog.dogstatsd.client.bytes_sent",
+		Points: []metrics.Point{
+			{Ts: 12340.0, Value: float64(1)},
+			{Ts: 12340.0, Value: float64(423)},
+			{Ts: 12340.0, Value: float64(8234)},
+		},
+		Tags:  tagset.CompositeTagsFromSlice([]string{"client_transport:udp", "client_version:5.4.2", "client:ruby"}),
+		Host:  "",
+		MType: metrics.APICountType,
+	}
+
+	value, tags := getDetailsFromSerie(&serie1)
+
+	assert.Equal(t, 8658.0, value)
+	assert.Equal(t, tags, []string{"ruby", "5.4.2", "udp"})
+}

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -57,7 +57,7 @@ type Demultiplexer interface {
 
 	// SetTimeSamplersBlocklist triggers a reconfiguration of the blocklist
 	// applied in the time samplers.
-	SetTimeSamplersBlocklist(*utilstrings.Blocklist)
+	SetTimeSamplersBlocklist(*utilstrings.FilterList)
 
 	// Senders API, mainly used by collectors/checks
 	// --

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -172,6 +172,7 @@ func initAgentDemultiplexer(log log.Component,
 	log.Debug("the Demultiplexer will use", statsdPipelinesCount, "pipelines")
 
 	statsdWorkers := make([]*timeSamplerWorker, statsdPipelinesCount)
+	flushCoatlist := newCOATBlocklist()
 
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
@@ -182,7 +183,7 @@ func initAgentDemultiplexer(log log.Component,
 		// its worker (process loop + flush/serialization mechanism)
 
 		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval,
-			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore)
+			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore, &flushCoatlist)
 	}
 
 	var noAggWorker *noAggregationStreamWorker

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -172,7 +172,7 @@ func initAgentDemultiplexer(log log.Component,
 	log.Debug("the Demultiplexer will use", statsdPipelinesCount, "pipelines")
 
 	statsdWorkers := make([]*timeSamplerWorker, statsdPipelinesCount)
-	flushCoatlist := newCOATBlocklist()
+	flushAgentTelemList := newAgentTelemFilterList()
 
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
@@ -183,7 +183,7 @@ func initAgentDemultiplexer(log log.Component,
 		// its worker (process loop + flush/serialization mechanism)
 
 		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval,
-			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore, &flushCoatlist)
+			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore, &flushAgentTelemList)
 	}
 
 	var noAggWorker *noAggregationStreamWorker
@@ -504,7 +504,7 @@ func (d *AgentDemultiplexer) GetEventPlatformForwarder() (eventplatform.Forwarde
 
 // SetTimeSamplersBlocklist triggers a reconfiguration of the blocklist
 // applied in the time samplers.
-func (d *AgentDemultiplexer) SetTimeSamplersBlocklist(blocklist *utilstrings.Blocklist) {
+func (d *AgentDemultiplexer) SetTimeSamplersBlocklist(blocklist *utilstrings.FilterList) {
 	for _, worker := range d.statsd.workers {
 		worker.blocklistChan <- blocklist
 	}

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -177,7 +177,7 @@ func (d *ServerlessDemultiplexer) SendSamplesWithoutAggregation(_ metrics.Metric
 }
 
 // SetTimeSamplersBlocklist is not supported in the Serverless Agent implementation.
-func (d *ServerlessDemultiplexer) SetTimeSamplersBlocklist(blocklist *utilstrings.Blocklist) {
+func (d *ServerlessDemultiplexer) SetTimeSamplersBlocklist(blocklist *utilstrings.FilterList) {
 	d.statsdWorker.blocklistChan <- blocklist
 }
 

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -61,7 +61,7 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKey
 
 	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore, tagger, "")
 	flushAndSerializeInParallel := NewFlushAndSerializeInParallel(pkgconfigsetup.Datadog())
-	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore)
+	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel, tagsStore, nil)
 
 	demux := &ServerlessDemultiplexer{
 		log:                         logger,

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -126,7 +126,7 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 	return ss
 }
 
-func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink, blocklist *utilstrings.Blocklist, coatlist *utilstrings.Blocklist, forceFlushAll bool) {
+func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink, blocklist *utilstrings.FilterList, coatlist *utilstrings.FilterList, forceFlushAll bool) {
 	// Map to hold the expired contexts that will need to be deleted after the flush so that we stop sending zeros
 	contextMetricsFlusher := metrics.NewContextMetricsFlusher()
 
@@ -166,8 +166,8 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 	rawSeries []*metrics.Serie,
 	serieSink metrics.SerieSink,
 	serieBySignature map[SerieSignature]*metrics.Serie,
-	blocklist *utilstrings.Blocklist,
-	coatlist *utilstrings.Blocklist,
+	blocklist *utilstrings.FilterList,
+	coatlist *utilstrings.FilterList,
 ) {
 	// clear the map. Reuse serieBySignature
 	for k := range serieBySignature {
@@ -239,7 +239,7 @@ func (s *TimeSampler) flushSketches(cutoffTime int64, sketchesSink metrics.Sketc
 	}
 }
 
-func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketches metrics.SketchesSink, blocklist *utilstrings.Blocklist, coatlist *utilstrings.Blocklist, forceFlushAll bool) {
+func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketches metrics.SketchesSink, blocklist *utilstrings.FilterList, coatlist *utilstrings.FilterList, forceFlushAll bool) {
 	// Compute a limit timestamp
 	cutoffTime := s.calculateBucketStart(timestamp)
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -126,7 +126,7 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 	return ss
 }
 
-func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink, blocklist *utilstrings.Blocklist, forceFlushAll bool) {
+func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink, blocklist *utilstrings.Blocklist, coatlist *utilstrings.Blocklist, forceFlushAll bool) {
 	// Map to hold the expired contexts that will need to be deleted after the flush so that we stop sending zeros
 	contextMetricsFlusher := metrics.NewContextMetricsFlusher()
 
@@ -158,7 +158,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64, series metrics.SerieSink, bl
 	serieBySignature := make(map[SerieSignature]*metrics.Serie)
 	s.flushContextMetrics(contextMetricsFlusher, func(rawSeries []*metrics.Serie) {
 		// Note: rawSeries is reused at each call
-		s.dedupSerieBySerieSignature(rawSeries, series, serieBySignature, blocklist)
+		s.dedupSerieBySerieSignature(rawSeries, series, serieBySignature, blocklist, coatlist)
 	})
 }
 
@@ -167,6 +167,7 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 	serieSink metrics.SerieSink,
 	serieBySignature map[SerieSignature]*metrics.Serie,
 	blocklist *utilstrings.Blocklist,
+	coatlist *utilstrings.Blocklist,
 ) {
 	// clear the map. Reuse serieBySignature
 	for k := range serieBySignature {
@@ -205,6 +206,11 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 			tlmDogstatsdBlockedMetrics.Inc()
 			continue
 		}
+
+		if coatlist != nil && coatlist.Test(serie.Name) {
+			// Add to internal telemetry.
+			addToAgentTelemetry(serie)
+		}
 		serieSink.Append(serie)
 	}
 }
@@ -233,11 +239,11 @@ func (s *TimeSampler) flushSketches(cutoffTime int64, sketchesSink metrics.Sketc
 	}
 }
 
-func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketches metrics.SketchesSink, blocklist *utilstrings.Blocklist, forceFlushAll bool) {
+func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketches metrics.SketchesSink, blocklist *utilstrings.Blocklist, coatlist *utilstrings.Blocklist, forceFlushAll bool) {
 	// Compute a limit timestamp
 	cutoffTime := s.calculateBucketStart(timestamp)
 
-	s.flushSeries(cutoffTime, series, blocklist, forceFlushAll)
+	s.flushSeries(cutoffTime, series, blocklist, coatlist, forceFlushAll)
 	s.flushSketches(cutoffTime, sketches, forceFlushAll)
 	// expiring contexts
 	s.contextResolver.expireContexts(int64(timestamp))

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -199,6 +199,13 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 	}
 
 	for _, serie := range serieBySignature {
+		// Check the telemetry list before the block list so even if metrics are blocked
+		// they get added to the internal telemetry.
+		if coatlist != nil && coatlist.Test(serie.Name) {
+			// Add to internal telemetry.
+			addToAgentTelemetry(serie)
+		}
+
 		// it is the final stage before flushing the series to the serialisation
 		// part of the pipeline but also, here is a stage where all series have been
 		// generated & processed (even the ones generated from a histogram metric).
@@ -207,10 +214,6 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 			continue
 		}
 
-		if coatlist != nil && coatlist.Test(serie.Name) {
-			// Add to internal telemetry.
-			addToAgentTelemetry(serie)
-		}
 		serieSink.Append(serie)
 	}
 }

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -683,7 +683,7 @@ func flushSerie(sampler *TimeSampler, timestamp float64, forceFlushAll bool) (me
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches, nil, forceFlushAll)
+	sampler.flush(timestamp, &series, &sketches, nil, nil, forceFlushAll)
 	return series, sketches
 }
 
@@ -691,6 +691,6 @@ func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilst
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches, bl, forceFlushAll)
+	sampler.flush(timestamp, &series, &sketches, bl, nil, forceFlushAll)
 	return series, sketches
 }

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -554,7 +554,7 @@ func testFlushBlocklist(t *testing.T, store *tags.Store) {
 		Mtype:      metrics.DistributionType,
 		SampleRate: 1,
 	}, 1000)
-	bl := utilstrings.NewBlocklist([]string{
+	bl := utilstrings.NewFilterList([]string{
 		"test.histogram.avg",
 		"test.histogram.count",
 	}, false)
@@ -687,7 +687,7 @@ func flushSerie(sampler *TimeSampler, timestamp float64, forceFlushAll bool) (me
 	return series, sketches
 }
 
-func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilstrings.Blocklist, forceFlushAll bool) (metrics.Series, metrics.SketchSeriesList) {
+func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilstrings.FilterList, forceFlushAll bool) (metrics.Series, metrics.SketchSeriesList) {
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -31,9 +31,9 @@ type timeSamplerWorker struct {
 	// flushBlocklist is the blocklist used when flushing metrics to the serializer.
 	// It's main use-case is to filter out some metrics after their aggregation
 	// process, such as histograms which create several metrics.
-	flushBlocklist *utilstrings.Blocklist
+	flushBlocklist *utilstrings.FilterList
 
-	flushCoatlist *utilstrings.Blocklist
+	flushCoatlist *utilstrings.FilterList
 
 	// parallel serialization configuration
 	parallelSerialization FlushAndSerializeInParallel
@@ -44,7 +44,7 @@ type timeSamplerWorker struct {
 	// use this chan to trigger a flush of the time sampler
 	flushChan chan flushTrigger
 	// use this chan to trigger a blocklist reconfiguration
-	blocklistChan chan *utilstrings.Blocklist
+	blocklistChan chan *utilstrings.FilterList
 	// use this chan to stop the timeSamplerWorker
 	stopChan chan struct{}
 	// channel to trigger interactive dump of the context resolver
@@ -63,7 +63,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 	metricSamplePool *metrics.MetricSamplePool,
 	parallelSerialization FlushAndSerializeInParallel,
 	tagsStore *tags.Store,
-	flushCoatlist *utilstrings.Blocklist,
+	flushCoatlist *utilstrings.FilterList,
 ) *timeSamplerWorker {
 	return &timeSamplerWorker{
 		sampler: sampler,
@@ -78,7 +78,7 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 		stopChan:      make(chan struct{}),
 		flushChan:     make(chan flushTrigger),
 		dumpChan:      make(chan dumpTrigger),
-		blocklistChan: make(chan *utilstrings.Blocklist),
+		blocklistChan: make(chan *utilstrings.FilterList),
 
 		tagsStore: tagsStore,
 	}

--- a/pkg/util/strings/filterlist.go
+++ b/pkg/util/strings/filterlist.go
@@ -11,16 +11,16 @@ import (
 	"strings"
 )
 
-// Blocklist is a strings blocklist.
-// See `NewBlocklist` for details.
-type Blocklist struct {
+// FilterList is a strings blocklist.
+// See `NewFilterList` for details.
+type FilterList struct {
 	data        []string
 	matchPrefix bool
 }
 
-// NewBlocklist creates a new strings blocklist.
-// Use `matchPrefix` to  create a prefixes blocklist.
-func NewBlocklist(data []string, matchPrefix bool) Blocklist {
+// NewFilterList creates a new strings filterlist.
+// Use `matchPrefix` to  create a prefixes filter.
+func NewFilterList(data []string, matchPrefix bool) FilterList {
 	data = slices.Clone(data)
 	sort.Strings(data)
 
@@ -41,16 +41,16 @@ func NewBlocklist(data []string, matchPrefix bool) Blocklist {
 	// Invariants for data:
 	// For all i, j such that i < j, data[i] < data[j].
 	// for all i, j such that i != j, !HasPrefix(data[i], data[j]).
-	return Blocklist{
+	return FilterList{
 		data:        data,
 		matchPrefix: matchPrefix,
 	}
 }
 
-// Test returns true if the given name is in the blocklist
-// or matching by prefix if the string blocklist has been
+// Test returns true if the given name is in the filterlist
+// or matching by prefix if the string filterlist has been
 // created with `matchPrefix`.
-func (b *Blocklist) Test(name string) bool {
+func (b *FilterList) Test(name string) bool {
 	if b == nil {
 		return false
 	}

--- a/pkg/util/strings/filterlist_test.go
+++ b/pkg/util/strings/filterlist_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewBlocklist(t *testing.T) {
+func TestNewFilterList(t *testing.T) {
 	check := func(data []string) []string {
-		b := NewBlocklist(data, true)
+		b := NewFilterList(data, true)
 		return b.data
 	}
 
@@ -47,7 +47,7 @@ func TestIsStringBlocked(t *testing.T) {
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%v-%v-%v", c.name, c.blocklist, c.matchPrefix),
 			func(t *testing.T) {
-				b := NewBlocklist(c.blocklist, c.matchPrefix)
+				b := NewFilterList(c.blocklist, c.matchPrefix)
 				assert.Equal(t, c.result, b.Test(c.name))
 			})
 	}
@@ -90,7 +90,7 @@ func benchmarkBlocklist(b *testing.B, words, values []string) {
 	words[0] = values[0]
 	words[3] = values[100]
 
-	blocklist := NewBlocklist(values, false)
+	blocklist := NewFilterList(values, false)
 
 	for n := 0; n < b.N; n++ {
 		blocklist.Test(words[n%len(words)])

--- a/releasenotes/notes/dogstatsd_internal_telemetry-53a893bbf2381b8b.yaml
+++ b/releasenotes/notes/dogstatsd_internal_telemetry-53a893bbf2381b8b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Internal telemetry from the dogstatsd clients is now added to the internal
+    agents telemetry.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds selected dogstatsd metrics to metrics posted to cross org telemetry.

### Motivation

It would be useful to observe the usage of the dogstatsd client libraries. Which versions are being used, which ones cause problems with dropped metrics etc...

Since these metrics are posted by dogstatsd and do not form part of the internal agents telemetry, this intercepts the metrics and when a given metric is encountered it adds this as an internal metric. The metrics are added to the cross origin telemetry list.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I tested manually using the Ruby dogstatsd client to check that the dogstatsd metrics and tags are now being sent in the instrumentation telemetry payload.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->