### PR TITLE
windows: move `system-probe-unit-tests` linting to `lint-windows` job

### DIFF
--- a/tasks/winbuildscripts/Invoke-Linters.ps1
+++ b/tasks/winbuildscripts/Invoke-Linters.ps1
@@ -55,6 +55,14 @@ Invoke-BuildScript `
         exit $err
     }
 
+    # Lint system-probe Go
+    & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg
+    Write-Host system-probe Go linter result is $err
+    if($err -ne 0){
+        Write-Host -ForegroundColor Red "system-probe go linter failed $err"
+        exit $err
+    }
+
     # Lint MSI .NET
     $timeTaken = Measure-Command {
         & dotnet format --verify-no-changes .\\tools\\windows\\DatadogAgentInstaller

--- a/tasks/winbuildscripts/Invoke-Linters.ps1
+++ b/tasks/winbuildscripts/Invoke-Linters.ps1
@@ -57,6 +57,7 @@ Invoke-BuildScript `
 
     # Lint system-probe Go
     & dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg
+    $err = $LASTEXITCODE
     Write-Host system-probe Go linter result is $err
     if($err -ne 0){
         Write-Host -ForegroundColor Red "system-probe go linter failed $err"

--- a/tasks/winbuildscripts/secagent.ps1
+++ b/tasks/winbuildscripts/secagent.ps1
@@ -17,12 +17,6 @@ $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:
 & dda inv -- -e deps
 & dda inv -- -e install-tools
 
-# Must build the rtloader libs cgo depends on before running golangci-lint, which requires code to be compilable
-$archflag = "x64"
-if ($Env:TARGET_ARCH -eq "x86") {
-    $archflag = "x86"
-}
-
 & dda inv -- -e security-agent.e2e-prepare-win
 
 $err = $LASTEXITCODE

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -15,16 +15,6 @@ $Env:PATH="$PROBE_BUILD_ROOT\dev\lib;$Env:GOPATH\bin;$Env:Python3_ROOT_DIR;$Env:
 & dda inv -- -e deps
 & dda inv -- -e install-tools
 
-# Must build the rtloader libs cgo depends on before running golangci-lint, which requires code to be compilable
-& .\tasks\winbuildscripts\pre-go-build.ps1 -PythonRuntimes "$Env:PY_RUNTIMES"
-
-& dda inv -- -e linter.go --build system-probe-unit-tests --targets .\pkg
-$err = $LASTEXITCODE
-if ($err -ne 0) {
-    Write-Host -ForegroundColor Red "linter.go failed $err"
-    [Environment]::Exit($err)
-}
-
 & dda inv -- -e system-probe.e2e-prepare --ci
 
 $err = $LASTEXITCODE


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves the system-probe specific go linting job to the common windows lint job. Allowing to centralize the linting into one job, and letting `tests_windows_sysprobe_x64` do only the e2e testsuite building. This separation will allow `tests_windows_sysprobe_x64` to be removed from the merge queue.

The added time to lint system-probe specific code is in the order of 80 seconds, in the noise of this ~25min job.
- PR job https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1060582318
- main job https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1060548858

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->