### PR TITLE
dyninst/symdb: translate package paths with dots properly

### DIFF
--- a/pkg/dyninst/symdb/func_name.go
+++ b/pkg/dyninst/symdb/func_name.go
@@ -160,6 +160,14 @@ func parseFuncName(qualifiedName string) (parseFuncNameResult, error) {
 		name = groups[standaloneFuncRENameIdx]
 	}
 
+	// If the last element of the package's import path contains dots, they are
+	// replaced with %2e in DWARF to differentiate them from the dot
+	// that separates the package path from the function name.
+	// For example, functions in package "gopkg.in/square/go-jose.v2" will
+	// appear in DWARF as "gopkg.in/square/go-jose%2ev2.newBuffer".
+	// See https://groups.google.com/g/golang-nuts/c/Can9WXHrqHg/m/kMfx1x6sBgAJ
+	pkg = strings.ReplaceAll(pkg, "%2e", ".")
+
 	// Check whether we're with anonymous functions. If we are, they might have
 	// parsed as a method, but they are not actually methods, so we need to
 	// rectify the results of the parsing and wipe the type.

--- a/pkg/dyninst/symdb/func_name_test.go
+++ b/pkg/dyninst/symdb/func_name_test.go
@@ -120,6 +120,14 @@ func TestParseFuncName(t *testing.T) {
 				failureReason: parseFuncNameFailureReasonMapInit,
 			},
 		},
+		{"import path with dot", "gopkg.in/square/go-jose%2ev2.newBuffer",
+			parseFuncNameResult{
+				funcName: funcName{
+					Package: "gopkg.in/square/go-jose.v2",
+					Type:    "",
+					Name:    "newBuffer",
+				},
+			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -135,7 +135,7 @@ Package: main
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
 		Arg: e: error (declared at line 60, available: [60-60])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [18:43]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:45]
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -629,5 +629,7 @@ Package: main
 	Type: main.structWithNoStrings
 		Field: aUint8: uint8
 		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [15:16]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -135,7 +135,7 @@ Package: main
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
 		Arg: e: error (declared at line 60, available: [60-60])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [18:43]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:45]
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -629,5 +629,7 @@ Package: main
 	Type: main.structWithNoStrings
 		Field: aUint8: uint8
 		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [15:16]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package lib_v2 is a package in a directory with a dot in its name (package
+// names do not need to correspond to directory names necessarily). This dot
+// gets escaped in DWARF, making this useful for our tests.
+package lib_v2
+
+var dummy int
+
+//go:noinline
+func FooV2() {
+	dummy++
+}

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2"
 )
 
 func main() {
@@ -33,6 +34,7 @@ func main() {
 	executePointerFuncs()
 	executeComplexFuncs()
 	lib.Foo()
+	lib_v2.FooV2()
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()


### PR DESCRIPTION
When parsing function and type names, we were not dealing properly with packages
whose last element of the path contains dots; we were not decoding their
names properly. If the last element of the package's import path contains dots,
they are replaced with %2e in DWARF in order to differentiate them from
the dot that separates the package path from the function name. For
example, functions in package
"gopkg.in/square/go-jose.v2" will appear in DWARF as
"gopkg.in/square/go-jose%2ev2.newBuffer".

See https://groups.google.com/g/golang-nuts/c/Can9WXHrqHg/m/kMfx1x6sBgAJ