### PR TITLE
Cleanup datadog-installer tmp directory with GarbageCollector and Purge

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
@@ -41,3 +41,45 @@ func TestGetInstallPath(t *testing.T) {
 		t.Fatalf("Expected install path to be %s, got %s", exePath, installPath)
 	}
 }
+
+func TestGetInstallPathSystemTemp(t *testing.T) {
+	// create temp directory
+	tmpDir := t.TempDir()
+
+	// add an exe to the temp directory
+	exePath := filepath.Join(tmpDir, "datadog-installer.exe")
+
+	// touch exe PATH
+	file, err := os.Create(exePath)
+	if err != nil {
+		t.Fatalf("Failed to create exe file: %v", err)
+	}
+	err = file.Close()
+	if err != nil {
+		t.Fatalf("Failed to close exe file: %v", err)
+	}
+
+	// get the install path
+	installPath, err := getInstallerPath(t.Context(), tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to get install path: %v", err)
+	}
+
+	// check the install path
+	if installPath != exePath {
+		t.Fatalf("Expected install path to be %s, got %s", exePath, installPath)
+	}
+
+	// check the install path is in the system temp directory
+	systemTempPath := filepath.Join(os.TempDir(), "datadog-installer.exe")
+
+	installPath, err = moveInstallerToSystemTemp(installPath)
+	if err != nil {
+		t.Fatalf("Failed to move installer to system temp: %v", err)
+	}
+
+	// check the install path is in the system temp directory
+	if installPath != systemTempPath {
+		t.Fatalf("Expected install path to be %s, got %s", systemTempPath, installPath)
+	}
+}

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -663,6 +663,11 @@ func (i *installerImpl) Purge(ctx context.Context) {
 	if err != nil {
 		log.Warnf("could not delete packages dir: %v", err)
 	}
+
+	err = cleanupTmpDirectory(paths.RootTmpDir)
+	if err != nil {
+		log.Warnf("could not cleanup tmp directory: %v", err)
+	}
 }
 
 // Remove uninstalls a package.
@@ -695,6 +700,10 @@ func (i *installerImpl) GarbageCollect(ctx context.Context) error {
 	err = i.configs.Cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup configs: %w", err)
+	}
+	err = cleanupTmpDirectory(paths.RootTmpDir)
+	if err != nil {
+		return fmt.Errorf("could not cleanup tmp directory: %w", err)
 	}
 	return nil
 }
@@ -982,6 +991,55 @@ func ensureRepositoriesExist() error {
 	err = os.MkdirAll(paths.RunPath, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating tmp directory: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupTmpDirectory removes files and directories in RootTmpDir that are older than 24 hours
+func cleanupTmpDirectory(rootTmpDir string) error {
+	// Check if RootTmpDir exists
+	if _, err := os.Stat(rootTmpDir); os.IsNotExist(err) {
+		// Directory doesn't exist, nothing to clean up
+		return nil
+	}
+
+	// Calculate the cutoff time (24 hours ago)
+	cutoffTime := time.Now().Add(-24 * time.Hour)
+
+	// Read the directory contents
+	entries, err := os.ReadDir(rootTmpDir)
+	if err != nil {
+		return fmt.Errorf("could not read tmp directory: %w", err)
+	}
+
+	var cleanupErrors []string
+	for _, entry := range entries {
+		entryPath := filepath.Join(rootTmpDir, entry.Name())
+
+		// Get file info to check modification time
+		info, err := entry.Info()
+		if err != nil {
+			log.Warnf("Could not get info for %s: %v", entryPath, err)
+			continue
+		}
+
+		// Check if the file/directory is older than 24 hours
+		if info.ModTime().Before(cutoffTime) {
+			log.Debugf("Removing old tmp file/directory: %s (modified: %v)", entryPath, info.ModTime())
+
+			err := os.RemoveAll(entryPath)
+			if err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("failed to remove %s: %v", entryPath, err))
+				log.Warnf("Could not remove old tmp file/directory %s: %v", entryPath, err)
+			} else {
+				log.Debugf("Successfully removed old tmp file/directory: %s", entryPath)
+			}
+		}
+	}
+
+	if len(cleanupErrors) > 0 {
+		return fmt.Errorf("tmp directory cleanup completed with errors: %s", strings.Join(cleanupErrors, "; "))
 	}
 
 	return nil

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -405,7 +405,9 @@ func TestPurge(t *testing.T) {
 		installer := newTestPackageManager(t, s, rootPath)
 		installer.testHooks.noop = true
 		tmpPath := filepath.Join(rootPath, "tmp")
-		err := os.WriteFile(filepath.Join(tmpPath, "test.txt"), []byte("test"), 0644)
+		err := os.MkdirAll(tmpPath, 0755)
+		assert.NoError(t, err)
+		err = os.WriteFile(filepath.Join(tmpPath, "test.txt"), []byte("test"), 0644)
 		assert.NoError(t, err)
 
 		err = instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -404,8 +404,11 @@ func TestPurge(t *testing.T) {
 		rootPath := t.TempDir()
 		installer := newTestPackageManager(t, s, rootPath)
 		installer.testHooks.noop = true
+		tmpPath := filepath.Join(rootPath, "tmp")
+		err := os.WriteFile(filepath.Join(tmpPath, "test.txt"), []byte("test"), 0644)
+		assert.NoError(t, err)
 
-		err := instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+		err = instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 		assert.NoError(t, err)
 		r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
 
@@ -417,6 +420,7 @@ func TestPurge(t *testing.T) {
 		assert.NoFileExists(t, filepath.Join(rootPath, "packages.db"), "purge should remove the packages database")
 		assert.NoDirExists(t, rootPath, "purge should remove the packages directory")
 		assert.Nil(t, installer.db, "purge should close the packages database")
+		assert.NoFileExists(t, filepath.Join(tmpPath, "test.txt"), "purge should remove all files in the tmp directory")
 	})
 }
 

--- a/releasenotes/notes/adding-tmp-cleanup-to-fleet-for-Windows-7d1f202eb14a8313.yaml
+++ b/releasenotes/notes/adding-tmp-cleanup-to-fleet-for-Windows-7d1f202eb14a8313.yaml
@@ -1,0 +1,4 @@
+
+enhancements:
+  - |
+      Added garbage collection of the tmp directory to the datadog-installer.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds additional functionality GarbageCollector and Purge so that the `tmp` directory is cleaned up. This is to avoid issues with `tmp` taking up too much disk space after several fleet automation upgrades. 

To help with this, the `datadog-installer.exe` in `tmp` is moved to the system temp directory and run from there. This will help avoid issues with cleaning up `tmp` due to the exe being used.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1478

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added some tests to make sure that `tmp` is cleaned up and that `datadog-installer.exe` is moved to the system temp directory.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->