### PR TITLE
Revert "Fix secrets tests no longer being run"

### DIFF
--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -81,13 +81,11 @@ func getBackendCommandBinary(t *testing.T) (string, func()) {
 
 // TestMain runs before other tests in this package. It hooks the getDDAgentUserSID
 // function to make it work for Windows tests
-func TestMain(m *testing.M) {
+func TestMain(_ *testing.M) {
 	// Windows-only fix for running on CI. Instead of checking the registry for
 	// permissions (the agent wasn't installed, so that wouldn't work), use a stub
 	// function that gets permissions info directly from the current User
 	testCheckRightsStub()
-
-	os.Exit(m.Run())
 }
 
 func TestExecCommandError(t *testing.T) {


### PR DESCRIPTION
Reverts DataDog/datadog-agent#39408 for [#incident-41507](https://app.datadoghq.com/incidents/41507)
The PR was re-enabling the `TestExecCommandError` test which is broken.