### PR TITLE
[dyninst] Address all different framelessness cases

### DIFF
--- a/pkg/dyninst/dwarf/loclist/parse.go
+++ b/pkg/dyninst/dwarf/loclist/parse.go
@@ -226,11 +226,11 @@ func readSLEB128(reader *bytes.Buffer) (int64, error) {
 		val |= int64(b&0x7f) << shift
 		shift += 7
 		if b&0x80 == 0 {
+			if b&0x40 != 0 {
+				val -= 1 << shift
+			}
 			break
 		}
-	}
-	if val&0x40 != 0 {
-		val -= 1 << shift
 	}
 	return val, nil
 }

--- a/pkg/dyninst/ebpf/cfa.h
+++ b/pkg/dyninst/ebpf/cfa.h
@@ -1,0 +1,183 @@
+#ifndef __CFA_H__
+#define __CFA_H__
+
+#include "bpf_helpers.h"
+#include "bpf_tracing.h"
+
+static inline uint64_t calculate_cfa(struct pt_regs* regs, bool frameless) {
+  // Stack layout is slightly different in Go between arm64 and x86_64.
+  // Established based on following documentation and machine code reads:
+  // https://tip.golang.org/src/cmd/compile/abi-internal#architecture-specifics
+
+  // Code examples:
+
+  // amd64, framefull function with inlined function
+
+  // Target variable in executeInlined
+  // 0x000450c3:     DW_TAG_variable
+  //                   DW_AT_name    ("a")
+  //                   DW_AT_decl_line       (76)
+  //                   DW_AT_type    (0x0000000000242414 "int[5]")
+  //                   DW_AT_location        (0x00087bf9: 
+  //                      [0x0000000000cd4cbb, 0x0000000000cd4d55): DW_OP_fbreg -56)
+
+  // Target variable in testInlinedSumArray
+  // 0x000450e9:       DW_TAG_formal_parameter
+  //                     DW_AT_abstract_origin       (0x000000000003e970 "a")
+  //                     DW_AT_location      (0x00087c2d: 
+  //                        [0x0000000000cd4ce4, 0x0000000000cd4d55): DW_OP_fbreg -96)
+
+  // 0000000000cd4ca0 <main.executeInlined>:
+  // ; func executeInlined() {
+  //   cd4ca0: 49 3b 66 10                   cmpq    16(%r14), %rsp
+  //   cd4ca4: 0f 86 a1 00 00 00             jbe     0xcd4d4b <main.executeInlined+0xab>
+  //   cd4caa: 55                            pushq   %rbp
+  //   cd4cab: 48 89 e5                      movq    %rsp, %rbp
+  // Injection point for executeInlined
+  // %rsp == %rbp
+  // array offset == %rsp-104+64 == %rsp-40 == (%rbp+16)-56
+  //   cd4cae: 48 83 ec 68                   subq    $104, %rsp
+  // ;       a := [5]int{1, 2, 3, 4, 5}
+  //   cd4cb2: 48 c7 44 24 40 01 00 00 00    movq    $1, 64(%rsp)
+  //   cd4cbb: 48 c7 44 24 48 02 00 00 00    movq    $2, 72(%rsp)
+  //   cd4cc4: 48 c7 44 24 50 03 00 00 00    movq    $3, 80(%rsp)
+  //   cd4ccd: 48 c7 44 24 58 04 00 00 00    movq    $4, 88(%rsp)
+  //   cd4cd6: 48 c7 44 24 60 05 00 00 00    movq    $5, 96(%rsp)
+  // ;       y := testInlinedSumArray(a)
+  //   cd4cdf: 48 8b 4c 24 40                movq    64(%rsp), %rcx
+  //   cd4ce4: 48 89 4c 24 18                movq    %rcx, 24(%rsp)
+  //   cd4ce9: 0f 10 44 24 48                movups  72(%rsp), %xmm0
+  //   cd4cee: 0f 11 44 24 20                movups  %xmm0, 32(%rsp)
+  //   cd4cf3: 0f 10 44 24 58                movups  88(%rsp), %xmm0
+  //   cd4cf8: 0f 11 44 24 30                movups  %xmm0, 48(%rsp)
+  // ;       return a[0] + a[1] + a[2] + a[3] + a[4]
+  // Injection point for testInlinedSumArray
+  // %rsp == %rbp-104
+  // array offset == %rsp + 24 == %rbp-104+24 == %rbp-80 == (%rbp+16)-96
+  //   cd4cfd: 48 8b 5c 24 18                movq    24(%rsp), %rbx
+  //   cd4d02: 48 03 5c 24 20                addq    32(%rsp), %rbx
+  //   cd4d07: 48 03 5c 24 28                addq    40(%rsp), %rbx
+  //   cd4d0c: 48 03 5c 24 30                addq    48(%rsp), %rbx
+  //   cd4d11: 48 03 5c 24 38                addq    56(%rsp), %rbx
+  //   cd4d16: 48 89 5c 24 10                movq    %rbx, 16(%rsp)
+
+  // arm64, function inlined into framefull
+
+  // Target variable in executeInlined
+  // 0x0004336f:     DW_TAG_variable
+  //                   DW_AT_name    ("a")
+  //                   DW_AT_decl_line       (76)
+  //                   DW_AT_type    (0x00000000002425fe "int[5]")
+  //                   DW_AT_location        (0x000862b8: 
+  //                      [0x000000000084a144, 0x000000000084a1e0): DW_OP_fbreg -48)
+
+  // Target variable in testInlinedSumArray
+  // 0x00043395:       DW_TAG_formal_parameter
+  //                     DW_AT_abstract_origin       (0x000000000003ccfe "a")
+  //                     DW_AT_location      (0x000862ec: 
+  //                        [0x000000000084a164, 0x000000000084a1e0): DW_OP_fbreg -88)
+
+  // 000000000084a120 <main.executeInlined>:
+  // sp == x29+8
+  // ; func executeInlined() {
+  //   84a120: 90 0b 40 f9   ldr     x16, [x28, #16]
+  //   84a124: ff 63 30 eb   cmp     sp, x16
+  //   84a128: 29 05 00 54   b.ls    0x84a1cc <main.executeInlined+0xac>
+  // Injection point for executeInlined
+  // array offset == sp+80 == (x29+8)-128+80 == (x29+8)-48
+  //   84a12c: fe 0f 18 f8   str     x30, [sp, #-128]!
+  //   84a130: fd 83 1f f8   stur    x29, [sp, #-8]
+  //   84a134: fd 23 00 d1   sub     x29, sp, #8
+  // ;       a := [5]int{1, 2, 3, 4, 5}
+  //   84a138: 3b 20 00 90   adrp    x27, 0xc4e000 <main.executeMapFuncs+0x798>
+  //   84a13c: 7b 43 23 91   add     x27, x27, #2256
+  //   84a140: 62 0f 40 a9   ldp     x2, x3, [x27]
+  //   84a144: 3b 20 00 90   adrp    x27, 0xc4e000 <main.executeMapFuncs+0x7a4>
+  //   84a148: 7b 83 23 91   add     x27, x27, #2272
+  //   84a14c: 64 17 40 a9   ldp     x4, x5, [x27]
+  //   84a150: e2 0f 05 a9   stp     x2, x3, [sp, #80]
+  //   84a154: e4 17 06 a9   stp     x4, x5, [sp, #96]
+  //   84a158: a2 00 80 d2   mov     x2, #5
+  //   84a15c: e2 3b 00 f9   str     x2, [sp, #112]
+  // ;       y := testInlinedSumArray(a)
+  //   84a160: e2 0f 45 a9   ldp     x2, x3, [sp, #80]
+  //   84a164: e4 17 46 a9   ldp     x4, x5, [sp, #96]
+  //   84a168: e2 8f 02 a9   stp     x2, x3, [sp, #40]
+  //   84a16c: e4 97 03 a9   stp     x4, x5, [sp, #56]
+  //   84a170: e2 3b 40 f9   ldr     x2, [sp, #112]
+  //   84a174: e2 27 00 f9   str     x2, [sp, #72]
+  // ;       return a[0] + a[1] + a[2] + a[3] + a[4]
+  // Injection point for testInlinedSumArray
+  // sp == [sp-8]+8-128 == [sp-8]-120
+  // sp+40 == [sp-8]-120+40 = [sp-8]-80 = ([sp-8]+8)-88
+  //   84a178: e2 17 40 f9   ldr     x2, [sp, #40]
+  //   84a17c: e3 1b 40 f9   ldr     x3, [sp, #48]
+  //   84a180: 62 00 02 8b   add     x2, x3, x2
+  //   84a184: e3 1f 40 f9   ldr     x3, [sp, #56]
+  //   84a188: 62 00 02 8b   add     x2, x3, x2
+  //   84a18c: e3 23 40 f9   ldr     x3, [sp, #64]
+  //   84a190: 62 00 02 8b   add     x2, x3, x2
+  //   84a194: e3 27 40 f9   ldr     x3, [sp, #72]
+  //   84a198: 61 00 02 8b   add     x1, x3, x2
+  //   84a19c: e1 13 00 f9   str     x1, [sp, #32]
+
+  // amd64, frameless function
+
+  // 0x00043f62:     DW_TAG_formal_parameter
+  //                   DW_AT_name    ("x")
+  //                   DW_AT_variable_parameter      (0x00)
+  //                   DW_AT_decl_line       (18)
+  //                   DW_AT_type    (0x0000000000122012 "int32[2]")
+  //                   DW_AT_location        (DW_OP_call_frame_cfa)
+
+  // Call site
+  // ;        ([2]byte{1, 1})
+  //   cd3b3f: 66 c7 04 24 01 01             movw    $257, (%rsp)            # imm = 0x101
+  //   cd3b45: e8 36 fd ff ff                callq   0xcd3880 <main.testByteArray>
+
+  // ; func testByteArray(x [2]byte) {}
+  // Injection point
+  // array offset == %rsp+8 (was ==rsp before a call which pushed 8 bytes on stack)
+  //   cd3880: c3                            retq
+
+  // arm64, frameless function
+
+  // 0x000421c1:     DW_TAG_formal_parameter
+  //                   DW_AT_name    ("x")
+  //                   DW_AT_variable_parameter      (0x00)
+  //                   DW_AT_decl_line       (14)
+  //                   DW_AT_type    (0x000000000011a5e1 "uint8[2]")
+  //                   DW_AT_location        (DW_OP_fbreg +8)
+
+  // Call site
+  // sp == x29+8
+  //   849288: e0 13 00 79   strh    w0, [sp, #8]
+  //   84928c: 9d ff ff 97   bl      0x849100 <main.testByteArray>
+
+  // ; func testByteArray(x [2]byte) {}
+  // Injection point
+  // array offset == sp == x29+8
+  //   849100: c0 03 5f d6   ret
+
+  #if defined(bpf_target_arm64)
+  if (frameless) {
+    return regs->DWARF_BP_REG + 8;
+  } else {
+    uint64_t bp;
+    if (bpf_probe_read_user(&bp, sizeof(bp), (void*)(regs->DWARF_SP_REG-8)) != 0) {
+      return 0;
+    }
+    return bp + 8;
+  }
+  #elif defined(bpf_target_x86)
+  if (frameless) {
+    return regs->DWARF_SP_REG + 8;
+  } else {
+    return regs->DWARF_BP_REG + 16;
+  }
+  #else
+      #error "Unsupported architecture"
+  #endif
+}
+
+#endif // __CFA_H__

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -4,6 +4,7 @@
 #include "bpf_metadata.h"
 #include "bpf_helpers.h"
 #include "bpf_tracing.h"
+#include "cfa.h"
 #include "compiler.h"
 #include "context.h"
 #include "framing.h"
@@ -78,9 +79,9 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   global_ctx.stack_walk->regs = *regs;
   global_ctx.stack_walk->stack.pcs.pcs[0] = regs->DWARF_PC_REG;
 #if defined(bpf_target_x86)
-  bool frameless = *(volatile bool *)&params->frameless;
   global_ctx.stack_walk->stack.fps[0] = regs->DWARF_BP_REG;
-  if (frameless) {
+  if (params->frameless) {
+    // Call instruction saves return address on the stack.
     if (bpf_probe_read_user(&global_ctx.stack_walk->stack.pcs.pcs[1],
                             sizeof(global_ctx.stack_walk->stack.pcs.pcs[1]),
                             (void*)(regs->sp))) {
@@ -90,12 +91,13 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
     global_ctx.stack_walk->idx_shift = 1;
   }
 #elif defined(bpf_target_arm64)
-  // Use the link register to populate the next frame's pc.
-  global_ctx.stack_walk->stack.pcs.pcs[1] = regs->DWARF_REGISTER(30);
-  // For reasons explained below when setting up the cfa, the BP register is
-  // pointing to the caller's frame pointer at this point.
-  global_ctx.stack_walk->stack.fps[1] = regs->DWARF_BP_REG;
-  global_ctx.stack_walk->idx_shift = 1;
+  global_ctx.stack_walk->stack.fps[0] = regs->DWARF_SP_REG - 8;
+  if (params->frameless) {
+    // Call instruction saves return address in the link register.
+    global_ctx.stack_walk->stack.pcs.pcs[1] = regs->DWARF_REGISTER(30);
+    global_ctx.stack_walk->stack.fps[1] = regs->DWARF_SP_REG - 8;
+    global_ctx.stack_walk->idx_shift = 1;
+  }
 #else
   #error "Unsupported architecture"
 #endif
@@ -123,43 +125,7 @@ SEC("uprobe") int probe_run_with_cookie(struct pt_regs* regs) {
   frame_data_t frame_data = {
     .stack_idx = 0,
   };
-// Stack layout is slightly different in Go between arm64 and x86_64.
-// Established based on following documentation and machine code reads:
-// https://tip.golang.org/src/cmd/compile/abi-internal#architecture-specifics
-//
-// There's some trickery to get our hands on the CFA in Go based on whether or
-// not the leaf function is frameless. If it is frameless, then we need to
-// assume that the frame pointer is actually set up for the caller's frame.
-#if defined(bpf_target_arm64)
-// On arm, if the function is framless, the base pointer will be pointing to at
-// the lowest entry of our caller's frame which is almost our CFA. If it's not
-// frameless, then the base pointer will be pointing to the lowest entry of our
-// frame and it needs to be dereferenced to get to the CFA. Fortunately, we
-// already did that dereferencing in the stack walk.
-//
-// Or at least you might think that'd be the situation. Unfortunately, or
-// perhaps fortunately, Go is marking the beginning of the prologue stack
-// adjustment as the end of the prologue. So, when we use the prologue_end
-// marker set by Go in DWARF to find the prologue end, we're actually getting
-// the beginning of the prologue adjustment and can assume the registers are
-// still set up for the caller's frame.
-//
-// See https://github.com/golang/go/issues/74357.
-    *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_BP_REG + 8;
-#elif defined(bpf_target_x86)
-// On x86, if the function is frameless, the stack pointer is pointing to the
-// return pc, so one word above that is our CFA. If it's not frameless, then the
-// base pointer is pointing to our frame pointer which is 16 bytes less than our
-// CFA.
-    if (frameless) {
-      *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_SP_REG + 8;
-    } else {
-      *(volatile uint64_t*)(&frame_data.cfa) = global_ctx.regs->DWARF_BP_REG + 16;
-    }
-#else
-    #error "Unsupported architecture"
-#endif
-
+  frame_data.cfa = calculate_cfa(global_ctx.regs, params->frameless);
   if (params->stack_machine_pc != 0) {
     process_steps = stack_machine_process_frame(&global_ctx, &frame_data,
                                                 params->stack_machine_pc);

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -696,6 +696,10 @@ func waitForLogMessages(
 	{
 		redactors := append(make([]jsonRedactor, 0, len(defaultRedactors)), defaultRedactors...)
 		redactors = append(redactors, redactor(
+			prefixMatcher("/debugger/snapshot/stack"),
+			replacement(`"[stack]"`),
+		))
+		redactors = append(redactors, redactor(
 			prefixSuffixMatcher{
 				"/debugger/snapshot/captures/",
 				"/RemoteAddr/value",

--- a/pkg/dyninst/gosym/symtab_test.go
+++ b/pkg/dyninst/gosym/symtab_test.go
@@ -90,9 +90,9 @@ func runTest(
 		for _, pcr := range sp.OutOfLinePCRanges {
 			pcs = append(pcs, pcr[0], (pcr[0]+pcr[1])/2)
 		}
-		for _, inlinedInstance := range sp.InlinePCRanges {
+		for _, inlined := range sp.InlinePCRanges {
 			inlinedSp = sp
-			for _, pcr := range inlinedInstance {
+			for _, pcr := range inlined.Ranges {
 				pcs = append(pcs, pcr[0], (pcr[0]+pcr[1])/2)
 			}
 		}
@@ -106,7 +106,7 @@ func runTest(
 		}
 	}
 	require.NotNil(t, inlinedSp)
-	pc := inlinedSp.InlinePCRanges[0][0][0]
+	pc := inlinedSp.InlinePCRanges[0].Ranges[0][0]
 	fmt.Fprintf(&out, "FunctionLines: 0x%x\n", pc)
 	lines, err := symtab.FunctionLines(pc)
 	require.NoError(t, err)

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -42,6 +42,16 @@ type Program struct {
 	Issues []ProbeIssue
 }
 
+// InlinePCRanges represent the pc ranges for a single instance of an inlined subprogram.
+// Ranges correspond to the inlined instance itself. RootRanges correspond to the pc ranges
+// of a subprogram at the root of the tree formed by inlined subroutines. E.g. if this is a
+// subprogram A, that has been inlined into subprogram B, and subprogram B has been inlined
+// to a subprogram C, and C is not inlined, then these are pc ranges of C.
+type InlinePCRanges struct {
+	Ranges     []PCRange
+	RootRanges []PCRange
+}
+
 // Subprogram represents a function or method in the program.
 type Subprogram struct {
 	// ID is the ID of the subprogram.
@@ -51,11 +61,11 @@ type Subprogram struct {
 	// OutOfLinePCRanges are the ranges of PC values that will be probed for the
 	// out-of-line-instances of the subprogram. These are sorted by start PC.
 	// Some functions may be inlined only in certain callers, in which case
-	// both OutOfLinePCRanges and InlinePCRanges will be non-empty.
+	// both OutOfLinePCRanges and InlinedPCRanges will be non-empty.
 	OutOfLinePCRanges []PCRange
 	// InlinePCRanges are the ranges of PC values that will be probed for the
 	// inlined instances of the subprogram. These are sorted by start PC.
-	InlinePCRanges [][]PCRange
+	InlinePCRanges []InlinePCRanges
 	// Variables are the variables that are used in the subprogram.
 	Variables []*Variable
 }

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -77,7 +77,7 @@ Subprograms:
             - Range: 0xd31137..0xd31152
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd31152..0xd31239
-              Pieces: [{Size: 8, Op: {CfaOffset: 16256}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       events:
         - ID: 1
           Type: 304 EventRootType Probe[main.HandleHTTP]
-          InjectionPoints: [{PC: "0x8a08d0", Frameless: false}]
+          InjectionPoints: [{PC: "0x8a08d0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
@@ -24,7 +24,7 @@ Probes:
       events:
         - ID: 2
           Type: 305 EventRootType Probe[main.LookAtTheRequest]
-          InjectionPoints: [{PC: "0x8a0bcc", Frameless: false}]
+          InjectionPoints: [{PC: "0x8a0bcc", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -77,7 +77,7 @@ Subprograms:
             - Range: 0x8a0a0c..0x8a0a20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8a0a20..0x8a0af0
-              Pieces: [{Size: 8, Op: {CfaOffset: 16264}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       events:
         - ID: 1
           Type: 219 EventRootType Probe[main.HandleHTTP]
-          InjectionPoints: [{PC: "0x86c110", Frameless: false}]
+          InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
       version: 0
@@ -24,7 +24,7 @@ Probes:
       events:
         - ID: 2
           Type: 220 EventRootType Probe[main.LookAtTheRequest]
-          InjectionPoints: [{PC: "0x86c41c", Frameless: false}]
+          InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -70,7 +70,7 @@ Subprograms:
             - Range: 0x86c254..0x86c268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x86c268..0x86c340
-              Pieces: [{Size: 8, Op: {CfaOffset: 16256}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
           IsParameter: false
           IsReturn: false
         - Name: span

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 99
           Type: 387 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd4a86", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4a86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -362,7 +362,7 @@ Probes:
       events:
         - ID: 100
           Type: 388 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd4b93", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4b93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -376,7 +376,7 @@ Probes:
       events:
         - ID: 101
           Type: 389 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd4c46", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4c46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -395,13 +395,13 @@ Probes:
             - PC: "0xcd47ea"
               Frameless: false
             - PC: "0xcd4871"
-              Frameless: true
+              Frameless: false
             - PC: "0xcd49b2"
-              Frameless: true
+              Frameless: false
             - PC: "0xcd4a3c"
-              Frameless: true
+              Frameless: false
             - PC: "0xcd4b0f"
-              Frameless: true
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -415,7 +415,7 @@ Probes:
       events:
         - ID: 102
           Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd4ca1", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4ca1", Frameless: false}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -432,9 +432,9 @@ Probes:
           Type: 391 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd4ce5"
-              Frameless: true
+              Frameless: false
             - PC: "0xcd4d85"
-              Frameless: true
+              Frameless: false
           Condition: null
     - id: testInt16Array
       version: 0
@@ -2034,9 +2034,9 @@ Subprograms:
           Type: 1 BaseType int
           Locations:
             - Range: 0xcd4bdb..0xcd4be5
-              Pieces: [{Size: 8, Op: {CfaOffset: 16304}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
             - Range: 0xcd4be5..0xcd4c00
-              Pieces: [{Size: 8, Op: {CfaOffset: 16304}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
             - Range: 0xcd4c00..0xcd4c14
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
@@ -2045,9 +2045,9 @@ Subprograms:
           Type: 1 BaseType int
           Locations:
             - Range: 0xcd4bd6..0xcd4be0
-              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0xcd4be0..0xcd4c00
-              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0xcd4c00..0xcd4c0f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
@@ -2125,19 +2125,19 @@ Subprograms:
             - Range: 0xcd5022..0xcd503b
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd503b..0xcd5045
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {CfaOffset: -136}
             - Range: 0xcd5045..0xcd522d
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {CfaOffset: -136}
           IsParameter: false
@@ -2154,19 +2154,19 @@ Subprograms:
             - Range: 0xcd5082..0xcd509c
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16256}
+                  Op: {CfaOffset: -128}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd509c..0xcd50a5
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16256}
+                  Op: {CfaOffset: -128}
                 - Size: 8
                   Op: {CfaOffset: -160}
             - Range: 0xcd50a5..0xcd522d
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16256}
+                  Op: {CfaOffset: -128}
                 - Size: 8
                   Op: {CfaOffset: -160}
           IsParameter: false
@@ -2183,19 +2183,19 @@ Subprograms:
             - Range: 0xcd50e2..0xcd50fc
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd50fc..0xcd5105
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {CfaOffset: -152}
             - Range: 0xcd5105..0xcd522d
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {CfaOffset: -152}
           IsParameter: false
@@ -2212,19 +2212,19 @@ Subprograms:
             - Range: 0xcd5142..0xcd516a
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd516a..0xcd516f
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {CfaOffset: -144}
             - Range: 0xcd516f..0xcd522d
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {CfaOffset: -144}
           IsParameter: false
@@ -3149,7 +3149,7 @@ Subprograms:
             - Range: 0xcd4ccd..0xcd4d03
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
             - Range: 0xcd4d6c..0xcd4ea5
-              Pieces: [{Size: 40, Op: {CfaOffset: 16256}}]
+              Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
 Types:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 81
-          Type: 368 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd7d2a", Frameless: false}]
+        - ID: 87
+          Type: 375 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd7f4a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 302 EventRootType Probe[main.testArrayOfArrays]
+          Type: 303 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd3a40", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -36,10 +36,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 304 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd3a80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -50,11 +50,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 46
-          Type: 333 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd5320", Frameless: true}]
+        - ID: 52
+          Type: 340 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -64,10 +64,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 303 EventRootType Probe[main.testArrayOfStrings]
+          Type: 304 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd3a60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -78,10 +78,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 322 EventRootType Probe[main.testBigStruct]
+          Type: 323 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -92,10 +92,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 291 EventRootType Probe[main.testBoolArray]
+          Type: 292 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd38e0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -106,10 +106,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 288 EventRootType Probe[main.testByteArray]
+          Type: 289 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd3880", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -120,11 +120,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 62
-          Type: 349 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd6fe0", Frameless: true}]
+        - ID: 68
+          Type: 356 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd7200", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 60
-          Type: 347 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd6c00", Frameless: true}]
+        - ID: 66
+          Type: 354 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd6e20", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 70
-          Type: 357 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd73a0", Frameless: true}]
+        - ID: 76
+          Type: 364 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd75c0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 72
-          Type: 359 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd78e0", Frameless: true}]
+        - ID: 78
+          Type: 366 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd7b00", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 75
-          Type: 362 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7940", Frameless: true}]
+        - ID: 81
+          Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd7b60", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 89
-          Type: 376 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd7e60", Frameless: true}]
+        - ID: 95
+          Type: 383 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 91
-          Type: 378 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd8260", Frameless: true}]
+        - ID: 97
+          Type: 385 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 39
-          Type: 326 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd5020", Frameless: true}]
+        - ID: 45
+          Type: 333 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcd5240", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -232,10 +232,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 324 EventRootType Probe[main.testEsotericHeap]
+          Type: 325 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd454a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -246,13 +246,83 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 323 EventRootType Probe[main.testEsotericStack]
+          Type: 324 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd442e", Frameless: false}]
           Condition: null
-    - id: testInlinedBBC
+    - id: testFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFrameless}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 48}
+      events:
+        - ID: 42
+          Type: 330 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
+          Condition: null
+    - id: testFramelessArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFramelessArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 49}
+      events:
+        - ID: 43
+          Type: 331 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcd4cc4", Frameless: false}]
+          Condition: null
+    - id: testInlinedBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 38
+          Type: 326 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcd498a", Frameless: false}]
+          Condition: null
+    - id: testInlinedBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 45}
+      events:
+        - ID: 39
+          Type: 327 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcd4a2e", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 46}
+      events:
+        - ID: 40
+          Type: 328 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcd4b0a", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
@@ -262,22 +332,65 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 93
-          Type: 380 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd4a38", Frameless: true}]
+        - ID: 99
+          Type: 387 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcd4a86", Frameless: true}]
+          Condition: null
+    - id: testInlinedBC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 47}
+      events:
+        - ID: 41
+          Type: 329 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcd4b8e", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 100
+          Type: 388 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcd4b93", Frameless: true}]
+          Condition: null
+    - id: testInlinedBCB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 101
+          Type: 389 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcd4c46", Frameless: true}]
           Condition: null
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 92
-          Type: 379 EventRootType Probe[main.testInlinedPrint]
+        - ID: 98
+          Type: 386 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd47ea"
               Frameless: false
@@ -285,7 +398,42 @@ Probes:
               Frameless: true
             - PC: "0xcd49b2"
               Frameless: true
-            - PC: "0xcd4aaf"
+            - PC: "0xcd4a3c"
+              Frameless: true
+            - PC: "0xcd4b0f"
+              Frameless: true
+          Condition: null
+    - id: testInlinedSq
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSq}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 102
+          Type: 390 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcd4ca1", Frameless: true}]
+          Condition: null
+    - id: testInlinedSumArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSumArray}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 103
+          Type: 391 EventRootType Probe[main.testInlinedSumArray]
+          InjectionPoints:
+            - PC: "0xcd4ce5"
+              Frameless: true
+            - PC: "0xcd4d85"
               Frameless: true
           Condition: null
     - id: testInt16Array
@@ -296,10 +444,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 294 EventRootType Probe[main.testInt16Array]
+          Type: 295 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd3940", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -310,10 +458,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 295 EventRootType Probe[main.testInt32Array]
+          Type: 296 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd3960", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -324,10 +472,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 296 EventRootType Probe[main.testInt64Array]
+          Type: 297 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd3980", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -338,10 +486,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 293 EventRootType Probe[main.testInt8Array]
+          Type: 294 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd3920", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -352,10 +500,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 292 EventRootType Probe[main.testIntArray]
+          Type: 293 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd3900", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -366,11 +514,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 38
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd4d93", Frameless: false}]
+        - ID: 44
+          Type: 332 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcd4fb3", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -380,11 +528,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 64
-          Type: 351 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd71c0", Frameless: true}]
+        - ID: 70
+          Type: 358 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd73e0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -394,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 44
-          Type: 331 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd52e0", Frameless: true}]
+        - ID: 50
+          Type: 338 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -408,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 50
-          Type: 337 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd53a0", Frameless: true}]
+        - ID: 56
+          Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -422,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 48
-          Type: 335 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd5360", Frameless: true}]
+        - ID: 54
+          Type: 342 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -436,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 59
-          Type: 346 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd54c0", Frameless: true}]
+        - ID: 65
+          Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -450,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 58
-          Type: 345 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
+        - ID: 64
+          Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -464,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 49
-          Type: 336 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd5380", Frameless: true}]
+        - ID: 55
+          Type: 343 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -478,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 57
-          Type: 344 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd5480", Frameless: true}]
+        - ID: 63
+          Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -492,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 56
-          Type: 343 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5460", Frameless: true}]
+        - ID: 62
+          Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -506,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 42
-          Type: 329 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd52a0", Frameless: true}]
+        - ID: 48
+          Type: 336 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd54c0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -520,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 43
-          Type: 330 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd52c0", Frameless: true}]
+        - ID: 49
+          Type: 337 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd54e0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -534,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 41
-          Type: 328 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd5280", Frameless: true}]
+        - ID: 47
+          Type: 335 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -548,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 51
-          Type: 338 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd53c0", Frameless: true}]
+        - ID: 57
+          Type: 345 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd55e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -562,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 54
-          Type: 341 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd5420", Frameless: true}]
+        - ID: 60
+          Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -576,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 55
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd5440", Frameless: true}]
+        - ID: 61
+          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -590,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 52
-          Type: 339 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd53e0", Frameless: true}]
+        - ID: 58
+          Type: 346 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -604,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 53
-          Type: 340 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd5400", Frameless: true}]
+        - ID: 59
+          Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -618,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 87
-          Type: 374 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd7e20", Frameless: true}]
+        - ID: 93
+          Type: 381 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -632,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 61
-          Type: 348 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd6dc0", Frameless: true}]
+        - ID: 67
+          Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd6fe0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -646,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 69
-          Type: 356 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd7360", Frameless: true}]
+        - ID: 75
+          Type: 363 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd7580", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -660,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 79
-          Type: 366 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
+        - ID: 85
+          Type: 373 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd7be0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -674,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 76
-          Type: 363 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7960", Frameless: true}]
+        - ID: 82
+          Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd7b80", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -688,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 78
-          Type: 365 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd79a0", Frameless: true}]
+        - ID: 84
+          Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd7bc0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -702,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 86
-          Type: 373 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd7e00", Frameless: true}]
+        - ID: 92
+          Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -716,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 65
-          Type: 352 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd71e0", Frameless: true}]
+        - ID: 71
+          Type: 359 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd7400", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -730,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 47
-          Type: 334 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd5340", Frameless: true}]
+        - ID: 53
+          Type: 341 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -744,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 63
-          Type: 350 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd71a0", Frameless: true}]
+        - ID: 69
+          Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd73c0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -758,10 +906,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 289 EventRootType Probe[main.testRuneArray]
+          Type: 290 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd38a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -772,10 +920,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 308 EventRootType Probe[main.testSingleBool]
+          Type: 309 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -786,10 +934,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 306 EventRootType Probe[main.testSingleByte]
+          Type: 307 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd3e60", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -800,10 +948,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 319 EventRootType Probe[main.testSingleFloat32]
+          Type: 320 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4000", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -814,10 +962,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 320 EventRootType Probe[main.testSingleFloat64]
+          Type: 321 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd4020", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -828,10 +976,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 309 EventRootType Probe[main.testSingleInt]
+          Type: 310 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd3ec0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -842,10 +990,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 311 EventRootType Probe[main.testSingleInt16]
+          Type: 312 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd3f00", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -856,10 +1004,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 312 EventRootType Probe[main.testSingleInt32]
+          Type: 313 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd3f20", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -870,10 +1018,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 313 EventRootType Probe[main.testSingleInt64]
+          Type: 314 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd3f40", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -884,10 +1032,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 310 EventRootType Probe[main.testSingleInt8]
+          Type: 311 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd3ee0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -898,10 +1046,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 307 EventRootType Probe[main.testSingleRune]
+          Type: 308 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd3e80", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -912,11 +1060,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 82
-          Type: 369 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd7d80", Frameless: true}]
+        - ID: 88
+          Type: 376 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -926,10 +1074,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 314 EventRootType Probe[main.testSingleUint]
+          Type: 315 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd3f60", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -940,10 +1088,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 316 EventRootType Probe[main.testSingleUint16]
+          Type: 317 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd3fa0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -954,10 +1102,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 317 EventRootType Probe[main.testSingleUint32]
+          Type: 318 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd3fc0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -968,10 +1116,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 318 EventRootType Probe[main.testSingleUint64]
+          Type: 319 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd3fe0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -982,10 +1130,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 315 EventRootType Probe[main.testSingleUint8]
+          Type: 316 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd3f80", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -996,11 +1144,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 73
-          Type: 360 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd7900", Frameless: true}]
+        - ID: 79
+          Type: 367 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd7b20", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1010,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 45
-          Type: 332 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd5300", Frameless: true}]
+        - ID: 51
+          Type: 339 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1024,10 +1172,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 290 EventRootType Probe[main.testStringArray]
+          Type: 291 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd38c0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1038,11 +1186,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 68
-          Type: 355 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd7320", Frameless: true}]
+        - ID: 74
+          Type: 362 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd7540", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1052,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 77
-          Type: 364 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd7980", Frameless: true}]
+        - ID: 83
+          Type: 371 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd7ba0", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1066,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 90
-          Type: 377 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd80e0", Frameless: true}]
+        - ID: 96
+          Type: 384 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd8300", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1080,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 74
-          Type: 361 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd7920", Frameless: true}]
+        - ID: 80
+          Type: 368 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd7b40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1094,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 40
-          Type: 327 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd5260", Frameless: true}]
+        - ID: 46
+          Type: 334 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd5480", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1108,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 83
-          Type: 370 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd7da0", Frameless: true}]
+        - ID: 89
+          Type: 377 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1122,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 84
-          Type: 371 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd7dc0", Frameless: true}]
+        - ID: 90
+          Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1136,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 85
-          Type: 372 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd7de0", Frameless: true}]
+        - ID: 91
+          Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1150,10 +1298,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 321 EventRootType Probe[main.testTypeAlias]
+          Type: 322 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4040", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1164,10 +1312,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 299 EventRootType Probe[main.testUint16Array]
+          Type: 300 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd39e0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1178,10 +1326,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 300 EventRootType Probe[main.testUint32Array]
+          Type: 301 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd3a00", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1192,10 +1340,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 301 EventRootType Probe[main.testUint64Array]
+          Type: 302 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd3a20", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1206,10 +1354,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 298 EventRootType Probe[main.testUint8Array]
+          Type: 299 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd39c0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1220,10 +1368,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 297 EventRootType Probe[main.testUintArray]
+          Type: 298 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd39a0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1234,11 +1382,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 67
-          Type: 354 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd7240", Frameless: true}]
+        - ID: 73
+          Type: 361 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1248,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 71
-          Type: 358 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd78c0", Frameless: true}]
+        - ID: 77
+          Type: 365 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd7ae0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1262,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 88
-          Type: 375 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd7e40", Frameless: true}]
+        - ID: 94
+          Type: 382 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1276,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 66
-          Type: 353 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd7200", Frameless: true}]
+        - ID: 72
+          Type: 360 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd7420", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1290,10 +1438,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 305 EventRootType Probe[main.testVeryLargeArray]
+          Type: 306 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd3ae0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1304,266 +1452,266 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 80
-          Type: 367 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd79e0", Frameless: true}]
+        - ID: 86
+          Type: 374 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd7c00", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 3
+    - ID: 7
       Name: main.testByteArray
       OutOfLinePCRanges: [0xcd3880..0xcd3881]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 2 ArrayType [2]uint8
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0xcd3880..0xcd3881
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 4
+    - ID: 8
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd38a0..0xcd38a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 ArrayType [2]int32
+          Type: 5 ArrayType [2]int32
           Locations:
             - Range: 0xcd38a0..0xcd38a1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 9
       Name: main.testStringArray
       OutOfLinePCRanges: [0xcd38c0..0xcd38c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 ArrayType [2]string
+          Type: 7 ArrayType [2]string
           Locations:
             - Range: 0xcd38c0..0xcd38c1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 10
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd38e0..0xcd38e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 9 ArrayType [2]bool
+          Type: 10 ArrayType [2]bool
           Locations:
             - Range: 0xcd38e0..0xcd38e1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 11
       Name: main.testIntArray
       OutOfLinePCRanges: [0xcd3900..0xcd3901]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 ArrayType [2]int
+          Type: 12 ArrayType [2]int
           Locations:
             - Range: 0xcd3900..0xcd3901
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 12
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xcd3920..0xcd3921]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int8
+          Type: 13 ArrayType [2]int8
           Locations:
             - Range: 0xcd3920..0xcd3921
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 13
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xcd3940..0xcd3941]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 ArrayType [2]int16
+          Type: 15 ArrayType [2]int16
           Locations:
             - Range: 0xcd3940..0xcd3941
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 14
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xcd3960..0xcd3961]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 ArrayType [2]int32
+          Type: 5 ArrayType [2]int32
           Locations:
             - Range: 0xcd3960..0xcd3961
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 15
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xcd3980..0xcd3981]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 ArrayType [2]int64
+          Type: 17 ArrayType [2]int64
           Locations:
             - Range: 0xcd3980..0xcd3981
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 16
       Name: main.testUintArray
       OutOfLinePCRanges: [0xcd39a0..0xcd39a1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 ArrayType [2]uint
+          Type: 19 ArrayType [2]uint
           Locations:
             - Range: 0xcd39a0..0xcd39a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 17
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xcd39c0..0xcd39c1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 2 ArrayType [2]uint8
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0xcd39c0..0xcd39c1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 18
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xcd39e0..0xcd39e1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 ArrayType [2]uint16
+          Type: 21 ArrayType [2]uint16
           Locations:
             - Range: 0xcd39e0..0xcd39e1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 19
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xcd3a00..0xcd3a01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 ArrayType [2]uint32
+          Type: 23 ArrayType [2]uint32
           Locations:
             - Range: 0xcd3a00..0xcd3a01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 20
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd3a20..0xcd3a21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 ArrayType [2]uint64
+          Type: 25 ArrayType [2]uint64
           Locations:
             - Range: 0xcd3a20..0xcd3a21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 21
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xcd3a40..0xcd3a41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 26 ArrayType [2][2]int
+          Type: 27 ArrayType [2][2]int
           Locations:
             - Range: 0xcd3a40..0xcd3a41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 22
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xcd3a60..0xcd3a61]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 6 ArrayType [2]string
+          Type: 7 ArrayType [2]string
           Locations:
             - Range: 0xcd3a60..0xcd3a61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 23
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xcd3a80..0xcd3a81]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 27 ArrayType [2][2][2]int
+          Type: 28 ArrayType [2][2][2]int
           Locations:
             - Range: 0xcd3a80..0xcd3a81
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 24
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xcd3ae0..0xcd3ae1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 28 ArrayType [100]uint
+          Type: 29 ArrayType [100]uint
           Locations:
             - Range: 0xcd3ae0..0xcd3ae1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 25
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xcd3e60..0xcd3e61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0xcd3e60..0xcd3e61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 26
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd3e80..0xcd3e81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
           Locations:
             - Range: 0xcd3e80..0xcd3e81
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 27
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xcd3ea0..0xcd3ea1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
           Locations:
             - Range: 0xcd3ea0..0xcd3ea1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 28
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd3ec0..0xcd3ec1]
       InlinePCRanges: []
@@ -1575,157 +1723,157 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 29
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xcd3ee0..0xcd3ee1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 BaseType int8
+          Type: 14 BaseType int8
           Locations:
             - Range: 0xcd3ee0..0xcd3ee1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 30
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xcd3f00..0xcd3f01]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 BaseType int16
+          Type: 16 BaseType int16
           Locations:
             - Range: 0xcd3f00..0xcd3f01
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 31
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xcd3f20..0xcd3f21]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
           Locations:
             - Range: 0xcd3f20..0xcd3f21
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 32
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xcd3f40..0xcd3f41]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 BaseType int64
+          Type: 18 BaseType int64
           Locations:
             - Range: 0xcd3f40..0xcd3f41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 33
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xcd3f60..0xcd3f61]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
           Locations:
             - Range: 0xcd3f60..0xcd3f61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 34
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd3f80..0xcd3f81]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0xcd3f80..0xcd3f81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 35
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xcd3fa0..0xcd3fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
           Locations:
             - Range: 0xcd3fa0..0xcd3fa1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 36
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xcd3fc0..0xcd3fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
           Locations:
             - Range: 0xcd3fc0..0xcd3fc1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 37
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xcd3fe0..0xcd3fe1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
           Locations:
             - Range: 0xcd3fe0..0xcd3fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 38
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xcd4000..0xcd4001]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 29 BaseType float32
+          Type: 30 BaseType float32
           Locations:
             - Range: 0xcd4000..0xcd4001
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 39
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xcd4020..0xcd4021]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float64
+          Type: 31 BaseType float64
           Locations:
             - Range: 0xcd4020..0xcd4021
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 40
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xcd4040..0xcd4041]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType main.typeAlias
+          Type: 32 BaseType main.typeAlias
           Locations:
             - Range: 0xcd4040..0xcd4041
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 41
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xcd41a0..0xcd41bf]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 32 StructureType main.bigStruct
+          Type: 33 StructureType main.bigStruct
           Locations:
             - Range: 0xcd41a0..0xcd41bf
               Pieces:
@@ -1743,13 +1891,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 42
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xcd4420..0xcd4525]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 57 StructureType main.esotericStack
           Locations:
             - Range: 0xcd4420..0xcd4473
               Pieces:
