### PR TITLE
chore: rewire the cloud run jobs check to move it out of demultiplexer_serverless.go

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -81,6 +81,11 @@ func (a *AppService) GetShutdownMetricName() string {
 	return fmt.Sprintf("%s.enhanced.shutdown", appServicePrefix)
 }
 
+// ShouldForceFlushAllOnForceFlushToSerializer is false usually.
+func (a *AppService) ShouldForceFlushAllOnForceFlushToSerializer() bool {
+	return false
+}
+
 func isAppService() bool {
 	_, exists := os.LookupEnv(WebsiteStack)
 	return exists

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -160,6 +160,11 @@ func (c *CloudRun) GetShutdownMetricName() string {
 	return fmt.Sprintf("%s.enhanced.shutdown", cloudRunPrefix)
 }
 
+// ShouldForceFlushAllOnForceFlushToSerializer is false usually.
+func (c *CloudRun) ShouldForceFlushAllOnForceFlushToSerializer() bool {
+	return false
+}
+
 func isCloudRunService() bool {
 	_, exists := os.LookupEnv(ServiceNameEnvVar)
 	return exists

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -110,6 +110,11 @@ func (c *CloudRunJobs) GetShutdownMetricName() string {
 	return fmt.Sprintf("%s.enhanced.task.ended", cloudRunJobsPrefix)
 }
 
+// ShouldForceFlushAllOnForceFlushToSerializer is true for cloud run jobs.
+func (c *CloudRunJobs) ShouldForceFlushAllOnForceFlushToSerializer() bool {
+	return true
+}
+
 func isCloudRunJob() bool {
 	_, exists := os.LookupEnv(cloudRunJobNameEnvVar)
 	return exists

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -155,6 +155,11 @@ func (c *ContainerApp) GetShutdownMetricName() string {
 	return fmt.Sprintf("%s.enhanced.shutdown", containerAppPrefix)
 }
 
+// ShouldForceFlushAllOnForceFlushToSerializer is false usually.
+func (c *ContainerApp) ShouldForceFlushAllOnForceFlushToSerializer() bool {
+	return false
+}
+
 func isContainerAppService() bool {
 	_, exists := os.LookupEnv(ContainerAppNameEnvVar)
 	return exists

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -35,6 +35,14 @@ type CloudService interface {
 
 	// GetShutdownMetricName returns the metric name for shutdown events
 	GetShutdownMetricName() string
+
+	// ShouldForceFlushAllOnForceFlushToSerializer is used for the
+	// forceFlushAll parameter on the call to forceFlushToSerializer in the
+	// pkg/aggregator/demultiplexer_serverless.ServerlessDemultiplexer.ForceFlushToSerializer
+	// method. This is currently necessary to support Cloud Run Jobs where the
+	// shutdown flow is more abrupt than other environments. We may want to
+	// unravel this thread in a cleaner way in the future.
+	ShouldForceFlushAllOnForceFlushToSerializer() bool
 }
 
 //nolint:revive // TODO(SERV) Fix revive linter
@@ -73,6 +81,11 @@ func (l *LocalService) GetStartMetricName() string {
 // GetShutdownMetricName returns the metric name for container shutdown events
 func (l *LocalService) GetShutdownMetricName() string {
 	return fmt.Sprintf("%s.enhanced.shutdown", defaultPrefix)
+}
+
+// ShouldForceFlushAllOnForceFlushToSerializer is false usually.
+func (l *LocalService) ShouldForceFlushAllOnForceFlushToSerializer() bool {
+	return false
 }
 
 // GetCloudServiceType TODO: Refactor to avoid leaking individual service implementation details into the interface layer

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -153,7 +153,7 @@ func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Com
 	functionTags := strings.Join(configuredTags, ",")
 	traceAgent := setupTraceAgent(tags, functionTags, tagger)
 
-	metricAgent := setupMetricAgent(tags, tagger)
+	metricAgent := setupMetricAgent(tags, tagger, cloudService.ShouldForceFlushAllOnForceFlushToSerializer())
 
 	metric.Add(cloudService.GetStartMetricName(), 1.0, cloudService.GetSource(), *metricAgent)
 
@@ -197,7 +197,7 @@ func setupTraceAgent(tags map[string]string, functionTags string, tagger tagger.
 	return traceAgent
 }
 
-func setupMetricAgent(tags map[string]string, tagger tagger.Component) *metrics.ServerlessMetricAgent {
+func setupMetricAgent(tags map[string]string, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) *metrics.ServerlessMetricAgent {
 	pkgconfigsetup.Datadog().Set("use_v2_api.series", false, model.SourceAgentRuntime)
 	pkgconfigsetup.Datadog().Set("dogstatsd_socket", "", model.SourceAgentRuntime)
 
@@ -207,7 +207,7 @@ func setupMetricAgent(tags map[string]string, tagger tagger.Component) *metrics.
 	}
 	// we don't want to add certain tags to metrics for cardinality reasons
 	tags = serverlessInitTag.WithoutHighCardinalityTags(tags)
-	metricAgent.Start(5*time.Second, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
+	metricAgent.Start(5*time.Second, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{}, shouldForceFlushAllOnForceFlushToSerializer)
 	metricAgent.SetExtraTags(serverlessTag.MapToArray(tags))
 	return metricAgent
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -220,7 +220,7 @@ func startMetricAgent(serverlessDaemon *daemon.Daemon, logChannel chan *logConfi
 		SketchesBucketOffset: time.Second * 10,
 		Tagger:               tagger,
 	}
-	metricAgent.Start(daemon.FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
+	metricAgent.Start(daemon.FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{}, false)
 	serverlessDaemon.SetStatsdServer(metricAgent)
 	serverlessDaemon.SetupLogCollectionHandler(logsAPICollectionRoute, logChannel, pkgconfigsetup.Datadog().GetBool("serverless.logs_enabled"), pkgconfigsetup.Datadog().GetBool("enhanced_metrics"), lambdaInitMetricChan)
 	return metricAgent

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -7,7 +7,6 @@ package aggregator
 
 import (
 	"context"
-	"os"
 	"sync"
 	"time"
 

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -42,11 +42,14 @@ type ServerlessDemultiplexer struct {
 
 	hostTagProvider *HostTagProvider
 
+	// used by some serveless environments to force flush all metrics.
+	shouldForceFlushAllOnForceFlushToSerializer bool
+
 	*senders
 }
 
 // InitAndStartServerlessDemultiplexer creates and starts new Demultiplexer for the serverless agent.
-func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKeys, forwarderTimeout time.Duration, tagger tagger.Component) (*ServerlessDemultiplexer, error) {
+func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKeys, forwarderTimeout time.Duration, tagger tagger.Component, shouldForceFlushAllOnForceFlushToSerializer bool) (*ServerlessDemultiplexer, error) {
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 	logger := logimpl.NewTemporaryLoggerWithoutInit()
 	forwarder, err := forwarder.NewSyncForwarder(pkgconfigsetup.Datadog(), logger, keysPerDomain, forwarderTimeout)
@@ -74,6 +77,8 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKey
 		flushLock:                   &sync.Mutex{},
 		hostTagProvider:             NewHostTagProvider(),
 		flushAndSerializeInParallel: flushAndSerializeInParallel,
+
+		shouldForceFlushAllOnForceFlushToSerializer: shouldForceFlushAllOnForceFlushToSerializer,
 	}
 
 	// start routines
@@ -112,8 +117,7 @@ func (d *ServerlessDemultiplexer) Stop(flush bool) {
 
 // ForceFlushToSerializer flushes all data from the time sampler to the serializer.
 func (d *ServerlessDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
-	_, forceFlushAll := os.LookupEnv("CLOUD_RUN_JOB")
-	d.forceFlushToSerializer(start, waitForSerializer, forceFlushAll)
+	d.forceFlushToSerializer(start, waitForSerializer, d.shouldForceFlushAllOnForceFlushToSerializer)
 }
 
 func (d *ServerlessDemultiplexer) forceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -497,7 +497,7 @@ func startAgents() *Daemon {
 		SketchesBucketOffset: time.Second * 10,
 		Tagger:               nooptagger.NewComponent(),
 	}
-	ma.Start(FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
+	ma.Start(FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{}, false)
 	d.SetStatsdServer(ma)
 
 	d.InvocationProcessor = &invocationlifecycle.LifecycleProcessor{

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -49,7 +49,7 @@ func TestStartDoesNotBlock(t *testing.T) {
 		Tagger:               nooptagger.NewComponent(),
 	}
 	defer metricAgent.Stop()
-	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
+	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{}, false)
 	assert.NotNil(t, metricAgent.Demux)
 	assert.True(t, metricAgent.IsReady())
 }
@@ -72,7 +72,7 @@ func TestStartInvalidConfig(t *testing.T) {
 		Tagger:               nooptagger.NewComponent(),
 	}
 	defer metricAgent.Stop()
-	metricAgent.Start(1*time.Second, &InvalidMetricConfigMocked{}, &MetricDogStatsD{})
+	metricAgent.Start(1*time.Second, &InvalidMetricConfigMocked{}, &MetricDogStatsD{}, false)
 	assert.False(t, metricAgent.IsReady())
 }
 
@@ -90,7 +90,7 @@ func TestStartInvalidDogStatsD(t *testing.T) {
 		Tagger:               nooptagger.NewComponent(),
 	}
 	defer metricAgent.Stop()
-	metricAgent.Start(1*time.Second, &MetricConfig{}, &MetricDogStatsDMocked{})
+	metricAgent.Start(1*time.Second, &MetricConfig{}, &MetricDogStatsDMocked{}, false)
 	assert.False(t, metricAgent.IsReady())
 }
 
@@ -106,7 +106,7 @@ func TestStartWithProxy(t *testing.T) {
 		Tagger:               nooptagger.NewComponent(),
 	}
 	defer metricAgent.Stop()
-	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
+	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{}, false)
 
 	expected := []string{
 		invocationsMetric,
@@ -126,7 +126,7 @@ func TestRaceFlushVersusAddSample(t *testing.T) {
 		Tagger:               nooptagger.NewComponent(),
 	}
 	defer metricAgent.Stop()
-	metricAgent.Start(10*time.Second, &ValidMetricConfigMocked{}, &MetricDogStatsD{})
+	metricAgent.Start(10*time.Second, &ValidMetricConfigMocked{}, &MetricDogStatsD{}, false)
 
 	assert.NotNil(t, metricAgent.Demux)
 
@@ -219,7 +219,7 @@ func TestRaceFlushVersusParsePacket(t *testing.T) {
 	require.NoError(t, err)
 	mockConfig.SetDefault("dogstatsd_port", port)
 
-	demux, err := aggregator.InitAndStartServerlessDemultiplexer(nil, time.Second*1000, nooptagger.NewComponent())
+	demux, err := aggregator.InitAndStartServerlessDemultiplexer(nil, time.Second*1000, nooptagger.NewComponent(), false)
 	require.NoError(t, err, "cannot start Demultiplexer")
 
 	s, err := dogstatsdServer.NewServerlessServer(demux)


### PR DESCRIPTION
### What does this PR do?
Moves a cloud run env var check out of `demultiplexer_serverless.go` and into the serverless-init cmd and serverless pkg.

### Possible Drawbacks / Trade-offs
This brings some of our architectural issues to the forefront, but I think that is better than hiding a surprising cloud-run-jobs-specific check deep in code that isn't in the serverless directories.