### PR TITLE
discovery: add discovered_services metric to process collector

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -38,6 +38,7 @@ import (
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -65,12 +66,13 @@ type collector struct {
 	containerProvider      proccontainers.ContainerProvider
 
 	// Service discovery fields
-	sysProbeClient *http.Client
-	startTime      time.Time
-	startupTimeout time.Duration
-	serviceRetries map[int32]uint
-	ignoredPids    core.PidSet
-	pidHeartbeats  map[int32]time.Time
+	sysProbeClient           *http.Client
+	startTime                time.Time
+	startupTimeout           time.Duration
+	serviceRetries           map[int32]uint
+	ignoredPids              core.PidSet
+	pidHeartbeats            map[int32]time.Time
+	metricDiscoveredServices telemetry.Gauge
 }
 
 // EventType represents the type of collector event
@@ -176,6 +178,15 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	}
 
 	if c.isServiceDiscoveryEnabled() {
+		// Initialize service discovery metric
+		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
+			"service_discovery",
+			"discovered_services",
+			[]string{},
+			"Number of discovered alive services.",
+			telemetry.DefaultOptions,
+		)
+
 		if c.isProcessCollectionEnabled() {
 			go c.collectServicesCached(ctx, c.clock.Ticker(serviceCollectionInterval))
 		} else {
@@ -528,6 +539,17 @@ func (c *collector) cleanDiscoveryMaps(alivePids core.PidSet) {
 	cleanPidMaps(alivePids, c.pidHeartbeats)
 }
 
+// updateDiscoveredServicesMetric updates the metric with the count of discovered services
+func (c *collector) updateDiscoveredServicesMetric() {
+	if c.metricDiscoveredServices == nil {
+		return
+	}
+
+	count := len(c.pidHeartbeats)
+	log.Debugf("discovered services count: %d", count)
+	c.metricDiscoveredServices.Set(float64(count))
+}
+
 // getDiscoveryURL builds the URL for the discovery endpoint
 func getDiscoveryURL(endpoint string) string {
 	URL := &url.URL{
@@ -616,6 +638,7 @@ func (c *collector) collectServicesNoCache(ctx context.Context, collectionTicker
 			c.mux.Unlock()
 
 			c.cleanDiscoveryMaps(alivePids)
+			c.updateDiscoveredServicesMetric()
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return
@@ -664,6 +687,7 @@ func (c *collector) collectServicesCached(ctx context.Context, collectionTicker 
 			}
 
 			c.cleanDiscoveryMaps(alivePids)
+			c.updateDiscoveredServicesMetric()
 		case <-ctx.Done():
 			log.Infof("The %s service collector has stopped", collectorID)
 			return

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -180,7 +180,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	if c.isServiceDiscoveryEnabled() {
 		// Initialize service discovery metric
 		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
-			"service_discovery",
+			collectorID,
 			"discovered_services",
 			[]string{},
 			"Number of discovered alive services.",

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -41,9 +40,8 @@ var newOSImpl func() (osImpl, error)
 // Check reports discovered services.
 type Check struct {
 	corechecks.CheckBase
-	os                       osImpl
-	sender                   *telemetrySender
-	metricDiscoveredServices telemetry.Gauge
+	os     osImpl
+	sender *telemetrySender
 }
 
 // Factory creates a new check factory
@@ -89,14 +87,6 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, instance
 		return err
 	}
 
-	c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
-		CheckName,
-		"discovered_services",
-		[]string{},
-		"Number of discovered alive services.",
-		telemetry.DefaultOptions,
-	)
-
 	return nil
 }
 
@@ -108,7 +98,6 @@ func (c *Check) Run() error {
 	}
 
 	log.Debugf("runningServices: %d", response.RunningServicesCount)
-	c.metricDiscoveredServices.Set(float64(response.RunningServicesCount))
 
 	for _, p := range response.StartedServices {
 		c.sender.sendStartServiceEvent(p)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the `process_collector.discovered_services` metric to the new process collector. It serves a similar purpose as the `service_discovery.discovered_services` metric and aims to fully replace it once the old check is removed.

### Motivation

Make sure the new process collector have the same metric as the old discovery check.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->