@@ -1813,33 +1961,146 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 43
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xcd4540..0xcd45a3]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 62 PointerType *main.esotericHeap
+          Type: 63 PointerType *main.esotericHeap
           Locations:
             - Range: 0xcd4540..0xcd456d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 44
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xcd4980..0xcd4a08]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4980..0xcd4995
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 45
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xcd4a20..0xcd4ae5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4a20..0xcd4a36
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4a20..0xcd4a47
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4a36..0xcd4a47
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd4a47..0xcd4ae5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 46
+      Name: main.testInlinedBBA
+      OutOfLinePCRanges: [0xcd4b00..0xcd4b62]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4b00..0xcd4b1a
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 47
+      Name: main.testInlinedBC
+      OutOfLinePCRanges: [0xcd4b80..0xcd4c8e]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4bdb..0xcd4be5
+              Pieces: [{Size: 8, Op: {CfaOffset: 16304}}]
+            - Range: 0xcd4be5..0xcd4c00
+              Pieces: [{Size: 8, Op: {CfaOffset: 16304}}]
+            - Range: 0xcd4c00..0xcd4c14
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4bd6..0xcd4be0
+              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+            - Range: 0xcd4be0..0xcd4c00
+              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+            - Range: 0xcd4c00..0xcd4c0f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 48
+      Name: main.testFrameless
+      OutOfLinePCRanges: [0xcd4ca0..0xcd4ca6]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4ca0..0xcd4ca5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0xcd4ca0..0xcd4ca6, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 49
+      Name: main.testFramelessArray
+      OutOfLinePCRanges: [0xcd4cc0..0xcd4d03]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0xcd4cc0..0xcd4d03
+              Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0xcd4cc0..0xcd4d03, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd4d80..0xcd500d]
+      OutOfLinePCRanges: [0xcd4fa0..0xcd522d]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 75 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd4d80..0xcd4dbe
+            - Range: 0xcd4fa0..0xcd4fde
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd4dbe..0xcd4dc5
+            - Range: 0xcd4fde..0xcd4fe5
               Pieces:
                 - Size: 8
                   Op: null
@@ -1848,32 +2109,32 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 7 GoStringHeaderType string
-          Locations: [{Range: 0xcd4d80..0xcd500d, Pieces: []}]
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xcd4fa0..0xcd522d, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: hash
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd4dfd..0xcd4e02
+            - Range: 0xcd501d..0xcd5022
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xcd4e02..0xcd4e1b
+            - Range: 0xcd5022..0xcd503b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd4e1b..0xcd4e25
+            - Range: 0xcd503b..0xcd5045
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
                 - Size: 8
                   Op: {CfaOffset: -136}
-            - Range: 0xcd4e25..0xcd500d
+            - Range: 0xcd5045..0xcd522d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
@@ -1882,27 +2143,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: inter
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd4e5d..0xcd4e62
+            - Range: 0xcd507d..0xcd5082
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xcd4e62..0xcd4e7c
+            - Range: 0xcd5082..0xcd509c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16256}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd4e7c..0xcd4e85
+            - Range: 0xcd509c..0xcd50a5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16256}
                 - Size: 8
                   Op: {CfaOffset: -160}
-            - Range: 0xcd4e85..0xcd500d
+            - Range: 0xcd50a5..0xcd522d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16256}
@@ -1911,27 +2172,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: iType
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd4ebd..0xcd4ec2
+            - Range: 0xcd50dd..0xcd50e2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xcd4ec2..0xcd4edc
+            - Range: 0xcd50e2..0xcd50fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd4edc..0xcd4ee5
+            - Range: 0xcd50fc..0xcd5105
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
                 - Size: 8
                   Op: {CfaOffset: -152}
-            - Range: 0xcd4ee5..0xcd500d
+            - Range: 0xcd5105..0xcd522d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
@@ -1940,27 +2201,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: iFun
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd4f1d..0xcd4f22
+            - Range: 0xcd513d..0xcd5142
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0xcd4f22..0xcd4f4a
+            - Range: 0xcd5142..0xcd516a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd4f4a..0xcd4f4f
+            - Range: 0xcd516a..0xcd516f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
                 - Size: 8
                   Op: {CfaOffset: -144}
-            - Range: 0xcd4f4f..0xcd500d
+            - Range: 0xcd516f..0xcd522d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
@@ -1968,15 +2229,15 @@ Subprograms:
                   Op: {CfaOffset: -144}
           IsParameter: false
           IsReturn: false
-    - ID: 41
+    - ID: 51
       Name: main.testError
-      OutOfLinePCRanges: [0xcd5020..0xcd5021]
+      OutOfLinePCRanges: [0xcd5240..0xcd5241]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 75 GoInterfaceType error
+          Type: 76 GoInterfaceType error
           Locations:
-            - Range: 0xcd5020..0xcd5021
+            - Range: 0xcd5240..0xcd5241
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1984,548 +2245,498 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
-      Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd5260..0xcd5261]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 76 StructureType main.structWithMap
-          Locations:
-            - Range: 0xcd5260..0xcd5261
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 43
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd5280..0xcd5281]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 88 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0xcd5280..0xcd5281
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 44
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd52a0..0xcd52a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd52a0..0xcd52a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 45
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd52c0..0xcd52c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd52c0..0xcd52c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd52e0..0xcd52e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 123 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd52e0..0xcd52e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 47
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd5300..0xcd5301]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd5300..0xcd5301
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd5320..0xcd5321]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 135 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0xcd5320..0xcd5321
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd5340..0xcd5341]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 136 PointerType *map[string]int
-          Locations:
-            - Range: 0xcd5340..0xcd5341
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd5360..0xcd5361]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 77 GoMapType map[int]int
-          Locations:
-            - Range: 0xcd5360..0xcd5361
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd5380..0xcd5381]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 137 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcd5380..0xcd5381
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
     - ID: 52
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcd53a0..0xcd53a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 137 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0xcd53a0..0xcd53a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 53
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcd53c0..0xcd53c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 150 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0xcd53c0..0xcd53c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcd53e0..0xcd53e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 163 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcd53e0..0xcd53e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcd5400..0xcd5401]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 163 GoMapType map[int]uint8
-          Locations:
-            - Range: 0xcd5400..0xcd5401
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcd5420..0xcd5421]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcd5420..0xcd5421
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcd5440..0xcd5441]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcd5440..0xcd5441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcd5460..0xcd5461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 174 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcd5460..0xcd5461
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testMapSmallKeyLargeValue
+      Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcd5480..0xcd5481]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 185 GoMapType map[uint8][4]int
+        - Name: s
+          Type: 77 StructureType main.structWithMap
           Locations:
             - Range: 0xcd5480..0xcd5481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
-      Name: main.testMapLargeKeySmallValue
+    - ID: 53
+      Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 197 GoMapType map[[4]int]uint8
+          Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd54a0..0xcd54a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 54
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd54c0..0xcd54c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 208 GoMapType map[[4]int][4]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcd54c0..0xcd54c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd6c00..0xcd6c01]
+    - ID: 55
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0xcd54e0..0xcd54e1]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 3 BaseType uint8
+        - Name: m
+          Type: 112 GoMapType map[string][]string
           Locations:
-            - Range: 0xcd6c00..0xcd6c01
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd54e0..0xcd54e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: x
-          Type: 3 BaseType uint8
+    - ID: 56
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0xcd5500..0xcd5501]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 124 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcd6c00..0xcd6c01
-              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd5500..0xcd5501
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-        - Name: y
-          Type: 29 BaseType float32
+    - ID: 57
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0xcd5520..0xcd5521]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0xcd6c00..0xcd6c01
-              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+            - Range: 0xcd5520..0xcd5521
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 58
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0xcd5540..0xcd5541]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0xcd5540..0xcd5541
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 59
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0xcd5560..0xcd5561]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 137 PointerType *map[string]int
+          Locations:
+            - Range: 0xcd5560..0xcd5561
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 60
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0xcd5580..0xcd5581]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 78 GoMapType map[int]int
+          Locations:
+            - Range: 0xcd5580..0xcd5581
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 61
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0xcd55a0..0xcd55a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 138 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcd55a0..0xcd55a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 62
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0xcd55c0..0xcd55c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0xcd55c0..0xcd55c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd6dc0..0xcd6dc1]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0xcd55e0..0xcd55e1]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 10 BaseType bool
+        - Name: m
+          Type: 151 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcd6dc0..0xcd6dc1
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: b
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0xcd6dc0..0xcd6dc1
-              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: c
-          Type: 5 BaseType int32
-          Locations:
-            - Range: 0xcd6dc0..0xcd6dc1
-              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: d
-          Type: 19 BaseType uint
-          Locations:
-            - Range: 0xcd6dc0..0xcd6dc1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: e
-          Type: 7 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd6dc0..0xcd6dc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 8, Shift: 0}
+            - Range: 0xcd55e0..0xcd55e1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testChannel
-      OutOfLinePCRanges: [0xcd6fe0..0xcd6fe1]
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0xcd5600..0xcd5601]
       InlinePCRanges: []
       Variables:
-        - Name: c
-          Type: 219 GoChannelType chan bool
+        - Name: m
+          Type: 164 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
-              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5600..0xcd5601
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd71a0..0xcd71a1]
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0xcd5620..0xcd5621]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 220 PointerType *main.structWithTwoValues
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd71a0..0xcd71a1
+            - Range: 0xcd5620..0xcd5621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd71c0..0xcd71c1]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd5640..0xcd5641]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 161 StructureType main.node
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd71c0..0xcd71c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd5640..0xcd5641
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
-      Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd71e0..0xcd71e1]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd5660..0xcd5661]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 162 PointerType *main.node
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd71e0..0xcd71e1
+            - Range: 0xcd5660..0xcd5661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 68
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd7200..0xcd7201]
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd5680..0xcd5681]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 55 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd7200..0xcd7201
+            - Range: 0xcd5680..0xcd5681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 69
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd7240..0xcd7241]
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd56a0..0xcd56a1]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 222 PointerType *uint
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcd7240..0xcd7241
+            - Range: 0xcd56a0..0xcd56a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 70
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd7320..0xcd7321]
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd56c0..0xcd56c1]
       InlinePCRanges: []
       Variables:
-        - Name: z
-          Type: 35 PointerType *string
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcd7320..0xcd7321
+            - Range: 0xcd56c0..0xcd56c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 71
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd7360..0xcd7361]
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd56e0..0xcd56e1]
       InlinePCRanges: []
       Variables:
-        - Name: z
-          Type: 223 PointerType *bool
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcd7360..0xcd7361
+            - Range: 0xcd56e0..0xcd56e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 19 BaseType uint
-          Locations:
-            - Range: 0xcd7360..0xcd7361
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testCycle
-      OutOfLinePCRanges: [0xcd73a0..0xcd73a1]
+      Name: main.testCombinedByte
+      OutOfLinePCRanges: [0xcd6e20..0xcd6e21]
       InlinePCRanges: []
       Variables:
-        - Name: t
-          Type: 224 PointerType *main.t
+        - Name: w
+          Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd73a0..0xcd73a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd6e20..0xcd6e21
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xcd6e20..0xcd6e21
+              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0xcd6e20..0xcd6e21
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd78c0..0xcd78c1]
+      Name: main.testMultipleSimpleParams
+      OutOfLinePCRanges: [0xcd6fe0..0xcd6fe1]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 227 GoSliceHeaderType []uint
+        - Name: a
+          Type: 11 BaseType bool
           Locations:
-            - Range: 0xcd78c0..0xcd78c1
+            - Range: 0xcd6fe0..0xcd6fe1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0xcd6fe0..0xcd6fe1
+              Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0xcd6fe0..0xcd6fe1
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xcd6fe0..0xcd6fe1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd6fe0..0xcd6fe1
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 4, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+                  Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 74
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd78e0..0xcd78e1]
+      Name: main.testChannel
+      OutOfLinePCRanges: [0xcd7200..0xcd7201]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 227 GoSliceHeaderType []uint
+        - Name: c
+          Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0xcd78e0..0xcd78e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd7200..0xcd7201
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd7900..0xcd7901]
+      Name: main.testPointerToSimpleStruct
+      OutOfLinePCRanges: [0xcd73c0..0xcd73c1]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 228 GoSliceHeaderType [][]uint
+        - Name: a
+          Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd7900..0xcd7901
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd73c0..0xcd73c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 76
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd7920..0xcd7921]
+      Name: main.testLinkedList
+      OutOfLinePCRanges: [0xcd73e0..0xcd73e1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
+        - Name: a
+          Type: 162 StructureType main.node
           Locations:
-            - Range: 0xcd7920..0xcd7921
+            - Range: 0xcd73e0..0xcd73e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7920..0xcd7921
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 77
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd7940..0xcd7941]
+      Name: main.testPointerLoop
+      OutOfLinePCRanges: [0xcd7400..0xcd7401]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7940..0xcd7941
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 163 PointerType *main.node
           Locations:
-            - Range: 0xcd7940..0xcd7941
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcd7400..0xcd7401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 78
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd7960..0xcd7961]
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0xcd7420..0xcd7421]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 56 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0xcd7420..0xcd7421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 79
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0xcd7460..0xcd7461]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 223 PointerType *uint
+          Locations:
+            - Range: 0xcd7460..0xcd7461
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 80
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0xcd7540..0xcd7541]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 36 PointerType *string
+          Locations:
+            - Range: 0xcd7540..0xcd7541
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 81
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0xcd7580..0xcd7581]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 224 PointerType *bool
+          Locations:
+            - Range: 0xcd7580..0xcd7581
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0xcd7580..0xcd7581
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 82
+      Name: main.testCycle
+      OutOfLinePCRanges: [0xcd75c0..0xcd75c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 225 PointerType *main.t
+          Locations:
+            - Range: 0xcd75c0..0xcd75c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 83
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd7ae0..0xcd7ae1]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd7ae0..0xcd7ae1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 84
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd7b00..0xcd7b01]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd7b00..0xcd7b01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 85
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcd7b20..0xcd7b21]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 229 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcd7b20..0xcd7b21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 86
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd7b40..0xcd7b41]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd7960..0xcd7961
+            - Range: 0xcd7b40..0xcd7b41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2538,19 +2749,19 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd7960..0xcd7961
+            - Range: 0xcd7b40..0xcd7b41
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcd7980..0xcd7981]
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd7b60..0xcd7b61]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 122 GoSliceHeaderType []string
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd7980..0xcd7981
+            - Range: 0xcd7b60..0xcd7b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2560,22 +2771,72 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7b60..0xcd7b61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd7b80..0xcd7b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd7b80..0xcd7b81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7b80..0xcd7b81
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd7ba0..0xcd7ba1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 123 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd7ba0..0xcd7ba1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd79a0..0xcd79a1]
+      OutOfLinePCRanges: [0xcd7bc0..0xcd7bc1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 13 BaseType int8
+          Type: 14 BaseType int8
           Locations:
-            - Range: 0xcd79a0..0xcd79a1
+            - Range: 0xcd7bc0..0xcd7bc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 233 GoSliceHeaderType []bool
+          Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd79a0..0xcd79a1
+            - Range: 0xcd7bc0..0xcd7bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -2586,21 +2847,21 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd79a0..0xcd79a1
+            - Range: 0xcd7bc0..0xcd7bc1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 91
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd79c0..0xcd79c1]
+      OutOfLinePCRanges: [0xcd7be0..0xcd7be1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 234 GoSliceHeaderType []uint16
+          Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd79c0..0xcd79c1
+            - Range: 0xcd7be0..0xcd7be1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2610,15 +2871,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 92
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd79e0..0xcd79e1]
+      OutOfLinePCRanges: [0xcd7c00..0xcd7c01]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []uint
+          Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd79e0..0xcd79e1
+            - Range: 0xcd7c00..0xcd7c01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2628,25 +2889,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 93
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd7d20..0xcd7d72]
+      OutOfLinePCRanges: [0xcd7f40..0xcd7f92]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 7 GoStringHeaderType string
-          Locations: [{Range: 0xcd7d20..0xcd7d72, Pieces: []}]
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xcd7f40..0xcd7f92, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 84
+    - ID: 94
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd7d80..0xcd7d81]
+      OutOfLinePCRanges: [0xcd7fa0..0xcd7fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7d80..0xcd7d81
+            - Range: 0xcd7fa0..0xcd7fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2654,15 +2915,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 95
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd7da0..0xcd7da1]
+      OutOfLinePCRanges: [0xcd7fc0..0xcd7fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7da0..0xcd7da1
+            - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2671,9 +2932,9 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7da0..0xcd7da1
+            - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2682,9 +2943,9 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7da0..0xcd7da1
+            - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2692,15 +2953,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 96
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd7dc0..0xcd7ddf]
+      OutOfLinePCRanges: [0xcd7fe0..0xcd7fff]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 236 StructureType main.threeStringStruct
+          Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd7dc0..0xcd7ddf
+            - Range: 0xcd7fe0..0xcd7fff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2716,39 +2977,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 97
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd7de0..0xcd7de1]
+      OutOfLinePCRanges: [0xcd8000..0xcd8001]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 237 PointerType *main.threeStringStruct
+          Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd7de0..0xcd7de1
+            - Range: 0xcd8000..0xcd8001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 98
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd7e00..0xcd7e01]
+      OutOfLinePCRanges: [0xcd8020..0xcd8021]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 238 PointerType *main.oneStringStruct
+          Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd7e00..0xcd7e01
+            - Range: 0xcd8020..0xcd8021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 99
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd7e20..0xcd7e21]
+      OutOfLinePCRanges: [0xcd8040..0xcd8041]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7e20..0xcd7e21
+            - Range: 0xcd8040..0xcd8041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2756,15 +3017,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 100
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd7e40..0xcd7e41]
+      OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7e40..0xcd7e41
+            - Range: 0xcd8060..0xcd8061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2772,15 +3033,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 101
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd7e60..0xcd7e61]
+      OutOfLinePCRanges: [0xcd8080..0xcd8081]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7e60..0xcd7e61
+            - Range: 0xcd8080..0xcd8081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2788,15 +3049,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 102
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd80e0..0xcd8103]
+      OutOfLinePCRanges: [0xcd8300..0xcd8323]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 240 StructureType main.aStruct
+          Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0xcd80e0..0xcd8103
+            - Range: 0xcd8300..0xcd8323
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -2814,14 +3075,14 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 103
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd8260..0xcd8261]
+      OutOfLinePCRanges: [0xcd8480..0xcd8481]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 241 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd8260..0xcd8261, Pieces: []}]
+          Type: 242 StructureType main.emptyStruct
+          Locations: [{Range: 0xcd8480..0xcd8481, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
@@ -2830,7 +3091,8 @@ Subprograms:
       InlinePCRanges:
         - - 0xcd4871..0xcd48ad
         - - 0xcd49b2..0xcd49ee
-        - - 0xcd4aaf..0xcd4aeb
+        - - 0xcd4a3c..0xcd4a78
+        - - 0xcd4b0f..0xcd4b4b
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -2841,15 +3103,55 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd49b2..0xcd49bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4aa0..0xcd4aba
+            - Range: 0xcd4a36..0xcd4a47
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd4a47..0xcd4ae5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcd4b00..0xcd4b1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4a38..0xcd4a70]]
+      InlinePCRanges: [[0xcd4a86..0xcd4abe]]
       Variables: []
+    - ID: 3
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0xcd4b93..0xcd4bd1]]
+      Variables: []
+    - ID: 4
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0xcd4c46..0xcd4c7e]]
+      Variables: []
+    - ID: 5
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0xcd4ca1..0xcd4ca5]]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd4ca0..0xcd4ca5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.testInlinedSumArray
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0xcd4ce5..0xcd4cfd], [0xcd4d85..0xcd4da3]]
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0xcd4ccd..0xcd4d03
+              Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
+            - Range: 0xcd4d6c..0xcd4ea5
+              Pieces: [{Size: 40, Op: {CfaOffset: 16256}}]
+          IsParameter: true
+          IsReturn: false
 Types:
     - __kind: BaseType
       ID: 1
@@ -2859,45 +3161,53 @@ Types:
       GoKind: 2
     - __kind: ArrayType
       ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 3
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 674496
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 3 BaseType uint8
+      Element: 4 BaseType uint8
     - __kind: BaseType
-      ID: 3
+      ID: 4
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 575104
       GoKind: 8
     - __kind: ArrayType
-      ID: 4
+      ID: 5
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 674592
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 5 BaseType int32
+      Element: 6 BaseType int32
     - __kind: BaseType
-      ID: 5
+      ID: 6
       Name: int32
       ByteSize: 4
       GoRuntimeType: 575296
       GoKind: 5
     - __kind: ArrayType
-      ID: 6
+      ID: 7
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 674688
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 8
       Name: string
       ByteSize: 16
       GoRuntimeType: 574976
@@ -2905,34 +3215,34 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *string.str
+          Type: 244 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 242 GoStringDataType string.str
+      Data: 243 GoStringDataType string.str
     - __kind: PointerType
-      ID: 8
+      ID: 9
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 385312
       GoKind: 22
-      Pointee: 3 BaseType uint8
+      Pointee: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 9
+      ID: 10
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 10 BaseType bool
+      Element: 11 BaseType bool
     - __kind: BaseType
-      ID: 10
+      ID: 11
       Name: bool
       ByteSize: 1
       GoRuntimeType: 576000
       GoKind: 1
     - __kind: ArrayType
-      ID: 11
+      ID: 12
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 673440
@@ -2941,162 +3251,162 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: ArrayType
-      ID: 12
+      ID: 13
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 13 BaseType int8
+      Element: 14 BaseType int8
     - __kind: BaseType
