### PR TITLE
Add commit sha to images pushed by `dev_branch-full`

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -213,7 +213,7 @@ dev_branch-full:
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
-    IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-full
+    IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-full,agent-dev:${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-full
 
 dev_branch-ot-standalone:
   extends: .docker_publish_job_definition


### PR DESCRIPTION
### What does this PR do?

Adds a new destination for `dev_branch-full` that includes `CI_COMMIT_SHORT_SHA`

### Motivation

When pulling arbitrary agent images to do one off testing with SMP it is often useful to manually run `dev_branch-full` to push an image from a pipeline on main to docker/agent-dev but in order to more accurately trace back to what commit we pulled from, having the commit sha would be useful.

### Describe how you validated your changes

Will manually trigger

### Possible Drawbacks / Trade-offs

### Additional Notes

If there is a different way to do this I am open to suggestions. This is very similar to this previous [PR](https://github.com/DataDog/datadog-agent/pull/36203)