### PR TITLE
[CWS] make sure the hash action post check is not crashing

### DIFF
--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -1110,3 +1110,48 @@ func (e *Event) GetFileField(field string) (*FileEvent, error) {
 		return nil, fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
 	}
 }
+
+// ValidateFileField validates that GetFileField would return a valid FileEvent
+func (e *Event) ValidateFileField(field string) error {
+	// TODO(lebauce): generate this function + keep in sync with GetFileField
+	switch field {
+	case "open.file":
+	case "exec.file":
+	case "cgroup_write.file":
+	case "chdir.file":
+	case "chmod.file":
+	case "chown.file":
+	case "exec.interpreter.file":
+	case "exit.file":
+	case "exit.interpreter.file":
+	case "link.file":
+	case "load_module.file":
+	case "mkdir.file":
+	case "mmap.file":
+	case "process.file":
+	case "process.interpreter.file":
+	case "process.parent.file":
+	case "process.parent.interpreter.file":
+	case "ptrace.tracee.file":
+	case "ptrace.tracee.interpreter.file":
+	case "ptrace.tracee.parent.file":
+	case "ptrace.tracee.parent.interpreter.file":
+	case "removexattr.file":
+	case "rename.file":
+	case "rmdir.file":
+	case "setrlimit.target.file":
+	case "setrlimit.target.interpreter.file":
+	case "setrlimit.target.parent.file":
+	case "setrlimit.target.parent.interpreter.file":
+	case "setxattr.file":
+	case "signal.target.file":
+	case "signal.target.interpreter":
+	case "signal.target.parent.file":
+	case "signal.target.parent.interpreter.file":
+	case "splice.file":
+	case "unlink.file":
+	case "utimes.file":
+		return nil
+	}
+	return fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
+}

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -262,3 +262,16 @@ func (e *Event) GetFileField(field string) (*FileEvent, error) {
 		return nil, fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
 	}
 }
+
+// ValidateFileField validates that GetFileField would return a valid FileEvent
+func (e *Event) ValidateFileField(field string) error {
+	// TODO(lebauce): generate this function + keep in sync with GetFileField
+	switch field {
+	case "exec.file":
+	case "exit.file":
+	case "process.file":
+	case "process.parent.file":
+		return nil
+	}
+	return fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
+}

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -332,7 +332,7 @@ func (h *HashDefinition) PostCheck(rule *eval.Rule) error {
 	}
 
 	ev.Type = uint32(eventType)
-	if _, err := ev.GetFileField(h.Field); err != nil {
+	if err := ev.ValidateFileField(h.Field); err != nil {
 		return err
 	}
 

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -262,3 +262,16 @@ func (e *Event) GetFileField(field string) (*FileEvent, error) {
 		return nil, fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
 	}
 }
+
+// ValidateFileField validates that GetFileField would return a valid FileEvent
+func (e *Event) ValidateFileField(field string) error {
+	// TODO(lebauce): generate this function + keep in sync with GetFileField
+	switch field {
+	case "exec.file":
+	case "exit.file":
+	case "process.file":
+	case "process.parent.file":
+		return nil
+	}
+	return fmt.Errorf("invalid field %s on event %s", field, e.GetEventType())
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`GetFileField` returns a pointer to the file event, which does not yet exist on exec events when doing the `PostCheck` for hash actions over a fake event. To fix this, the `PostCheck` is done through a new `ValidateFileField` that does the same switch case, but without accessing the event at all.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->