-      ID: 13
+      ID: 14
       Name: int8
       ByteSize: 1
       GoRuntimeType: 575040
       GoKind: 3
     - __kind: ArrayType
-      ID: 14
+      ID: 15
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 15 BaseType int16
+      Element: 16 BaseType int16
     - __kind: BaseType
-      ID: 15
+      ID: 16
       Name: int16
       ByteSize: 2
       GoRuntimeType: 575168
       GoKind: 4
     - __kind: ArrayType
-      ID: 16
+      ID: 17
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 17 BaseType int64
+      Element: 18 BaseType int64
     - __kind: BaseType
-      ID: 17
+      ID: 18
       Name: int64
       ByteSize: 8
       GoRuntimeType: 575424
       GoKind: 6
     - __kind: ArrayType
-      ID: 18
+      ID: 19
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: BaseType
-      ID: 19
+      ID: 20
       Name: uint
       ByteSize: 8
       GoRuntimeType: 575616
       GoKind: 7
     - __kind: ArrayType
-      ID: 20
+      ID: 21
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 21 BaseType uint16
+      Element: 22 BaseType uint16
     - __kind: BaseType
-      ID: 21
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 575232
       GoKind: 9
     - __kind: ArrayType
-      ID: 22
+      ID: 23
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 23 BaseType uint32
+      Element: 24 BaseType uint32
     - __kind: BaseType
-      ID: 23
+      ID: 24
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 575360
       GoKind: 10
     - __kind: ArrayType
-      ID: 24
+      ID: 25
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 674784
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 25 BaseType uint64
+      Element: 26 BaseType uint64
     - __kind: BaseType
-      ID: 25
+      ID: 26
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 575488
       GoKind: 11
     - __kind: ArrayType
-      ID: 26
+      ID: 27
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 ArrayType [2]int
+      Element: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 28
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 ArrayType [2][2]int
+      Element: 27 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 28
+      ID: 29
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: BaseType
-      ID: 29
+      ID: 30
       Name: float32
       ByteSize: 4
       GoRuntimeType: 575872
       GoKind: 13
     - __kind: BaseType
-      ID: 30
+      ID: 31
       Name: float64
       ByteSize: 8
       GoRuntimeType: 575936
       GoKind: 14
     - __kind: BaseType
-      ID: 31
+      ID: 32
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 32
+      ID: 33
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 33 GoSliceHeaderType []*string
+          Type: 34 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
           Type: 1 BaseType int
         - Name: writer
           Offset: 32
-          Type: 36 GoInterfaceType io.Writer
+          Type: 37 GoInterfaceType io.Writer
     - __kind: GoSliceHeaderType
-      ID: 33
+      ID: 34
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 470624
@@ -3104,56 +3414,56 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 34 PointerType **string
+          Type: 35 PointerType **string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 244 GoSliceDataType []*string.array
+      Data: 245 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 34
+      ID: 35
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 519072
       GoKind: 22
-      Pointee: 35 PointerType *string
+      Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 35
+      ID: 36
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 385184
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 36
+      ID: 37
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.01216e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
-      ID: 37
+      ID: 38
       Name: runtime.iface
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 PointerType *internal/abi.ITab
+          Type: 39 PointerType *internal/abi.ITab
         - Name: data
           Offset: 8
-          Type: 55 VoidPointerType unsafe.Pointer
+          Type: 56 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 38
+      ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
       GoRuntimeType: 408288
       GoKind: 22
-      Pointee: 39 StructureType internal/abi.ITab
+      Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
-      ID: 39
+      ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
       GoRuntimeType: 1.741536e+06
@@ -3161,25 +3471,25 @@ Types:
       RawFields:
         - Name: Inter
           Offset: 0
-          Type: 40 PointerType *internal/abi.InterfaceType
+          Type: 41 PointerType *internal/abi.InterfaceType
         - Name: Type
           Offset: 8
-          Type: 53 PointerType *internal/abi.Type
+          Type: 54 PointerType *internal/abi.Type
         - Name: Hash
           Offset: 16
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
         - Name: Fun
           Offset: 24
-          Type: 54 ArrayType [1]uintptr
+          Type: 55 ArrayType [1]uintptr
     - __kind: PointerType
-      ID: 40
+      ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
       GoRuntimeType: 2.189056e+06
       GoKind: 22
-      Pointee: 41 StructureType internal/abi.InterfaceType
+      Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
-      ID: 41
+      ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
       GoRuntimeType: 1.617792e+06
@@ -3187,15 +3497,15 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 42 StructureType internal/abi.Type
+          Type: 43 StructureType internal/abi.Type
         - Name: PkgPath
           Offset: 48
-          Type: 49 StructureType internal/abi.Name
+          Type: 50 StructureType internal/abi.Name
         - Name: Methods
           Offset: 56
-          Type: 50 GoSliceHeaderType []internal/abi.Imethod
+          Type: 51 GoSliceHeaderType []internal/abi.Imethod
     - __kind: StructureType
-      ID: 42
+      ID: 43
       Name: internal/abi.Type
       ByteSize: 48
       GoRuntimeType: 2.109696e+06
@@ -3203,75 +3513,75 @@ Types:
       RawFields:
         - Name: Size_
           Offset: 0
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: PtrBytes
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: Hash
           Offset: 16
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
         - Name: TFlag
           Offset: 20
-          Type: 44 BaseType internal/abi.TFlag
+          Type: 45 BaseType internal/abi.TFlag
         - Name: Align_
           Offset: 21
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: FieldAlign_
           Offset: 22
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: Kind_
           Offset: 23
-          Type: 45 BaseType internal/abi.Kind
+          Type: 46 BaseType internal/abi.Kind
         - Name: Equal
           Offset: 24
-          Type: 46 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
         - Name: GCData
           Offset: 32
-          Type: 8 PointerType *uint8
+          Type: 9 PointerType *uint8
         - Name: Str
           Offset: 40
-          Type: 47 BaseType internal/abi.NameOff
+          Type: 48 BaseType internal/abi.NameOff
         - Name: PtrToThis
           Offset: 44
-          Type: 48 BaseType internal/abi.TypeOff
+          Type: 49 BaseType internal/abi.TypeOff
     - __kind: BaseType
-      ID: 43
+      ID: 44
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 575680
       GoKind: 12
     - __kind: BaseType
-      ID: 44
+      ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
       GoRuntimeType: 578432
       GoKind: 8
     - __kind: BaseType
-      ID: 45
+      ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
       GoRuntimeType: 824608
       GoKind: 8
     - __kind: GoSubroutineType
-      ID: 46
+      ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
       GoRuntimeType: 834784
       GoKind: 19
     - __kind: BaseType
-      ID: 47
+      ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
       GoRuntimeType: 578496
       GoKind: 5
     - __kind: BaseType
-      ID: 48
+      ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
       GoRuntimeType: 578560
       GoKind: 5
     - __kind: StructureType
-      ID: 49
+      ID: 50
       Name: internal/abi.Name
       ByteSize: 8
       GoRuntimeType: 1.953824e+06
@@ -3279,9 +3589,9 @@ Types:
       RawFields:
         - Name: Bytes
           Offset: 0
-          Type: 8 PointerType *uint8
+          Type: 9 PointerType *uint8
     - __kind: GoSliceHeaderType
-      ID: 50
+      ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
       GoRuntimeType: 497568
@@ -3289,23 +3599,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 51 PointerType *internal/abi.Imethod
+          Type: 52 PointerType *internal/abi.Imethod
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 246 GoSliceDataType []internal/abi.Imethod.array
+      Data: 247 GoSliceDataType []internal/abi.Imethod.array
     - __kind: PointerType
-      ID: 51
+      ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
       GoRuntimeType: 408224
       GoKind: 22
-      Pointee: 52 StructureType internal/abi.Imethod
+      Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
-      ID: 52
+      ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
       GoRuntimeType: 1.469376e+06
@@ -3313,34 +3623,34 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 47 BaseType internal/abi.NameOff
+          Type: 48 BaseType internal/abi.NameOff
         - Name: Typ
           Offset: 4
-          Type: 48 BaseType internal/abi.TypeOff
+          Type: 49 BaseType internal/abi.TypeOff
     - __kind: PointerType
-      ID: 53
+      ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.189504e+06
       GoKind: 22
-      Pointee: 42 StructureType internal/abi.Type
+      Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
-      ID: 54
+      ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
       GoRuntimeType: 672480
       GoKind: 17
       Count: 1
       HasCount: true
-      Element: 43 BaseType uintptr
+      Element: 44 BaseType uintptr
     - __kind: VoidPointerType
-      ID: 55
+      ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 576064
       GoKind: 26
     - __kind: StructureType
-      ID: 56
+      ID: 57
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.945184e+06
@@ -3348,71 +3658,71 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 58 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 59 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 60 GoInterfaceType main.something
+          Type: 61 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 61 GoSubroutineType func()
+          Type: 62 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 57
+      ID: 58
       Name: chan struct {}
       GoRuntimeType: 586240
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 59
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 838240
       GoKind: 20
-      UnderlyingStructure: 59 StructureType runtime.eface
+      UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
-      ID: 59
+      ID: 60
       Name: runtime.eface
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 53 PointerType *internal/abi.Type
+          Type: 54 PointerType *internal/abi.Type
         - Name: data
           Offset: 8
-          Type: 55 VoidPointerType unsafe.Pointer
+          Type: 56 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 60
+      ID: 61
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.011904e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
-      ID: 61
+      ID: 62
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468896
       GoKind: 19
     - __kind: PointerType
-      ID: 62
+      ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380192
       GoKind: 22
-      Pointee: 63 StructureType main.esotericHeap
+      Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 63
+      ID: 64
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.811584e+06
@@ -3420,21 +3730,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 57 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 64 StructureType sync.Mutex
+          Type: 65 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 67 StructureType sync.Once
+          Type: 68 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 70 StructureType sync.WaitGroup
+          Type: 71 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 73 StructureType sync/atomic.Int32
+          Type: 74 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 64
+      ID: 65
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.445056e+06
@@ -3442,18 +3752,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 66 StructureType internal/sync.Mutex
+          Type: 67 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 65
+      ID: 66
       Name: sync.noCopy
       GoRuntimeType: 977536
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 66
+      ID: 67
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.454336e+06
@@ -3461,12 +3771,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 67
+      ID: 68
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593408e+06
@@ -3474,15 +3784,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 68 StructureType sync/atomic.Uint32
+          Type: 69 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 64 StructureType sync.Mutex
+          Type: 65 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 68
+      ID: 69
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446496e+06
@@ -3490,18 +3800,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 69
+      ID: 70
       Name: sync/atomic.noCopy
       GoRuntimeType: 977632
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 70
+      ID: 71
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.5936e+06
@@ -3509,15 +3819,15 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 71 StructureType sync/atomic.Uint64
+          Type: 72 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 71
+      ID: 72
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.593984e+06
@@ -3525,21 +3835,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 72 StructureType sync/atomic.align64
+          Type: 73 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 72
+      ID: 73
       Name: sync/atomic.align64
       GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 73
+      ID: 74
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.446336e+06
@@ -3547,26 +3857,26 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 75
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.011776e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 76
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.016128e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
-      ID: 76
+      ID: 77
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.173344e+06
@@ -3574,106 +3884,106 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 77 GoMapType map[int]int
+          Type: 78 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 77
+      ID: 78
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<int,int>
+      HeaderType: 80 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 78
+      ID: 79
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 79 GoSwissMapHeaderType map<int,int>
+      Pointee: 80 GoSwissMapHeaderType map<int,int>
     - __kind: GoSwissMapHeaderType
-      ID: 79
+      ID: 80
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 80 PointerType **table<int,int>
+          Type: 81 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<int,int>.array
-      GroupType: 85 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 80
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 81 PointerType *table<int,int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 249 GoSliceDataType []*table<int,int>.array
+      GroupType: 86 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 81
+      Name: '**table<int,int>'
+      ByteSize: 8
+      Pointee: 82 PointerType *table<int,int>
+    - __kind: PointerType
+      ID: 82
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 82 StructureType table<int,int>
+      Pointee: 83 StructureType table<int,int>
     - __kind: StructureType
-      ID: 82
+      ID: 83
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 83 GoSwissMapGroupsType groupReference<int,int>
+          Type: 84 GoSwissMapGroupsType groupReference<int,int>
     - __kind: GoSwissMapGroupsType
-      ID: 83
+      ID: 84
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 84 PointerType *noalg.map.group[int]int
+          Type: 85 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 85 StructureType noalg.map.group[int]int
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[int]int.array
+          Type: 26 BaseType uint64
+      GroupType: 86 StructureType noalg.map.group[int]int
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
-      ID: 84
+      ID: 85
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 85 StructureType noalg.map.group[int]int
+      Pointee: 86 StructureType noalg.map.group[int]int
     - __kind: StructureType
-      ID: 85
+      ID: 86
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27632e+06
@@ -3681,21 +3991,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 86 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 87 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: ArrayType
-      ID: 86
+      ID: 87
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671232
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 87 StructureType noalg.struct { key int; elem int }
+      Element: 88 StructureType noalg.struct { key int; elem int }
     - __kind: StructureType
-      ID: 87
+      ID: 88
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276192e+06
@@ -3708,104 +4018,104 @@ Types:
           Offset: 8
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 88
+      ID: 89
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.118432e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 89
+      ID: 90
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 90 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 90
+      ID: 91
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 91 PointerType **table<string,main.nestedStruct>
+          Type: 92 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 96 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 91
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 92 PointerType *table<string,main.nestedStruct>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 251 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
       ID: 92
+      Name: '**table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 93 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 93 StructureType table<string,main.nestedStruct>
+      Pointee: 94 StructureType table<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 93
+      ID: 94
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 94 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 95 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 94
+      ID: 95
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 95 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 96 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 96 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+          Type: 26 BaseType uint64
+      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 96 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: StructureType
-      ID: 96
+      ID: 97
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279136e+06
@@ -3813,21 +4123,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 97 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 98 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 97
+      ID: 98
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 674112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 98 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 99 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 98
+      ID: 99
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279008e+06
@@ -3835,12 +4145,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 99 StructureType main.nestedStruct
+          Type: 100 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 99
+      ID: 100
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.443776e+06
@@ -3851,106 +4161,106 @@ Types:
           Type: 1 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.118304e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,int>.array
-      GroupType: 108 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 103
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 253 GoSliceDataType []*table<string,int>.array
+      GroupType: 109 StructureType noalg.map.group[string]int
     - __kind: PointerType
       ID: 104
+      Name: '**table<string,int>'
+      ByteSize: 8
+      Pointee: 105 PointerType *table<string,int>
+    - __kind: PointerType
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 105 StructureType table<string,int>
+      Pointee: 106 StructureType table<string,int>
     - __kind: StructureType
-      ID: 105
+      ID: 106
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 106 GoSwissMapGroupsType groupReference<string,int>
+          Type: 107 GoSwissMapGroupsType groupReference<string,int>
     - __kind: GoSwissMapGroupsType
-      ID: 106
+      ID: 107
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 107 PointerType *noalg.map.group[string]int
+          Type: 108 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 108 StructureType noalg.map.group[string]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]int.array
+          Type: 26 BaseType uint64
+      GroupType: 109 StructureType noalg.map.group[string]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 108 StructureType noalg.map.group[string]int
+      Pointee: 109 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 108
+      ID: 109
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27888e+06
@@ -3958,21 +4268,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 109 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 110 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 109
+      ID: 110
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 674016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 110 StructureType noalg.struct { key string; elem int }
+      Element: 111 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 110
+      ID: 111
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278752e+06
@@ -3980,109 +4290,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 111
+      ID: 112
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118176e+06
       GoKind: 21
-      HeaderType: 113 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 113 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 113
+      ID: 114
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 114 PointerType **table<string,[]string>
+          Type: 115 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 119 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 114
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 115 PointerType *table<string,[]string>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 255 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 120 StructureType noalg.map.group[string][]string
     - __kind: PointerType
       ID: 115
+      Name: '**table<string,[]string>'
+      ByteSize: 8
+      Pointee: 116 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 116
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 116 StructureType table<string,[]string>
+      Pointee: 117 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 116
+      ID: 117
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 117 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 118 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: GoSwissMapGroupsType
-      ID: 117
+      ID: 118
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 118 PointerType *noalg.map.group[string][]string
+          Type: 119 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 119 StructureType noalg.map.group[string][]string
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 26 BaseType uint64
+      GroupType: 120 StructureType noalg.map.group[string][]string
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 119 StructureType noalg.map.group[string][]string
+      Pointee: 120 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 119
+      ID: 120
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -4090,21 +4400,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 120 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 121 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 120
+      ID: 121
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673920
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 121 StructureType noalg.struct { key string; elem []string }
+      Element: 122 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 121
+      ID: 122
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -4112,12 +4422,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 122 GoSliceHeaderType []string
+          Type: 123 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 123
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478560
@@ -4125,113 +4435,113 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType *string
+          Type: 36 PointerType *string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 256 GoSliceDataType []string.array
+      Data: 257 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 123
+      ID: 124
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117664e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 126
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]string,[2]int>
+          Type: 127 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 131 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<[4]string,[2]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 259 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 127
+      Name: '**table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 128 PointerType *table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 128
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 128 StructureType table<[4]string,[2]int>
+      Pointee: 129 StructureType table<[4]string,[2]int>
     - __kind: StructureType
-      ID: 128
+      ID: 129
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 130 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 130
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[[4]string][2]int
+          Type: 131 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+          Type: 26 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: StructureType
-      ID: 131
+      ID: 132
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.2776e+06
@@ -4239,21 +4549,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 133 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 132
+      ID: 133
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 134 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 133
+      ID: 134
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277472e+06
@@ -4261,132 +4571,132 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 134 ArrayType [4]string
+          Type: 135 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 11 ArrayType [2]int
+          Type: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 134
+      ID: 135
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673344
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 135
+      ID: 136
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<string,[]main.structWithMap>
+          Type: 141 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 145 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 140
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 141 PointerType *table<string,[]main.structWithMap>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 261 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
       ID: 141
+      Name: '**table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 142 PointerType *table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 142
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 142 StructureType table<string,[]main.structWithMap>
+      Pointee: 143 StructureType table<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 142
+      ID: 143
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 143 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 144 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: GoSwissMapGroupsType
-      ID: 143
+      ID: 144
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 144 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 145 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 145 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+          Type: 26 BaseType uint64
+      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 145 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 146 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: StructureType
-      ID: 145
+      ID: 146
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278368e+06
@@ -4394,21 +4704,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 146 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 147 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 146
+      ID: 147
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673824
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 147 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 148 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 147
+      ID: 148
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.27824e+06
@@ -4416,12 +4726,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 148 GoSliceHeaderType []main.structWithMap
+          Type: 149 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 148
+      ID: 149
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469856
@@ -4429,120 +4739,120 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 149 PointerType *main.structWithMap
+          Type: 150 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 262 GoSliceDataType []main.structWithMap.array
+      Data: 263 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380128
       GoKind: 22
-      Pointee: 76 StructureType main.structWithMap
+      Pointee: 77 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 150
+      ID: 151
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 21
-      HeaderType: 152 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 152 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoSwissMapHeaderType
-      ID: 152
+      ID: 153
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 153 PointerType **table<bool,main.node>
+          Type: 154 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 158 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 153
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 154 PointerType *table<bool,main.node>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 265 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 159 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
       ID: 154
+      Name: '**table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 155 PointerType *table<bool,main.node>
+    - __kind: PointerType
+      ID: 155
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 155 StructureType table<bool,main.node>
+      Pointee: 156 StructureType table<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 157 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 157
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[bool]main.node
+          Type: 158 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[bool]main.node.array
+          Type: 26 BaseType uint64
+      GroupType: 159 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 266 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[bool]main.node
+      Pointee: 159 StructureType noalg.map.group[bool]main.node
     - __kind: StructureType
-      ID: 158
+      ID: 159
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277856e+06
@@ -4550,21 +4860,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 160 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 160
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673632
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key bool; elem main.node }
+      Element: 161 StructureType noalg.struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 160
+      ID: 161
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277728e+06
@@ -4572,12 +4882,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 161 StructureType main.node
+          Type: 162 StructureType main.node
     - __kind: StructureType
-      ID: 161
+      ID: 162
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443616e+06
@@ -4588,113 +4898,113 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 162 PointerType *main.node
+          Type: 163 PointerType *main.node
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380256
       GoKind: 22
-      Pointee: 161 StructureType main.node
+      Pointee: 162 StructureType main.node
     - __kind: GoMapType
-      ID: 163
+      ID: 164
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.11792e+06
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 164
+      ID: 165
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 165 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 165
+      ID: 166
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 166 PointerType **table<int,uint8>
+          Type: 167 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 171 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 166
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 167 PointerType *table<int,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 267 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 172 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
       ID: 167
+      Name: '**table<int,uint8>'
+      ByteSize: 8
+      Pointee: 168 PointerType *table<int,uint8>
+    - __kind: PointerType
+      ID: 168
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 169 StructureType table<int,uint8>
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 169 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 170 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 169
+      ID: 170
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 170 PointerType *noalg.map.group[int]uint8
+          Type: 171 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 171 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[int]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 172 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 171 StructureType noalg.map.group[int]uint8
+      Pointee: 172 StructureType noalg.map.group[int]uint8
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278112e+06
@@ -4702,21 +5012,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 172 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 173 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 172
+      ID: 173
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 173 StructureType noalg.struct { key int; elem uint8 }
+      Element: 174 StructureType noalg.struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277984e+06
@@ -4727,106 +5037,106 @@ Types:
           Type: 1 BaseType int
         - Name: elem
           Offset: 8
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 174
+      ID: 175
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 177
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<uint8,uint8>
+          Type: 178 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 182 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 177
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 178 PointerType *table<uint8,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 269 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 178
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 179 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 179
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 179 StructureType table<uint8,uint8>
+      Pointee: 180 StructureType table<uint8,uint8>
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 181 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 181
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[uint8]uint8
+          Type: 182 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[uint8]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 183 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 270 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[uint8]uint8
+      Pointee: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279648e+06
@@ -4834,21 +5144,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 184 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: ArrayType
-      ID: 183
+      ID: 184
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 185 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 184
+      ID: 185
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27952e+06
@@ -4856,109 +5166,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 185
+      ID: 186
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.11856e+06
       GoKind: 21
-      HeaderType: 187 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 186
+      ID: 187
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 187 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 187
+      ID: 188
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 188 PointerType **table<uint8,[4]int>
+          Type: 189 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 270 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 193 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 188
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 189 PointerType *table<uint8,[4]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 271 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
       ID: 189
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 190 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 190
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 190 StructureType table<uint8,[4]int>
+      Pointee: 191 StructureType table<uint8,[4]int>
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 191 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 192 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 191
+      ID: 192
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 192 PointerType *noalg.map.group[uint8][4]int
+          Type: 193 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 193 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 271 GoSliceDataType []noalg.map.group[uint8][4]int.array
+          Type: 26 BaseType uint64
+      GroupType: 194 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 272 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
-      ID: 192
+      ID: 193
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 193 StructureType noalg.map.group[uint8][4]int
+      Pointee: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279392e+06
@@ -4966,21 +5276,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 194 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 195 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 194
+      ID: 195
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 195 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 196 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279264e+06
@@ -4988,12 +5298,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 673056
@@ -5002,104 +5312,104 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 197
+      ID: 198
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117536e+06
       GoKind: 21
-      HeaderType: 199 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 198
+      ID: 199
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 199 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 199
+      ID: 200
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 200 PointerType **table<[4]int,uint8>
+          Type: 201 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 272 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 205 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 200
-      Name: '**table<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 201 PointerType *table<[4]int,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 273 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
       ID: 201
+      Name: '**table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 202 PointerType *table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 202
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 202 StructureType table<[4]int,uint8>
+      Pointee: 203 StructureType table<[4]int,uint8>
     - __kind: StructureType
-      ID: 202
+      ID: 203
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 273 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277344e+06
@@ -5107,21 +5417,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 207 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 206
+      ID: 207
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 208 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 207
+      ID: 208
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277216e+06
@@ -5129,109 +5439,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 208
+      ID: 209
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.117408e+06
       GoKind: 21
-      HeaderType: 210 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 209
+      ID: 210
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 210 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 210
+      ID: 211
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 211 PointerType **table<[4]int,[4]int>
+          Type: 212 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 216 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 211
-      Name: '**table<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 212 PointerType *table<[4]int,[4]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 275 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 212
+      Name: '**table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 213 PointerType *table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 213
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 213 StructureType table<[4]int,[4]int>
+      Pointee: 214 StructureType table<[4]int,[4]int>
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 215 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 215
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[[4]int][4]int
+          Type: 216 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+          Type: 26 BaseType uint64
+      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
-      ID: 215
+      ID: 216
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 217 StructureType noalg.map.group[[4]int][4]int
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277088e+06
@@ -5239,21 +5549,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 217
+      ID: 218
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 673152
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 219 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 218
+      ID: 219
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27696e+06
@@ -5261,76 +5571,76 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 219
+      ID: 220
       Name: chan bool
       GoRuntimeType: 587328
       GoKind: 18
     - __kind: PointerType
-      ID: 220
+      ID: 221
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 221 StructureType main.structWithTwoValues
+      Pointee: 222 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
         - Name: b
           Offset: 8
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 222
+      ID: 223
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385824
       GoKind: 22
-      Pointee: 19 BaseType uint
+      Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 223
+      ID: 224
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386208
       GoKind: 22
-      Pointee: 10 BaseType bool
+      Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 224
+      ID: 225
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 225 GoSliceHeaderType main.t
+      Pointee: 226 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 226
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType **main.t
+          Type: 227 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 276 GoSliceDataType main.t.array
+      Data: 277 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 224 PointerType *main.t
+      Pointee: 225 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 228
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478048
@@ -5338,70 +5648,70 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 222 PointerType *uint
+          Type: 223 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 278 GoSliceDataType []uint.array
+      Data: 279 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 229
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 229 PointerType *[]uint
+          Type: 230 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 280 GoSliceDataType [][]uint.array
+      Data: 281 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 229
+      ID: 230
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 227 GoSliceHeaderType []uint
+      Pointee: 228 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 231
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 231 PointerType *main.structWithNoStrings
+          Type: 232 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 282 GoSliceDataType []main.structWithNoStrings.array
+      Data: 283 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 232 StructureType main.structWithNoStrings
+      Pointee: 233 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 232
+      ID: 233
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 233
+      ID: 234
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478432
@@ -5409,16 +5719,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType *bool
+          Type: 224 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 284 GoSliceDataType []bool.array
+      Data: 285 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 235
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477408
@@ -5426,311 +5736,311 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 235 PointerType *uint16
+          Type: 236 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 286 GoSliceDataType []uint16.array
+      Data: 287 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385440
       GoKind: 22
-      Pointee: 21 BaseType uint16
+      Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 237
+      ID: 238
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 236 StructureType main.threeStringStruct
+      Pointee: 237 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 238
+      ID: 239
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 239 StructureType main.oneStringStruct
+      Pointee: 240 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 240
+      ID: 241
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 99 StructureType main.nestedStruct
+          Type: 100 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 241
+      ID: 242
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 242
+      ID: 243
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 243
+      ID: 244
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType string.str
+      Pointee: 243 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 245
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 35 PointerType *string
+      Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*string.array
+      Pointee: 245 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 247
       Name: '[]internal/abi.Imethod.array'
       ByteSize: 2048
-      Element: 52 StructureType internal/abi.Imethod
+      Element: 53 StructureType internal/abi.Imethod
     - __kind: PointerType
-      ID: 247
+      ID: 248
       Name: '*[]internal/abi.Imethod.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 81 PointerType *table<int,int>
+      Pointee: 247 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoSliceDataType
       ID: 249
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 85 StructureType noalg.map.group[int]int
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 82 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 250
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 92 PointerType *table<string,main.nestedStruct>
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 86 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 251
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 96 StructureType noalg.map.group[string]main.nestedStruct
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 93 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 252
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 253
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 108 StructureType noalg.map.group[string]int
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 254
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 115 PointerType *table<string,[]string>
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 109 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 255
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 119 StructureType noalg.map.group[string][]string
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 116 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 256
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 120 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 257
+      ID: 258
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<[4]string,[2]int>
+      Pointee: 257 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 259
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[[4]string][2]int
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 260
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 141 PointerType *table<string,[]main.structWithMap>
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 261
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 145 StructureType noalg.map.group[string][]main.structWithMap
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 142 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 262
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 146 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 263
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 76 StructureType main.structWithMap
+      Element: 77 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 263
+      ID: 264
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 154 PointerType *table<bool,main.node>
+      Pointee: 263 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 265
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[bool]main.node
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 155 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 266
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 167 PointerType *table<int,uint8>
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 159 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 267
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 171 StructureType noalg.map.group[int]uint8
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 168 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 268
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 178 PointerType *table<uint8,uint8>
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 172 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 269
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[uint8]uint8
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 179 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
       ID: 270
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 189 PointerType *table<uint8,[4]int>
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
       ID: 271
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 193 StructureType noalg.map.group[uint8][4]int
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 190 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 272
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 201 PointerType *table<[4]int,uint8>
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 273
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[[4]int]uint8
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 202 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 274
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 212 PointerType *table<[4]int,[4]int>
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 275
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[[4]int][4]int
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 213 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 276
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 217 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 277
       Name: main.t.array
       ByteSize: 2048
-      Element: 224 PointerType *main.t
+      Element: 225 PointerType *main.t
     - __kind: PointerType
