### PR TITLE
dyninst/symdb: fix counting of unique file names

### DIFF
--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -124,11 +124,12 @@ func statsFromSymbols(s symdb.Symbols) symbolStats {
 		numFunctions:   0,
 		numSourceFiles: 0,
 	}
+	sourceFiles := make(map[string]struct{})
 	for _, pkg := range s.Packages {
-		s := pkg.Stats()
+		s := pkg.Stats(sourceFiles)
 		stats.numTypes += s.NumTypes
 		stats.numFunctions += s.NumFunctions
-		stats.numSourceFiles += s.NumSourceFiles
 	}
+	stats.numSourceFiles = len(sourceFiles)
 	return stats
 }


### PR DESCRIPTION
Counting unique files across packages was broken.