### PR TITLE
APM: Correct log about getting root span

### DIFF
--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -60,7 +60,7 @@ func GetRoot(t pb.Trace) *pb.Span {
 	}
 
 	// Have a safe behavior if that's not the case
-	// Pick the first span without its parent
+	// Pick a random span without its parent
 	for parentID := range parentIDToChild {
 		return parentIDToChild[parentID]
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the comment in the GetRoot function, I have misunderstood this function multiple times because this comment made me think we picked a consistent span. However _we do not_. The iteration there is over a map which is explicitly NOT a consistent ordering.

### Motivation
Clarity in reading this function

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
No QA, no behavior change just fixing this comment

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->