-      ID: 277
+      ID: 278
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType main.t.array
+      Pointee: 277 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 279
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint.array
+      Pointee: 279 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 281
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 227 GoSliceHeaderType []uint
+      Element: 228 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 281
+      ID: 282
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]uint.array
+      Pointee: 281 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 232 StructureType main.structWithNoStrings
+      Element: 233 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 283
+      ID: 284
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 283 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 10 BaseType bool
+      Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 285
+      ID: 286
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []bool.array
+      Pointee: 285 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 287
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 21 BaseType uint16
+      Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []uint16.array
+      Pointee: 287 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 288
+      ID: 289
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5738,14 +6048,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 2 ArrayType [2]uint8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 289
+      ID: 290
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5753,14 +6063,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 ArrayType [2]int32
+            Type: 5 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 291
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5768,14 +6078,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 ArrayType [2]string
+            Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 291
+      ID: 292
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5783,14 +6093,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 9 ArrayType [2]bool
+            Type: 10 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 292
+      ID: 293
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5798,14 +6108,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 ArrayType [2]int
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 294
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5813,14 +6123,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int8
+            Type: 13 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 294
+      ID: 295
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5828,14 +6138,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 ArrayType [2]int16
+            Type: 15 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 295
+      ID: 296
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5843,14 +6153,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 ArrayType [2]int32
+            Type: 5 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 297
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5858,14 +6168,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 ArrayType [2]int64
+            Type: 17 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 15, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 298
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5873,14 +6183,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 ArrayType [2]uint
+            Type: 19 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 16, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 299
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5888,14 +6198,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 2 ArrayType [2]uint8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 17, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 299
+      ID: 300
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5903,14 +6213,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 ArrayType [2]uint16
+            Type: 21 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 18, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 300
+      ID: 301
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5918,14 +6228,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 ArrayType [2]uint32
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 302
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5933,14 +6243,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 ArrayType [2]uint64
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 302
+      ID: 303
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5948,14 +6258,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 26 ArrayType [2][2]int
+            Type: 27 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: a}
+                  Variable: {subprogram: 21, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 303
+      ID: 304
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5963,14 +6273,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 6 ArrayType [2]string
+            Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: a}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 304
+      ID: 305
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5978,14 +6288,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2][2]int
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: b}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 305
+      ID: 306
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5993,14 +6303,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 28 ArrayType [100]uint
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 306
+      ID: 307
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6008,14 +6318,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 307
+      ID: 308
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6023,14 +6333,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 308
+      ID: 309
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6038,14 +6348,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 BaseType bool
+            Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 309
+      ID: 310
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6056,11 +6366,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 311
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6068,14 +6378,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 BaseType int8
+            Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6083,14 +6393,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 BaseType int16
+            Type: 16 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6098,14 +6408,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6113,14 +6423,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 BaseType int64
+            Type: 18 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6128,14 +6438,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6143,14 +6453,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 316
+      ID: 317
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6158,14 +6468,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 BaseType uint16
+            Type: 22 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6173,14 +6483,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 BaseType uint32
+            Type: 24 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6188,14 +6498,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 BaseType uint64
+            Type: 26 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 37, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6203,14 +6513,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 29 BaseType float32
+            Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 320
+      ID: 321
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6218,14 +6528,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float64
+            Type: 31 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 322
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6233,14 +6543,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType main.typeAlias
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 322
+      ID: 323
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6248,14 +6558,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 32 StructureType main.bigStruct
+            Type: 33 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: b}
+                  Variable: {subprogram: 41, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 323
+      ID: 324
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6263,14 +6573,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 57 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: e}
+                  Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6278,14 +6588,101 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 62 PointerType *main.esotericHeap
+            Type: 63 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: e}
+                  Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 326
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6293,14 +6690,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 75 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: b}
+                  Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 333
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6308,14 +6705,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType error
+            Type: 76 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: e}
+                  Variable: {subprogram: 51, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 334
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6323,14 +6720,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 76 StructureType main.structWithMap
+            Type: 77 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 335
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6338,14 +6735,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 88 GoMapType map[string]main.nestedStruct
+            Type: 89 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 336
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6353,14 +6750,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 337
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6368,14 +6765,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 111 GoMapType map[string][]string
+            Type: 112 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 338
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6383,14 +6780,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]string][2]int
+            Type: 124 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 339
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6398,14 +6795,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 340
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6413,14 +6810,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 ArrayType [2]map[string]int
+            Type: 136 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 341
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6428,14 +6825,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 PointerType *map[string]int
+            Type: 137 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 342
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6443,14 +6840,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 77 GoMapType map[int]int
+            Type: 78 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 343
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6458,14 +6855,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[string][]main.structWithMap
+            Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 344
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6473,14 +6870,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[string][]main.structWithMap
+            Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 345
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6488,14 +6885,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 150 GoMapType map[bool]main.node
+            Type: 151 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 346
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6503,14 +6900,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 163 GoMapType map[int]uint8
+            Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 347
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6518,14 +6915,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 163 GoMapType map[int]uint8
+            Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 348
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6533,14 +6930,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 349
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6548,14 +6945,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 350
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6563,14 +6960,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 351
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6578,14 +6975,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 185 GoMapType map[uint8][4]int
+            Type: 186 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 352
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6593,14 +6990,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 197 GoMapType map[[4]int]uint8
+            Type: 198 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 353
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,14 +7005,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 208 GoMapType map[[4]int][4]int
+            Type: 209 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 354
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6623,32 +7020,32 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: w}
+                  Variable: {subprogram: 72, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 1, name: x}
+                  Variable: {subprogram: 72, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 29 BaseType float32
+            Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 2, name: y}
+                  Variable: {subprogram: 72, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 348
+      ID: 355
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6656,50 +7053,50 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 10 BaseType bool
+            Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: a}
+                  Variable: {subprogram: 73, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 1, name: b}
+                  Variable: {subprogram: 73, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 2, name: c}
+                  Variable: {subprogram: 73, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 3, name: d}
+                  Variable: {subprogram: 73, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 4, name: e}
+                  Variable: {subprogram: 73, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 356
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6707,14 +7104,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 219 GoChannelType chan bool
+            Type: 220 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: c}
+                  Variable: {subprogram: 74, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 350
+      ID: 357
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,14 +7119,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.structWithTwoValues
+            Type: 221 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: a}
+                  Variable: {subprogram: 75, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 358
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6737,14 +7134,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 StructureType main.node
+            Type: 162 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 359
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6752,14 +7149,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 162 PointerType *main.node
+            Type: 163 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 360
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,14 +7164,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 55 VoidPointerType unsafe.Pointer
+            Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: x}
+                  Variable: {subprogram: 78, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 361
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,14 +7179,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 222 PointerType *uint
+            Type: 223 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 362
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6797,14 +7194,14 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 35 PointerType *string
+            Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: z}
+                  Variable: {subprogram: 80, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 363
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6812,23 +7209,23 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 223 PointerType *bool
+            Type: 224 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 364
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6836,14 +7233,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 224 PointerType *main.t
+            Type: 225 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: t}
+                  Variable: {subprogram: 82, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 365
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6851,14 +7248,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: u}
+                  Variable: {subprogram: 83, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 359
+      ID: 366
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6866,14 +7263,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: u}
+                  Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 360
+      ID: 367
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6881,14 +7278,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType [][]uint
+            Type: 229 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: u}
+                  Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 361
+      ID: 368
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6896,10 +7293,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6908,11 +7305,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 369
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6920,10 +7317,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6932,11 +7329,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 370
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6944,10 +7341,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: xs}
+                  Variable: {subprogram: 88, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6956,11 +7353,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: a}
+                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 371
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6968,14 +7365,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 122 GoSliceHeaderType []string
+            Type: 123 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: s}
+                  Variable: {subprogram: 89, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 365
+      ID: 372
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6983,32 +7380,32 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 13 BaseType int8
+            Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 233 GoSliceHeaderType []bool
+            Type: 234 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 1, name: s}
+                  Variable: {subprogram: 90, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 2, name: x}
+                  Variable: {subprogram: 90, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 373
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7016,14 +7413,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 234 GoSliceHeaderType []uint16
+            Type: 235 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 367
+      ID: 374
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7031,17 +7428,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
+      ID: 375
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 369
+      ID: 376
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7049,14 +7446,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 370
+      ID: 377
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7064,32 +7461,32 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: y}
+                  Variable: {subprogram: 95, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: z}
+                  Variable: {subprogram: 95, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 371
+      ID: 378
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7097,14 +7494,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 236 StructureType main.threeStringStruct
+            Type: 237 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 96, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 372
+      ID: 379
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7112,14 +7509,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 237 PointerType *main.threeStringStruct
+            Type: 238 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 380
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7127,14 +7524,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 238 PointerType *main.oneStringStruct
+            Type: 239 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 381
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7142,14 +7539,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 375
+      ID: 382
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7157,14 +7554,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 376
+      ID: 383
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7172,14 +7569,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 101, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
+      ID: 384
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7187,14 +7584,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 240 StructureType main.aStruct
+            Type: 241 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 378
+      ID: 385
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7202,14 +7599,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 241 StructureType main.emptyStruct
+            Type: 242 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: e}
+                  Variable: {subprogram: 103, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 379
+      ID: 386
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7224,7 +7621,43 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 387
       Name: Probe[main.testInlinedBBB]
-MaxTypeID: 380
+    - __kind: EventRootType
+      ID: 388
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 389
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 390
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 391
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+MaxTypeID: 391
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -415,7 +415,7 @@ Probes:
       events:
         - ID: 102
           Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd4ca1", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd4ca1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -3089,10 +3089,14 @@ Subprograms:
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd47e0..0xcd4842]
       InlinePCRanges:
-        - - 0xcd4871..0xcd48ad
-        - - 0xcd49b2..0xcd49ee
-        - - 0xcd4a3c..0xcd4a78
-        - - 0xcd4b0f..0xcd4b4b
+        - Ranges: [0xcd4871..0xcd48ad]
+          RootRanges: [0xcd4860..0xcd48d1]
+        - Ranges: [0xcd49b2..0xcd49ee]
+          RootRanges: [0xcd4980..0xcd4a08]
+        - Ranges: [0xcd4a3c..0xcd4a78]
+          RootRanges: [0xcd4a20..0xcd4ae5]
+        - Ranges: [0xcd4b0f..0xcd4b4b]
+          RootRanges: [0xcd4b00..0xcd4b62]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -3114,22 +3118,30 @@ Subprograms:
     - ID: 2
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4a86..0xcd4abe]]
+      InlinePCRanges:
+        - Ranges: [0xcd4a86..0xcd4abe]
+          RootRanges: [0xcd4a20..0xcd4ae5]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4b93..0xcd4bd1]]
+      InlinePCRanges:
+        - Ranges: [0xcd4b93..0xcd4bd1]
+          RootRanges: [0xcd4b80..0xcd4c8e]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4c46..0xcd4c7e]]
+      InlinePCRanges:
+        - Ranges: [0xcd4c46..0xcd4c7e]
+          RootRanges: [0xcd4b80..0xcd4c8e]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4ca1..0xcd4ca5]]
+      InlinePCRanges:
+        - Ranges: [0xcd4ca1..0xcd4ca5]
+          RootRanges: [0xcd4ca0..0xcd4ca6]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -3141,7 +3153,11 @@ Subprograms:
     - ID: 6
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xcd4ce5..0xcd4cfd], [0xcd4d85..0xcd4da3]]
+      InlinePCRanges:
+        - Ranges: [0xcd4ce5..0xcd4cfd]
+          RootRanges: [0xcd4cc0..0xcd4d03]
+        - Ranges: [0xcd4d85..0xcd4da3]
+          RootRanges: [0xcd4d20..0xcd4ea5]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,11 +8,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 81
-          Type: 368 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84c6bc", Frameless: false}]
+        - ID: 87
+          Type: 375 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84c85c", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -22,10 +22,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 17}
+      subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 302 EventRootType Probe[main.testArrayOfArrays]
+          Type: 303 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x8491e0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -36,10 +36,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 19}
+      subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 304 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849200", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -50,11 +50,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 46
-          Type: 333 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84a690", Frameless: true}]
+        - ID: 52
+          Type: 340 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84a830", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -64,10 +64,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 18}
+      subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 303 EventRootType Probe[main.testArrayOfStrings]
+          Type: 304 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x8491f0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -78,10 +78,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 37}
+      subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 322 EventRootType Probe[main.testBigStruct]
+          Type: 323 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849760", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -92,10 +92,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 6}
+      subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 291 EventRootType Probe[main.testBoolArray]
+          Type: 292 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x849130", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -106,10 +106,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 3}
+      subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 288 EventRootType Probe[main.testByteArray]
+          Type: 289 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849100", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -120,11 +120,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 62
-          Type: 349 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84bce0", Frameless: true}]
+        - ID: 68
+          Type: 356 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84be80", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 60
-          Type: 347 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84ba60", Frameless: true}]
+        - ID: 66
+          Type: 354 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 70
-          Type: 357 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84bf80", Frameless: true}]
+        - ID: 76
+          Type: 364 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84c120", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 72
-          Type: 359 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84c360", Frameless: true}]
+        - ID: 78
+          Type: 366 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84c500", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 75
-          Type: 362 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84c390", Frameless: true}]
+        - ID: 81
+          Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 89
-          Type: 376 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84c7a0", Frameless: true}]
+        - ID: 95
+          Type: 383 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84c940", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 91
-          Type: 378 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84cab0", Frameless: true}]
+        - ID: 97
+          Type: 385 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84cc50", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 41}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 39
-          Type: 326 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84a410", Frameless: true}]
+        - ID: 45
+          Type: 333 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x84a5b0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -232,10 +232,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 39}
+      subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 324 EventRootType Probe[main.testEsotericHeap]
+          Type: 325 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8499fc", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -246,13 +246,83 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 38}
+      subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 323 EventRootType Probe[main.testEsotericStack]
+          Type: 324 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84992c", Frameless: false}]
           Condition: null
-    - id: testInlinedBBC
+    - id: testFrameless
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFrameless}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 48}
+      events:
+        - ID: 42
+          Type: 330 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x84a120", Frameless: true}]
+          Condition: null
+    - id: testFramelessArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testFramelessArray}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 49}
+      events:
+        - ID: 43
+          Type: 331 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x84a130", Frameless: false}]
+          Condition: null
+    - id: testInlinedBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 38
+          Type: 326 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x849e3c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 45}
+      events:
+        - ID: 39
+          Type: 327 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x849ecc", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBBA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 46}
+      events:
+        - ID: 40
+          Type: 328 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x849f8c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInlinedBBB}
@@ -262,22 +332,65 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 93
-          Type: 380 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x849ee4", Frameless: true}]
+        - ID: 99
+          Type: 387 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x849f28", Frameless: true}]
+          Condition: null
+    - id: testInlinedBC
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBC}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 47}
+      events:
+        - ID: 41
+          Type: 329 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x84a00c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCA
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCA}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 3}
+      events:
+        - ID: 100
+          Type: 388 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x84a01c", Frameless: true}]
+          Condition: null
+    - id: testInlinedBCB
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedBCB}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 4}
+      events:
+        - ID: 101
+          Type: 389 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
           Condition: null
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInlinedPrint}
       tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 92
-          Type: 379 EventRootType Probe[main.testInlinedPrint]
+        - ID: 98
+          Type: 386 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x849c9c"
               Frameless: false
@@ -285,7 +398,42 @@ Probes:
               Frameless: true
             - PC: "0x849e68"
               Frameless: true
-            - PC: "0x849f5c"
+            - PC: "0x849ee4"
+              Frameless: true
+            - PC: "0x849f9c"
+              Frameless: true
+          Condition: null
+    - id: testInlinedSq
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSq}
+      tags: ['foo:bar']
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 5}
+      events:
+        - ID: 102
+          Type: 390 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x84a124", Frameless: true}]
+          Condition: null
+    - id: testInlinedSumArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testInlinedSumArray}
+      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 6}
+      events:
+        - ID: 103
+          Type: 391 EventRootType Probe[main.testInlinedSumArray]
+          InjectionPoints:
+            - PC: "0x84a154"
+              Frameless: true
+            - PC: "0x84a1ec"
               Frameless: true
           Condition: null
     - id: testInt16Array
@@ -296,10 +444,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 9}
+      subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 294 EventRootType Probe[main.testInt16Array]
+          Type: 295 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x849160", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -310,10 +458,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 10}
+      subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 295 EventRootType Probe[main.testInt32Array]
+          Type: 296 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x849170", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -324,10 +472,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 11}
+      subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 296 EventRootType Probe[main.testInt64Array]
+          Type: 297 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x849180", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -338,10 +486,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 8}
+      subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 293 EventRootType Probe[main.testInt8Array]
+          Type: 294 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x849150", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -352,10 +500,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 7}
+      subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 292 EventRootType Probe[main.testIntArray]
+          Type: 293 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x849140", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -366,11 +514,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 40}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 38
-          Type: 325 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84a230", Frameless: false}]
+        - ID: 44
+          Type: 332 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x84a3d0", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -380,11 +528,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 64
-          Type: 351 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84be90", Frameless: true}]
+        - ID: 70
+          Type: 358 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84c030", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -394,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 44
-          Type: 331 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84a670", Frameless: true}]
+        - ID: 50
+          Type: 338 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84a810", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -408,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 50
-          Type: 337 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84a6d0", Frameless: true}]
+        - ID: 56
+          Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84a870", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -422,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 48
-          Type: 335 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84a6b0", Frameless: true}]
+        - ID: 54
+          Type: 342 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84a850", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -436,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 59
-          Type: 346 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84a760", Frameless: true}]
+        - ID: 65
+          Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84a900", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -450,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 58
-          Type: 345 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84a750", Frameless: true}]
+        - ID: 64
+          Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84a8f0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -464,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 49
-          Type: 336 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84a6c0", Frameless: true}]
+        - ID: 55
+          Type: 343 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84a860", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -478,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 57
-          Type: 344 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84a740", Frameless: true}]
+        - ID: 63
+          Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84a8e0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -492,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 56
-          Type: 343 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84a730", Frameless: true}]
+        - ID: 62
+          Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84a8d0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -506,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 42
-          Type: 329 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84a650", Frameless: true}]
+        - ID: 48
+          Type: 336 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84a7f0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -520,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 43
-          Type: 330 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84a660", Frameless: true}]
+        - ID: 49
+          Type: 337 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84a800", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -534,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 43}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 41
-          Type: 328 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84a640", Frameless: true}]
+        - ID: 47
+          Type: 335 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84a7e0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -548,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 51
-          Type: 338 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84a6e0", Frameless: true}]
+        - ID: 57
+          Type: 345 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84a880", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -562,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 54
-          Type: 341 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84a710", Frameless: true}]
+        - ID: 60
+          Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84a8b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -576,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 55
-          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84a720", Frameless: true}]
+        - ID: 61
+          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -590,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 52
-          Type: 339 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84a6f0", Frameless: true}]
+        - ID: 58
+          Type: 346 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84a890", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -604,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 53
-          Type: 340 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84a700", Frameless: true}]
+        - ID: 59
+          Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84a8a0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -618,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 87
-          Type: 374 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84c780", Frameless: true}]
+        - ID: 93
+          Type: 381 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84c920", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -632,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 61
-          Type: 348 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
+        - ID: 67
+          Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84bce0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -646,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 69
-          Type: 356 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84bf60", Frameless: true}]
+        - ID: 75
+          Type: 363 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84c100", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -660,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 79
-          Type: 366 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84c3d0", Frameless: true}]
+        - ID: 85
+          Type: 373 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84c570", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -674,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 76
-          Type: 363 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84c3a0", Frameless: true}]
+        - ID: 82
+          Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84c540", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -688,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 78
-          Type: 365 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84c3c0", Frameless: true}]
+        - ID: 84
+          Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84c560", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -702,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 86
-          Type: 373 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84c770", Frameless: true}]
+        - ID: 92
+          Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84c910", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -716,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 65
-          Type: 352 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84bea0", Frameless: true}]
+        - ID: 71
+          Type: 359 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84c040", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -730,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 47
-          Type: 334 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84a6a0", Frameless: true}]
+        - ID: 53
+          Type: 341 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84a840", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -744,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 63
-          Type: 350 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84be80", Frameless: true}]
+        - ID: 69
+          Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84c020", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -758,10 +906,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 4}
+      subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 289 EventRootType Probe[main.testRuneArray]
+          Type: 290 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849110", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -772,10 +920,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 23}
+      subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 308 EventRootType Probe[main.testSingleBool]
+          Type: 309 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849580", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -786,10 +934,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 21}
+      subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 306 EventRootType Probe[main.testSingleByte]
+          Type: 307 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849560", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -800,10 +948,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 319 EventRootType Probe[main.testSingleFloat32]
+          Type: 320 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849630", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -814,10 +962,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 320 EventRootType Probe[main.testSingleFloat64]
+          Type: 321 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849640", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -828,10 +976,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 24}
+      subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 309 EventRootType Probe[main.testSingleInt]
+          Type: 310 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849590", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -842,10 +990,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 26}
+      subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 311 EventRootType Probe[main.testSingleInt16]
+          Type: 312 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -856,10 +1004,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 27}
+      subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 312 EventRootType Probe[main.testSingleInt32]
+          Type: 313 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -870,10 +1018,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 28}
+      subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 313 EventRootType Probe[main.testSingleInt64]
+          Type: 314 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -884,10 +1032,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 25}
+      subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 310 EventRootType Probe[main.testSingleInt8]
+          Type: 311 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -898,10 +1046,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 22}
+      subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 307 EventRootType Probe[main.testSingleRune]
+          Type: 308 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849570", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -912,11 +1060,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 82
-          Type: 369 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84c720", Frameless: true}]
+        - ID: 88
+          Type: 376 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84c8c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -926,10 +1074,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 29}
+      subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 314 EventRootType Probe[main.testSingleUint]
+          Type: 315 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x8495e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -940,10 +1088,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 31}
+      subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 316 EventRootType Probe[main.testSingleUint16]
+          Type: 317 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849600", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -954,10 +1102,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 317 EventRootType Probe[main.testSingleUint32]
+          Type: 318 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849610", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -968,10 +1116,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 318 EventRootType Probe[main.testSingleUint64]
+          Type: 319 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849620", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -982,10 +1130,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 30}
+      subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 315 EventRootType Probe[main.testSingleUint8]
+          Type: 316 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x8495f0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -996,11 +1144,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 73
-          Type: 360 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84c370", Frameless: true}]
+        - ID: 79
+          Type: 367 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84c510", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1010,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 45
-          Type: 332 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84a680", Frameless: true}]
+        - ID: 51
+          Type: 339 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84a820", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1024,10 +1172,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 5}
+      subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 290 EventRootType Probe[main.testStringArray]
+          Type: 291 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849120", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1038,11 +1186,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 68
-          Type: 355 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84bf40", Frameless: true}]
+        - ID: 74
+          Type: 362 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84c0e0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1052,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 77
-          Type: 364 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84c3b0", Frameless: true}]
+        - ID: 83
+          Type: 371 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84c550", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1066,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 90
-          Type: 377 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84c9b0", Frameless: true}]
+        - ID: 96
+          Type: 384 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84cb50", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1080,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 74
-          Type: 361 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84c380", Frameless: true}]
+        - ID: 80
+          Type: 368 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84c520", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1094,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 42}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 40
-          Type: 327 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84a630", Frameless: true}]
+        - ID: 46
+          Type: 334 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84a7d0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1108,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 83
-          Type: 370 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84c730", Frameless: true}]
+        - ID: 89
+          Type: 377 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84c8d0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1122,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 84
-          Type: 371 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84c740", Frameless: true}]
+        - ID: 90
+          Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84c8e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1136,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 85
-          Type: 372 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84c760", Frameless: true}]
+        - ID: 91
+          Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84c900", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1150,10 +1298,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 36}
+      subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 321 EventRootType Probe[main.testTypeAlias]
+          Type: 322 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849650", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1164,10 +1312,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 14}
+      subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 299 EventRootType Probe[main.testUint16Array]
+          Type: 300 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x8491b0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1178,10 +1326,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 15}
+      subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 300 EventRootType Probe[main.testUint32Array]
+          Type: 301 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x8491c0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1192,10 +1340,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 16}
+      subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 301 EventRootType Probe[main.testUint64Array]
+          Type: 302 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x8491d0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1206,10 +1354,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 13}
+      subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 298 EventRootType Probe[main.testUint8Array]
+          Type: 299 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x8491a0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1220,10 +1368,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 12}
+      subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 297 EventRootType Probe[main.testUintArray]
+          Type: 298 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849190", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1234,11 +1382,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 67
-          Type: 354 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84bed0", Frameless: true}]
+        - ID: 73
+          Type: 361 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84c070", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1248,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 71
-          Type: 358 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84c350", Frameless: true}]
+        - ID: 77
+          Type: 365 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84c4f0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1262,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 88
-          Type: 375 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84c790", Frameless: true}]
+        - ID: 94
+          Type: 382 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84c930", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1276,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 66
-          Type: 353 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84beb0", Frameless: true}]
+        - ID: 72
+          Type: 360 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84c050", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1290,10 +1438,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 20}
+      subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 305 EventRootType Probe[main.testVeryLargeArray]
+          Type: 306 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849230", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1304,266 +1452,266 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 80
-          Type: 367 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84c3e0", Frameless: true}]
+        - ID: 86
+          Type: 374 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84c580", Frameless: true}]
           Condition: null
 Subprograms:
-    - ID: 3
+    - ID: 7
       Name: main.testByteArray
       OutOfLinePCRanges: [0x849100..0x849110]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 2 ArrayType [2]uint8
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0x849100..0x849110
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 4
+    - ID: 8
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x849110..0x849120]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 ArrayType [2]int32
+          Type: 5 ArrayType [2]int32
           Locations:
             - Range: 0x849110..0x849120
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 5
+    - ID: 9
       Name: main.testStringArray
       OutOfLinePCRanges: [0x849120..0x849130]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 6 ArrayType [2]string
+          Type: 7 ArrayType [2]string
           Locations:
             - Range: 0x849120..0x849130
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 6
+    - ID: 10
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x849130..0x849140]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 9 ArrayType [2]bool
+          Type: 10 ArrayType [2]bool
           Locations:
             - Range: 0x849130..0x849140
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 7
+    - ID: 11
       Name: main.testIntArray
       OutOfLinePCRanges: [0x849140..0x849150]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 11 ArrayType [2]int
+          Type: 12 ArrayType [2]int
           Locations:
             - Range: 0x849140..0x849150
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 8
+    - ID: 12
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x849150..0x849160]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 12 ArrayType [2]int8
+          Type: 13 ArrayType [2]int8
           Locations:
             - Range: 0x849150..0x849160
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 9
+    - ID: 13
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x849160..0x849170]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 14 ArrayType [2]int16
+          Type: 15 ArrayType [2]int16
           Locations:
             - Range: 0x849160..0x849170
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 10
+    - ID: 14
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x849170..0x849180]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 4 ArrayType [2]int32
+          Type: 5 ArrayType [2]int32
           Locations:
             - Range: 0x849170..0x849180
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
+    - ID: 15
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x849180..0x849190]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 16 ArrayType [2]int64
+          Type: 17 ArrayType [2]int64
           Locations:
             - Range: 0x849180..0x849190
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 12
+    - ID: 16
       Name: main.testUintArray
       OutOfLinePCRanges: [0x849190..0x8491a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 18 ArrayType [2]uint
+          Type: 19 ArrayType [2]uint
           Locations:
             - Range: 0x849190..0x8491a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 13
+    - ID: 17
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x8491a0..0x8491b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 2 ArrayType [2]uint8
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0x8491a0..0x8491b0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 14
+    - ID: 18
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x8491b0..0x8491c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 20 ArrayType [2]uint16
+          Type: 21 ArrayType [2]uint16
           Locations:
             - Range: 0x8491b0..0x8491c0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 15
+    - ID: 19
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x8491c0..0x8491d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 22 ArrayType [2]uint32
+          Type: 23 ArrayType [2]uint32
           Locations:
             - Range: 0x8491c0..0x8491d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 16
+    - ID: 20
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x8491d0..0x8491e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 24 ArrayType [2]uint64
+          Type: 25 ArrayType [2]uint64
           Locations:
             - Range: 0x8491d0..0x8491e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 17
+    - ID: 21
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x8491e0..0x8491f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 26 ArrayType [2][2]int
+          Type: 27 ArrayType [2][2]int
           Locations:
             - Range: 0x8491e0..0x8491f0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 18
+    - ID: 22
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x8491f0..0x849200]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 6 ArrayType [2]string
+          Type: 7 ArrayType [2]string
           Locations:
             - Range: 0x8491f0..0x849200
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 19
+    - ID: 23
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x849200..0x849210]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 27 ArrayType [2][2][2]int
+          Type: 28 ArrayType [2][2][2]int
           Locations:
             - Range: 0x849200..0x849210
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 20
+    - ID: 24
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x849230..0x849240]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 28 ArrayType [100]uint
+          Type: 29 ArrayType [100]uint
           Locations:
             - Range: 0x849230..0x849240
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 21
+    - ID: 25
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x849560..0x849570]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x849560..0x849570
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 22
+    - ID: 26
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x849570..0x849580]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
           Locations:
             - Range: 0x849570..0x849580
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 23
+    - ID: 27
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x849580..0x849590]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
           Locations:
             - Range: 0x849580..0x849590
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 24
+    - ID: 28
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x849590..0x8495a0]
       InlinePCRanges: []
@@ -1575,157 +1723,157 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 25
+    - ID: 29
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x8495a0..0x8495b0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 13 BaseType int8
+          Type: 14 BaseType int8
           Locations:
             - Range: 0x8495a0..0x8495b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 26
+    - ID: 30
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x8495b0..0x8495c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 15 BaseType int16
+          Type: 16 BaseType int16
           Locations:
             - Range: 0x8495b0..0x8495c0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 27
+    - ID: 31
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x8495c0..0x8495d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
           Locations:
             - Range: 0x8495c0..0x8495d0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 28
+    - ID: 32
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x8495d0..0x8495e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 17 BaseType int64
+          Type: 18 BaseType int64
           Locations:
             - Range: 0x8495d0..0x8495e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 29
+    - ID: 33
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x8495e0..0x8495f0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
           Locations:
             - Range: 0x8495e0..0x8495f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 30
+    - ID: 34
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x8495f0..0x849600]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
           Locations:
             - Range: 0x8495f0..0x849600
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 31
+    - ID: 35
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x849600..0x849610]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
           Locations:
             - Range: 0x849600..0x849610
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 32
+    - ID: 36
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x849610..0x849620]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
           Locations:
             - Range: 0x849610..0x849620
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 33
+    - ID: 37
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x849620..0x849630]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
           Locations:
             - Range: 0x849620..0x849630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 34
+    - ID: 38
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x849630..0x849640]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 29 BaseType float32
+          Type: 30 BaseType float32
           Locations:
             - Range: 0x849630..0x849640
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 35
+    - ID: 39
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x849640..0x849650]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 30 BaseType float64
+          Type: 31 BaseType float64
           Locations:
             - Range: 0x849640..0x849650
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 36
+    - ID: 40
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x849650..0x849660]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 31 BaseType main.typeAlias
+          Type: 32 BaseType main.typeAlias
           Locations:
             - Range: 0x849650..0x849660
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 37
+    - ID: 41
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x849760..0x849780]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 32 StructureType main.bigStruct
+          Type: 33 StructureType main.bigStruct
           Locations:
             - Range: 0x849760..0x849780
               Pieces:
@@ -1743,13 +1891,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 38
+    - ID: 42
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x849920..0x8499f0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 56 StructureType main.esotericStack
+          Type: 57 StructureType main.esotericStack
           Locations:
             - Range: 0x849920..0x849968
               Pieces:
@@ -1813,33 +1961,146 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 39
+    - ID: 43
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x8499f0..0x849a70]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 62 PointerType *main.esotericHeap
+          Type: 63 PointerType *main.esotericHeap
           Locations:
             - Range: 0x8499f0..0x849a28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 40
+    - ID: 44
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x849e30..0x849ec0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x849e30..0x849e68
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 45
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x849ec0..0x849f80]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x849ec0..0x849edc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x849ec0..0x849eec
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: z
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x849edc..0x849eec
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x849eec..0x849f80
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 46
+      Name: main.testInlinedBBA
+      OutOfLinePCRanges: [0x849f80..0x84a000]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x849f80..0x849fa4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 47
+      Name: main.testInlinedBC
+      OutOfLinePCRanges: [0x84a000..0x84a120]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84a068..0x84a070
+              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+            - Range: 0x84a070..0x84a088
+              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+            - Range: 0x84a088..0x84a09c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84a064..0x84a06c
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x84a06c..0x84a088
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x84a088..0x84a098
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 48
+      Name: main.testFrameless
+      OutOfLinePCRanges: [0x84a120..0x84a130]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84a120..0x84a128
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0x84a120..0x84a130, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 49
+      Name: main.testFramelessArray
+      OutOfLinePCRanges: [0x84a130..0x84a190]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0x84a130..0x84a190
+              Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 1 BaseType int
+          Locations: [{Range: 0x84a130..0x84a190, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84a220..0x84a410]
+      OutOfLinePCRanges: [0x84a3c0..0x84a5b0]
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 75 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84a220..0x84a24c
+            - Range: 0x84a3c0..0x84a3ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a24c..0x84a250
+            - Range: 0x84a3ec..0x84a3f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1848,32 +2109,32 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: ~r0
-          Type: 7 GoStringHeaderType string
-          Locations: [{Range: 0x84a220..0x84a410, Pieces: []}]
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x84a3c0..0x84a5b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: hash
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84a280..0x84a284
+            - Range: 0x84a420..0x84a424
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84a284..0x84a290
+            - Range: 0x84a424..0x84a430
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16288}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a290..0x84a294
+            - Range: 0x84a430..0x84a434
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16288}
                 - Size: 8
                   Op: {CfaOffset: -136}
-            - Range: 0x84a294..0x84a410
+            - Range: 0x84a434..0x84a5b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16288}
@@ -1882,27 +2143,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: inter
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84a2c4..0x84a2c8
+            - Range: 0x84a464..0x84a468
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84a2c8..0x84a2d4
+            - Range: 0x84a468..0x84a474
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a2d4..0x84a2d8
+            - Range: 0x84a474..0x84a478
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
                 - Size: 8
                   Op: {CfaOffset: -160}
