### PR TITLE
pkg/dyninst: Fix map slots entry size calculation

### DIFF
--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -269,13 +269,12 @@ func (s *goSwissMapHeaderType) encodeSwissMapGroup(
 ) (valuesEncoded int, err error) {
 	slotsData := groupData[s.slotsOffset : s.slotsOffset+s.slotsSize]
 	controlWord := binary.LittleEndian.Uint64(groupData[s.ctrlOffset : s.ctrlOffset+uint32(s.ctrlSize)])
-	entrySize := (s.valueFieldOffset - s.keyFieldOffset) + s.valueTypeSize
 	for i := range 8 {
 		if controlWord&(1<<(7+(8*i))) != 0 {
 			// slot is empty or deleted
 			continue
 		}
-		entryData := slotsData[uint32(i)*entrySize : uint32(i+1)*entrySize]
+		entryData := slotsData[uint32(i)*s.slotsArrayEntrySize : uint32(i+1)*s.slotsArrayEntrySize]
 		keyData := entryData[s.keyFieldOffset : s.keyFieldOffset+s.keyTypeSize]
 		valueData := entryData[s.valueFieldOffset : s.valueFieldOffset+s.valueTypeSize]
 

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -148,7 +148,7 @@ func newDecoderType(
 		}
 		slotsFieldType, ok := types[slotsField.Type.GetID()]
 		if !ok {
-			return nil, errors.New("type map slot field not found in types: " + s.GroupType.Name)
+			return nil, fmt.Errorf("type map slot field not found in types: %s", s.GroupType.Name)
 		}
 		ctrlField, err := getFieldByName(s.GroupType.RawFields, "ctrl")
 		if err != nil {
@@ -158,18 +158,18 @@ func newDecoderType(
 		ctrlSize := ctrlField.Type.GetByteSize()
 		entryArray, ok := slotsFieldType.(*ir.ArrayType)
 		if !ok {
-			return nil, errors.New("type map slot field is not an array type: " + slotsFieldType.GetName())
+			return nil, fmt.Errorf("type map slot field is not an array type: %s", slotsFieldType.GetName())
 		}
 		noalgstructType, ok := entryArray.Element.(*ir.StructureType)
 		if !ok {
-			return nil, errors.New("type map entry array element is not a structure type: " + entryArray.Element.GetName())
+			return nil, fmt.Errorf("type map entry array element is not a structure type: %s", entryArray.Element.GetName())
 		}
 		keyField, err := getFieldByName(noalgstructType.RawFields, "key")
 		if err != nil {
 			return nil, fmt.Errorf("malformed swiss map header type: %w", err)
 		}
 		if keyField == nil {
-			return nil, errors.New("type map entry array element has no key field: " + entryArray.Element.GetName())
+			return nil, fmt.Errorf("type map entry array element has no key field: %s", entryArray.Element.GetName())
 		}
 		elem, err := getFieldByName(noalgstructType.RawFields, "elem")
 		if err != nil {
@@ -211,7 +211,7 @@ func newDecoderType(
 			valueFieldOffset: valueFieldOffset,
 
 			// Fields in go swiss map internal representation
-			// Seehttps://github.com/golang/go/blob/cd3655a8243b5f52b6a274a0aba5e01d998906c0/src/internal/runtime/maps/map.go#L195
+			// See https://github.com/golang/go/blob/cd3655a8/src/internal/runtime/maps/map.go#L195
 			dirLenOffset:     dirLenOffset,
 			dirLenSize:       dirLenSize,
 			dirPtrOffset:     dirPtrOffset,

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -58,14 +58,15 @@ type goHMapBucketType ir.GoHMapBucketType
 type goSwissMapHeaderType struct {
 	*ir.GoSwissMapHeaderType
 	// User-defined key and value type information
-	keyTypeID        ir.TypeID
-	keyTypeName      string
-	keyTypeSize      uint32
-	valueTypeID      ir.TypeID
-	valueTypeName    string
-	valueTypeSize    uint32
-	keyFieldOffset   uint32
-	valueFieldOffset uint32
+	keyTypeID           ir.TypeID
+	keyTypeName         string
+	keyTypeSize         uint32
+	valueTypeID         ir.TypeID
+	valueTypeName       string
+	valueTypeSize       uint32
+	keyFieldOffset      uint32
+	valueFieldOffset    uint32
+	slotsArrayEntrySize uint32
 
 	// Internal Go swiss map representation fields
 	dirPtrOffset     uint32
@@ -200,15 +201,15 @@ func newDecoderType(
 		return &goSwissMapHeaderType{
 			GoSwissMapHeaderType: s,
 			// Fields related to user defined key and value types
-			keyTypeID:     keyField.Type.GetID(),
-			valueTypeID:   elem.Type.GetID(),
-			keyTypeSize:   keyField.Type.GetByteSize(),
-			valueTypeSize: elem.Type.GetByteSize(),
-			keyTypeName:   keyField.Type.GetName(),
-			valueTypeName: elem.Type.GetName(),
-
-			keyFieldOffset:   keyFieldOffset,
-			valueFieldOffset: valueFieldOffset,
+			keyTypeID:           keyField.Type.GetID(),
+			valueTypeID:         elem.Type.GetID(),
+			keyTypeSize:         keyField.Type.GetByteSize(),
+			valueTypeSize:       elem.Type.GetByteSize(),
+			keyTypeName:         keyField.Type.GetName(),
+			valueTypeName:       elem.Type.GetName(),
+			slotsArrayEntrySize: noalgstructType.GetByteSize(),
+			keyFieldOffset:      keyFieldOffset,
+			valueFieldOffset:    valueFieldOffset,
 
 			// Fields in go swiss map internal representation
 			// See https://github.com/golang/go/blob/cd3655a8/src/internal/runtime/maps/map.go#L195

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -163,19 +163,51 @@ Package: main
 		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
 	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
 		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
-	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [65:75]
-		Arg: entriesCount: int (declared at line 65, available: [65-75])
-		Arg: ~r0: map[string][]main.structWithMap (declared at line 65, available: )
-		Var: result: map[string][]main.structWithMap (declared at line 66, available: [65-75])
-		Scope: 65-75
-			Var: i: int (declared at line 67, available: [65-75])
-	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [79:140]
-		Var: m: map[string]int (declared at line 82, available: [79-140])
-		Var: j: map[string]int (declared at line 83, available: [79-140])
-		Var: b: main.node (declared at line 108, available: )
-		Scope: 95-98
-			Var: v: int (declared at line 95, available: [95-95], [96-96])
-			Var: k: string (declared at line 95, available: [96-96])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: redactMyEntries: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: current: *main.node (declared at line 141, available: [142-143], [147-147])
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-199], [200-200], [202-202])
 	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
 		Arg: a: uint8 (declared at line 15, available: [18-18])
 		Arg: b: uint8 (declared at line 15, available: [18-18])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -170,7 +170,7 @@ Package: main
 	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
 		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
 	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
-		Arg: redactMyEntries: map[uint8]uint8 (declared at line 78, available: [78-78])
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
 	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
 		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
 	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -163,19 +163,51 @@ Package: main
 		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
 	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
 		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
-	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [65:75]
-		Arg: entriesCount: int (declared at line 65, available: [65-75])
-		Arg: ~r0: map[string][]main.structWithMap (declared at line 65, available: )
-		Var: result: map[string][]main.structWithMap (declared at line 66, available: [65-75])
-		Scope: 65-75
-			Var: i: int (declared at line 67, available: [65-75])
-	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [79:140]
-		Var: m: map[string]int (declared at line 82, available: [79-140])
-		Var: j: map[string]int (declared at line 83, available: [79-140])
-		Var: b: main.node (declared at line 108, available: )
-		Scope: 95-98
-			Var: v: int (declared at line 95, available: [95-95], [96-96])
-			Var: k: string (declared at line 95, available: [96-96])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: redactMyEntries: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: current: *main.node (declared at line 141, available: [142-142], [143-143], [147-147])
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-190], [191-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-200], [202-202])
 	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
 		Arg: a: uint8 (declared at line 15, available: [18-18])
 		Arg: b: uint8 (declared at line 15, available: [18-18])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -170,7 +170,7 @@ Package: main
 	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
 		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
 	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
-		Arg: redactMyEntries: map[uint8]uint8 (declared at line 78, available: [78-78])
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
 	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
 		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
 	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -1,0 +1,92 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testArrayOfMaps",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testArrayOfMaps",
+          "location": {
+            "method": "main.testArrayOfMaps"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "[2]map[string]int",
+                "size": "2",
+                "elements": [
+                  {
+                    "type": "map[string]int",
+                    "size": "2",
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "bar"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "foo"
+                        },
+                        {
+                          "type": "int",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "type": "map[string]int",
+                    "size": "2",
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "bar"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "foo"
+                        },
+                        {
+                          "type": "int",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -27,8 +27,468 @@
               "m": {
                 "type": "map[[4]int][4]int",
                 "size": "10",
-                "entries": [],
-                "notCapturedReason": "pruned"
+                "entries": [
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "1"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "int",
+                          "value": "3"
+                        },
+                        {
+                          "type": "int",
+                          "value": "4"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "10"
+                        },
+                        {
+                          "type": "int",
+                          "value": "20"
+                        },
+                        {
+                          "type": "int",
+                          "value": "30"
+                        },
+                        {
+                          "type": "int",
+                          "value": "40"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "int",
+                          "value": "4"
+                        },
+                        {
+                          "type": "int",
+                          "value": "6"
+                        },
+                        {
+                          "type": "int",
+                          "value": "8"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "20"
+                        },
+                        {
+                          "type": "int",
+                          "value": "40"
+                        },
+                        {
+                          "type": "int",
+                          "value": "60"
+                        },
+                        {
+                          "type": "int",
+                          "value": "80"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "3"
+                        },
+                        {
+                          "type": "int",
+                          "value": "6"
+                        },
+                        {
+                          "type": "int",
+                          "value": "9"
+                        },
+                        {
+                          "type": "int",
+                          "value": "12"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "30"
+                        },
+                        {
+                          "type": "int",
+                          "value": "60"
+                        },
+                        {
+                          "type": "int",
+                          "value": "90"
+                        },
+                        {
+                          "type": "int",
+                          "value": "120"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "4"
+                        },
+                        {
+                          "type": "int",
+                          "value": "8"
+                        },
+                        {
+                          "type": "int",
+                          "value": "12"
+                        },
+                        {
+                          "type": "int",
+                          "value": "16"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "40"
+                        },
+                        {
+                          "type": "int",
+                          "value": "80"
+                        },
+                        {
+                          "type": "int",
+                          "value": "120"
+                        },
+                        {
+                          "type": "int",
+                          "value": "160"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "5"
+                        },
+                        {
+                          "type": "int",
+                          "value": "10"
+                        },
+                        {
+                          "type": "int",
+                          "value": "15"
+                        },
+                        {
+                          "type": "int",
+                          "value": "20"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "50"
+                        },
+                        {
+                          "type": "int",
+                          "value": "100"
+                        },
+                        {
+                          "type": "int",
+                          "value": "150"
+                        },
+                        {
+                          "type": "int",
+                          "value": "200"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "6"
+                        },
+                        {
+                          "type": "int",
+                          "value": "12"
+                        },
+                        {
+                          "type": "int",
+                          "value": "18"
+                        },
+                        {
+                          "type": "int",
+                          "value": "24"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "60"
+                        },
+                        {
+                          "type": "int",
+                          "value": "120"
+                        },
+                        {
+                          "type": "int",
+                          "value": "180"
+                        },
+                        {
+                          "type": "int",
+                          "value": "240"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "7"
+                        },
+                        {
+                          "type": "int",
+                          "value": "14"
+                        },
+                        {
+                          "type": "int",
+                          "value": "21"
+                        },
+                        {
+                          "type": "int",
+                          "value": "28"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "70"
+                        },
+                        {
+                          "type": "int",
+                          "value": "140"
+                        },
+                        {
+                          "type": "int",
+                          "value": "210"
+                        },
+                        {
+                          "type": "int",
+                          "value": "280"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "8"
+                        },
+                        {
+                          "type": "int",
+                          "value": "16"
+                        },
+                        {
+                          "type": "int",
+                          "value": "24"
+                        },
+                        {
+                          "type": "int",
+                          "value": "32"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "80"
+                        },
+                        {
+                          "type": "int",
+                          "value": "160"
+                        },
+                        {
+                          "type": "int",
+                          "value": "240"
+                        },
+                        {
+                          "type": "int",
+                          "value": "320"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "9"
+                        },
+                        {
+                          "type": "int",
+                          "value": "18"
+                        },
+                        {
+                          "type": "int",
+                          "value": "27"
+                        },
+                        {
+                          "type": "int",
+                          "value": "36"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "90"
+                        },
+                        {
+                          "type": "int",
+                          "value": "180"
+                        },
+                        {
+                          "type": "int",
+                          "value": "270"
+                        },
+                        {
+                          "type": "int",
+                          "value": "360"
+                        }
+                      ]
+                    }
+                  ]
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -1,0 +1,40 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapLargeKeyLargeValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapLargeKeyLargeValue",
+          "location": {
+            "method": "main.testMapLargeKeyLargeValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[[4]int][4]int",
+                "size": "10",
+                "entries": [],
+                "notCapturedReason": "pruned"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -1,0 +1,124 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapLargeKeySmallValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapLargeKeySmallValue",
+          "location": {
+            "method": "main.testMapLargeKeySmallValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[[4]int]uint8",
+                "size": "3",
+                "entries": [
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "1"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "int",
+                          "value": "3"
+                        },
+                        {
+                          "type": "int",
+                          "value": "4"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "5"
+                        },
+                        {
+                          "type": "int",
+                          "value": "6"
+                        },
+                        {
+                          "type": "int",
+                          "value": "7"
+                        },
+                        {
+                          "type": "int",
+                          "value": "8"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "9"
+                        },
+                        {
+                          "type": "int",
+                          "value": "10"
+                        },
+                        {
+                          "type": "int",
+                          "value": "11"
+                        },
+                        {
+                          "type": "int",
+                          "value": "12"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "3"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -1,0 +1,124 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapSmallKeyLargeValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapSmallKeyLargeValue",
+          "location": {
+            "method": "main.testMapSmallKeyLargeValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[uint8][4]int",
+                "size": "3",
+                "entries": [
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        },
+                        {
+                          "type": "int",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "1"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "int",
+                          "value": "3"
+                        },
+                        {
+                          "type": "int",
+                          "value": "4"
+                        }
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    },
+                    {
+                      "type": "[4]int",
+                      "size": "4",
+                      "elements": [
+                        {
+                          "type": "int",
+                          "value": "2"
+                        },
+                        {
+                          "type": "int",
+                          "value": "4"
+                        },
+                        {
+                          "type": "int",
+                          "value": "6"
+                        },
+                        {
+                          "type": "int",
+                          "value": "8"
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -1,0 +1,140 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapSmallKeySmallValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapSmallKeySmallValue",
+          "location": {
+            "method": "main.testMapSmallKeySmallValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[uint8]uint8",
+                "size": "10",
+                "entries": [
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "3"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "5"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "12"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "7"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "14"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "16"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "9"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "18"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -82,7 +82,147 @@
                                             },
                                             "b": {
                                               "type": "*main.node",
-                                              "isNull": true
+                                              "address": "[addr]",
+                                              "fields": {
+                                                "val": {
+                                                  "type": "int",
+                                                  "value": "7"
+                                                },
+                                                "b": {
+                                                  "type": "*main.node",
+                                                  "address": "[addr]",
+                                                  "fields": {
+                                                    "val": {
+                                                      "type": "int",
+                                                      "value": "8"
+                                                    },
+                                                    "b": {
+                                                      "type": "*main.node",
+                                                      "address": "[addr]",
+                                                      "fields": {
+                                                        "val": {
+                                                          "type": "int",
+                                                          "value": "9"
+                                                        },
+                                                        "b": {
+                                                          "type": "*main.node",
+                                                          "address": "[addr]",
+                                                          "fields": {
+                                                            "val": {
+                                                              "type": "int",
+                                                              "value": "10"
+                                                            },
+                                                            "b": {
+                                                              "type": "*main.node",
+                                                              "address": "[addr]",
+                                                              "fields": {
+                                                                "val": {
+                                                                  "type": "int",
+                                                                  "value": "11"
+                                                                },
+                                                                "b": {
+                                                                  "type": "*main.node",
+                                                                  "address": "[addr]",
+                                                                  "fields": {
+                                                                    "val": {
+                                                                      "type": "int",
+                                                                      "value": "12"
+                                                                    },
+                                                                    "b": {
+                                                                      "type": "*main.node",
+                                                                      "address": "[addr]",
+                                                                      "fields": {
+                                                                        "val": {
+                                                                          "type": "int",
+                                                                          "value": "13"
+                                                                        },
+                                                                        "b": {
+                                                                          "type": "*main.node",
+                                                                          "address": "[addr]",
+                                                                          "fields": {
+                                                                            "val": {
+                                                                              "type": "int",
+                                                                              "value": "14"
+                                                                            },
+                                                                            "b": {
+                                                                              "type": "*main.node",
+                                                                              "address": "[addr]",
+                                                                              "fields": {
+                                                                                "val": {
+                                                                                  "type": "int",
+                                                                                  "value": "15"
+                                                                                },
+                                                                                "b": {
+                                                                                  "type": "*main.node",
+                                                                                  "address": "[addr]",
+                                                                                  "fields": {
+                                                                                    "val": {
+                                                                                      "type": "int",
+                                                                                      "value": "16"
+                                                                                    },
+                                                                                    "b": {
+                                                                                      "type": "*main.node",
+                                                                                      "address": "[addr]",
+                                                                                      "fields": {
+                                                                                        "val": {
+                                                                                          "type": "int",
+                                                                                          "value": "17"
+                                                                                        },
+                                                                                        "b": {
+                                                                                          "type": "*main.node",
+                                                                                          "address": "[addr]",
+                                                                                          "fields": {
+                                                                                            "val": {
+                                                                                              "type": "int",
+                                                                                              "value": "18"
+                                                                                            },
+                                                                                            "b": {
+                                                                                              "type": "*main.node",
+                                                                                              "address": "[addr]",
+                                                                                              "fields": {
+                                                                                                "val": {
+                                                                                                  "type": "int",
+                                                                                                  "value": "19"
+                                                                                                },
+                                                                                                "b": {
+                                                                                                  "type": "*main.node",
+                                                                                                  "address": "[addr]",
+                                                                                                  "fields": {
+                                                                                                    "val": {
+                                                                                                      "type": "int",
+                                                                                                      "value": "20"
+                                                                                                    },
+                                                                                                    "b": {
+                                                                                                      "type": "*main.node",
+                                                                                                      "isNull": true
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
                                             }
                                           }
                                         }

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -1,0 +1,140 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapWithSmallKeyAndValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapWithSmallKeyAndValue",
+          "location": {
+            "method": "main.testMapWithSmallKeyAndValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[uint8]uint8",
+                "size": "10",
+                "entries": [
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "3"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "5"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "12"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "7"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "14"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "16"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "9"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "18"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -24,11 +24,2561 @@
         "captures": {
           "entry": {
             "arguments": {
-              "redactMyEntries": {
+              "m": {
                 "type": "map[uint8]uint8",
                 "size": "255",
-                "entries": "[redacted-entries]",
-                "notCapturedReason": "pruned"
+                "entries": [
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "20"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "100"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "200"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "101"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "202"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "102"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "204"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "103"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "206"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "104"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "208"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "105"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "210"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "106"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "212"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "107"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "214"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "108"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "216"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "109"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "218"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "11"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "22"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "110"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "220"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "111"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "222"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "112"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "224"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "113"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "226"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "114"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "228"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "115"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "230"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "116"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "232"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "117"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "234"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "118"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "236"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "119"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "238"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "12"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "24"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "120"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "240"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "121"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "242"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "122"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "244"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "123"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "246"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "124"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "248"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "125"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "250"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "126"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "252"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "127"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "254"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "128"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "0"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "129"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "13"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "26"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "130"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "131"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "132"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "133"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "134"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "12"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "135"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "14"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "136"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "16"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "137"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "18"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "138"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "20"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "139"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "22"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "14"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "28"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "140"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "24"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "141"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "26"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "142"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "28"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "143"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "30"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "144"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "32"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "145"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "34"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "146"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "36"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "147"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "38"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "148"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "40"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "149"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "42"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "15"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "30"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "150"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "44"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "151"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "46"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "152"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "48"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "153"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "50"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "154"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "52"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "155"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "54"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "156"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "56"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "157"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "58"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "158"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "60"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "159"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "62"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "16"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "32"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "160"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "64"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "161"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "66"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "162"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "68"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "163"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "70"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "164"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "72"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "165"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "74"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "166"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "76"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "167"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "78"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "168"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "80"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "169"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "82"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "17"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "34"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "170"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "84"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "171"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "86"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "172"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "88"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "173"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "90"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "174"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "92"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "175"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "94"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "176"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "96"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "177"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "98"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "178"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "100"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "179"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "102"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "18"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "36"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "180"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "104"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "181"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "106"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "182"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "108"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "183"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "110"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "184"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "112"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "185"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "114"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "186"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "116"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "187"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "118"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "188"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "120"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "189"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "122"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "19"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "38"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "190"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "124"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "191"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "126"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "192"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "128"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "193"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "130"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "194"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "132"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "195"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "134"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "196"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "136"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "197"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "138"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "198"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "140"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "199"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "142"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "20"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "40"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "200"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "144"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "201"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "146"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "202"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "148"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "203"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "150"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "204"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "152"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "205"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "154"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "206"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "156"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "207"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "158"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "208"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "160"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "209"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "162"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "21"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "42"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "210"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "164"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "211"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "166"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "212"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "168"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "213"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "170"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "214"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "172"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "215"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "174"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "216"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "176"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "217"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "178"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "218"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "180"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "219"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "182"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "22"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "44"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "220"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "184"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "221"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "186"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "222"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "188"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "223"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "190"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "224"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "192"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "225"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "194"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "226"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "196"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "227"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "198"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "228"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "200"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "229"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "202"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "23"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "46"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "230"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "204"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "231"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "206"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "232"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "208"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "233"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "210"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "234"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "212"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "235"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "214"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "236"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "216"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "237"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "218"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "238"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "220"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "239"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "222"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "24"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "48"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "240"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "224"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "241"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "226"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "242"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "228"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "243"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "230"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "244"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "232"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "245"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "234"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "246"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "236"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "247"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "238"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "248"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "240"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "249"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "242"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "25"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "50"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "250"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "244"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "251"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "246"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "252"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "248"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "253"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "250"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "254"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "252"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "26"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "52"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "27"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "54"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "28"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "56"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "29"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "58"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "3"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "30"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "60"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "31"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "62"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "32"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "64"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "33"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "66"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "34"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "68"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "35"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "70"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "36"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "72"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "37"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "74"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "38"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "76"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "39"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "78"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "40"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "80"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "41"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "82"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "42"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "84"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "43"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "86"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "44"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "88"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "45"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "90"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "46"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "92"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "47"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "94"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "48"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "96"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "49"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "98"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "5"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "50"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "100"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "51"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "102"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "52"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "104"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "53"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "106"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "54"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "108"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "55"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "110"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "56"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "112"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "57"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "114"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "58"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "116"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "59"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "118"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "12"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "60"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "120"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "61"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "122"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "62"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "124"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "63"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "126"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "64"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "128"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "65"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "130"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "66"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "132"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "67"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "134"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "68"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "136"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "69"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "138"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "7"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "14"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "70"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "140"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "71"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "142"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "72"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "144"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "73"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "146"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "74"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "148"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "75"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "150"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "76"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "152"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "77"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "154"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "78"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "156"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "79"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "158"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "16"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "80"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "160"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "81"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "162"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "82"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "164"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "83"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "166"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "84"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "168"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "85"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "170"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "86"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "172"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "87"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "174"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "88"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "176"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "89"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "178"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "9"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "18"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "90"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "180"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "91"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "182"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "92"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "184"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "93"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "186"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "94"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "188"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "95"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "190"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "96"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "192"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "97"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "194"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "98"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "196"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "99"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "198"
+                    }
+                  ]
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -1,0 +1,40 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapWithSmallKeyAndValueMassive",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapWithSmallKeyAndValueMassive",
+          "location": {
+            "method": "main.testMapWithSmallKeyAndValueMassive"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "redactMyEntries": {
+                "type": "map[uint8]uint8",
+                "size": "255",
+                "entries": "[redacted-entries]",
+                "notCapturedReason": "pruned"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -1,0 +1,140 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapWithSmallValue",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapWithSmallValue",
+          "location": {
+            "method": "main.testMapWithSmallValue"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[int]uint8",
+                "size": "10",
+                "entries": [
+                  [
+                    {
+                      "type": "int",
+                      "value": "1"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "10"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "10"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "2"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "3"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "3"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "4"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "4"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "5"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "5"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "6"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "6"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "7"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "7"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "8"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "8"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "int",
+                      "value": "9"
+                    },
+                    {
+                      "type": "uint8",
+                      "value": "9"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -1,0 +1,40 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMapWithSmallValueMassive",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testMapWithSmallValueMassive",
+          "location": {
+            "method": "main.testMapWithSmallValueMassive"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "redactMyEntries": {
+                "type": "map[int]uint8",
+                "size": "10000",
+                "entries": "[redacted-entries]",
+                "notCapturedReason": "pruned"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testPointerToMap",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testPointerToMap",
+          "location": {
+            "method": "main.testPointerToMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "*map[string]int",
+                "address": "[addr]",
+                "size": "2",
+                "entries": [
+                  [
+                    {
+                      "type": "string",
+                      "value": "bar"
+                    },
+                    {
+                      "type": "int",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "string",
+                      "value": "foo"
+                    },
+                    {
+                      "type": "int",
+                      "value": "1"
+                    }
+                  ]
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -1,0 +1,55 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStructWithMap",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": "[stack-unredact-me]",
+        "probe": {
+          "id": "testStructWithMap",
+          "location": {
+            "method": "main.testStructWithMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "main.structWithMap",
+                "fields": {
+                  "m": {
+                    "type": "map[int]int",
+                    "size": "1",
+                    "entries": [
+                      [
+                        {
+                          "type": "int",
+                          "value": "1"
+                        },
+                        {
+                          "type": "int",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testprogs/progs/sample/maps.go
+++ b/pkg/dyninst/testprogs/progs/sample/maps.go
@@ -75,7 +75,7 @@ func testMapWithSmallKeyAndValue(m map[uint8]uint8) {}
 
 //nolint:all
 //go:noinline
-func testMapWithSmallKeyAndValueMassive(redactMyEntries map[uint8]uint8) {}
+func testMapWithSmallKeyAndValueMassive(m map[uint8]uint8) {}
 
 //nolint:all
 //go:noinline

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -565,3 +565,80 @@ probes:
   where:
     methodName: main.testMapWithLinkedList
   captureSnapshot: true
+- id: testMapWithSmallValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapWithSmallValue
+  captureSnapshot: true
+- id: testMapWithSmallValueMassive
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapWithSmallValueMassive
+  captureSnapshot: true
+- id: testMapWithSmallKeyAndValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapWithSmallKeyAndValue
+  captureSnapshot: true
+- id: testMapWithSmallKeyAndValueMassive
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapWithSmallKeyAndValueMassive
+  captureSnapshot: true
+- id: testMapSmallKeySmallValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapSmallKeySmallValue
+  captureSnapshot: true
+- id: testMapSmallKeyLargeValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapSmallKeyLargeValue
+  captureSnapshot: true
+- id: testMapLargeKeySmallValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapLargeKeySmallValue
+  captureSnapshot: true
+- id: testMapLargeKeyLargeValue
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testMapLargeKeyLargeValue
+  captureSnapshot: true
+- id: testStructWithMap
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testStructWithMap
+  captureSnapshot: true
+- id: testArrayOfMaps
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testArrayOfMaps
+  captureSnapshot: true
+- id: testPointerToMap
+  type: LOG_PROBE
+  tags:
+    - "foo:bar"
+  where:
+    methodName: main.testPointerToMap
+  captureSnapshot: true


### PR DESCRIPTION
### What does this PR do?

There was an issue with the way I calculated entry size of the swiss map slots array. This fixes it to use info from DWARF instead.

+ test cases
+ a couple style fixes

### Motivation

Fixing map support in dynamic instrumentation

### Describe how you validated your changes

Added more test cases

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->