### PR TITLE
[FA] Add copy and remove_all instructions

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -443,6 +443,7 @@ func (d *daemonImpl) StartConfigExperiment(ctx context.Context, url string, vers
 	d.m.Lock()
 	defer d.m.Unlock()
 	return d.startConfigExperiment(ctx, url, version, []experimentConfigAction{
+		{ActionType: "remove_all"},
 		{ActionType: "write", ConfigID: version},
 	})
 }

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -611,7 +611,6 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		_, err = os.Stat(filepath.Join(tempDir, "datadog.yaml"))
 		assert.True(t, os.IsNotExist(err))
 	})
-}
 
 	// Test case 2: Write config file in subdirectory
 	t.Run("write_config_in_subdirectory", func(t *testing.T) {

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
@@ -595,39 +594,7 @@ func copyDirectory(sourcePath, targetPath string) error {
 			return os.MkdirAll(targetFilePath, info.Mode())
 		}
 
-		// open source file
-		source, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("failed to open source file: %w", err)
-		}
-		defer source.Close()
-
-		var stat *syscall.Stat_t
-		var ok bool
-		stat, ok = info.Sys().(*syscall.Stat_t)
-		if !ok || stat == nil {
-			return fmt.Errorf("could not get file stat")
-		}
-
-		// create dst file with same permissions
-		var dstFile *os.File
-		dstFile, err = os.OpenFile(targetFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
-		if err != nil {
-			return err
-		}
-		defer dstFile.Close()
-
-		// copy content
-		if _, err = io.Copy(dstFile, source); err != nil {
-			return err
-		}
-
-		// set ownership
-		if err = os.Chown(targetFilePath, int(stat.Uid), int(stat.Gid)); err != nil {
-			return err
-		}
-
-		return nil
+		return copyFileWithPermissions(path, targetFilePath, info)
 	})
 }
 

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -217,7 +217,7 @@ func (r *Repository) Delete(ctx context.Context) error {
 
 // CopyStable copies the stable package to the given destination path.
 func (r *Repository) CopyStable(ctx context.Context, destPath string) (err error) {
-	span, ctx := telemetry.StartSpanFromContext(ctx, "repository.CopyStable")
+	span, _ := telemetry.StartSpanFromContext(ctx, "repository.CopyStable")
 	defer func() { 
 		span.Finish(err)
 	}()

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -218,7 +218,7 @@ func (r *Repository) Delete(ctx context.Context) error {
 // CopyStable copies the stable package to the given destination path.
 func (r *Repository) CopyStable(ctx context.Context, destPath string) (err error) {
 	span, _ := telemetry.StartSpanFromContext(ctx, "repository.CopyStable")
-	defer func() { 
+	defer func() {
 		span.Finish(err)
 	}()
 

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -215,7 +216,12 @@ func (r *Repository) Delete(ctx context.Context) error {
 }
 
 // CopyStable copies the stable package to the given destination path.
-func (r *Repository) CopyStable(ctx context.Context, destPath string) error {
+func (r *Repository) CopyStable(ctx context.Context, destPath string) (err error) {
+	span, ctx := telemetry.StartSpanFromContext(ctx, "repository.CopyStable")
+	defer func() { 
+		span.Finish(err)
+	}()
+
 	repository, err := readRepository(r.rootPath, nil)
 	if err != nil {
 		return err

--- a/pkg/fleet/installer/repository/repository_nix.go
+++ b/pkg/fleet/installer/repository/repository_nix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package repository
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// copyFileWithPermissions copies a file from src to dst with the same permissions.
+func copyFileWithPermissions(src, dst string, info os.FileInfo) error {
+	// open source file
+	source, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer source.Close()
+
+	var stat *syscall.Stat_t
+	var ok bool
+	stat, ok = info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return fmt.Errorf("could not get file stat")
+	}
+
+	// create dst file with same permissions
+	var dstFile *os.File
+	dstFile, err = os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	// copy content
+	if _, err = io.Copy(dstFile, source); err != nil {
+		return err
+	}
+
+	// set ownership
+	if err = os.Chown(dst, int(stat.Uid), int(stat.Gid)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fleet/installer/repository/repository_nix.go
+++ b/pkg/fleet/installer/repository/repository_nix.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build !windows
 
 package repository

--- a/pkg/fleet/installer/repository/repository_nix.go
+++ b/pkg/fleet/installer/repository/repository_nix.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
@@ -28,6 +29,11 @@ func copyFileWithPermissions(src, dst string, info os.FileInfo) error {
 	stat, ok = info.Sys().(*syscall.Stat_t)
 	if !ok || stat == nil {
 		return fmt.Errorf("could not get file stat")
+	}
+
+	// Ensure the destination directory exists
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
 	}
 
 	// create dst file with same permissions

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -522,8 +522,8 @@ func TestCopyDirectoryTargetDoesNotExist(t *testing.T) {
 	targetDir := filepath.Join(t.TempDir(), "non-existent-target")
 
 	err := copyDirectory(sourceDir, targetDir)
-	assert.Error(t, err)
-	assert.NoDirExists(t, targetDir)
+	assert.NoError(t, err)
+	assert.DirExists(t, targetDir)
 }
 
 func TestCopyDirectoryWithSpecialCharacters(t *testing.T) {

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -522,9 +522,8 @@ func TestCopyDirectoryTargetDoesNotExist(t *testing.T) {
 	targetDir := filepath.Join(t.TempDir(), "non-existent-target")
 
 	err := copyDirectory(sourceDir, targetDir)
-	assert.NoError(t, err)
-
-	verifyDirectoryContent(t, targetDir, sourceFiles)
+	assert.Error(t, err)
+	assert.NoDirExists(t, targetDir)
 }
 
 func TestCopyDirectoryWithSpecialCharacters(t *testing.T) {

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -405,6 +405,208 @@ func TestRepairDirectoryDifferentCasing(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCopyDirectoryEmptySource(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	// Target should be empty since source is empty
+	files, err := os.ReadDir(targetDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestCopyDirectorySimpleFiles(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt": "content1",
+		"file2.txt": "content2",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := t.TempDir()
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+}
+
+func TestCopyDirectoryWithSubdirectories(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt":         "content1",
+		"file2.txt":         "content2",
+		"subdir/file3.txt":  "content3",
+		"subdir/file4.txt":  "content4",
+		"subdir2/file5.txt": "content5",
+		"subdir2/file6.txt": "content6",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := t.TempDir()
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+}
+
+func TestCopyDirectoryWithNestedSubdirectories(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt":                    "content1",
+		"subdir/file2.txt":             "content2",
+		"subdir/nested/file3.txt":      "content3",
+		"subdir/nested/deep/file4.txt": "content4",
+		"subdir2/file5.txt":            "content5",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := t.TempDir()
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+}
+
+func TestCopyDirectoryToExistingTarget(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt":        "content1",
+		"subdir/file2.txt": "content2",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := t.TempDir()
+
+	// Create some existing content in target
+	existingFiles := map[string]string{
+		"existing.txt": "existing content",
+	}
+	createTestDirectory(t, existingFiles) // This creates a temp dir, we need to use targetDir
+	for path, content := range existingFiles {
+		fullPath := filepath.Join(targetDir, path)
+		err := os.WriteFile(fullPath, []byte(content), 0644)
+		assert.NoError(t, err)
+	}
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	// Verify source files were copied
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+
+	// Verify existing files are still there
+	for path, content := range existingFiles {
+		targetPath := filepath.Join(targetDir, path)
+		data, err := os.ReadFile(targetPath)
+		assert.NoError(t, err)
+		assert.Equal(t, content, string(data))
+	}
+}
+
+func TestCopyDirectorySourceDoesNotExist(t *testing.T) {
+	targetDir := t.TempDir()
+	nonExistentSource := filepath.Join(t.TempDir(), "non-existent")
+
+	err := copyDirectory(nonExistentSource, targetDir)
+	assert.Error(t, err)
+}
+
+func TestCopyDirectoryTargetDoesNotExist(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt": "content1",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := filepath.Join(t.TempDir(), "non-existent-target")
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+}
+
+func TestCopyDirectoryWithSpecialCharacters(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file with spaces.txt":             "content1",
+		"file-with-dashes.txt":             "content2",
+		"file_with_underscores.txt":        "content3",
+		"subdir/file with spaces.txt":      "content4",
+		"subdir/file-with-dashes.txt":      "content5",
+		"subdir/file_with_underscores.txt": "content6",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := t.TempDir()
+
+	err := copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	verifyDirectoryContent(t, targetDir, sourceFiles)
+}
+
+func TestCopyDirectoryPreservesFilePermissions(t *testing.T) {
+	sourceDir := t.TempDir()
+
+	// Create a file with specific permissions
+	filePath := filepath.Join(sourceDir, "test.txt")
+	err := os.WriteFile(filePath, []byte("test content"), 0755)
+	assert.NoError(t, err)
+
+	targetDir := t.TempDir()
+
+	err = copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	// Check that the file was copied
+	targetFilePath := filepath.Join(targetDir, "test.txt")
+	assert.FileExists(t, targetFilePath)
+
+	// Check file content
+	data, err := os.ReadFile(targetFilePath)
+	assert.NoError(t, err)
+	assert.Equal(t, "test content", string(data))
+
+	// Note: On some systems, file permissions might be modified during copy
+	// This test focuses on successful copying rather than exact permission preservation
+}
+
+func TestCopyDirectoryLargeFile(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Create a large file (1MB)
+	largeContent := make([]byte, 1024*1024)
+	for i := range largeContent {
+		largeContent[i] = byte(i % 256)
+	}
+
+	filePath := filepath.Join(sourceDir, "large.txt")
+	err := os.WriteFile(filePath, largeContent, 0644)
+	assert.NoError(t, err)
+
+	err = copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+
+	// Verify the large file was copied correctly
+	targetFilePath := filepath.Join(targetDir, "large.txt")
+	data, err := os.ReadFile(targetFilePath)
+	assert.NoError(t, err)
+	assert.Equal(t, largeContent, data)
+}
+
+func TestCopyDirectoryWithSymlinks(t *testing.T) {
+	sourceDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	err := os.Symlink(sourceDir, filepath.Join(targetDir, "symlink"))
+	assert.NoError(t, err)
+
+	err = copyDirectory(sourceDir, targetDir)
+	assert.NoError(t, err)
+}
+
 // This test is used to verify that the repository can handle external packages that are symlinked.
 // Example:
 // ls -al /opt/datadog-packages/datadog-agent/

--- a/pkg/fleet/installer/repository/repository_win.go
+++ b/pkg/fleet/installer/repository/repository_win.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package repository
+
+import "os"
+
+// copyFileWithPermissions copies a file from src to dst with the same permissions.
+func copyFileWithPermissions(src, dst string, _ os.FileInfo) error {
+	return copyFile(src, dst)
+}

--- a/pkg/fleet/installer/repository/repository_win.go
+++ b/pkg/fleet/installer/repository/repository_win.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build windows
 
 package repository

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -627,11 +627,11 @@ func (s *upgradeScenarioSuite) TestUpgradeAppendConfig() {
 		},
 	}
 
-	s.mustStartConfigExperiment(datadogAgent, installerConfig{ID: "append-config"}, configActions2)
-	s.assertSuccessfulConfigStartExperiment(timestamp, "append-config")
+	s.mustStartConfigExperiment(datadogAgent, installerConfig{ID: "append-config-2"}, configActions2)
+	s.assertSuccessfulConfigStartExperiment(timestamp, "append-config-2")
 
 	s.mustPromoteConfigExperiment(datadogAgent)
-	s.assertSuccessfulConfigPromoteExperiment(timestamp, "append-config")
+	s.assertSuccessfulConfigPromoteExperiment(timestamp, "append-config-2")
 }
 
 func (s *upgradeScenarioSuite) TestUpgradeRemoveAllConfig() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Copy stable folder in experiment before starting the config update, and add a `remove_all` instruction
When receiving an old config format, will do the `remove_all` first

Followup of https://github.com/DataDog/datadog-agent/pull/39428

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->