-            - Range: 0x84a2d8..0x84a410
+            - Range: 0x84a478..0x84a5b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16264}
@@ -1911,27 +2172,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: iType
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84a308..0x84a30c
+            - Range: 0x84a4a8..0x84a4ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84a30c..0x84a318
+            - Range: 0x84a4ac..0x84a4b8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a318..0x84a324
+            - Range: 0x84a4b8..0x84a4c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
                 - Size: 8
                   Op: {CfaOffset: -152}
-            - Range: 0x84a324..0x84a410
+            - Range: 0x84a4c4..0x84a5b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16272}
@@ -1940,27 +2201,27 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: iFun
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84a354..0x84a358
+            - Range: 0x84a4f4..0x84a4f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84a358..0x84a370
+            - Range: 0x84a4f8..0x84a510
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a370..0x84a374
+            - Range: 0x84a510..0x84a514
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
                 - Size: 8
                   Op: {CfaOffset: -144}
-            - Range: 0x84a374..0x84a410
+            - Range: 0x84a514..0x84a5b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16280}
@@ -1968,15 +2229,15 @@ Subprograms:
                   Op: {CfaOffset: -144}
           IsParameter: false
           IsReturn: false
-    - ID: 41
+    - ID: 51
       Name: main.testError
-      OutOfLinePCRanges: [0x84a410..0x84a420]
+      OutOfLinePCRanges: [0x84a5b0..0x84a5c0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 75 GoInterfaceType error
+          Type: 76 GoInterfaceType error
           Locations:
-            - Range: 0x84a410..0x84a420
+            - Range: 0x84a5b0..0x84a5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1984,548 +2245,498 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 42
+    - ID: 52
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84a630..0x84a640]
+      OutOfLinePCRanges: [0x84a7d0..0x84a7e0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 76 StructureType main.structWithMap
+          Type: 77 StructureType main.structWithMap
           Locations:
-            - Range: 0x84a630..0x84a640
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 43
-      Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84a640..0x84a650]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 88 GoMapType map[string]main.nestedStruct
-          Locations:
-            - Range: 0x84a640..0x84a650
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 44
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84a650..0x84a660]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x84a650..0x84a660
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 45
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84a660..0x84a670]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 111 GoMapType map[string][]string
-          Locations:
-            - Range: 0x84a660..0x84a670
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84a670..0x84a680]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 123 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x84a670..0x84a680
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 47
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84a680..0x84a690]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x84a680..0x84a690
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 48
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84a690..0x84a6a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 135 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x84a690..0x84a6a0
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 49
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84a6a0..0x84a6b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 136 PointerType *map[string]int
-          Locations:
-            - Range: 0x84a6a0..0x84a6b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 50
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84a6b0..0x84a6c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 77 GoMapType map[int]int
-          Locations:
-            - Range: 0x84a6b0..0x84a6c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 51
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84a6c0..0x84a6d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 137 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84a6c0..0x84a6d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 52
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84a6d0..0x84a6e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 137 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84a6d0..0x84a6e0
+            - Range: 0x84a7d0..0x84a7e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 53
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84a6e0..0x84a6f0]
+      Name: main.testMapStringToStruct
+      OutOfLinePCRanges: [0x84a7e0..0x84a7f0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 150 GoMapType map[bool]main.node
+          Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84a6e0..0x84a6f0
+            - Range: 0x84a7e0..0x84a7f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 54
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84a6f0..0x84a700]
+      Name: main.testMapStringToInt
+      OutOfLinePCRanges: [0x84a7f0..0x84a800]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 163 GoMapType map[int]uint8
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x84a6f0..0x84a700
+            - Range: 0x84a7f0..0x84a800
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 55
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84a700..0x84a710]
+      Name: main.testMapStringToSlice
+      OutOfLinePCRanges: [0x84a800..0x84a810]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 163 GoMapType map[int]uint8
+        - Name: m
+          Type: 112 GoMapType map[string][]string
           Locations:
-            - Range: 0x84a700..0x84a710
+            - Range: 0x84a800..0x84a810
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84a710..0x84a720]
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x84a810..0x84a820]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 174 GoMapType map[uint8]uint8
+          Type: 124 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84a710..0x84a720
+            - Range: 0x84a810..0x84a820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84a720..0x84a730]
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84a820..0x84a830]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 174 GoMapType map[uint8]uint8
+          Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x84a720..0x84a730
+            - Range: 0x84a820..0x84a830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84a730..0x84a740]
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x84a830..0x84a840]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 174 GoMapType map[uint8]uint8
+          Type: 136 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84a730..0x84a740
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84a830..0x84a840
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84a740..0x84a750]
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x84a840..0x84a850]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 185 GoMapType map[uint8][4]int
+          Type: 137 PointerType *map[string]int
           Locations:
-            - Range: 0x84a740..0x84a750
+            - Range: 0x84a840..0x84a850
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
-      Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84a750..0x84a760]
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x84a850..0x84a860]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 197 GoMapType map[[4]int]uint8
+          Type: 78 GoMapType map[int]int
           Locations:
-            - Range: 0x84a750..0x84a760
+            - Range: 0x84a850..0x84a860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
-      Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84a760..0x84a770]
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x84a860..0x84a870]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 208 GoMapType map[[4]int][4]int
+        - Name: redactMyEntries
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84a760..0x84a770
+            - Range: 0x84a860..0x84a870
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 62
-      Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84ba60..0x84ba70]
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x84a870..0x84a880]
       InlinePCRanges: []
       Variables:
-        - Name: w
-          Type: 3 BaseType uint8
+        - Name: m
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84ba60..0x84ba70
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: x
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0x84ba60..0x84ba70
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: y
-          Type: 29 BaseType float32
-          Locations:
-            - Range: 0x84ba60..0x84ba70
-              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x84a870..0x84a880
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 63
-      Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84bb40..0x84bb50]
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x84a880..0x84a890]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 10 BaseType bool
+        - Name: m
+          Type: 151 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84bb40..0x84bb50
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: b
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0x84bb40..0x84bb50
-              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: c
-          Type: 5 BaseType int32
-          Locations:
-            - Range: 0x84bb40..0x84bb50
-              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: d
-          Type: 19 BaseType uint
-          Locations:
-            - Range: 0x84bb40..0x84bb50
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: e
-          Type: 7 GoStringHeaderType string
-          Locations:
-            - Range: 0x84bb40..0x84bb50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x84a880..0x84a890
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 64
-      Name: main.testChannel
-      OutOfLinePCRanges: [0x84bce0..0x84bcf0]
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x84a890..0x84a8a0]
       InlinePCRanges: []
       Variables:
-        - Name: c
-          Type: 219 GoChannelType chan bool
+        - Name: m
+          Type: 164 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84bce0..0x84bcf0
-              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84a890..0x84a8a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 65
-      Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84be80..0x84be90]
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x84a8a0..0x84a8b0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 220 PointerType *main.structWithTwoValues
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84be80..0x84be90
+            - Range: 0x84a8a0..0x84a8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 66
-      Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84be90..0x84bea0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84a8b0..0x84a8c0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 161 StructureType main.node
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84be90..0x84bea0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84a8b0..0x84a8c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 67
-      Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84bea0..0x84beb0]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 162 PointerType *main.node
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84bea0..0x84beb0
+            - Range: 0x84a8c0..0x84a8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 68
-      Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84beb0..0x84bec0]
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84a8d0..0x84a8e0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 55 VoidPointerType unsafe.Pointer
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84beb0..0x84bec0
+            - Range: 0x84a8d0..0x84a8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 69
-      Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84bed0..0x84bee0]
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84a8e0..0x84a8f0]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 222 PointerType *uint
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x84bed0..0x84bee0
+            - Range: 0x84a8e0..0x84a8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 70
-      Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84bf40..0x84bf50]
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84a8f0..0x84a900]
       InlinePCRanges: []
       Variables:
-        - Name: z
-          Type: 35 PointerType *string
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x84bf40..0x84bf50
+            - Range: 0x84a8f0..0x84a900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 71
-      Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84bf60..0x84bf70]
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84a900..0x84a910]
       InlinePCRanges: []
       Variables:
-        - Name: z
-          Type: 223 PointerType *bool
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x84bf60..0x84bf70
+            - Range: 0x84a900..0x84a910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 19 BaseType uint
-          Locations:
-            - Range: 0x84bf60..0x84bf70
-              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testCycle
-      OutOfLinePCRanges: [0x84bf80..0x84bf90]
+      Name: main.testCombinedByte
+      OutOfLinePCRanges: [0x84bc00..0x84bc10]
       InlinePCRanges: []
       Variables:
-        - Name: t
-          Type: 224 PointerType *main.t
+        - Name: w
+          Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84bf80..0x84bf90
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84bc00..0x84bc10
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: x
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x84bc00..0x84bc10
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: y
+          Type: 30 BaseType float32
+          Locations:
+            - Range: 0x84bc00..0x84bc10
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84c350..0x84c360]
+      Name: main.testMultipleSimpleParams
+      OutOfLinePCRanges: [0x84bce0..0x84bcf0]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 227 GoSliceHeaderType []uint
+        - Name: a
+          Type: 11 BaseType bool
           Locations:
-            - Range: 0x84c350..0x84c360
+            - Range: 0x84bce0..0x84bcf0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 4 BaseType uint8
+          Locations:
+            - Range: 0x84bce0..0x84bcf0
+              Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 6 BaseType int32
+          Locations:
+            - Range: 0x84bce0..0x84bcf0
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x84bce0..0x84bcf0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x84bce0..0x84bcf0
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
+                  Op: {RegNo: 4, Shift: 0}
                 - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+                  Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
     - ID: 74
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84c360..0x84c370]
+      Name: main.testChannel
+      OutOfLinePCRanges: [0x84be80..0x84be90]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 227 GoSliceHeaderType []uint
+        - Name: c
+          Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0x84c360..0x84c370
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x84be80..0x84be90
+              Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84c370..0x84c380]
+      Name: main.testPointerToSimpleStruct
+      OutOfLinePCRanges: [0x84c020..0x84c030]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 228 GoSliceHeaderType [][]uint
+        - Name: a
+          Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84c370..0x84c380
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x84c020..0x84c030
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 76
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84c380..0x84c390]
+      Name: main.testLinkedList
+      OutOfLinePCRanges: [0x84c030..0x84c040]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
+        - Name: a
+          Type: 162 StructureType main.node
           Locations:
-            - Range: 0x84c380..0x84c390
+            - Range: 0x84c030..0x84c040
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x84c380..0x84c390
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 77
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84c390..0x84c3a0]
+      Name: main.testPointerLoop
+      OutOfLinePCRanges: [0x84c040..0x84c050]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84c390..0x84c3a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
         - Name: a
-          Type: 1 BaseType int
+          Type: 163 PointerType *main.node
           Locations:
-            - Range: 0x84c390..0x84c3a0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84c040..0x84c050
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 78
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84c3a0..0x84c3b0]
+      Name: main.testUnsafePointer
+      OutOfLinePCRanges: [0x84c050..0x84c060]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 56 VoidPointerType unsafe.Pointer
+          Locations:
+            - Range: 0x84c050..0x84c060
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 79
+      Name: main.testUintPointer
+      OutOfLinePCRanges: [0x84c070..0x84c080]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 223 PointerType *uint
+          Locations:
+            - Range: 0x84c070..0x84c080
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 80
+      Name: main.testStringPointer
+      OutOfLinePCRanges: [0x84c0e0..0x84c0f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 36 PointerType *string
+          Locations:
+            - Range: 0x84c0e0..0x84c0f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 81
+      Name: main.testNilPointer
+      OutOfLinePCRanges: [0x84c100..0x84c110]
+      InlinePCRanges: []
+      Variables:
+        - Name: z
+          Type: 224 PointerType *bool
+          Locations:
+            - Range: 0x84c100..0x84c110
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 20 BaseType uint
+          Locations:
+            - Range: 0x84c100..0x84c110
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 82
+      Name: main.testCycle
+      OutOfLinePCRanges: [0x84c120..0x84c130]
+      InlinePCRanges: []
+      Variables:
+        - Name: t
+          Type: 225 PointerType *main.t
+          Locations:
+            - Range: 0x84c120..0x84c130
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 83
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84c4f0..0x84c500]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84c4f0..0x84c500
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 84
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84c500..0x84c510]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84c500..0x84c510
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 85
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84c510..0x84c520]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 229 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x84c510..0x84c520
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 86
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84c520..0x84c530]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 230 GoSliceHeaderType []main.structWithNoStrings
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84c3a0..0x84c3b0
+            - Range: 0x84c520..0x84c530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2538,19 +2749,19 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84c3a0..0x84c3b0
+            - Range: 0x84c520..0x84c530
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84c3b0..0x84c3c0]
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84c530..0x84c540]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 122 GoSliceHeaderType []string
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84c3b0..0x84c3c0
+            - Range: 0x84c530..0x84c540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2560,22 +2771,72 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 80
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84c530..0x84c540
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84c540..0x84c550]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84c540..0x84c550
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84c540..0x84c550
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84c550..0x84c560]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 123 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84c550..0x84c560
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84c3c0..0x84c3d0]
+      OutOfLinePCRanges: [0x84c560..0x84c570]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 13 BaseType int8
+          Type: 14 BaseType int8
           Locations:
-            - Range: 0x84c3c0..0x84c3d0
+            - Range: 0x84c560..0x84c570
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 233 GoSliceHeaderType []bool
+          Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84c3c0..0x84c3d0
+            - Range: 0x84c560..0x84c570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -2586,21 +2847,21 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: x
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c3c0..0x84c3d0
+            - Range: 0x84c560..0x84c570
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 91
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84c3d0..0x84c3e0]
+      OutOfLinePCRanges: [0x84c570..0x84c580]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 234 GoSliceHeaderType []uint16
+          Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84c3d0..0x84c3e0
+            - Range: 0x84c570..0x84c580
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2610,15 +2871,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 92
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84c3e0..0x84c3f0]
+      OutOfLinePCRanges: [0x84c580..0x84c590]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 227 GoSliceHeaderType []uint
+          Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c3e0..0x84c3f0
+            - Range: 0x84c580..0x84c590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2628,25 +2889,25 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 93
       Name: main.stackC
-      OutOfLinePCRanges: [0x84c6b0..0x84c720]
+      OutOfLinePCRanges: [0x84c850..0x84c8c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 7 GoStringHeaderType string
-          Locations: [{Range: 0x84c6b0..0x84c720, Pieces: []}]
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x84c850..0x84c8c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 84
+    - ID: 94
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84c720..0x84c730]
+      OutOfLinePCRanges: [0x84c8c0..0x84c8d0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c720..0x84c730
+            - Range: 0x84c8c0..0x84c8d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2654,15 +2915,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 95
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84c730..0x84c740]
+      OutOfLinePCRanges: [0x84c8d0..0x84c8e0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c730..0x84c740
+            - Range: 0x84c8d0..0x84c8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2671,9 +2932,9 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: y
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c730..0x84c740
+            - Range: 0x84c8d0..0x84c8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2682,9 +2943,9 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: z
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c730..0x84c740
+            - Range: 0x84c8d0..0x84c8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2692,15 +2953,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 96
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84c740..0x84c760]
+      OutOfLinePCRanges: [0x84c8e0..0x84c900]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 236 StructureType main.threeStringStruct
+          Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84c740..0x84c760
+            - Range: 0x84c8e0..0x84c900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2716,39 +2977,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 97
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84c760..0x84c770]
+      OutOfLinePCRanges: [0x84c900..0x84c910]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 237 PointerType *main.threeStringStruct
+          Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84c760..0x84c770
+            - Range: 0x84c900..0x84c910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 98
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84c770..0x84c780]
+      OutOfLinePCRanges: [0x84c910..0x84c920]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 238 PointerType *main.oneStringStruct
+          Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84c770..0x84c780
+            - Range: 0x84c910..0x84c920
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 89
+    - ID: 99
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84c780..0x84c790]
+      OutOfLinePCRanges: [0x84c920..0x84c930]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c780..0x84c790
+            - Range: 0x84c920..0x84c930
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2756,15 +3017,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 100
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84c790..0x84c7a0]
+      OutOfLinePCRanges: [0x84c930..0x84c940]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c790..0x84c7a0
+            - Range: 0x84c930..0x84c940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2772,15 +3033,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 101
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84c7a0..0x84c7b0]
+      OutOfLinePCRanges: [0x84c940..0x84c950]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c7a0..0x84c7b0
+            - Range: 0x84c940..0x84c950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2788,15 +3049,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 92
+    - ID: 102
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84c9b0..0x84c9d0]
+      OutOfLinePCRanges: [0x84cb50..0x84cb70]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 240 StructureType main.aStruct
+          Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0x84c9b0..0x84c9d0
+            - Range: 0x84cb50..0x84cb70
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -2814,14 +3075,14 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 93
+    - ID: 103
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84cab0..0x84cac0]
+      OutOfLinePCRanges: [0x84cc50..0x84cc60]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 241 StructureType main.emptyStruct
-          Locations: [{Range: 0x84cab0..0x84cac0, Pieces: []}]
+          Type: 242 StructureType main.emptyStruct
+          Locations: [{Range: 0x84cc50..0x84cc60, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
@@ -2830,7 +3091,8 @@ Subprograms:
       InlinePCRanges:
         - - 0x849d1c..0x849d54
         - - 0x849e68..0x849ea0
-        - - 0x849f5c..0x849f94
+        - - 0x849ee4..0x849f1c
+        - - 0x849f9c..0x849fd4
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -2841,15 +3103,55 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x849e68..0x849e70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x849f40..0x849f64
+            - Range: 0x849edc..0x849eec
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x849eec..0x849f80
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x849f80..0x849fa4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 2
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x849ee4..0x849f1c]]
+      InlinePCRanges: [[0x849f28..0x849f60]]
       Variables: []
+    - ID: 3
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0x84a01c..0x84a060]]
+      Variables: []
+    - ID: 4
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0x84a0d0..0x84a108]]
+      Variables: []
+    - ID: 5
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0x84a124..0x84a128]]
+      Variables:
+        - Name: x
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84a120..0x84a128
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 6
+      Name: main.testInlinedSumArray
+      OutOfLinePCRanges: []
+      InlinePCRanges: [[0x84a154..0x84a178], [0x84a1ec..0x84a214]]
+      Variables:
+        - Name: a
+          Type: 2 ArrayType [5]int
+          Locations:
+            - Range: 0x84a140..0x84a190
+              Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
+            - Range: 0x84a1d8..0x84a2e0
+              Pieces: [{Size: 40, Op: {CfaOffset: 16264}}]
+          IsParameter: true
+          IsReturn: false
 Types:
     - __kind: BaseType
       ID: 1
@@ -2859,45 +3161,53 @@ Types:
       GoKind: 2
     - __kind: ArrayType
       ID: 2
+      Name: '[5]int'
+      ByteSize: 40
+      GoKind: 17
+      Count: 5
+      HasCount: true
+      Element: 1 BaseType int
+    - __kind: ArrayType
+      ID: 3
       Name: '[2]uint8'
       ByteSize: 2
       GoRuntimeType: 674272
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 3 BaseType uint8
+      Element: 4 BaseType uint8
     - __kind: BaseType
-      ID: 3
+      ID: 4
       Name: uint8
       ByteSize: 1
       GoRuntimeType: 574880
       GoKind: 8
     - __kind: ArrayType
-      ID: 4
+      ID: 5
       Name: '[2]int32'
       ByteSize: 8
       GoRuntimeType: 674368
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 5 BaseType int32
+      Element: 6 BaseType int32
     - __kind: BaseType
-      ID: 5
+      ID: 6
       Name: int32
       ByteSize: 4
       GoRuntimeType: 575072
       GoKind: 5
     - __kind: ArrayType
-      ID: 6
+      ID: 7
       Name: '[2]string'
       ByteSize: 32
       GoRuntimeType: 674464
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 7
+      ID: 8
       Name: string
       ByteSize: 16
       GoRuntimeType: 574752
@@ -2905,34 +3215,34 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 243 PointerType *string.str
+          Type: 244 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 242 GoStringDataType string.str
+      Data: 243 GoStringDataType string.str
     - __kind: PointerType
-      ID: 8
+      ID: 9
       Name: '*uint8'
       ByteSize: 8
       GoRuntimeType: 385216
       GoKind: 22
-      Pointee: 3 BaseType uint8
+      Pointee: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 9
+      ID: 10
       Name: '[2]bool'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 10 BaseType bool
+      Element: 11 BaseType bool
     - __kind: BaseType
-      ID: 10
+      ID: 11
       Name: bool
       ByteSize: 1
       GoRuntimeType: 575776
       GoKind: 1
     - __kind: ArrayType
-      ID: 11
+      ID: 12
       Name: '[2]int'
       ByteSize: 16
       GoRuntimeType: 673216
@@ -2941,162 +3251,162 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: ArrayType
-      ID: 12
+      ID: 13
       Name: '[2]int8'
       ByteSize: 2
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 13 BaseType int8
+      Element: 14 BaseType int8
     - __kind: BaseType
-      ID: 13
+      ID: 14
       Name: int8
       ByteSize: 1
       GoRuntimeType: 574816
       GoKind: 3
     - __kind: ArrayType
-      ID: 14
+      ID: 15
       Name: '[2]int16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 15 BaseType int16
+      Element: 16 BaseType int16
     - __kind: BaseType
-      ID: 15
+      ID: 16
       Name: int16
       ByteSize: 2
       GoRuntimeType: 574944
       GoKind: 4
     - __kind: ArrayType
-      ID: 16
+      ID: 17
       Name: '[2]int64'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 17 BaseType int64
+      Element: 18 BaseType int64
     - __kind: BaseType
-      ID: 17
+      ID: 18
       Name: int64
       ByteSize: 8
       GoRuntimeType: 575200
       GoKind: 6
     - __kind: ArrayType
-      ID: 18
+      ID: 19
       Name: '[2]uint'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: BaseType
-      ID: 19
+      ID: 20
       Name: uint
       ByteSize: 8
       GoRuntimeType: 575392
       GoKind: 7
     - __kind: ArrayType
-      ID: 20
+      ID: 21
       Name: '[2]uint16'
       ByteSize: 4
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 21 BaseType uint16
+      Element: 22 BaseType uint16
     - __kind: BaseType
-      ID: 21
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 575008
       GoKind: 9
     - __kind: ArrayType
-      ID: 22
+      ID: 23
       Name: '[2]uint32'
       ByteSize: 8
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 23 BaseType uint32
+      Element: 24 BaseType uint32
     - __kind: BaseType
-      ID: 23
+      ID: 24
       Name: uint32
       ByteSize: 4
       GoRuntimeType: 575136
       GoKind: 10
     - __kind: ArrayType
-      ID: 24
+      ID: 25
       Name: '[2]uint64'
       ByteSize: 16
       GoRuntimeType: 674560
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 25 BaseType uint64
+      Element: 26 BaseType uint64
     - __kind: BaseType
-      ID: 25
+      ID: 26
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 575264
       GoKind: 11
     - __kind: ArrayType
-      ID: 26
+      ID: 27
       Name: '[2][2]int'
       ByteSize: 32
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 11 ArrayType [2]int
+      Element: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 27
+      ID: 28
       Name: '[2][2][2]int'
       ByteSize: 64
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 26 ArrayType [2][2]int
+      Element: 27 ArrayType [2][2]int
     - __kind: ArrayType
-      ID: 28
+      ID: 29
       Name: '[100]uint'
       ByteSize: 800
       GoKind: 17
       Count: 100
       HasCount: true
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: BaseType
-      ID: 29
+      ID: 30
       Name: float32
       ByteSize: 4
       GoRuntimeType: 575648
       GoKind: 13
     - __kind: BaseType
-      ID: 30
+      ID: 31
       Name: float64
       ByteSize: 8
       GoRuntimeType: 575712
       GoKind: 14
     - __kind: BaseType
-      ID: 31
+      ID: 32
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
     - __kind: StructureType
-      ID: 32
+      ID: 33
       Name: main.bigStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: x
           Offset: 0
-          Type: 33 GoSliceHeaderType []*string
+          Type: 34 GoSliceHeaderType []*string
         - Name: z
           Offset: 24
           Type: 1 BaseType int
         - Name: writer
           Offset: 32
-          Type: 36 GoInterfaceType io.Writer
+          Type: 37 GoInterfaceType io.Writer
     - __kind: GoSliceHeaderType
-      ID: 33
+      ID: 34
       Name: '[]*string'
       ByteSize: 24
       GoRuntimeType: 470464
@@ -3104,56 +3414,56 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 34 PointerType **string
+          Type: 35 PointerType **string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 244 GoSliceDataType []*string.array
+      Data: 245 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 34
+      ID: 35
       Name: '**string'
       ByteSize: 8
       GoRuntimeType: 518912
       GoKind: 22
-      Pointee: 35 PointerType *string
+      Pointee: 36 PointerType *string
     - __kind: PointerType
-      ID: 35
+      ID: 36
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 385088
       GoKind: 22
-      Pointee: 7 GoStringHeaderType string
+      Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 36
+      ID: 37
       Name: io.Writer
       ByteSize: 16
       GoRuntimeType: 1.011456e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
-      ID: 37
+      ID: 38
       Name: runtime.iface
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 38 PointerType *internal/abi.ITab
+          Type: 39 PointerType *internal/abi.ITab
         - Name: data
           Offset: 8
-          Type: 55 VoidPointerType unsafe.Pointer
+          Type: 56 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 38
+      ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
       GoRuntimeType: 408192
       GoKind: 22
-      Pointee: 39 StructureType internal/abi.ITab
+      Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
-      ID: 39
+      ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
       GoRuntimeType: 1.740992e+06
@@ -3161,25 +3471,25 @@ Types:
       RawFields:
         - Name: Inter
           Offset: 0
-          Type: 40 PointerType *internal/abi.InterfaceType
+          Type: 41 PointerType *internal/abi.InterfaceType
         - Name: Type
           Offset: 8
-          Type: 53 PointerType *internal/abi.Type
+          Type: 54 PointerType *internal/abi.Type
         - Name: Hash
           Offset: 16
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
         - Name: Fun
           Offset: 24
-          Type: 54 ArrayType [1]uintptr
+          Type: 55 ArrayType [1]uintptr
     - __kind: PointerType
-      ID: 40
+      ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
       GoRuntimeType: 2.188288e+06
       GoKind: 22
-      Pointee: 41 StructureType internal/abi.InterfaceType
+      Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
-      ID: 41
+      ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
       GoRuntimeType: 1.617248e+06
@@ -3187,15 +3497,15 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 42 StructureType internal/abi.Type
+          Type: 43 StructureType internal/abi.Type
         - Name: PkgPath
           Offset: 48
-          Type: 49 StructureType internal/abi.Name
+          Type: 50 StructureType internal/abi.Name
         - Name: Methods
           Offset: 56
-          Type: 50 GoSliceHeaderType []internal/abi.Imethod
+          Type: 51 GoSliceHeaderType []internal/abi.Imethod
     - __kind: StructureType
-      ID: 42
+      ID: 43
       Name: internal/abi.Type
       ByteSize: 48
       GoRuntimeType: 2.108928e+06
@@ -3203,75 +3513,75 @@ Types:
       RawFields:
         - Name: Size_
           Offset: 0
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: PtrBytes
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: Hash
           Offset: 16
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
         - Name: TFlag
           Offset: 20
-          Type: 44 BaseType internal/abi.TFlag
+          Type: 45 BaseType internal/abi.TFlag
         - Name: Align_
           Offset: 21
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: FieldAlign_
           Offset: 22
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: Kind_
           Offset: 23
-          Type: 45 BaseType internal/abi.Kind
+          Type: 46 BaseType internal/abi.Kind
         - Name: Equal
           Offset: 24
-          Type: 46 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
+          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
         - Name: GCData
           Offset: 32
-          Type: 8 PointerType *uint8
+          Type: 9 PointerType *uint8
         - Name: Str
           Offset: 40
-          Type: 47 BaseType internal/abi.NameOff
+          Type: 48 BaseType internal/abi.NameOff
         - Name: PtrToThis
           Offset: 44
-          Type: 48 BaseType internal/abi.TypeOff
+          Type: 49 BaseType internal/abi.TypeOff
     - __kind: BaseType
-      ID: 43
+      ID: 44
       Name: uintptr
       ByteSize: 8
       GoRuntimeType: 575456
       GoKind: 12
     - __kind: BaseType
-      ID: 44
+      ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
       GoRuntimeType: 578208
       GoKind: 8
     - __kind: BaseType
-      ID: 45
+      ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
       GoRuntimeType: 824000
       GoKind: 8
     - __kind: GoSubroutineType
-      ID: 46
+      ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
       GoRuntimeType: 834176
       GoKind: 19
     - __kind: BaseType
-      ID: 47
+      ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
       GoRuntimeType: 578272
       GoKind: 5
     - __kind: BaseType
-      ID: 48
+      ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
       GoRuntimeType: 578336
       GoKind: 5
     - __kind: StructureType
-      ID: 49
+      ID: 50
       Name: internal/abi.Name
       ByteSize: 8
       GoRuntimeType: 1.953056e+06
@@ -3279,9 +3589,9 @@ Types:
       RawFields:
         - Name: Bytes
           Offset: 0
-          Type: 8 PointerType *uint8
+          Type: 9 PointerType *uint8
     - __kind: GoSliceHeaderType
-      ID: 50
+      ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
       GoRuntimeType: 497408
@@ -3289,23 +3599,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 51 PointerType *internal/abi.Imethod
+          Type: 52 PointerType *internal/abi.Imethod
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 246 GoSliceDataType []internal/abi.Imethod.array
+      Data: 247 GoSliceDataType []internal/abi.Imethod.array
     - __kind: PointerType
-      ID: 51
+      ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
       GoRuntimeType: 408128
       GoKind: 22
-      Pointee: 52 StructureType internal/abi.Imethod
+      Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
-      ID: 52
+      ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
       GoRuntimeType: 1.468672e+06
@@ -3313,34 +3623,34 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 47 BaseType internal/abi.NameOff
+          Type: 48 BaseType internal/abi.NameOff
         - Name: Typ
           Offset: 4
-          Type: 48 BaseType internal/abi.TypeOff
+          Type: 49 BaseType internal/abi.TypeOff
     - __kind: PointerType
-      ID: 53
+      ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.188736e+06
       GoKind: 22
-      Pointee: 42 StructureType internal/abi.Type
+      Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
-      ID: 54
+      ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
       GoRuntimeType: 672256
       GoKind: 17
       Count: 1
       HasCount: true
-      Element: 43 BaseType uintptr
+      Element: 44 BaseType uintptr
     - __kind: VoidPointerType
-      ID: 55
+      ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 575840
       GoKind: 26
     - __kind: StructureType
-      ID: 56
+      ID: 57
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.944416e+06
@@ -3348,71 +3658,71 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: _valid
           Offset: 4
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 57 GoChannelType chan struct {}
+          Type: 58 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 58 GoEmptyInterfaceType interface {}
+          Type: 59 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 60 GoInterfaceType main.something
+          Type: 61 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 61 GoSubroutineType func()
+          Type: 62 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 57
+      ID: 58
       Name: chan struct {}
       GoRuntimeType: 586016
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 58
+      ID: 59
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 837632
       GoKind: 20
-      UnderlyingStructure: 59 StructureType runtime.eface
+      UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
-      ID: 59
+      ID: 60
       Name: runtime.eface
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 53 PointerType *internal/abi.Type
+          Type: 54 PointerType *internal/abi.Type
         - Name: data
           Offset: 8
-          Type: 55 VoidPointerType unsafe.Pointer
+          Type: 56 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 60
+      ID: 61
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.0112e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
-      ID: 61
+      ID: 62
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468736
       GoKind: 19
     - __kind: PointerType
