### PR TITLE
dynisnt: run some tests in merge queue to prevent skew

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -24,6 +24,10 @@
     - dda inv -- -e system-probe.object-files
     - dda inv -- -e linter.go --build system-probe-unit-tests --cpus 4 --targets ./pkg
     - dda inv -- -e security-agent.run-ebpf-unit-tests --verbose
+    # Run a subset of the dyninst tests that will at least exercise analysis of
+    # the test programs to try to prevent skew between concurrent changes.
+    - dda inv -- -e system-probe.build-dyninst-test-programs
+    - dda inv -- -e system-probe.test --packages='pkg/dyninst/irgen pkg/dyninst/symdb' --extra-arguments=--short --skip-object-files
     - dda inv -- -e linter.go --targets=./pkg/security/tests --cpus 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata"
   retry: !reference [.retry_only_infra_failure, retry]
 

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -88,6 +88,9 @@ var expectations embed.FS
 
 func TestEndToEnd(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping end-to-end test in short mode")
+	}
 	dyninsttest.SkipIfKernelNotSupported(t)
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -367,11 +367,17 @@ func runIntegrationTestSuite(
 			outputs.byTest[t.Name()] = actual
 		}
 		t.Run(fmt.Sprintf("debug=%t", debug), func(t *testing.T) {
+			if debug && testing.Short() {
+				t.Skip("skipping debug with short")
+			}
 			t.Parallel()
 			t.Run("all-probes", func(t *testing.T) { runTest(t, probes) })
 			for i := range probes {
 				probeID := probes[i].GetID()
 				t.Run(probeID, func(t *testing.T) {
+					if testing.Short() {
+						t.Skip("skipping individual probe with short")
+					}
 					runTest(t, probes[i:i+1])
 				})
 			}

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -30,6 +30,9 @@ import (
 )
 
 func TestIRGenAllProbes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
 	programs := testprogs.MustGetPrograms(t)
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	var objcopy string


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Run a small set of dyninst tests in the merge queue.

### Motivation

A bunch of the dyninst tests work by executing probes against test binaries. When the set of probes or the test binaries change, we get merge skew. There's some risks that the output of probes changing could conflict, but they are lower than the changes to what we test. This small set of tests should prevent most of the issues.

Fixes https://datadoghq.atlassian.net/browse/DEBUG-4265