### PR TITLE
Fix likely race condition in `collector_test`

### DIFF
--- a/pkg/trace/telemetry/collector_test.go
+++ b/pkg/trace/telemetry/collector_test.go
@@ -12,9 +12,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //nolint:revive // TODO(TEL) Fix revive linter
@@ -39,14 +41,13 @@ func TestSendFirstTrace(t *testing.T) {
 
 	collector := NewCollector(cfg)
 
-	var events []OnboardingEvent
-	server.assertReq = assertReqGetEvent(t, &events)
+	receiver := newOnboardingEventReceiver(server, t)
 	if !collector.SentFirstTrace() {
 		collector.SendFirstTrace()
 	}
 
 	assert.True(t, collector.SentFirstTrace(), true)
-	assert.Len(t, events, 1)
+	events := receiver.waitN(1, t)
 	assert.Equal(t, events[0].Payload.Tags.InstallID, "foobar")
 	assert.Equal(t, events[0].Payload.Tags.InstallTime, int64(1))
 	assert.Equal(t, events[0].Payload.Tags.InstallType, "manual")
@@ -64,14 +65,13 @@ func TestSendFirstTraceSignatureNotFound(t *testing.T) {
 
 	collector := NewCollector(cfg)
 
-	var events []OnboardingEvent
-	server.assertReq = assertReqGetEvent(t, &events)
+	r := newOnboardingEventReceiver(server, t)
 	if !collector.SentFirstTrace() {
 		collector.SendFirstTrace()
 	}
 
 	assert.True(t, collector.SentFirstTrace(), true)
-	assert.Len(t, events, 1)
+	events := r.waitN(1, t)
 	assert.Equal(t, events[0].Payload.Tags.InstallID, "")
 	assert.Equal(t, events[0].Payload.Tags.InstallTime, int64(0))
 	assert.Equal(t, events[0].Payload.Tags.InstallType, "")
@@ -90,8 +90,7 @@ func TestSendFirstTraceError(t *testing.T) {
 
 	collector := NewCollector(cfg)
 
-	var events []OnboardingEvent
-	server.assertReq = assertReqGetEvent(t, &events)
+	receiver := newOnboardingEventReceiver(server, t)
 	for i := 0; i < 5; i++ {
 		assert.False(t, collector.SentFirstTrace())
 		collector.SendFirstTrace()
@@ -101,7 +100,7 @@ func TestSendFirstTraceError(t *testing.T) {
 		assert.True(t, collector.SentFirstTrace())
 	}
 	assert.True(t, collector.SentFirstTrace(), true)
-	assert.Len(t, events, 5)
+	receiver.waitN(5, t)
 }
 
 func TestTelemetryDisabled(t *testing.T) {
@@ -149,13 +148,12 @@ func TestNoSuccessAfterError(t *testing.T) {
 	cfg := testCfg(server.URL)
 	collector := NewCollector(cfg)
 
-	var events []OnboardingEvent
-	server.assertReq = assertReqGetEvent(t, &events)
+	receiver := newOnboardingEventReceiver(server, t)
 
 	collector.SendStartupError(GenericError, fmt.Errorf(""))
 	collector.SendStartupSuccess()
 
-	assert.Len(t, events, 1)
+	events := receiver.waitN(1, t)
 	assert.Equal(t, "agent.startup.error", events[0].Payload.EventName)
 }
 
@@ -166,13 +164,12 @@ func TestErrorAfterSuccess(t *testing.T) {
 	cfg := testCfg(server.URL)
 	collector := NewCollector(cfg)
 
-	var events []OnboardingEvent
-	server.assertReq = assertReqGetEvent(t, &events)
+	receiver := newOnboardingEventReceiver(server, t)
 
 	collector.SendStartupSuccess()
 	collector.SendStartupError(GenericError, fmt.Errorf(""))
 
-	assert.Len(t, events, 2)
+	events := receiver.waitN(2, t)
 	assert.Equal(t, "agent.startup.success", events[0].Payload.EventName)
 	assert.Equal(t, "agent.startup.error", events[1].Payload.EventName)
 }
@@ -246,13 +243,44 @@ func (ts *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // Close closes the underlying http.Server.
 func (ts *testServer) Close() { ts.server.Close() }
 
-func assertReqGetEvent(t *testing.T, events *[]OnboardingEvent) func(*http.Request) {
-	return func(req *http.Request) {
+type onboardingEventReceiver struct {
+	eventsC chan OnboardingEvent
+}
+
+func newOnboardingEventReceiver(server *testServer, t *testing.T) *onboardingEventReceiver {
+	r := &onboardingEventReceiver{eventsC: make(chan OnboardingEvent, 10)}
+	server.assertReq = func(req *http.Request) {
 		body, err := io.ReadAll(req.Body)
 		assert.NoError(t, err)
 		ev := OnboardingEvent{}
 		err = json.Unmarshal(body, &ev)
 		assert.NoError(t, err)
-		*events = append(*events, ev)
+		select {
+		case r.eventsC <- ev:
+		default:
+			t.Logf("onboarding event buffer full")
+		}
 	}
+	return r
+}
+
+func (r *onboardingEventReceiver) waitN(expected int, t *testing.T) []OnboardingEvent {
+	events := make([]OnboardingEvent, 0, expected)
+	timer := time.NewTimer(time.Duration(expected) * time.Second) // generous
+	defer timer.Stop()
+loop:
+	for {
+		select {
+		case ev := <-r.eventsC:
+			events = append(events, ev)
+			if len(events) >= expected {
+				break loop
+			}
+		case <-timer.C:
+			t.Logf("timed out waiting for onboarding event")
+			break loop
+		}
+	}
+	require.Len(t, events, expected) // `assert` doesn't guard against any next out-of-bounds access to events[N]
+	return events
 }


### PR DESCRIPTION
### What does this PR do?
Since the `tests_macos_gitlab_arm64` job [failed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1058172508) right after a macOS-related PR of mine (#39368) was merged, I looked into what could explain the flakiness in the tests (_I didn't look at the production code itself_).
The only potential suspect I found is a probable race condition, since there is no guarantee that the involved request handler has finished collecting onboarding events before those events are inspected.
The proposed fix is simply to wait for the expected number of events with a timeout (generous enough should the shared runner be under stress).

### Motivation
Learn (Agent ecosystem) & contribute back, with a focus on build reliability.

### Additional Notes
Should GitLab logs go away, here's the test failure output:
```go
=== SKIP: pkg/trace/watchdog TestCPUHigh/100_goroutines (0.00s)
    info_test.go:50: skipping test in short mode
=== Failed
=== FAIL: pkg/trace/telemetry TestSendFirstTrace (0.00s)
    collector_test.go:48: 
        	Error Trace:	/Users/ec2-user/builds/UBPYdxHE3/0/DataDog/datadog-agent/pkg/trace/telemetry/collector_test.go:48
        	Error:      	Should be true
        	Test:       	TestSendFirstTrace
        	Messages:   	true
    collector_test.go:49: 
        	Error Trace:	/Users/ec2-user/builds/UBPYdxHE3/0/DataDog/datadog-agent/pkg/trace/telemetry/collector_test.go:49
        	Error:      	"[]" should have 1 item(s), but has 0
        	Test:       	TestSendFirstTrace
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
goroutine 36 [running]:
testing.tRunner.func1.2({0x103516be0, 0xc00003cdb0})
	/Users/ec2-user/.gimme/versions/go1.24.5.darwin.arm64/src/testing/testing.go:1734 +0x2bc
testing.tRunner.func1()
	/Users/ec2-user/.gimme/versions/go1.24.5.darwin.arm64/src/testing/testing.go:1737 +0x47c
panic({0x103516be0?, 0xc00003cdb0?})
	/Users/ec2-user/.gimme/versions/go1.24.5.darwin.arm64/src/runtime/panic.go:792 +0x124
github.com/DataDog/datadog-agent/pkg/trace/telemetry.TestSendFirstTrace(0xc000310700)
	/Users/ec2-user/builds/UBPYdxHE3/0/DataDog/datadog-agent/pkg/trace/telemetry/collector_test.go:50 +0x660
testing.tRunner(0xc000310700, 0x103573eb8)
	/Users/ec2-user/.gimme/versions/go1.24.5.darwin.arm64/src/testing/testing.go:1792 +0x184
created by testing.(*T).Run in goroutine 1
	/Users/ec2-user/.gimme/versions/go1.24.5.darwin.arm64/src/testing/testing.go:1851 +0x688
DONE 17256 tests, 45 skipped, 1 failure in 857.319s
ERROR rerun aborted because previous run had a suspected panic and some test may not have run
gocovmerge ./coverage.out.rerun.zggl7ai3sw > "./coverage.out"
Tests failed (base flavor)
Test failures:
- github.com/DataDog/datadog-agent/pkg/trace/telemetry TestSendFirstTrace
  See this test name on main in Test Visibility at https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.name%3A%22TestSendFirstTrace%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Ftrace%2Ftelemetry%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent
Processing test results for known flakes. Learn more about flake marker and test washer at https://datadoghq.atlassian.net/wiki/spaces/ADX/pages/3405611398/Flaky+tests+in+go+introducing+flake.Mark
The test command failed, the following tests failed and are not supposed to be flaky:
- github.com/DataDog/datadog-agent/pkg/trace/telemetry TestSendFirstTrace
```