-      ID: 62
+      ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380096
       GoKind: 22
-      Pointee: 63 StructureType main.esotericHeap
+      Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 63
+      ID: 64
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.81104e+06
@@ -3420,21 +3730,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 56 StructureType main.esotericStack
+          Type: 57 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 64 StructureType sync.Mutex
+          Type: 65 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 67 StructureType sync.Once
+          Type: 68 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 70 StructureType sync.WaitGroup
+          Type: 71 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 73 StructureType sync/atomic.Int32
+          Type: 74 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 64
+      ID: 65
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.444352e+06
@@ -3442,18 +3752,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 66 StructureType internal/sync.Mutex
+          Type: 67 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 65
+      ID: 66
       Name: sync.noCopy
       GoRuntimeType: 976832
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 66
+      ID: 67
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.453632e+06
@@ -3461,12 +3771,12 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 67
+      ID: 68
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.592864e+06
@@ -3474,15 +3784,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 68 StructureType sync/atomic.Uint32
+          Type: 69 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 64 StructureType sync.Mutex
+          Type: 65 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 68
+      ID: 69
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.445792e+06
@@ -3490,18 +3800,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 69
+      ID: 70
       Name: sync/atomic.noCopy
       GoRuntimeType: 976928
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 70
+      ID: 71
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593056e+06
@@ -3509,15 +3819,15 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 65 StructureType sync.noCopy
+          Type: 66 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 71 StructureType sync/atomic.Uint64
+          Type: 72 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
-          Type: 23 BaseType uint32
+          Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 71
+      ID: 72
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.59344e+06
@@ -3525,21 +3835,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 72 StructureType sync/atomic.align64
+          Type: 73 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 72
+      ID: 73
       Name: sync/atomic.align64
       GoRuntimeType: 977024
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 73
+      ID: 74
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.445632e+06
@@ -3547,26 +3857,26 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 69 StructureType sync/atomic.noCopy
+          Type: 70 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 5 BaseType int32
+          Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 75
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.011072e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 76
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.015424e+06
       GoKind: 20
-      UnderlyingStructure: 37 StructureType runtime.iface
+      UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
-      ID: 76
+      ID: 77
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.17264e+06
@@ -3574,106 +3884,106 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 77 GoMapType map[int]int
+          Type: 78 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 77
+      ID: 78
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.11632e+06
       GoKind: 21
-      HeaderType: 79 GoSwissMapHeaderType map<int,int>
+      HeaderType: 80 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 78
+      ID: 79
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 79 GoSwissMapHeaderType map<int,int>
+      Pointee: 80 GoSwissMapHeaderType map<int,int>
     - __kind: GoSwissMapHeaderType
-      ID: 79
+      ID: 80
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 80 PointerType **table<int,int>
+          Type: 81 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 248 GoSliceDataType []*table<int,int>.array
-      GroupType: 85 StructureType noalg.map.group[int]int
-    - __kind: PointerType
-      ID: 80
-      Name: '**table<int,int>'
-      ByteSize: 8
-      Pointee: 81 PointerType *table<int,int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 249 GoSliceDataType []*table<int,int>.array
+      GroupType: 86 StructureType noalg.map.group[int]int
     - __kind: PointerType
       ID: 81
+      Name: '**table<int,int>'
+      ByteSize: 8
+      Pointee: 82 PointerType *table<int,int>
+    - __kind: PointerType
+      ID: 82
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 82 StructureType table<int,int>
+      Pointee: 83 StructureType table<int,int>
     - __kind: StructureType
-      ID: 82
+      ID: 83
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 83 GoSwissMapGroupsType groupReference<int,int>
+          Type: 84 GoSwissMapGroupsType groupReference<int,int>
     - __kind: GoSwissMapGroupsType
-      ID: 83
+      ID: 84
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 84 PointerType *noalg.map.group[int]int
+          Type: 85 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 85 StructureType noalg.map.group[int]int
-      GroupSliceType: 249 GoSliceDataType []noalg.map.group[int]int.array
+          Type: 26 BaseType uint64
+      GroupType: 86 StructureType noalg.map.group[int]int
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
-      ID: 84
+      ID: 85
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 85 StructureType noalg.map.group[int]int
+      Pointee: 86 StructureType noalg.map.group[int]int
     - __kind: StructureType
-      ID: 85
+      ID: 86
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275616e+06
@@ -3681,21 +3991,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 86 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 87 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: ArrayType
-      ID: 86
+      ID: 87
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 87 StructureType noalg.struct { key int; elem int }
+      Element: 88 StructureType noalg.struct { key int; elem int }
     - __kind: StructureType
-      ID: 87
+      ID: 88
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.275488e+06
@@ -3708,104 +4018,104 @@ Types:
           Offset: 8
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 88
+      ID: 89
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.117728e+06
       GoKind: 21
-      HeaderType: 90 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 89
+      ID: 90
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 90 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 90
+      ID: 91
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 91 PointerType **table<string,main.nestedStruct>
+          Type: 92 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 250 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 96 StructureType noalg.map.group[string]main.nestedStruct
-    - __kind: PointerType
-      ID: 91
-      Name: '**table<string,main.nestedStruct>'
-      ByteSize: 8
-      Pointee: 92 PointerType *table<string,main.nestedStruct>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 251 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
       ID: 92
+      Name: '**table<string,main.nestedStruct>'
+      ByteSize: 8
+      Pointee: 93 PointerType *table<string,main.nestedStruct>
+    - __kind: PointerType
+      ID: 93
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 93 StructureType table<string,main.nestedStruct>
+      Pointee: 94 StructureType table<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 93
+      ID: 94
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 94 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 95 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 94
+      ID: 95
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 95 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 96 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 96 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 251 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+          Type: 26 BaseType uint64
+      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
-      ID: 95
+      ID: 96
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 96 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: StructureType
-      ID: 96
+      ID: 97
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278432e+06
@@ -3813,21 +4123,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 97 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 98 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 97
+      ID: 98
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 98 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 99 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 98
+      ID: 99
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278304e+06
@@ -3835,12 +4145,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 99 StructureType main.nestedStruct
+          Type: 100 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 99
+      ID: 100
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.443072e+06
@@ -3851,106 +4161,106 @@ Types:
           Type: 1 BaseType int
         - Name: anotherString
           Offset: 8
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 100
+      ID: 101
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.1176e+06
       GoKind: 21
-      HeaderType: 102 GoSwissMapHeaderType map<string,int>
+      HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 101
+      ID: 102
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 102 GoSwissMapHeaderType map<string,int>
+      Pointee: 103 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 102
+      ID: 103
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 103 PointerType **table<string,int>
+          Type: 104 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 252 GoSliceDataType []*table<string,int>.array
-      GroupType: 108 StructureType noalg.map.group[string]int
-    - __kind: PointerType
-      ID: 103
-      Name: '**table<string,int>'
-      ByteSize: 8
-      Pointee: 104 PointerType *table<string,int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 253 GoSliceDataType []*table<string,int>.array
+      GroupType: 109 StructureType noalg.map.group[string]int
     - __kind: PointerType
       ID: 104
+      Name: '**table<string,int>'
+      ByteSize: 8
+      Pointee: 105 PointerType *table<string,int>
+    - __kind: PointerType
+      ID: 105
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 105 StructureType table<string,int>
+      Pointee: 106 StructureType table<string,int>
     - __kind: StructureType
-      ID: 105
+      ID: 106
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 106 GoSwissMapGroupsType groupReference<string,int>
+          Type: 107 GoSwissMapGroupsType groupReference<string,int>
     - __kind: GoSwissMapGroupsType
-      ID: 106
+      ID: 107
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 107 PointerType *noalg.map.group[string]int
+          Type: 108 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 108 StructureType noalg.map.group[string]int
-      GroupSliceType: 253 GoSliceDataType []noalg.map.group[string]int.array
+          Type: 26 BaseType uint64
+      GroupType: 109 StructureType noalg.map.group[string]int
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 107
+      ID: 108
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 108 StructureType noalg.map.group[string]int
+      Pointee: 109 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 108
+      ID: 109
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278176e+06
@@ -3958,21 +4268,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 109 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 110 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 109
+      ID: 110
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673792
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 110 StructureType noalg.struct { key string; elem int }
+      Element: 111 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 110
+      ID: 111
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278048e+06
@@ -3980,109 +4290,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 111
+      ID: 112
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117472e+06
       GoKind: 21
-      HeaderType: 113 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 112
+      ID: 113
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 113 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 113
+      ID: 114
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 114 PointerType **table<string,[]string>
+          Type: 115 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 119 StructureType noalg.map.group[string][]string
-    - __kind: PointerType
-      ID: 114
-      Name: '**table<string,[]string>'
-      ByteSize: 8
-      Pointee: 115 PointerType *table<string,[]string>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 255 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 120 StructureType noalg.map.group[string][]string
     - __kind: PointerType
       ID: 115
+      Name: '**table<string,[]string>'
+      ByteSize: 8
+      Pointee: 116 PointerType *table<string,[]string>
+    - __kind: PointerType
+      ID: 116
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 116 StructureType table<string,[]string>
+      Pointee: 117 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 116
+      ID: 117
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 117 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 118 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: GoSwissMapGroupsType
-      ID: 117
+      ID: 118
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 118 PointerType *noalg.map.group[string][]string
+          Type: 119 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 119 StructureType noalg.map.group[string][]string
-      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 26 BaseType uint64
+      GroupType: 120 StructureType noalg.map.group[string][]string
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 118
+      ID: 119
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 119 StructureType noalg.map.group[string][]string
+      Pointee: 120 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 119
+      ID: 120
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.27792e+06
@@ -4090,21 +4400,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 120 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 121 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 120
+      ID: 121
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 121 StructureType noalg.struct { key string; elem []string }
+      Element: 122 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 121
+      ID: 122
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277792e+06
@@ -4112,12 +4422,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 122 GoSliceHeaderType []string
+          Type: 123 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 122
+      ID: 123
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478400
@@ -4125,113 +4435,113 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 35 PointerType *string
+          Type: 36 PointerType *string
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 256 GoSliceDataType []string.array
+      Data: 257 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 123
+      ID: 124
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.11696e+06
       GoKind: 21
-      HeaderType: 125 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 124
+      ID: 125
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 125 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoSwissMapHeaderType
-      ID: 125
+      ID: 126
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 126 PointerType **table<[4]string,[2]int>
+          Type: 127 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 258 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 131 StructureType noalg.map.group[[4]string][2]int
-    - __kind: PointerType
-      ID: 126
-      Name: '**table<[4]string,[2]int>'
-      ByteSize: 8
-      Pointee: 127 PointerType *table<[4]string,[2]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 259 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 127
+      Name: '**table<[4]string,[2]int>'
+      ByteSize: 8
+      Pointee: 128 PointerType *table<[4]string,[2]int>
+    - __kind: PointerType
+      ID: 128
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 128 StructureType table<[4]string,[2]int>
+      Pointee: 129 StructureType table<[4]string,[2]int>
     - __kind: StructureType
-      ID: 128
+      ID: 129
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 129 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 130 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: GoSwissMapGroupsType
-      ID: 129
+      ID: 130
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 130 PointerType *noalg.map.group[[4]string][2]int
+          Type: 131 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 131 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 259 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+          Type: 26 BaseType uint64
+      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 260 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
-      ID: 130
+      ID: 131
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 131 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: StructureType
-      ID: 131
+      ID: 132
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.276896e+06
@@ -4239,21 +4549,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 132 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 133 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 132
+      ID: 133
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 133 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 134 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 133
+      ID: 134
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.276768e+06
@@ -4261,132 +4571,132 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 134 ArrayType [4]string
+          Type: 135 ArrayType [4]string
         - Name: elem
           Offset: 64
-          Type: 11 ArrayType [2]int
+          Type: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 134
+      ID: 135
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673120
       GoKind: 17
       Count: 4
       HasCount: true
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 135
+      ID: 136
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 101 GoMapType map[string]int
     - __kind: PointerType
-      ID: 136
+      ID: 137
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 101 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 137
+      ID: 138
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.117344e+06
       GoKind: 21
-      HeaderType: 139 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 138
+      ID: 139
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 139 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoSwissMapHeaderType
-      ID: 139
+      ID: 140
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 140 PointerType **table<string,[]main.structWithMap>
+          Type: 141 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 260 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 145 StructureType noalg.map.group[string][]main.structWithMap
-    - __kind: PointerType
-      ID: 140
-      Name: '**table<string,[]main.structWithMap>'
-      ByteSize: 8
-      Pointee: 141 PointerType *table<string,[]main.structWithMap>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 261 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
       ID: 141
+      Name: '**table<string,[]main.structWithMap>'
+      ByteSize: 8
+      Pointee: 142 PointerType *table<string,[]main.structWithMap>
+    - __kind: PointerType
+      ID: 142
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 142 StructureType table<string,[]main.structWithMap>
+      Pointee: 143 StructureType table<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 142
+      ID: 143
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 143 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 144 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: GoSwissMapGroupsType
-      ID: 143
+      ID: 144
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 144 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 145 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 145 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 261 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+          Type: 26 BaseType uint64
+      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
-      ID: 144
+      ID: 145
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 145 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 146 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: StructureType
-      ID: 145
+      ID: 146
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277664e+06
@@ -4394,21 +4704,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 146 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 147 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 146
+      ID: 147
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673600
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 147 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 148 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 147
+      ID: 148
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277536e+06
@@ -4416,12 +4726,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 148 GoSliceHeaderType []main.structWithMap
+          Type: 149 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 148
+      ID: 149
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469696
@@ -4429,120 +4739,120 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 149 PointerType *main.structWithMap
+          Type: 150 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 262 GoSliceDataType []main.structWithMap.array
+      Data: 263 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 149
+      ID: 150
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380032
       GoKind: 22
-      Pointee: 76 StructureType main.structWithMap
+      Pointee: 77 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 150
+      ID: 151
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.117088e+06
       GoKind: 21
-      HeaderType: 152 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 151
+      ID: 152
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 152 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoSwissMapHeaderType
-      ID: 152
+      ID: 153
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 153 PointerType **table<bool,main.node>
+          Type: 154 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 264 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 158 StructureType noalg.map.group[bool]main.node
-    - __kind: PointerType
-      ID: 153
-      Name: '**table<bool,main.node>'
-      ByteSize: 8
-      Pointee: 154 PointerType *table<bool,main.node>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 265 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 159 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
       ID: 154
+      Name: '**table<bool,main.node>'
+      ByteSize: 8
+      Pointee: 155 PointerType *table<bool,main.node>
+    - __kind: PointerType
+      ID: 155
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 155 StructureType table<bool,main.node>
+      Pointee: 156 StructureType table<bool,main.node>
     - __kind: StructureType
-      ID: 155
+      ID: 156
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 156 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 157 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: GoSwissMapGroupsType
-      ID: 156
+      ID: 157
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 157 PointerType *noalg.map.group[bool]main.node
+          Type: 158 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 158 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 265 GoSliceDataType []noalg.map.group[bool]main.node.array
+          Type: 26 BaseType uint64
+      GroupType: 159 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 266 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
-      ID: 157
+      ID: 158
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 158 StructureType noalg.map.group[bool]main.node
+      Pointee: 159 StructureType noalg.map.group[bool]main.node
     - __kind: StructureType
-      ID: 158
+      ID: 159
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277152e+06
@@ -4550,21 +4860,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 159 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 160 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 159
+      ID: 160
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 160 StructureType noalg.struct { key bool; elem main.node }
+      Element: 161 StructureType noalg.struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 160
+      ID: 161
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277024e+06
@@ -4572,12 +4882,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 161 StructureType main.node
+          Type: 162 StructureType main.node
     - __kind: StructureType
-      ID: 161
+      ID: 162
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.442912e+06
@@ -4588,113 +4898,113 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 162 PointerType *main.node
+          Type: 163 PointerType *main.node
     - __kind: PointerType
-      ID: 162
+      ID: 163
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 161 StructureType main.node
+      Pointee: 162 StructureType main.node
     - __kind: GoMapType
-      ID: 163
+      ID: 164
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117216e+06
       GoKind: 21
-      HeaderType: 165 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 164
+      ID: 165
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 165 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 165
+      ID: 166
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 166 PointerType **table<int,uint8>
+          Type: 167 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 171 StructureType noalg.map.group[int]uint8
-    - __kind: PointerType
-      ID: 166
-      Name: '**table<int,uint8>'
-      ByteSize: 8
-      Pointee: 167 PointerType *table<int,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 267 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 172 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
       ID: 167
+      Name: '**table<int,uint8>'
+      ByteSize: 8
+      Pointee: 168 PointerType *table<int,uint8>
+    - __kind: PointerType
+      ID: 168
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 StructureType table<int,uint8>
+      Pointee: 169 StructureType table<int,uint8>
     - __kind: StructureType
-      ID: 168
+      ID: 169
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 169 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 170 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 169
+      ID: 170
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 170 PointerType *noalg.map.group[int]uint8
+          Type: 171 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 171 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[int]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 172 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 268 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
-      ID: 170
+      ID: 171
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 171 StructureType noalg.map.group[int]uint8
+      Pointee: 172 StructureType noalg.map.group[int]uint8
     - __kind: StructureType
-      ID: 171
+      ID: 172
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.277408e+06
@@ -4702,21 +5012,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 172 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 173 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 172
+      ID: 173
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 173 StructureType noalg.struct { key int; elem uint8 }
+      Element: 174 StructureType noalg.struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 173
+      ID: 174
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.27728e+06
@@ -4727,106 +5037,106 @@ Types:
           Type: 1 BaseType int
         - Name: elem
           Offset: 8
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 174
+      ID: 175
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 175
+      ID: 176
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 177
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<uint8,uint8>
+          Type: 178 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 268 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 182 StructureType noalg.map.group[uint8]uint8
-    - __kind: PointerType
-      ID: 177
-      Name: '**table<uint8,uint8>'
-      ByteSize: 8
-      Pointee: 178 PointerType *table<uint8,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 269 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 178
+      Name: '**table<uint8,uint8>'
+      ByteSize: 8
+      Pointee: 179 PointerType *table<uint8,uint8>
+    - __kind: PointerType
+      ID: 179
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 179 StructureType table<uint8,uint8>
+      Pointee: 180 StructureType table<uint8,uint8>
     - __kind: StructureType
-      ID: 179
+      ID: 180
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 180 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 181 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 180
+      ID: 181
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 181 PointerType *noalg.map.group[uint8]uint8
+          Type: 182 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 182 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 269 GoSliceDataType []noalg.map.group[uint8]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 183 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 270 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
-      ID: 181
+      ID: 182
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 182 StructureType noalg.map.group[uint8]uint8
+      Pointee: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: StructureType
-      ID: 182
+      ID: 183
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.278944e+06
@@ -4834,21 +5144,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 183 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 184 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: ArrayType
-      ID: 183
+      ID: 184
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674080
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 184 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 185 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 184
+      ID: 185
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.278816e+06
@@ -4856,109 +5166,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: elem
           Offset: 1
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 185
+      ID: 186
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.117856e+06
       GoKind: 21
-      HeaderType: 187 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 186
+      ID: 187
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 187 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 187
+      ID: 188
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 188 PointerType **table<uint8,[4]int>
+          Type: 189 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 270 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 193 StructureType noalg.map.group[uint8][4]int
-    - __kind: PointerType
-      ID: 188
-      Name: '**table<uint8,[4]int>'
-      ByteSize: 8
-      Pointee: 189 PointerType *table<uint8,[4]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 271 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
       ID: 189
+      Name: '**table<uint8,[4]int>'
+      ByteSize: 8
+      Pointee: 190 PointerType *table<uint8,[4]int>
+    - __kind: PointerType
+      ID: 190
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 190 StructureType table<uint8,[4]int>
+      Pointee: 191 StructureType table<uint8,[4]int>
     - __kind: StructureType
-      ID: 190
+      ID: 191
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 191 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 192 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 191
+      ID: 192
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 192 PointerType *noalg.map.group[uint8][4]int
+          Type: 193 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 193 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 271 GoSliceDataType []noalg.map.group[uint8][4]int.array
+          Type: 26 BaseType uint64
+      GroupType: 194 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 272 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
-      ID: 192
+      ID: 193
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 193 StructureType noalg.map.group[uint8][4]int
+      Pointee: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: StructureType
-      ID: 193
+      ID: 194
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.278688e+06
@@ -4966,21 +5276,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 194 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 195 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 194
+      ID: 195
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673984
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 195 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 196 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 195
+      ID: 196
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.27856e+06
@@ -4988,12 +5298,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
     - __kind: ArrayType
-      ID: 196
+      ID: 197
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672832
@@ -5002,104 +5312,104 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 197
+      ID: 198
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.116832e+06
       GoKind: 21
-      HeaderType: 199 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 198
+      ID: 199
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 199 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 199
+      ID: 200
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 200 PointerType **table<[4]int,uint8>
+          Type: 201 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 272 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 205 StructureType noalg.map.group[[4]int]uint8
-    - __kind: PointerType
-      ID: 200
-      Name: '**table<[4]int,uint8>'
-      ByteSize: 8
-      Pointee: 201 PointerType *table<[4]int,uint8>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 273 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
       ID: 201
+      Name: '**table<[4]int,uint8>'
+      ByteSize: 8
+      Pointee: 202 PointerType *table<[4]int,uint8>
+    - __kind: PointerType
+      ID: 202
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 202 StructureType table<[4]int,uint8>
+      Pointee: 203 StructureType table<[4]int,uint8>
     - __kind: StructureType
-      ID: 202
+      ID: 203
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 203 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 203
+      ID: 204
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 204 PointerType *noalg.map.group[[4]int]uint8
+          Type: 205 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 205 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 273 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+          Type: 26 BaseType uint64
+      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 274 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
-      ID: 204
+      ID: 205
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 205 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: StructureType
-      ID: 205
+      ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.27664e+06
@@ -5107,21 +5417,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 206 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 207 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 206
+      ID: 207
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 207 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 208 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 207
+      ID: 208
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276512e+06
@@ -5129,109 +5439,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 208
+      ID: 209
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.116704e+06
       GoKind: 21
-      HeaderType: 210 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 209
+      ID: 210
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 210 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 210
+      ID: 211
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 43 BaseType uintptr
+          Type: 44 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 211 PointerType **table<[4]int,[4]int>
+          Type: 212 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 25 BaseType uint64
-      TablePtrSliceType: 274 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 216 StructureType noalg.map.group[[4]int][4]int
-    - __kind: PointerType
-      ID: 211
-      Name: '**table<[4]int,[4]int>'
-      ByteSize: 8
-      Pointee: 212 PointerType *table<[4]int,[4]int>
+          Type: 26 BaseType uint64
+      TablePtrSliceType: 275 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 212
+      Name: '**table<[4]int,[4]int>'
+      ByteSize: 8
+      Pointee: 213 PointerType *table<[4]int,[4]int>
+    - __kind: PointerType
+      ID: 213
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 213 StructureType table<[4]int,[4]int>
+      Pointee: 214 StructureType table<[4]int,[4]int>
     - __kind: StructureType
-      ID: 213
+      ID: 214
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 21 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: index
           Offset: 8
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 214 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 215 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 214
+      ID: 215
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 215 PointerType *noalg.map.group[[4]int][4]int
+          Type: 216 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
-          Type: 25 BaseType uint64
-      GroupType: 216 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 275 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+          Type: 26 BaseType uint64
+      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 276 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
-      ID: 215
+      ID: 216
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 216 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 217 StructureType noalg.map.group[[4]int][4]int
     - __kind: StructureType
-      ID: 216
+      ID: 217
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276384e+06
@@ -5239,21 +5549,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 25 BaseType uint64
+          Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 217 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 218 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 217
+      ID: 218
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 218 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 219 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 218
+      ID: 219
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276256e+06
@@ -5261,76 +5571,76 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 196 ArrayType [4]int
+          Type: 197 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 219
+      ID: 220
       Name: chan bool
       GoRuntimeType: 587104
       GoKind: 18
     - __kind: PointerType
-      ID: 220
+      ID: 221
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 221 StructureType main.structWithTwoValues
+      Pointee: 222 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 221
+      ID: 222
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 19 BaseType uint
+          Type: 20 BaseType uint
         - Name: b
           Offset: 8
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 222
+      ID: 223
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385728
       GoKind: 22
-      Pointee: 19 BaseType uint
+      Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 223
+      ID: 224
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 10 BaseType bool
+      Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 224
+      ID: 225
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 225 GoSliceHeaderType main.t
+      Pointee: 226 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 225
+      ID: 226
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 226 PointerType **main.t
+          Type: 227 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 276 GoSliceDataType main.t.array
+      Data: 277 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 226
+      ID: 227
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 224 PointerType *main.t
+      Pointee: 225 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 227
+      ID: 228
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 477888
@@ -5338,70 +5648,70 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 222 PointerType *uint
+          Type: 223 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 278 GoSliceDataType []uint.array
+      Data: 279 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 229
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 229 PointerType *[]uint
+          Type: 230 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 280 GoSliceDataType [][]uint.array
+      Data: 281 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 229
+      ID: 230
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 227 GoSliceHeaderType []uint
+      Pointee: 228 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 230
+      ID: 231
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 231 PointerType *main.structWithNoStrings
+          Type: 232 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 282 GoSliceDataType []main.structWithNoStrings.array
+      Data: 283 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 231
+      ID: 232
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 232 StructureType main.structWithNoStrings
+      Pointee: 233 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 232
+      ID: 233
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
       RawFields:
         - Name: aUint8
           Offset: 0
-          Type: 3 BaseType uint8
+          Type: 4 BaseType uint8
         - Name: aBool
           Offset: 1
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 233
+      ID: 234
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478272
@@ -5409,16 +5719,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType *bool
+          Type: 224 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 284 GoSliceDataType []bool.array
+      Data: 285 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 235
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477248
@@ -5426,311 +5736,311 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 235 PointerType *uint16
+          Type: 236 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 286 GoSliceDataType []uint16.array
+      Data: 287 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 235
+      ID: 236
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385344
       GoKind: 22
-      Pointee: 21 BaseType uint16
+      Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 236
+      ID: 237
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: b
           Offset: 16
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: c
           Offset: 32
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 237
+      ID: 238
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 236 StructureType main.threeStringStruct
+      Pointee: 237 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 238
+      ID: 239
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 239 StructureType main.oneStringStruct
+      Pointee: 240 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 239
+      ID: 240
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: a
           Offset: 0
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 240
+      ID: 241
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
       RawFields:
         - Name: aBool
           Offset: 0
-          Type: 10 BaseType bool
+          Type: 11 BaseType bool
         - Name: aString
           Offset: 8
-          Type: 7 GoStringHeaderType string
+          Type: 8 GoStringHeaderType string
         - Name: aNumber
           Offset: 24
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 99 StructureType main.nestedStruct
+          Type: 100 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 241
+      ID: 242
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 242
+      ID: 243
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 243
+      ID: 244
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 242 GoStringDataType string.str
+      Pointee: 243 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 245
       Name: '[]*string.array'
       ByteSize: 2048
-      Element: 35 PointerType *string
+      Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 245
+      ID: 246
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []*string.array
+      Pointee: 245 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 247
       Name: '[]internal/abi.Imethod.array'
       ByteSize: 2048
-      Element: 52 StructureType internal/abi.Imethod
+      Element: 53 StructureType internal/abi.Imethod
     - __kind: PointerType
-      ID: 247
+      ID: 248
       Name: '*[]internal/abi.Imethod.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 248
-      Name: '[]*table<int,int>.array'
-      ByteSize: 8192
-      Element: 81 PointerType *table<int,int>
+      Pointee: 247 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoSliceDataType
       ID: 249
-      Name: '[]noalg.map.group[int]int.array'
-      ByteSize: 2048
-      Element: 85 StructureType noalg.map.group[int]int
+      Name: '[]*table<int,int>.array'
+      ByteSize: 8192
+      Element: 82 PointerType *table<int,int>
     - __kind: GoSliceDataType
       ID: 250
-      Name: '[]*table<string,main.nestedStruct>.array'
-      ByteSize: 8192
-      Element: 92 PointerType *table<string,main.nestedStruct>
+      Name: '[]noalg.map.group[int]int.array'
+      ByteSize: 2048
+      Element: 86 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
       ID: 251
-      Name: '[]noalg.map.group[string]main.nestedStruct.array'
-      ByteSize: 2048
-      Element: 96 StructureType noalg.map.group[string]main.nestedStruct
+      Name: '[]*table<string,main.nestedStruct>.array'
+      ByteSize: 8192
+      Element: 93 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
       ID: 252
-      Name: '[]*table<string,int>.array'
-      ByteSize: 8192
-      Element: 104 PointerType *table<string,int>
+      Name: '[]noalg.map.group[string]main.nestedStruct.array'
+      ByteSize: 2048
+      Element: 97 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
       ID: 253
-      Name: '[]noalg.map.group[string]int.array'
-      ByteSize: 2048
-      Element: 108 StructureType noalg.map.group[string]int
+      Name: '[]*table<string,int>.array'
+      ByteSize: 8192
+      Element: 105 PointerType *table<string,int>
     - __kind: GoSliceDataType
       ID: 254
-      Name: '[]*table<string,[]string>.array'
-      ByteSize: 8192
-      Element: 115 PointerType *table<string,[]string>
+      Name: '[]noalg.map.group[string]int.array'
+      ByteSize: 2048
+      Element: 109 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
       ID: 255
-      Name: '[]noalg.map.group[string][]string.array'
-      ByteSize: 2048
-      Element: 119 StructureType noalg.map.group[string][]string
+      Name: '[]*table<string,[]string>.array'
+      ByteSize: 8192
+      Element: 116 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
       ID: 256
+      Name: '[]noalg.map.group[string][]string.array'
+      ByteSize: 2048
+      Element: 120 StructureType noalg.map.group[string][]string
+    - __kind: GoSliceDataType
+      ID: 257
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 7 GoStringHeaderType string
+      Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 257
+      ID: 258
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []string.array
-    - __kind: GoSliceDataType
-      ID: 258
-      Name: '[]*table<[4]string,[2]int>.array'
-      ByteSize: 8192
-      Element: 127 PointerType *table<[4]string,[2]int>
+      Pointee: 257 GoSliceDataType []string.array
     - __kind: GoSliceDataType
       ID: 259
-      Name: '[]noalg.map.group[[4]string][2]int.array'
-      ByteSize: 2048
-      Element: 131 StructureType noalg.map.group[[4]string][2]int
+      Name: '[]*table<[4]string,[2]int>.array'
+      ByteSize: 8192
+      Element: 128 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
       ID: 260
-      Name: '[]*table<string,[]main.structWithMap>.array'
-      ByteSize: 8192
-      Element: 141 PointerType *table<string,[]main.structWithMap>
+      Name: '[]noalg.map.group[[4]string][2]int.array'
+      ByteSize: 2048
+      Element: 132 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
       ID: 261
-      Name: '[]noalg.map.group[string][]main.structWithMap.array'
-      ByteSize: 2048
-      Element: 145 StructureType noalg.map.group[string][]main.structWithMap
+      Name: '[]*table<string,[]main.structWithMap>.array'
+      ByteSize: 8192
+      Element: 142 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
       ID: 262
+      Name: '[]noalg.map.group[string][]main.structWithMap.array'
+      ByteSize: 2048
+      Element: 146 StructureType noalg.map.group[string][]main.structWithMap
+    - __kind: GoSliceDataType
+      ID: 263
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 76 StructureType main.structWithMap
+      Element: 77 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 263
+      ID: 264
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []main.structWithMap.array
-    - __kind: GoSliceDataType
-      ID: 264
-      Name: '[]*table<bool,main.node>.array'
-      ByteSize: 8192
-      Element: 154 PointerType *table<bool,main.node>
+      Pointee: 263 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
       ID: 265
