### PR TITLE
Fix failing unit tests for hosts with a GPU

### DIFF
--- a/pkg/gpu/tags/tags_dummy.go
+++ b/pkg/gpu/tags/tags_dummy.go
@@ -3,12 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && !test
+//go:build linux && test
 
 // Package tags provides gpu host tags to the host payload
 package tags
 
+// This is a dummy entry point into the module to avoid adding the gpu_host tags as host tags when running unit tests.
+// This prevent unit tests from failing depending on the type of host they're running on.
+
 // GetTags returns a slice of tags indicating GPU presence
 func GetTags() []string {
-	return getTags()
+	return nil
 }

--- a/pkg/gpu/tags/tags_logic.go
+++ b/pkg/gpu/tags/tags_logic.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package tags
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// getTags returns a slice of tags indicating GPU presence
+func getTags() []string {
+	// Get the host's proc directory path
+	procPath := kernel.ProcFSRoot()
+	nvidiaPath := filepath.Join(procPath, "driver", "nvidia", "gpus")
+
+	// Check if the NVIDIA directory exists
+	if _, err := os.Stat(nvidiaPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		log.Warnf("Failed to check NVIDIA GPU directory: %v", err)
+		return nil
+	}
+
+	// Read the directory to count GPU entries
+	entries, err := os.ReadDir(nvidiaPath)
+	if err != nil {
+		log.Warnf("Failed to read NVIDIA GPU directory: %v", err)
+		return nil
+	}
+
+	// If we have at least one entry, we have a GPU
+	if len(entries) > 0 {
+		return []string{"gpu_host:true"}
+	}
+
+	return nil
+}

--- a/pkg/gpu/tags/tags_test.go
+++ b/pkg/gpu/tags/tags_test.go
@@ -106,7 +106,7 @@ func TestGetTags(t *testing.T) {
 					t.Fatalf("Setup failed: %v", err)
 				}
 			}
-			gotTags := GetTags()
+			gotTags := getTags()
 			assert.Equal(t, tt.wantTags, gotTags)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

This prevents the gpu tag to be added by default to host tags when running unit tests. Adding it would break other unit tests across the code base depending on the presence of a GPU in the host.

### Describe how you validated your changes

Running the CI is enough