### PR TITLE
Fix JUnit uploads blocked by undrained output streams

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -2,15 +2,15 @@ import io
 import os
 import platform
 import re
-import sys
 import tarfile
 import tempfile
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from shutil import which
-from subprocess import PIPE, CalledProcessError, Popen
+from subprocess import check_call
 
 from invoke.exceptions import Exit
 
@@ -104,8 +104,7 @@ def junit_upload_from_tgz(junit_tgz, result_json, codeowners_path=".github/CODEO
         # Upload junit on a per-team basis (all folders except the one part of the original archive)
         team_folders = [item for item in working_dir.iterdir() if item.is_dir() and item not in xml_folders]
         with ThreadPoolExecutor() as executor:
-            for log in executor.map(upload_junitxmls, team_folders):
-                print(log)
+            _upload_junitxmls(team_folders, executor)
 
 
 def get_flaky_failures_and_marked_flaky_tests_from_test_output(result_json):
@@ -211,31 +210,38 @@ def split_junitxml(root_dir: Path, xml_path: Path, codeowners, flaky_failures, m
     return len(output_xmls)
 
 
-def upload_junitxmls(team_dir: Path):
+def _upload_junitxmls(team_dirs: list[Path], executor: ThreadPoolExecutor):
     """
-    Upload all per-team split JUnit XMLs from given directory.
+    Upload all per-team split JUnit XMLs from given directories.
     """
     datadog_ci_command = [get_datadog_ci_command(), "junit", "upload"]
+    futures = []
+    for team_dir in team_dirs:
+        for args, env in _generate_junitxmls(team_dir):
+            futures.append(executor.submit(check_call, args=datadog_ci_command + args, env=env))
+    exceptions = []
+    for future in futures:
+        try:
+            future.result()
+        except Exception as e:
+            exceptions.append(e)
+    if exceptions:
+        raise ExceptionGroup(f"{len(exceptions)} junit uploads failed", exceptions)
+
+
+def _generate_junitxmls(team_dir: Path) -> Iterator[tuple[list[str], dict[str, str]]]:
+    """
+    Generate all per-team split JUnit XMLs from given directory.
+    """
     additional_tags = read_additional_tags(team_dir.parent)
     process_env = _update_environ(team_dir.parent)
-    processes = []
-
     owner, flavor = team_dir.name.split("_")
     # Kitchen/e2e can generate additional tags
     xml_files = group_per_tags(team_dir, additional_tags)
     for flags, files in xml_files.items():
         args = set_tags(owner, flavor, flags, additional_tags, files[0])
         args.extend(files)
-        processes.append(Popen(datadog_ci_command + args, bufsize=-1, env=process_env, stdout=PIPE, stderr=PIPE))
-
-    for process in processes:
-        stdout, stderr = process.communicate()
-        print(stdout)
-        print(f" Uploaded {len(tuple(team_dir.iterdir()))} files for {team_dir.name}")
-        if stderr:
-            print(f"Failed uploading junit:\n{stderr.decode()}", file=sys.stderr)
-            raise CalledProcessError(process.returncode, datadog_ci_command)
-    return ""  # For ThreadPoolExecutor.map. Without this it prints None in the log output.
+        yield args, process_env
 
 
 def group_per_tags(team_dir: Path, additional_tags: list):

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -1,7 +1,8 @@
 import shutil
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from subprocess import CalledProcessError
+from unittest.mock import patch
 
 import tasks.libs.common.junit_upload_core as junit
 from tasks.libs.owners.parsing import read_owners
@@ -112,16 +113,34 @@ class TestSetTag(unittest.TestCase):
 class TestJUnitUploadFromTGZ(unittest.TestCase):
     @patch.dict("os.environ", {"CI_PIPELINE_ID": "1664"})
     @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "beer"})
-    @patch("tasks.libs.common.junit_upload_core.Popen")
+    @patch("tasks.libs.common.junit_upload_core.check_call")
     @patch("tasks.libs.common.junit_upload_core.which")
-    def test_e2e(self, mock_which, mock_popen):
-        mock_instance = MagicMock()
-        mock_instance.communicate.return_value = (b"stdout", b"")
-        mock_popen.return_value = mock_instance
+    def test_success(self, mock_which, mock_check_call):
         mock_which.side_effect = lambda cmd: f"/usr/local/bin/{cmd}"
         junit.junit_upload_from_tgz(
             "tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz",
             "tasks/unit_tests/testdata/test_output_no_failure.json",
         )
-        mock_popen.assert_called()
-        self.assertEqual(mock_popen.call_count, 29)
+        mock_check_call.assert_called()
+        self.assertEqual(mock_check_call.call_count, 29)
+
+    @patch.dict("os.environ", {"CI_PIPELINE_ID": "1664"})
+    @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "beer"})
+    @patch("tasks.libs.common.junit_upload_core.check_call")
+    @patch("tasks.libs.common.junit_upload_core.which")
+    def test_failure(self, mock_which, mock_check_call):
+        def raise_on_every_second_call(*args, **kwargs):
+            if mock_check_call.call_count % 2 == 0:
+                raise CalledProcessError(1, args[0])
+
+        mock_check_call.side_effect = raise_on_every_second_call
+        mock_which.side_effect = lambda cmd: f"/usr/local/bin/{cmd}"
+        with self.assertRaises(ExceptionGroup) as eg:
+            junit.junit_upload_from_tgz(
+                "tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz",
+                "tasks/unit_tests/testdata/test_output_no_failure.json",
+            )
+        mock_check_call.assert_called()
+        self.assertEqual(mock_check_call.call_count, 29)
+        self.assertEqual(eg.exception.message, "14 junit uploads failed")
+        self.assertEqual(len(eg.exception.exceptions), 14)


### PR DESCRIPTION
### What does this PR do?
This change improves the upload of JUnit reports, especially in the `tests_windows-x64` job.

It addresses two inefficiencies in how subprocesses are managed:
1. Upload processes were launched with `stdout`/`stderr` pipes, requiring the parent process to actively drain them. If not drained promptly, the child process blocks, ignoring graceful termination signals.
  In practice, subprocesses were only drained one at a time per caller thread using `communicate`.
2. Multiple subprocesses were launched from the same thread in the thread pool, exceeding the intended parallelism and defeating controlled scheduling.

The fix lets subprocesses inherit `stdout`/`stderr` directly (no pipes) and ensures each upload process runs in its own thread pool task.

### Motivation
- Failed jobs with seemingly lingering background processes, for instance: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1058500308
- Slack thread: https://dd.slack.com/archives/C06PBHLD4DQ/p1754040098218369
- Might help address [ACIX-968]

### Describe how you validated your changes
Temporarily forced `RUN_UNIT_TESTS: "on"` in an [intermediate commit](https://github.com/DataDog/datadog-agent/pull/39460/commits/55c48733f1e6e04cb0b28930e4dde60dca7d866a) (reverted since).
Output is no longer delayed and now renders verbatim: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1061859337

### Possible Drawbacks / Trade-offs
The original `ThreadPoolExecutor` is preserved by the change, but we could later consider switching to `asyncio` (Python's answer to writing clean, efficient, and scalable code for concurrent I/O operations).

### Additional Notes
[ACIX-968]: https://datadoghq.atlassian.net/browse/ACIX-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