-      Name: '[]noalg.map.group[bool]main.node.array'
-      ByteSize: 2048
-      Element: 158 StructureType noalg.map.group[bool]main.node
+      Name: '[]*table<bool,main.node>.array'
+      ByteSize: 8192
+      Element: 155 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
       ID: 266
-      Name: '[]*table<int,uint8>.array'
-      ByteSize: 8192
-      Element: 167 PointerType *table<int,uint8>
+      Name: '[]noalg.map.group[bool]main.node.array'
+      ByteSize: 2048
+      Element: 159 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
       ID: 267
-      Name: '[]noalg.map.group[int]uint8.array'
-      ByteSize: 2048
-      Element: 171 StructureType noalg.map.group[int]uint8
+      Name: '[]*table<int,uint8>.array'
+      ByteSize: 8192
+      Element: 168 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
       ID: 268
-      Name: '[]*table<uint8,uint8>.array'
-      ByteSize: 8192
-      Element: 178 PointerType *table<uint8,uint8>
+      Name: '[]noalg.map.group[int]uint8.array'
+      ByteSize: 2048
+      Element: 172 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
       ID: 269
-      Name: '[]noalg.map.group[uint8]uint8.array'
-      ByteSize: 2048
-      Element: 182 StructureType noalg.map.group[uint8]uint8
+      Name: '[]*table<uint8,uint8>.array'
+      ByteSize: 8192
+      Element: 179 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
       ID: 270
-      Name: '[]*table<uint8,[4]int>.array'
-      ByteSize: 8192
-      Element: 189 PointerType *table<uint8,[4]int>
+      Name: '[]noalg.map.group[uint8]uint8.array'
+      ByteSize: 2048
+      Element: 183 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
       ID: 271
-      Name: '[]noalg.map.group[uint8][4]int.array'
-      ByteSize: 2048
-      Element: 193 StructureType noalg.map.group[uint8][4]int
+      Name: '[]*table<uint8,[4]int>.array'
+      ByteSize: 8192
+      Element: 190 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
       ID: 272
-      Name: '[]*table<[4]int,uint8>.array'
-      ByteSize: 8192
-      Element: 201 PointerType *table<[4]int,uint8>
+      Name: '[]noalg.map.group[uint8][4]int.array'
+      ByteSize: 2048
+      Element: 194 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
       ID: 273
-      Name: '[]noalg.map.group[[4]int]uint8.array'
-      ByteSize: 2048
-      Element: 205 StructureType noalg.map.group[[4]int]uint8
+      Name: '[]*table<[4]int,uint8>.array'
+      ByteSize: 8192
+      Element: 202 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
       ID: 274
-      Name: '[]*table<[4]int,[4]int>.array'
-      ByteSize: 8192
-      Element: 212 PointerType *table<[4]int,[4]int>
+      Name: '[]noalg.map.group[[4]int]uint8.array'
+      ByteSize: 2048
+      Element: 206 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
       ID: 275
-      Name: '[]noalg.map.group[[4]int][4]int.array'
-      ByteSize: 2048
-      Element: 216 StructureType noalg.map.group[[4]int][4]int
+      Name: '[]*table<[4]int,[4]int>.array'
+      ByteSize: 8192
+      Element: 213 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
       ID: 276
+      Name: '[]noalg.map.group[[4]int][4]int.array'
+      ByteSize: 2048
+      Element: 217 StructureType noalg.map.group[[4]int][4]int
+    - __kind: GoSliceDataType
+      ID: 277
       Name: main.t.array
       ByteSize: 2048
-      Element: 224 PointerType *main.t
+      Element: 225 PointerType *main.t
     - __kind: PointerType
-      ID: 277
+      ID: 278
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType main.t.array
+      Pointee: 277 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 279
       Name: '[]uint.array'
       ByteSize: 2048
-      Element: 19 BaseType uint
+      Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 279
+      ID: 280
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []uint.array
+      Pointee: 279 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 281
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 227 GoSliceHeaderType []uint
+      Element: 228 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 281
+      ID: 282
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]uint.array
+      Pointee: 281 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 283
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 232 StructureType main.structWithNoStrings
+      Element: 233 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 283
+      ID: 284
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 283 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 285
       Name: '[]bool.array'
       ByteSize: 2048
-      Element: 10 BaseType bool
+      Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 285
+      ID: 286
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []bool.array
+      Pointee: 285 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 287
       Name: '[]uint16.array'
       ByteSize: 2048
-      Element: 21 BaseType uint16
+      Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 287
+      ID: 288
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 286 GoSliceDataType []uint16.array
+      Pointee: 287 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 288
+      ID: 289
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5738,14 +6048,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 2 ArrayType [2]uint8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 3, index: 0, name: x}
+                  Variable: {subprogram: 7, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 289
+      ID: 290
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5753,14 +6063,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 ArrayType [2]int32
+            Type: 5 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 4, index: 0, name: x}
+                  Variable: {subprogram: 8, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 291
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5768,14 +6078,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 6 ArrayType [2]string
+            Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 5, index: 0, name: x}
+                  Variable: {subprogram: 9, index: 0, name: x}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 291
+      ID: 292
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5783,14 +6093,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 9 ArrayType [2]bool
+            Type: 10 ArrayType [2]bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 6, index: 0, name: x}
+                  Variable: {subprogram: 10, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 292
+      ID: 293
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5798,14 +6108,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 11 ArrayType [2]int
+            Type: 12 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 7, index: 0, name: x}
+                  Variable: {subprogram: 11, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 294
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5813,14 +6123,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 12 ArrayType [2]int8
+            Type: 13 ArrayType [2]int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 8, index: 0, name: x}
+                  Variable: {subprogram: 12, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 294
+      ID: 295
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5828,14 +6138,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 14 ArrayType [2]int16
+            Type: 15 ArrayType [2]int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 9, index: 0, name: x}
+                  Variable: {subprogram: 13, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 295
+      ID: 296
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5843,14 +6153,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 4 ArrayType [2]int32
+            Type: 5 ArrayType [2]int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 10, index: 0, name: x}
+                  Variable: {subprogram: 14, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 297
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5858,14 +6168,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 16 ArrayType [2]int64
+            Type: 17 ArrayType [2]int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 11, index: 0, name: x}
+                  Variable: {subprogram: 15, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 298
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5873,14 +6183,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 18 ArrayType [2]uint
+            Type: 19 ArrayType [2]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 12, index: 0, name: x}
+                  Variable: {subprogram: 16, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 299
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5888,14 +6198,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 2 ArrayType [2]uint8
+            Type: 3 ArrayType [2]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 13, index: 0, name: x}
+                  Variable: {subprogram: 17, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 299
+      ID: 300
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5903,14 +6213,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 20 ArrayType [2]uint16
+            Type: 21 ArrayType [2]uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 14, index: 0, name: x}
+                  Variable: {subprogram: 18, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 300
+      ID: 301
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5918,14 +6228,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 22 ArrayType [2]uint32
+            Type: 23 ArrayType [2]uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 15, index: 0, name: x}
+                  Variable: {subprogram: 19, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 302
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5933,14 +6243,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 24 ArrayType [2]uint64
+            Type: 25 ArrayType [2]uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 16, index: 0, name: x}
+                  Variable: {subprogram: 20, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 302
+      ID: 303
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5948,14 +6258,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 26 ArrayType [2][2]int
+            Type: 27 ArrayType [2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 17, index: 0, name: a}
+                  Variable: {subprogram: 21, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 303
+      ID: 304
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5963,14 +6273,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 6 ArrayType [2]string
+            Type: 7 ArrayType [2]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 18, index: 0, name: a}
+                  Variable: {subprogram: 22, index: 0, name: a}
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 304
+      ID: 305
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5978,14 +6288,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 27 ArrayType [2][2][2]int
+            Type: 28 ArrayType [2][2][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 19, index: 0, name: b}
+                  Variable: {subprogram: 23, index: 0, name: b}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 305
+      ID: 306
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5993,14 +6303,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 28 ArrayType [100]uint
+            Type: 29 ArrayType [100]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 20, index: 0, name: a}
+                  Variable: {subprogram: 24, index: 0, name: a}
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 306
+      ID: 307
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6008,14 +6318,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 21, index: 0, name: x}
+                  Variable: {subprogram: 25, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 307
+      ID: 308
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6023,14 +6333,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
+                  Variable: {subprogram: 26, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 308
+      ID: 309
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6038,14 +6348,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 10 BaseType bool
+            Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 0, name: x}
+                  Variable: {subprogram: 27, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 309
+      ID: 310
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6056,11 +6366,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 0, name: x}
+                  Variable: {subprogram: 28, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 311
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6068,14 +6378,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 13 BaseType int8
+            Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 25, index: 0, name: x}
+                  Variable: {subprogram: 29, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6083,14 +6393,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 15 BaseType int16
+            Type: 16 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 26, index: 0, name: x}
+                  Variable: {subprogram: 30, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6098,14 +6408,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
+                  Variable: {subprogram: 31, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6113,14 +6423,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 17 BaseType int64
+            Type: 18 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 0, name: x}
+                  Variable: {subprogram: 32, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6128,14 +6438,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 29, index: 0, name: x}
+                  Variable: {subprogram: 33, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6143,14 +6453,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 30, index: 0, name: x}
+                  Variable: {subprogram: 34, index: 0, name: x}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 316
+      ID: 317
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6158,14 +6468,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 21 BaseType uint16
+            Type: 22 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 31, index: 0, name: x}
+                  Variable: {subprogram: 35, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6173,14 +6483,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 23 BaseType uint32
+            Type: 24 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: x}
+                  Variable: {subprogram: 36, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6188,14 +6498,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 25 BaseType uint64
+            Type: 26 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 37, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6203,14 +6513,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 29 BaseType float32
+            Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: x}
+                  Variable: {subprogram: 38, index: 0, name: x}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 320
+      ID: 321
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6218,14 +6528,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 30 BaseType float64
+            Type: 31 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: x}
+                  Variable: {subprogram: 39, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 322
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6233,14 +6543,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 31 BaseType main.typeAlias
+            Type: 32 BaseType main.typeAlias
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 36, index: 0, name: x}
+                  Variable: {subprogram: 40, index: 0, name: x}
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 322
+      ID: 323
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6248,14 +6558,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 32 StructureType main.bigStruct
+            Type: 33 StructureType main.bigStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 37, index: 0, name: b}
+                  Variable: {subprogram: 41, index: 0, name: b}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 323
+      ID: 324
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6263,14 +6573,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 56 StructureType main.esotericStack
+            Type: 57 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 0, name: e}
+                  Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6278,14 +6588,101 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 62 PointerType *main.esotericHeap
+            Type: 63 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 39, index: 0, name: e}
+                  Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 326
+      Name: Probe[main.testInlinedBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: y
+          Offset: 9
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 45, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.testInlinedBC]
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.testFramelessArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6293,14 +6690,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 75 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 40, index: 0, name: b}
+                  Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 333
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6308,14 +6705,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType error
+            Type: 76 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 41, index: 0, name: e}
+                  Variable: {subprogram: 51, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 334
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6323,14 +6720,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 76 StructureType main.structWithMap
+            Type: 77 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 42, index: 0, name: s}
+                  Variable: {subprogram: 52, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 335
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6338,14 +6735,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 88 GoMapType map[string]main.nestedStruct
+            Type: 89 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 43, index: 0, name: m}
+                  Variable: {subprogram: 53, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 336
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6353,14 +6750,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 337
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6368,14 +6765,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 111 GoMapType map[string][]string
+            Type: 112 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 338
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6383,14 +6780,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 123 GoMapType map[[4]string][2]int
+            Type: 124 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 339
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6398,14 +6795,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 340
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6413,14 +6810,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 135 ArrayType [2]map[string]int
+            Type: 136 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 341
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6428,14 +6825,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 PointerType *map[string]int
+            Type: 137 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 49, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 342
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6443,14 +6840,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 77 GoMapType map[int]int
+            Type: 78 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 343
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6458,14 +6855,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[string][]main.structWithMap
+            Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 344
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6473,14 +6870,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 GoMapType map[string][]main.structWithMap
+            Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 345
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6488,14 +6885,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 150 GoMapType map[bool]main.node
+            Type: 151 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 346
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6503,14 +6900,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 163 GoMapType map[int]uint8
+            Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 347
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6518,14 +6915,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 163 GoMapType map[int]uint8
+            Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 348
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6533,14 +6930,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 349
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6548,14 +6945,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 350
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6563,14 +6960,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 174 GoMapType map[uint8]uint8
+            Type: 175 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 351
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6578,14 +6975,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 185 GoMapType map[uint8][4]int
+            Type: 186 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 352
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6593,14 +6990,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 197 GoMapType map[[4]int]uint8
+            Type: 198 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 353
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,14 +7005,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 208 GoMapType map[[4]int][4]int
+            Type: 209 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 354
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6623,32 +7020,32 @@ Types:
         - Name: w
           Offset: 1
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: w}
+                  Variable: {subprogram: 72, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
           Offset: 2
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 1, name: x}
+                  Variable: {subprogram: 72, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
           Offset: 3
           Expression:
-            Type: 29 BaseType float32
+            Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 2, name: y}
+                  Variable: {subprogram: 72, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 348
+      ID: 355
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6656,50 +7053,50 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 10 BaseType bool
+            Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: a}
+                  Variable: {subprogram: 73, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
           Offset: 2
           Expression:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 1, name: b}
+                  Variable: {subprogram: 73, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
           Offset: 3
           Expression:
-            Type: 5 BaseType int32
+            Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 2, name: c}
+                  Variable: {subprogram: 73, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
           Offset: 7
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 3, name: d}
+                  Variable: {subprogram: 73, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
           Offset: 15
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 4, name: e}
+                  Variable: {subprogram: 73, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 356
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6707,14 +7104,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 219 GoChannelType chan bool
+            Type: 220 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: c}
+                  Variable: {subprogram: 74, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 350
+      ID: 357
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,14 +7119,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 220 PointerType *main.structWithTwoValues
+            Type: 221 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: a}
+                  Variable: {subprogram: 75, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 358
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6737,14 +7134,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 161 StructureType main.node
+            Type: 162 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 359
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6752,14 +7149,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 162 PointerType *main.node
+            Type: 163 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 360
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,14 +7164,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 55 VoidPointerType unsafe.Pointer
+            Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: x}
+                  Variable: {subprogram: 78, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 361
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,14 +7179,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 222 PointerType *uint
+            Type: 223 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 362
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6797,14 +7194,14 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 35 PointerType *string
+            Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: z}
+                  Variable: {subprogram: 80, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 363
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6812,23 +7209,23 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 223 PointerType *bool
+            Type: 224 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
           Offset: 9
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 1, name: a}
+                  Variable: {subprogram: 81, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 364
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6836,14 +7233,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 224 PointerType *main.t
+            Type: 225 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: t}
+                  Variable: {subprogram: 82, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 365
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6851,14 +7248,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: u}
+                  Variable: {subprogram: 83, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 359
+      ID: 366
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6866,14 +7263,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: u}
+                  Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 360
+      ID: 367
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6881,14 +7278,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType [][]uint
+            Type: 229 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: u}
+                  Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 361
+      ID: 368
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6896,10 +7293,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: xs}
+                  Variable: {subprogram: 86, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6908,11 +7305,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 1, name: a}
+                  Variable: {subprogram: 86, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 369
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6920,10 +7317,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: xs}
+                  Variable: {subprogram: 87, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6932,11 +7329,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 370
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6944,10 +7341,10 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 230 GoSliceHeaderType []main.structWithNoStrings
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: xs}
+                  Variable: {subprogram: 88, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -6956,11 +7353,11 @@ Types:
             Type: 1 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: a}
+                  Variable: {subprogram: 88, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 371
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6968,14 +7365,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 122 GoSliceHeaderType []string
+            Type: 123 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: s}
+                  Variable: {subprogram: 89, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 365
+      ID: 372
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6983,32 +7380,32 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 13 BaseType int8
+            Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Expression:
-            Type: 233 GoSliceHeaderType []bool
+            Type: 234 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 1, name: s}
+                  Variable: {subprogram: 90, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
           Offset: 26
           Expression:
-            Type: 19 BaseType uint
+            Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 2, name: x}
+                  Variable: {subprogram: 90, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 373
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7016,14 +7413,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 234 GoSliceHeaderType []uint16
+            Type: 235 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: xs}
+                  Variable: {subprogram: 91, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 367
+      ID: 374
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7031,17 +7428,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 227 GoSliceHeaderType []uint
+            Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
+      ID: 375
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 369
+      ID: 376
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7049,14 +7446,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 94, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 370
+      ID: 377
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7064,32 +7461,32 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: y}
+                  Variable: {subprogram: 95, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
           Offset: 33
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 2, name: z}
+                  Variable: {subprogram: 95, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 371
+      ID: 378
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7097,14 +7494,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 236 StructureType main.threeStringStruct
+            Type: 237 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 96, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 372
+      ID: 379
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7112,14 +7509,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 237 PointerType *main.threeStringStruct
+            Type: 238 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 380
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7127,14 +7524,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 238 PointerType *main.oneStringStruct
+            Type: 239 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 381
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7142,14 +7539,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 99, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 375
+      ID: 382
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7157,14 +7554,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 100, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 376
+      ID: 383
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7172,14 +7569,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 7 GoStringHeaderType string
+            Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 101, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 377
+      ID: 384
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7187,14 +7584,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 240 StructureType main.aStruct
+            Type: 241 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: x}
+                  Variable: {subprogram: 102, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 378
+      ID: 385
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7202,14 +7599,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 241 StructureType main.emptyStruct
+            Type: 242 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: e}
+                  Variable: {subprogram: 103, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 379
+      ID: 386
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7224,7 +7621,43 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 387
       Name: Probe[main.testInlinedBBB]
-MaxTypeID: 380
+    - __kind: EventRootType
+      ID: 388
+      Name: Probe[main.testInlinedBCA]
+    - __kind: EventRootType
+      ID: 389
+      Name: Probe[main.testInlinedBCB]
+    - __kind: EventRootType
+      ID: 390
+      Name: Probe[main.testInlinedSq]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 5, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 391
+      Name: Probe[main.testInlinedSumArray]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 2 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 6, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+MaxTypeID: 391
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 87
           Type: 375 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84c85c", Frameless: false}]
+          InjectionPoints: [{PC: "0x84c85c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -236,7 +236,7 @@ Probes:
       events:
         - ID: 37
           Type: 325 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x8499fc", Frameless: false}]
+          InjectionPoints: [{PC: "0x8499fc", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -250,7 +250,7 @@ Probes:
       events:
         - ID: 36
           Type: 324 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x84992c", Frameless: false}]
+          InjectionPoints: [{PC: "0x84992c", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -278,7 +278,7 @@ Probes:
       events:
         - ID: 43
           Type: 331 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x84a130", Frameless: false}]
+          InjectionPoints: [{PC: "0x84a130", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -292,7 +292,7 @@ Probes:
       events:
         - ID: 38
           Type: 326 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x849e3c", Frameless: false}]
+          InjectionPoints: [{PC: "0x849e3c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -306,7 +306,7 @@ Probes:
       events:
         - ID: 39
           Type: 327 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x849ecc", Frameless: false}]
+          InjectionPoints: [{PC: "0x849ecc", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -320,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Type: 328 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x849f8c", Frameless: false}]
+          InjectionPoints: [{PC: "0x849f8c", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -334,7 +334,7 @@ Probes:
       events:
         - ID: 99
           Type: 387 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x849f28", Frameless: true}]
+          InjectionPoints: [{PC: "0x849f28", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -348,7 +348,7 @@ Probes:
       events:
         - ID: 41
           Type: 329 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x84a00c", Frameless: false}]
+          InjectionPoints: [{PC: "0x84a00c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -362,7 +362,7 @@ Probes:
       events:
         - ID: 100
           Type: 388 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x84a01c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a01c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -376,7 +376,7 @@ Probes:
       events:
         - ID: 101
           Type: 389 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a0d0", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -393,15 +393,15 @@ Probes:
           Type: 386 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x849c9c"
-              Frameless: false
+              Frameless: true
             - PC: "0x849d1c"
-              Frameless: true
+              Frameless: false
             - PC: "0x849e68"
-              Frameless: true
+              Frameless: false
             - PC: "0x849ee4"
-              Frameless: true
+              Frameless: false
             - PC: "0x849f9c"
-              Frameless: true
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -415,7 +415,7 @@ Probes:
       events:
         - ID: 102
           Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84a124", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a124", Frameless: false}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -432,9 +432,9 @@ Probes:
           Type: 391 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84a154"
-              Frameless: true
+              Frameless: false
             - PC: "0x84a1ec"
-              Frameless: true
+              Frameless: false
           Condition: null
     - id: testInt16Array
       version: 0
@@ -518,7 +518,7 @@ Probes:
       events:
         - ID: 44
           Type: 332 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84a3d0", Frameless: false}]
+          InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -2034,9 +2034,9 @@ Subprograms:
           Type: 1 BaseType int
           Locations:
             - Range: 0x84a068..0x84a070
-              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0x84a070..0x84a088
-              Pieces: [{Size: 8, Op: {CfaOffset: 16312}}]
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0x84a088..0x84a09c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
@@ -2125,19 +2125,19 @@ Subprograms:
             - Range: 0x84a424..0x84a430
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16288}
+                  Op: {CfaOffset: -96}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84a430..0x84a434
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16288}
+                  Op: {CfaOffset: -96}
                 - Size: 8
                   Op: {CfaOffset: -136}
             - Range: 0x84a434..0x84a5b0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16288}
+                  Op: {CfaOffset: -96}
                 - Size: 8
                   Op: {CfaOffset: -136}
           IsParameter: false
@@ -2154,19 +2154,19 @@ Subprograms:
             - Range: 0x84a468..0x84a474
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84a474..0x84a478
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {CfaOffset: -160}
             - Range: 0x84a478..0x84a5b0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16264}
+                  Op: {CfaOffset: -120}
                 - Size: 8
                   Op: {CfaOffset: -160}
           IsParameter: false
@@ -2183,19 +2183,19 @@ Subprograms:
             - Range: 0x84a4ac..0x84a4b8
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84a4b8..0x84a4c4
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {CfaOffset: -152}
             - Range: 0x84a4c4..0x84a5b0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16272}
+                  Op: {CfaOffset: -112}
                 - Size: 8
                   Op: {CfaOffset: -152}
           IsParameter: false
@@ -2212,19 +2212,19 @@ Subprograms:
             - Range: 0x84a4f8..0x84a510
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84a510..0x84a514
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {CfaOffset: -144}
             - Range: 0x84a514..0x84a5b0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: 16280}
+                  Op: {CfaOffset: -104}
                 - Size: 8
                   Op: {CfaOffset: -144}
           IsParameter: false
@@ -3149,7 +3149,7 @@ Subprograms:
             - Range: 0x84a140..0x84a190
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
             - Range: 0x84a1d8..0x84a2e0
-              Pieces: [{Size: 40, Op: {CfaOffset: 16264}}]
+              Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
 Types:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -415,7 +415,7 @@ Probes:
       events:
         - ID: 102
           Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84a124", Frameless: false}]
+          InjectionPoints: [{PC: "0x84a124", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -3089,10 +3089,14 @@ Subprograms:
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x849c90..0x849d00]
       InlinePCRanges:
-        - - 0x849d1c..0x849d54
-        - - 0x849e68..0x849ea0
-        - - 0x849ee4..0x849f1c
-        - - 0x849f9c..0x849fd4
+        - Ranges: [0x849d1c..0x849d54]
+          RootRanges: [0x849d00..0x849d80]
+        - Ranges: [0x849e68..0x849ea0]
+          RootRanges: [0x849e30..0x849ec0]
+        - Ranges: [0x849ee4..0x849f1c]
+          RootRanges: [0x849ec0..0x849f80]
+        - Ranges: [0x849f9c..0x849fd4]
+          RootRanges: [0x849f80..0x84a000]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -3114,22 +3118,30 @@ Subprograms:
     - ID: 2
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x849f28..0x849f60]]
+      InlinePCRanges:
+        - Ranges: [0x849f28..0x849f60]
+          RootRanges: [0x849ec0..0x849f80]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x84a01c..0x84a060]]
+      InlinePCRanges:
+        - Ranges: [0x84a01c..0x84a060]
+          RootRanges: [0x84a000..0x84a120]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x84a0d0..0x84a108]]
+      InlinePCRanges:
+        - Ranges: [0x84a0d0..0x84a108]
+          RootRanges: [0x84a000..0x84a120]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x84a124..0x84a128]]
+      InlinePCRanges:
+        - Ranges: [0x84a124..0x84a128]
+          RootRanges: [0x84a120..0x84a130]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -3141,7 +3153,11 @@ Subprograms:
     - ID: 6
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x84a154..0x84a178], [0x84a1ec..0x84a214]]
+      InlinePCRanges:
+        - Ranges: [0x84a154..0x84a178]
+          RootRanges: [0x84a130..0x84a190]
+        - Ranges: [0x84a1ec..0x84a214]
+          RootRanges: [0x84a190..0x84a2e0]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -15,7 +15,7 @@ Probes:
       events:
         - ID: 11
           Type: 63 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0x4a8006", Frameless: true}]
+          InjectionPoints: [{PC: "0x4a8006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -32,7 +32,7 @@ Probes:
       events:
         - ID: 12
           Type: 64 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0x4a8050", Frameless: true}]
+          InjectionPoints: [{PC: "0x4a8050", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -63,7 +63,7 @@ Probes:
             - PC: "0x4a83ca"
               Frameless: false
             - PC: "0x4a7dce"
-              Frameless: true
+              Frameless: false
           Condition: null
     - id: intArg
       version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -299,7 +299,9 @@ Subprograms:
     - ID: 1
       Name: main.inlined
       OutOfLinePCRanges: [0x4a83c0..0x4a8422]
-      InlinePCRanges: [[0x4a7dce..0x4a7e1f]]
+      InlinePCRanges:
+        - Ranges: [0x4a7dce..0x4a7e1f]
+          RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -313,7 +315,9 @@ Subprograms:
     - ID: 2
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x4a8006..0x4a8045]]
+      InlinePCRanges:
+        - Ranges: [0x4a8006..0x4a8045]
+          RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
           Type: 2 PointerType *****int
@@ -325,7 +329,9 @@ Subprograms:
     - ID: 3
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0x4a8050..0x4a808a]]
+      InlinePCRanges:
+        - Ranges: [0x4a8050..0x4a808a]
+          RootRanges: [0x4a7c40..0x4a809d]
       Variables:
         - Name: ptr
           Type: 5 PointerType **int

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -299,7 +299,9 @@ Subprograms:
     - ID: 1
       Name: main.inlined
       OutOfLinePCRanges: [0xb5550..0xb55c0]
-      InlinePCRanges: [[0xb4fec..0xb5028]]
+      InlinePCRanges:
+        - Ranges: [0xb4fec..0xb5028]
+          RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: x
           Type: 1 BaseType int
@@ -313,7 +315,9 @@ Subprograms:
     - ID: 2
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xb51cc..0xb51fc]]
+      InlinePCRanges:
+        - Ranges: [0xb51cc..0xb51fc]
+          RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
           Type: 2 PointerType *****int
@@ -325,7 +329,9 @@ Subprograms:
     - ID: 3
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
-      InlinePCRanges: [[0xb5204..0xb5234]]
+      InlinePCRanges:
+        - Ranges: [0xb5204..0xb5234]
+          RootRanges: [0xb4e50..0xb5250]
       Variables:
         - Name: ptr
           Type: 5 PointerType **int

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -15,7 +15,7 @@ Probes:
       events:
         - ID: 11
           Type: 63 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: 741836, Frameless: true}]
+          InjectionPoints: [{PC: 741836, Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
       version: 0
@@ -32,7 +32,7 @@ Probes:
       events:
         - ID: 12
           Type: 64 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: 741892, Frameless: true}]
+          InjectionPoints: [{PC: 741892, Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -45,7 +45,7 @@ Probes:
       events:
         - ID: 9
           Type: 61 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: 743056, Frameless: false}]
+          InjectionPoints: [{PC: 743056, Frameless: true}]
           Condition: null
     - id: inlined
       version: 0
@@ -61,9 +61,9 @@ Probes:
           Type: 62 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: 742748
-              Frameless: false
-            - PC: 741356
               Frameless: true
+            - PC: 741356
+              Frameless: false
           Condition: null
     - id: intArg
       version: 0
@@ -76,7 +76,7 @@ Probes:
       events:
         - ID: 1
           Type: 53 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: 741980, Frameless: false}]
+          InjectionPoints: [{PC: 741980, Frameless: true}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -89,7 +89,7 @@ Probes:
       events:
         - ID: 4
           Type: 56 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: 742348, Frameless: false}]
+          InjectionPoints: [{PC: 742348, Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -115,7 +115,7 @@ Probes:
       events:
         - ID: 3
           Type: 55 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: 742220, Frameless: false}]
+          InjectionPoints: [{PC: 742220, Frameless: true}]
           Condition: null
     - id: mapArg
       version: 0
@@ -128,7 +128,7 @@ Probes:
       events:
         - ID: 8
           Type: 60 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: 742940, Frameless: false}]
+          InjectionPoints: [{PC: 742940, Frameless: true}]
           Condition: null
     - id: stringArg
       version: 0
@@ -141,7 +141,7 @@ Probes:
       events:
         - ID: 2
           Type: 54 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: 742092, Frameless: false}]
+          InjectionPoints: [{PC: 742092, Frameless: true}]
           Condition: null
     - id: stringArrayArg
       version: 0
@@ -154,7 +154,7 @@ Probes:
       events:
         - ID: 6
           Type: 58 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: 742604, Frameless: false}]
+          InjectionPoints: [{PC: 742604, Frameless: true}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -167,7 +167,7 @@ Probes:
       events:
         - ID: 5
           Type: 57 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: 742476, Frameless: false}]
+          InjectionPoints: [{PC: 742476, Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 4

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -80,6 +80,12 @@ func (m exactMatcher) matches(ptr jsontext.Pointer) bool {
 	return string(ptr) == string(m)
 }
 
+type reMatcher regexp.Regexp
+
+func (m *reMatcher) matches(ptr jsontext.Pointer) bool {
+	return (*regexp.Regexp)(m).MatchString(string(ptr))
+}
+
 type replacement jsontext.Value
 
 func (r replacement) replace(jsontext.Value) jsontext.Value {
@@ -88,9 +94,19 @@ func (r replacement) replace(jsontext.Value) jsontext.Value {
 
 type prefixSuffixMatcher [2]string
 
+func prefixMatcher(prefix string) prefixSuffixMatcher {
+	return prefixSuffixMatcher{prefix, ""}
+}
+
 func (m prefixSuffixMatcher) matches(ptr jsontext.Pointer) bool {
 	return strings.HasPrefix(string(ptr), m[0]) &&
 		strings.HasSuffix(string(ptr), m[1])
+}
+
+type replacerFunc func(jsontext.Value) jsontext.Value
+
+func (f replacerFunc) replace(v jsontext.Value) jsontext.Value {
+	return f(v)
 }
 
 func redactor(matcher matcher, replacer replacer) jsonRedactor {
@@ -98,78 +114,6 @@ func redactor(matcher matcher, replacer replacer) jsonRedactor {
 		matcher:  matcher,
 		replacer: replacer,
 	}
-}
-
-var defaultRedactors = []jsonRedactor{
-	redactor(
-		exactMatcher(`/debugger/snapshot/stack`),
-		replacement(`"[stack-unredact-me]"`),
-	),
-	redactor(
-		exactMatcher(`/debugger/snapshot/id`),
-		replacement(`"[id]"`),
-	),
-	redactor(
-		exactMatcher(`/debugger/snapshot/timestamp`),
-		replacement(`"[ts]"`),
-	),
-	redactor(
-		exactMatcher(`/timestamp`),
-		replacement(`"[ts]"`),
-	),
-	redactor(
-		prefixSuffixMatcher{"/debugger/snapshot/captures/", "/address"},
-		replacement(`"[addr]"`),
-	),
-	redactor(
-		prefixSuffixMatcher{"/debugger/snapshot/captures/entry/arguments/redactMyEntries", "/entries"},
-		replacement(`"[redacted-entries]"`),
-	),
-	redactor(
-		prefixSuffixMatcher{"/debugger/snapshot/captures/", "/entries"},
-		entriesSorter{},
-	),
-}
-
-func redactJSON(t *testing.T, ptrPrefix jsontext.Pointer, input []byte, redactors []jsonRedactor) []byte {
-	d := jsontext.NewDecoder(bytes.NewReader(input))
-	var buf bytes.Buffer
-	e := jsontext.NewEncoder(&buf, jsontext.WithIndent("  "), jsontext.WithIndentPrefix("  "))
-	stackPtr := func() jsontext.Pointer {
-		if ptrPrefix != "" {
-			return jsontext.Pointer(ptrPrefix + "/" + d.StackPointer())
-		}
-		return d.StackPointer()
-	}
-	for {
-		tok, err := d.ReadToken()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		kind, idx := d.StackIndex(d.StackDepth())
-		err = e.WriteToken(tok)
-		require.NoError(t, err)
-		if kind != '{' || idx%2 == 0 {
-			continue
-		}
-		ptr := stackPtr()
-		var redacted []byte
-		for _, redactor := range redactors {
-			if redactor.matcher.matches(ptr) {
-				v, err := d.ReadValue()
-				require.NoError(t, err)
-				redacted = redactor.replacer.replace(v)
-				break
-			}
-		}
-
-		if redacted != nil {
-			redacted = redactJSON(t, ptr, redacted, redactors)
-			require.NoError(t, e.WriteValue(redacted))
-		}
-	}
-	return bytes.TrimSpace(buf.Bytes())
 }
 
 type entriesSorter struct{}
@@ -208,300 +152,113 @@ func (e entriesSorter) replace(v jsontext.Value) jsontext.Value {
 	return sorted
 }
 
-func TestDefaultRedactors(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name: "redact snapshot id",
-			input: `{
-  "debugger": {
-    "snapshot": {
-      "id": "actual-snapshot-id-123"
-    }
-  }
-}`,
-			expected: `{
-    "debugger": {
-      "snapshot": {
-        "id": "[id]"
-      }
-    }
-  }`,
-		},
-		{
-			name: "redact snapshot timestamp",
-			input: `{
-  "debugger": {
-    "snapshot": {
-      "timestamp": "[ts]"
-    }
-  }
-}`,
-			expected: `{
-    "debugger": {
-      "snapshot": {
-        "timestamp": "[ts]"
-      }
-    }
-  }`,
-		},
-		{
-			name: "redact root timestamp",
-			input: `{
-  "timestamp": "2023-01-01T00:00:00Z",
-  "other": "data"
-}`,
-			expected: `{
-    "timestamp": "[ts]",
-    "other": "data"
-  }`,
-		},
-		{
-			name: "redact snapshot stack",
-			input: `{
-  "debugger": {
-    "snapshot": {
-      "stack": ["frame1", "frame2", "frame3"]
-    }
-  }
-}`,
-			expected: `{
-    "debugger": {
-      "snapshot": {
-        "stack": "[stack-unredact-me]"
-      }
-    }
-  }`,
-		},
-		{
-			name: "redact capture address",
-			input: `{
-  "debugger": {
-    "snapshot": {
-      "captures": {
-        "locals": {
-          "address": "0x7fff5fbff123"
-        }
-      }
-    }
-  }
-}`,
-			expected: `{
-    "debugger": {
-      "snapshot": {
-        "captures": {
-          "locals": {
-            "address": "[addr]"
-          }
-        }
-      }
-    }
-  }`,
-		},
-		{
-			name: "sort capture entries",
-			input: `{
-  "debugger": {
-    "snapshot": {
-      "captures": {
-        "locals": {
-          "entries": [
-            ["variable_z", {"value": "z"}],
-            ["variable_a", {"value": "a"}],
-            ["variable_m", {"notCapturedReason": "error"}]
-          ]
-        }
-      }
-    }
-  }
-}`,
-			expected: `{
-    "debugger": {
-      "snapshot": {
-        "captures": {
-          "locals": {
-            "entries": [
-              ["variable_a", {"value": "a"}],
-              ["variable_m", {"notCapturedReason": "error"}],
-              ["variable_z", {"value": "z"}]
-            ]
-          }
-        }
-      }
-    }
-  }`,
-		},
-		{
-			name: "multiple redactions",
-			input: `{
-  "timestamp": "2023-01-01T00:00:00Z",
-  "debugger": {
-    "snapshot": {
-      "id": "snap-123",
-      "timestamp": "2023-01-01T01:00:00Z",
-      "stack": ["frame1", "frame2"],
-      "captures": {
-        "locals": {
-          "address": "0x123456",
-          "entries": [
-            ["var_b", {"value": "b"}],
-            ["var_a", {"value": "a"}]
-          ]
-        }
-      }
-    }
-  }
-}`,
-			expected: `{
-    "timestamp": "[ts]",
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "stack": "[stack-unredact-me]",
-        "captures": {
-          "locals": {
-            "address": "[addr]",
-            "entries": [
-              ["var_a", {"value": "a"}],
-              ["var_b", {"value": "b"}]
-            ]
-          }
-        }
-      }
-    }
-  }`,
-		},
-		{
-			name: "no redactions needed",
-			input: `{
-  "normal": "field",
-  "data": {
-    "value": 123
-  }
-}`,
-			expected: `{
-    "normal": "field",
-    "data": {
-      "value": 123
-    }
-  }`,
-		},
-		{
-			name: "map with addr",
-			input: `{
-  "timestamp": "2023-01-01T00:00:00Z",
-  "debugger": {
-    "snapshot": {
-      "id": "snap-123",
-      "timestamp": "2023-01-01T01:00:00Z",
-      "stack": ["frame1", "frame2"],
-      "captures": {
-        "entry": {
-		  "arguments": {
-		    "m": {
-			  "type": "map[string]main.bigStruct",
-			  "address": "0x123456",
-			  "entries": [
-				[ {"key": "k1", "value": {"a": 1, "b": 2}}, {"key": "k2", "value": {"a": 3, "b": 4}} ]
-	          ]
-			}
-		  }
-        }
-      }
-    }
-  }
-}`,
-			expected: `{
-  "timestamp": "[ts]",
-  "debugger": {
-    "snapshot": {
-      "id": "[id]",
-      "timestamp": "[ts]",
-      "stack": "[stack-unredact-me]",
-      "captures": {
-        "entry": {
-		  "arguments": {
-		    "m": {
-			  "type": "map[string]main.bigStruct",
-			  "address": "[addr]",
-			  "entries": [
-				[ {"key": "k1", "value": {"a": 1, "b": 2}}, {"key": "k2", "value": {"a": 3, "b": 4}} ]
-	          ]
-			}
-		  }
-        }
-      }
-    }
-  }
-}`,
-		},
-		{
-			name: "pointer chain with duplicate address fields",
-			input: `{
-  "timestamp": "2023-01-01T00:00:00Z",
-  "debugger": {
-    "snapshot": {
-      "id": "snap-123",
-      "timestamp": "2023-01-01T01:00:00Z",
-      "stack": ["frame1", "frame2"],
-      "captures": {
-        "entry": {
-          "arguments": {
-            "ptr": {
-              "type": "*main.PointerChainArg",
-              "address": "0x7fff5fbff100",
-              "fields": {
-                "addr": {
-                  "type": "uintptr",
-                  "address": "0x7fff5fbff108",
-                  "value": "0x12345678"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}`,
-			expected: `{
-    "timestamp": "[ts]",
-    "debugger": {
-      "snapshot": {
-        "id": "[id]",
-        "timestamp": "[ts]",
-        "stack": "[stack-unredact-me]",
-        "captures": {
-          "entry": {
-            "arguments": {
-              "ptr": {
-                "type": "*main.PointerChainArg",
-                "address": "[addr]",
-                "fields": {
-                  "addr": {
-                    "type": "uintptr",
-                    "address": "[addr]",
-                    "value": "0x12345678"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }`,
-		},
-	}
+type stackFrame struct {
+	Function   string `json:"function"`
+	FileName   string `json:"fileName"`
+	LineNumber any    `json:"lineNumber"`
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := redactJSON(t, "", []byte(tt.input), defaultRedactors)
-			require.JSONEq(t, tt.expected, string(result), "redacted JSON should match expected output")
-		})
+func redactStackFrame(v jsontext.Value) jsontext.Value {
+	if v.Kind() != '{' {
+		return v
 	}
+	d := json.NewDecoder(bytes.NewReader(v))
+	d.UseNumber()
+	var f stackFrame
+	err := d.Decode(&f)
+	if err != nil {
+		return v
+	}
+	if !strings.HasPrefix(f.FileName, "runtime/asm_") {
+		return v
+	}
+	f.FileName = "runtime/asm_[arch].s"
+	f.LineNumber = "[lineNumber]"
+	buf, err := json.Marshal(f)
+	if err != nil {
+		return v
+	}
+	return jsontext.Value(buf)
+}
+
+var defaultRedactors = []jsonRedactor{
+	redactor(
+		(*reMatcher)(regexp.MustCompile(`^/debugger/snapshot/stack/[[:digit:]]+$`)),
+		replacerFunc(redactStackFrame),
+	),
+	redactor(
+		exactMatcher(`/debugger/snapshot/id`),
+		replacement(`"[id]"`),
+	),
+	redactor(
+		exactMatcher(`/debugger/snapshot/timestamp`),
+		replacement(`"[ts]"`),
+	),
+	redactor(
+		exactMatcher(`/timestamp`),
+		replacement(`"[ts]"`),
+	),
+	redactor(
+		prefixSuffixMatcher{"/debugger/snapshot/captures/", "/address"},
+		replacement(`"[addr]"`),
+	),
+	redactor(
+		prefixSuffixMatcher{"/debugger/snapshot/captures/entry/arguments/redactMyEntries", "/entries"},
+		replacement(`"[redacted-entries]"`),
+	),
+	redactor(
+		prefixSuffixMatcher{"/debugger/snapshot/captures/", "/entries"},
+		entriesSorter{},
+	),
+}
+
+func redactJSON(t *testing.T, ptrPrefix jsontext.Pointer, input []byte, redactors []jsonRedactor) []byte {
+	d := jsontext.NewDecoder(bytes.NewReader(input))
+	var buf bytes.Buffer
+	e := jsontext.NewEncoder(&buf, jsontext.WithIndent("  "), jsontext.WithIndentPrefix("  "))
+	ptrPrefix = jsontext.Pointer(strings.TrimSuffix(string(ptrPrefix), "/"))
+	stackPtr := func() jsontext.Pointer {
+		return jsontext.Pointer(
+			string(ptrPrefix) + "/" +
+				strings.TrimPrefix(string(d.StackPointer()), "/"))
+	}
+	copyToken := func() (done bool) {
+		tok, err := d.ReadToken()
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		err = e.WriteToken(tok)
+		require.NoError(t, err)
+		return false
+	}
+	for {
+		kind, idx := d.StackIndex(d.StackDepth())
+		// If we're in an object and this is a key, copy it across.
+		if kind == '{' && idx%2 == 0 || d.PeekKind() == ']' {
+			require.False(t, copyToken(), "unexpected EOF")
+		}
+		ptr := stackPtr()
+		var redacted []byte
+		for _, redactor := range redactors {
+			if redactor.matcher.matches(ptr) {
+				v, err := d.ReadValue()
+				require.NoError(t, err)
+				redacted = redactor.replacer.replace(v)
+				break
+			}
+		}
+
+		// If we read a whole value, recursively redact it and write that out,
+		// otherwise just copy the token across.
+		if redacted != nil {
+			switch jsontext.Value(redacted).Kind() {
+			case '{', '[': // apply recursive redaction
+				redacted = redactJSON(t, ptr, redacted, redactors)
+			}
+			require.NoError(t, e.WriteValue(redacted))
+		} else if copyToken() {
+			break
+		}
+	}
+	return bytes.TrimSpace(buf.Bytes())
 }

--- a/pkg/dyninst/object/object.go
+++ b/pkg/dyninst/object/object.go
@@ -24,6 +24,8 @@ type Architecture = bininspect.GoArch
 type File interface {
 	io.Closer
 
+	// Architecture returns the architecture of the object file.
+	Architecture() Architecture
 	// Access to the DWARF sections.
 	DwarfSections() *DebugSections
 	// Access to the DWARF data.

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -135,19 +135,26 @@ Package: main
 		Arg: f: func(int) (declared at line 28, available: [28-29])
 	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
 		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:41]
-		Arg: x: int (declared at line 37, available: [37-39])
-		Arg: y: int (declared at line 37, available: [37-40])
-		Var: z: int (declared at line 38, available: [39-40])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:59]
-		Var: s: int (declared at line 53, available: [54-57])
-		Scope: 54-57
-			Var: i: int (declared at line 54, available: [54-57])
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:76]
-		Var: x: int (declared at line 71, available: )
-		Var: y: int (declared at line 72, available: )
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
 		Arg: b: main.behavior (declared at line 48, available: [48-51])
 		Arg: ~r0: string (declared at line 48, available: )
@@ -493,11 +500,15 @@ Package: main
 		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
 		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:48]
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [61:62]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66]
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67]
 	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15]
 		Arg: x: int (declared at line 0, available: [13-14])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75]
+		Arg: x: int (declared at line 0, available: [75-75])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
+		Arg: a: [5]int (declared at line 0, available: [71-71])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -135,19 +135,26 @@ Package: main
 		Arg: f: func(int) (declared at line 28, available: [28-29])
 	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
 		Arg: x: int (declared at line 32, available: [32-34])
-	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:41]
-		Arg: x: int (declared at line 37, available: [37-39])
-		Arg: y: int (declared at line 37, available: [37-40])
-		Var: z: int (declared at line 38, available: [39-40])
-	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [43:45]
-		Arg: x: int (declared at line 43, available: [43-44])
-	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [51:59]
-		Var: s: int (declared at line 53, available: [54-57])
-		Scope: 54-57
-			Var: i: int (declared at line 54, available: [54-57])
-	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:76]
-		Var: x: int (declared at line 71, available: )
-		Var: y: int (declared at line 72, available: )
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
 		Arg: b: main.behavior (declared at line 48, available: [48-51])
 		Arg: ~r0: string (declared at line 48, available: )
@@ -493,11 +500,15 @@ Package: main
 		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
 		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
 	Function: executeStack (main.executeStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [29:30]
-	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [47:48]
-	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [61:62]
-	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [65:66]
+	Function: testInlinedBBB (main.testInlinedBBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [48:49]
+	Function: testInlinedBCA (main.testInlinedBCA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [62:63]
+	Function: testInlinedBCB (main.testInlinedBCB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [66:67]
 	Function: testInlinedPrint (main.testInlinedPrint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [13:15]
 		Arg: x: int (declared at line 0, available: [13-14])
+	Function: testInlinedSq (main.testInlinedSq) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [74:75]
+		Arg: x: int (declared at line 0, available: [75-75])
+	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
+		Arg: a: [5]int (declared at line 0, available: [71-71])
 	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -14,7 +14,43 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.stackC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.stackB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
+            "lineNumber": 19
+          },
+          {
+            "function": "main.stackA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
+            "lineNumber": 13
+          },
+          {
+            "function": "main.executeStack",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 33
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "stackC",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArrays.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testArrayOfArrays",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 70
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 115
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testArrayOfArrays",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfArraysOfArrays.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testArrayOfArraysOfArrays",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 78
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 118
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testArrayOfArraysOfArrays",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testArrayOfMaps",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 135
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testArrayOfMaps",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfStrings.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testArrayOfStrings",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 74
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 116
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testArrayOfStrings",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testBigStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 81
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 110
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testBigStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBoolArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testBoolArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 26
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 103
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testBoolArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testByteArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testByteArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testByteArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 100
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testByteArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testChannel.json
+++ b/pkg/dyninst/testdata/decoded/sample/testChannel.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testChannel",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeOther",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
+            "lineNumber": 41
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 26
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testChannel",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCombinedByte.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testCombinedByte",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeMultiParamFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 100
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 28
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testCombinedByte",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testCycle.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCycle.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testCycle",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 109
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 177
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testCycle",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEmptySlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 33
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 88
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEmptySlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEmptySliceOfStructs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 45
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 76
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEmptySliceOfStructs",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyString.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEmptyString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 63
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEmptyString",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptyStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEmptyStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 96
+          },
+          {
+            "function": "main.executeStructFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 158
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEmptyStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testError",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 60
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 66
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testError",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEsotericHeap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go",
+            "lineNumber": 47
+          },
+          {
+            "function": "main.executeEsoteric",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go",
+            "lineNumber": 68
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 41
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEsotericHeap",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testEsotericStack",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.executeEsoteric",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go",
+            "lineNumber": 60
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 41
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testEsotericStack",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -1,0 +1,64 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testFrameless",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testFrameless",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 79
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 104
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testFrameless",
+          "location": {
+            "method": "main.testFrameless"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "10"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -1,0 +1,86 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testFramelessArray",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testFramelessArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 92
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 105
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testFramelessArray",
+          "location": {
+            "method": "main.testFramelessArray"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "[5]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  {
+                    "type": "int",
+                    "value": "5"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBA.json
@@ -1,0 +1,69 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBA",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBA",
+          "location": {
+            "method": "main.testInlinedBA"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "10"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBB.json
@@ -1,0 +1,73 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBB",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 37
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBB",
+          "location": {
+            "method": "main.testInlinedBB"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "10"
+              },
+              "y": {
+                "type": "int",
+                "value": "15"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBA.json
@@ -1,0 +1,74 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBBA",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 44
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBBA",
+          "location": {
+            "method": "main.testInlinedBBA"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "150"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -1,0 +1,69 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBBB",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 49
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 41
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBBB",
+          "location": {
+            "method": "main.testInlinedBBB"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {}
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBC.json
@@ -14,7 +14,43 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInlinedBBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 48
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 74
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInlinedBBC",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -1,0 +1,64 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBC",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 52
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBC",
+          "location": {
+            "method": "main.testInlinedBC"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {}
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -1,0 +1,69 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBCA",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBCA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 63
+          },
+          {
+            "function": "main.testInlinedBC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 53
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBCA",
+          "location": {
+            "method": "main.testInlinedBCA"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {}
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -1,0 +1,69 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBCB",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBCB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 67
+          },
+          {
+            "function": "main.testInlinedBC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 59
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBCB",
+          "location": {
+            "method": "main.testInlinedBCB"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {}
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -28,7 +28,7 @@
           {
             "function": "main.executeInlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 73
+            "lineNumber": 101
           },
           {
             "function": "main.main",
@@ -57,7 +57,295 @@
             "arguments": {
               "x": {
                 "type": "int",
-                "value": "30"
+                "value": "25"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrint",
+          "location": {
+            "method": "main.testInlinedPrint"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 39
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrint",
+          "location": {
+            "method": "main.testInlinedPrint"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "150"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 45
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrint",
+          "location": {
+            "method": "main.testInlinedPrint"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "150"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 13
+          },
+          {
+            "function": "main.forceOutOfLine",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 103
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrint",
+          "location": {
+            "method": "main.testInlinedPrint"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "1"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrint.json
@@ -14,7 +14,38 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInlinedPrint",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintArray.json
@@ -1,0 +1,38 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrintArray",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testInlinedPrintArray",
+          "location": {
+            "method": "main.testInlinedPrintArray"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "[5]int",
+                "notCapturedReason": "unavailable"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -1,0 +1,69 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedSq",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedSq",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 75
+          },
+          {
+            "function": "main.testFrameless",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 80
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 104
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedSq",
+          "location": {
+            "method": "main.testInlinedSq"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "10"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -26,6 +26,11 @@
             "lineNumber": 80
           },
           {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 104
+          },
+          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 34

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSq.json
@@ -26,11 +26,6 @@
             "lineNumber": 80
           },
           {
-            "function": "main.executeInlined",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
-            "lineNumber": 104
-          },
-          {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
             "lineNumber": 34

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -1,0 +1,175 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedSumArray",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedSumArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 71
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 100
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedSumArray",
+          "location": {
+            "method": "main.testInlinedSumArray"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "[5]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "-1"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824639497536"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824642174368"
+                  },
+                  {
+                    "type": "int",
+                    "value": "4486988"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824639490376"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedSumArray",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedSumArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 71
+          },
+          {
+            "function": "main.testFramelessArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 93
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 105
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedSumArray",
+          "location": {
+            "method": "main.testInlinedSumArray"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "[5]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "824635032592"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824642158024"
+                  },
+                  {
+                    "type": "int",
+                    "value": "5303624"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824634982448"
+                  },
+                  {
+                    "type": "int",
+                    "value": "824633788880"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSumArray.json
@@ -56,23 +56,23 @@
                 "elements": [
                   {
                     "type": "int",
-                    "value": "-1"
+                    "value": "1"
                   },
                   {
                     "type": "int",
-                    "value": "824639497536"
+                    "value": "2"
                   },
                   {
                     "type": "int",
-                    "value": "824642174368"
+                    "value": "3"
                   },
                   {
                     "type": "int",
-                    "value": "4486988"
+                    "value": "4"
                   },
                   {
                     "type": "int",
-                    "value": "824639490376"
+                    "value": "5"
                   }
                 ]
               }
@@ -145,23 +145,23 @@
                 "elements": [
                   {
                     "type": "int",
-                    "value": "824635032592"
+                    "value": "1"
                   },
                   {
                     "type": "int",
-                    "value": "824642158024"
+                    "value": "2"
                   },
                   {
                     "type": "int",
-                    "value": "5303624"
+                    "value": "3"
                   },
                   {
                     "type": "int",
-                    "value": "824634982448"
+                    "value": "4"
                   },
                   {
                     "type": "int",
-                    "value": "824633788880"
+                    "value": "5"
                   }
                 ]
               }

--- a/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt16Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInt16Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 38
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 106
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInt16Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt32Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInt32Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 107
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInt32Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt64Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInt64Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 108
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInt64Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInt8Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInt8Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 105
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInt8Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testIntArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testIntArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testIntArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 104
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testIntArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testInterface",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 48
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 64
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 44
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testInterface",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLinkedList.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testLinkedList",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 155
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testLinkedList",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapArrayToArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 151
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapArrayToArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapEmbeddedMaps",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 58
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 157
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapEmbeddedMaps",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapIntToInt",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 133
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapIntToInt",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapLargeKeyLargeValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 94
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 195
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapLargeKeyLargeValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapLargeKeySmallValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 90
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 202
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapLargeKeySmallValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapMassive",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 158
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapMassive",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapSmallKeyLargeValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 86
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 187
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapSmallKeyLargeValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapSmallKeySmallValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 82
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 181
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapSmallKeySmallValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapStringToInt",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 26
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 130
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapStringToInt",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapStringToSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 138
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapStringToSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapStringToStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 131
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapStringToStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapWithLinkedList",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 62
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 146
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapWithLinkedList",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapWithSmallKeyAndValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 74
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 179
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapWithSmallKeyAndValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapWithSmallKeyAndValueMassive",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 78
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 180
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapWithSmallKeyAndValueMassive",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapWithSmallValue",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 66
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 168
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapWithSmallValue",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMapWithSmallValueMassive",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 70
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 169
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMapWithSmallValueMassive",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMassiveString.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMassiveString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 59
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMassiveString",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleSimpleParams.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testMultipleSimpleParams",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 78
+          },
+          {
+            "function": "main.executeMultiParamFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 87
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 28
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testMultipleSimpleParams",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilPointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testNilPointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 165
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testNilPointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testNilSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 61
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 91
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testNilSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceOfStructs.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testNilSliceOfStructs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 49
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 77
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testNilSliceOfStructs",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNilSliceWithOtherParams.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testNilSliceWithOtherParams",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 57
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 90
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testNilSliceWithOtherParams",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testOneStringInStructPointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testOneStringInStructPointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 38
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 58
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testOneStringInStructPointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testPointerLoop",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 176
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testPointerLoop",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testPointerToMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 137
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testPointerToMap",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToSimpleStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testPointerToSimpleStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 38
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 135
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testPointerToSimpleStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testRuneArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testRuneArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 101
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testRuneArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleBool.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleBool",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 19
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 89
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleBool",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleByte.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleByte",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 11
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 90
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleByte",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat32.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleFloat32",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 63
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 86
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleFloat32",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleFloat64.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleFloat64",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 67
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 87
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleFloat64",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleInt",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 92
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleInt",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt16.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleInt16",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 78
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleInt16",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt32.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleInt32",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 79
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleInt32",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt64.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleInt64",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 39
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 80
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleInt64",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleInt8.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleInt8",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 77
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleInt8",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleRune.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleRune",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 15
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 91
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleRune",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleString.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 12
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleString",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleUint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 93
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleUint",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint16.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleUint16",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 51
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 83
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleUint16",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint32.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleUint32",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 55
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 84
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleUint32",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint64.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleUint64",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 59
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 85
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleUint64",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSingleUint8.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSingleUint8",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 47
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 82
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSingleUint8",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSliceOfSlices.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSliceOfSlices",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 37
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 83
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSliceOfSlices",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testSmallMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 38
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 112
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testSmallMap",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStringArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStringArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStringArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringPointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStringPointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 91
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 132
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStringPointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStringSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 53
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStringSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeStructFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 111
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStructSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 41
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 75
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStructSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testStructWithMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeMapFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go",
+            "lineNumber": 136
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 43
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testStructWithMap",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStrings.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testThreeStrings",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 16
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 55
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testThreeStrings",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStruct.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testThreeStringsInStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testThreeStringsInStruct",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testThreeStringsInStructPointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testThreeStringsInStructPointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 57
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testThreeStringsInStructPointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
+++ b/pkg/dyninst/testdata/decoded/sample/testTypeAlias.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testTypeAlias",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.executeBasicFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go",
+            "lineNumber": 94
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 27
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testTypeAlias",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint16Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUint16Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 58
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 111
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUint16Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint32Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUint32Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 62
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 112
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUint32Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint64Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUint64Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 66
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 113
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUint64Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUint8Array.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUint8Array",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 54
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 110
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUint8Array",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUintArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUintArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 109
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUintArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintPointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUintPointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 63
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 121
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUintPointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUintSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUintSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 74
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUintSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnitializedString.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUnitializedString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "main.executeStringFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go",
+            "lineNumber": 62
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUnitializedString",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testUnsafePointer.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testUnsafePointer",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 55
+          },
+          {
+            "function": "main.executePointerFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go",
+            "lineNumber": 157
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 35
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testUnsafePointer",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeArray.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testVeryLargeArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 95
+          },
+          {
+            "function": "main.executeArrayFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go",
+            "lineNumber": 99
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testVeryLargeArray",
           "location": {

--- a/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testVeryLargeSlice.json
@@ -14,7 +14,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.testVeryLargeSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 65
+          },
+          {
+            "function": "main.executeSliceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go",
+            "lineNumber": 82
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 31
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "testVeryLargeSlice",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.PointerChainArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 111
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 37
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "PointerChainArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.PointerSmallChainArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 115
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 38
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "PointerSmallChainArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.bigMapArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "bigMapArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.inlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 76
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 26
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "inlined",
           "location": {
@@ -50,7 +71,33 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.inlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 75
+          },
+          {
+            "function": "main.funcArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 81
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 28
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "inlined",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.intArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 42
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 19
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "intArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.intArrayArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 57
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "intArrayArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.stringArrayArgFrameless",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 25
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "intArrayArgFrameless",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.intSliceArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 52
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 21
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "intSliceArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.mapArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 85
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "mapArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.stringArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 47
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 20
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "stringArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.stringArrayArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 67
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "stringArrayArg",
           "location": {

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -14,7 +14,28 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": [
+          {
+            "function": "main.stringSliceArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 62
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": 283
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
         "probe": {
           "id": "stringSliceArg",
           "location": {

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -14,7 +14,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "http_handler",
           "location": {
@@ -281,7 +281,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "look_at_the_request",
           "location": {
@@ -317,7 +317,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "http_handler",
           "location": {
@@ -584,7 +584,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "look_at_the_request",
           "location": {
@@ -620,7 +620,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "http_handler",
           "location": {
@@ -887,7 +887,7 @@
         "id": "[id]",
         "timestamp": "[ts]",
         "language": "go",
-        "stack": "[stack-unredact-me]",
+        "stack": "[stack]",
         "probe": {
           "id": "look_at_the_request",
           "location": {

--- a/pkg/dyninst/testprogs/progs/sample/inlined.go
+++ b/pkg/dyninst/testprogs/progs/sample/inlined.go
@@ -36,6 +36,7 @@ func testInlinedBA(x int) {
 
 func testInlinedBB(x, y int) {
 	z := x * y
+	testInlinedPrint(z)
 	testInlinedBBA(z)
 	testInlinedBBB()
 }
@@ -66,11 +67,40 @@ func testInlinedBCB() {
 	fmt.Println("inlinedBCB")
 }
 
+func testInlinedSumArray(a [5]int) int {
+	return a[0] + a[1] + a[2] + a[3] + a[4]
+}
+
+func testInlinedSq(x int) int {
+	return x * x
+}
+
+//go:noinline
+func testFrameless(x int) int {
+	return testInlinedSq(x)
+}
+
+// Despite best efforts, the compiler doesn't make the following function
+// frameless. Seems impossible currently to have a function inlined into
+// a frameless function if it accesses stack (even though the data is put
+// on the stack by the caller). Best we can do is the function above, which
+// doesn't test cfa resolution, but at least we test stack unwinding. We
+// keep this test in case, in the future, the compiler decides to make this
+// function frameless.
+//
+//go:noinline
+func testFramelessArray(a [5]int) int {
+	return testInlinedSumArray(a)
+}
+
 //nolint:all
 func executeInlined() {
+	a := [5]int{1, 2, 3, 4, 5}
 	x := 10
-	y := 20
+	y := testInlinedSumArray(a)
 	testInlinedA(x, y)
 	testInlinedB(x, y)
 	forceOutOfLine(testInlinedPrint)
+	fmt.Println(testFrameless(x))
+	fmt.Println(testFramelessArray(a))
 }

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -649,10 +649,84 @@ probes:
   where:
     methodName: main.testInlinedPrint
   captureSnapshot: true
-- id: testInlinedBBC
+  sampling:
+    snapshotsPerSecond: 10
+- id: testInlinedSumArray
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedSumArray
+  captureSnapshot: true
+  sampling:
+    snapshotsPerSecond: 10
+- id: testInlinedSq
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedSq
+  captureSnapshot: true
+- id: testInlinedBA
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBA
+  captureSnapshot: true
+- id: testInlinedBB
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBB
+  captureSnapshot: true
+- id: testInlinedBBA
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBBA
+  captureSnapshot: true
+- id: testInlinedBBB
   type: LOG_PROBE
   tags:
     - "foo:bar"
   where:
     methodName: main.testInlinedBBB
+  captureSnapshot: true
+- id: testInlinedBC
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBC
+  captureSnapshot: true
+- id: testInlinedBCA
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBCA
+  captureSnapshot: true
+- id: testInlinedBCB
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testInlinedBCB
+  captureSnapshot: true
+- id: testFrameless
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testFrameless
+  captureSnapshot: true
+- id: testFramelessArray
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testFramelessArray
   captureSnapshot: true


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/DEBUG-4094

Handle frameless/framefull cases on each architecture, for cfa calculation and stack unwinding.
Correctly determine framelessness for concrete and inlined subroutines, on each architecture.

This PR adds tests and unredacts stacks, polluting the change diff. However, individual commits that change actual logic should have limited test diffs.
