### PR TITLE
[CNM-4606] Emit empty failed connections for handshake timeouts

### DIFF
--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -368,8 +368,6 @@ __maybe_unused static __always_inline bool tcp_failed_connections_enabled() {
     return val > 0;
 }
 
-
-
 // get_tcp_failure returns an error code for tcp_done/tcp_close, if there was one
 static __always_inline int get_tcp_failure(struct sock *sk) {
     int err = 0;
@@ -377,7 +375,6 @@ static __always_inline int get_tcp_failure(struct sock *sk) {
     if (err != 0) {
         return err;
     }
-
 
     struct sock_common *skc = (struct sock_common*) sk;
     unsigned char state = 0;

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -368,37 +368,64 @@ __maybe_unused static __always_inline bool tcp_failed_connections_enabled() {
     return val > 0;
 }
 
+
+
+
+static __always_inline int get_tcp_failure(struct sock *sk) {
+    int err = BPF_CORE_READ(sk, sk_err);
+    if (err != 0) {
+        return err;
+    }
+
+    int state = BPF_CORE_READ(sk, __sk_common).skc_state;
+    if (state == TCP_SYN_SENT) {
+        return TCP_CONN_FAILED_CANCELED;
+    }
+
+    return 0;
+}
+
+static __always_inline bool is_tcp_failure_recognized(int err) {
+    switch(err) {
+        case TCP_CONN_FAILED_RESET:
+        case TCP_CONN_FAILED_TIMEOUT:
+        case TCP_CONN_FAILED_REFUSED:
+        case TCP_CONN_FAILED_EHOSTUNREACH:
+        case TCP_CONN_FAILED_ENETUNREACH:
+        case TCP_CONN_FAILED_CANCELED:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static __always_inline void report_unrecognized_tcp_failure(int err) {
+    // initialize if no-exist
+    __u64 one = 1;
+    bpf_map_update_with_telemetry(tcp_failure_telemetry, &err, &one, BPF_NOEXIST, -EEXIST);
+    __u64 *count = bpf_map_lookup_elem(&tcp_failure_telemetry, &err);
+    if (count != NULL) {
+        __sync_fetch_and_add(count, one);
+    }
+}
+
 // handle_tcp_failure handles TCP connection failures on the socket pointer and adds them to the connection tuple
 // returns an integer to the caller indicating if there was a failure or not
 static __always_inline bool handle_tcp_failure(struct sock *sk, conn_tuple_t *t) {
     if (!tcp_failed_connections_enabled()) {
         return false;
     }
-    int err = 0;
-    BPF_CORE_READ_INTO(&err, sk, sk_err);
-
-    switch (err) {
-        case 0:
-            return false; // no error
-        case TCP_CONN_FAILED_RESET:
-        case TCP_CONN_FAILED_TIMEOUT:
-        case TCP_CONN_FAILED_REFUSED:
-        case TCP_CONN_FAILED_EHOSTUNREACH:
-        case TCP_CONN_FAILED_ENETUNREACH:
-        {
-            tcp_stats_t stats = { .failure_reason = err };
-            update_tcp_stats(t, stats);
-            return true;
-        }
-    }
-    // initialize if no-exist
-    __u64 one = 1;
-    bpf_map_update_with_telemetry(tcp_failure_telemetry, &err, &one, BPF_NOEXIST, -EEXIST);
-    __u64 *count = bpf_map_lookup_elem(&tcp_failure_telemetry, &err);
-    if (count == NULL) {
+    int err = get_tcp_failure(sk);
+    if (err == 0) {
         return false;
     }
-    __sync_fetch_and_add(count, one);
+    if (is_tcp_failure_recognized(err)) {
+        tcp_stats_t stats = { .failure_reason = err };
+        update_tcp_stats(t, stats);
+        return true;
+    }
+
+    report_unrecognized_tcp_failure(err);
 
     return false;
 }

--- a/pkg/network/ebpf/c/tracer/tracer.h
+++ b/pkg/network/ebpf/c/tracer/tracer.h
@@ -16,6 +16,8 @@
 #define TCP_CONN_FAILED_REFUSED 111
 #define TCP_CONN_FAILED_EHOSTUNREACH 113
 #define TCP_CONN_FAILED_ENETUNREACH 101
+// this isn't really a failure from the kernel, this happens when userspace closes the socket during SYN_SENT
+#define TCP_CONN_FAILED_CANCELED 125
 
 typedef enum {
     CONN_DIRECTION_UNKNOWN = 0b00,

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2554,6 +2554,8 @@ LOOP:
 		conn, found := findConnection(c.LocalAddr(), srv.Addr(), conns)
 		require.True(collect, found, "could not find connection")
 		require.True(collect, conn.IsClosed, "connection should be closed")
+		require.Empty(collect, conn.TCPFailures, "connection should have no failures")
+
 		// after closing the client connection, the duration should be
 		// updated to a value between 1s and 2s
 		require.Greater(collect, conn.Duration, time.Second, "connection duration should be between 1 and 2 seconds")

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2573,6 +2573,87 @@ func checkSkipFailureConnectionsTests(t *testing.T) {
 }
 
 func (s *TracerSuite) TestTCPFailureConnectionTimeout() {
+	remoteAddr := &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 10000,
+	}
+	makeConn := func(t *testing.T, nonblocking bool) net.Conn {
+		addr := syscall.SockaddrInet4{
+			Port: remoteAddr.Port,
+		}
+		copy(addr.Addr[:], remoteAddr.IP)
+
+		flags := syscall.SOCK_STREAM
+		expectedErr := syscall.ETIMEDOUT
+		if nonblocking {
+			flags |= syscall.SOCK_NONBLOCK
+			expectedErr = syscall.EINPROGRESS
+		}
+		sfd, err := syscall.Socket(syscall.AF_INET, flags, syscall.IPPROTO_TCP)
+		require.NoError(t, err)
+		defer syscall.Close(sfd)
+
+		//syscall.TCP_USER_TIMEOUT is 18 but not defined in our linter. Set it to 500ms
+		err = syscall.SetsockoptInt(sfd, syscall.IPPROTO_TCP, 18, 500)
+		require.NoError(t, err)
+
+		err = syscall.Connect(sfd, &addr)
+		if err != nil {
+			if errors.Is(err, expectedErr) {
+				t.Logf("Connection had an error as expected: %s", expectedErr)
+			} else {
+				require.NoError(t, err, "could not connect to server: ", err)
+			}
+		}
+
+		f := os.NewFile(uintptr(sfd), "")
+		c, err := net.FileConn(f)
+		require.NoError(t, err)
+		t.Cleanup(func() { c.Close() })
+		return c
+	}
+
+	testcases := []struct {
+		name      string
+		makeConn  func(t *testing.T) net.Conn
+		checkConn func(collect *assert.CollectT, stats *network.ConnectionStats)
+	}{
+		{
+			name: "blocking kernel timeout",
+			makeConn: func(t *testing.T) net.Conn {
+				return makeConn(t, false)
+			},
+			checkConn: func(collect *assert.CollectT, conn *network.ConnectionStats) {
+				assert.Equal(collect, uint32(1), conn.TCPFailures[110], "expected 1 connection timeout")
+				assert.Equal(collect, uint32(0), conn.TCPFailures[125], "expected 0 connection cancelled")
+			},
+		},
+		{
+			name: "nonblocking kernel timeout",
+			makeConn: func(t *testing.T) net.Conn {
+				// connection will time out in 500ms while checkConn is running
+				return makeConn(t, true)
+			},
+			checkConn: func(collect *assert.CollectT, conn *network.ConnectionStats) {
+				assert.Equal(collect, uint32(1), conn.TCPFailures[110], "expected 1 connection timeout")
+				assert.Equal(collect, uint32(0), conn.TCPFailures[125], "expected 0 connection cancelled")
+			},
+		},
+		{
+			name: "userspace cancel",
+			makeConn: func(t *testing.T) net.Conn {
+				c := makeConn(t, true)
+				// immediately close c to cause a cancellation
+				require.NoError(t, c.Close())
+				return c
+			},
+			checkConn: func(collect *assert.CollectT, conn *network.ConnectionStats) {
+				assert.Equal(collect, uint32(0), conn.TCPFailures[110], "expected 0 connection timeout")
+				assert.Equal(collect, uint32(1), conn.TCPFailures[125], "expected 1 connection cancelled")
+			},
+		},
+	}
+
 	t := s.T()
 
 	checkSkipFailureConnectionsTests(t)
@@ -2586,56 +2667,35 @@ func (s *TracerSuite) TestTCPFailureConnectionTimeout() {
 	cfg.TCPFailedConnectionsEnabled = true
 	tr := setupTracer(t, cfg)
 
-	srvAddr := "127.0.0.1:10000"
-	ipString, portString, err := net.SplitHostPort(srvAddr)
-	require.NoError(t, err)
-	ip := netip.MustParseAddr(ipString)
-	port, err := strconv.Atoi(portString)
-	require.NoError(t, err)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// use the testcase's connection
+			c := tc.makeConn(t)
 
-	addr := syscall.SockaddrInet4{
-		Port: port,
-		Addr: ip.As4(),
+			// the addr here is 0.0.0.0, but the tracer sees it as 127.0.0.1
+			port := c.LocalAddr().(*net.TCPAddr).Port
+			localAddr := &net.TCPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: port,
+			}
+
+			// Check if the connection was recorded as failed due to timeout or cancel
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				conns, cleanup := getConnections(collect, tr)
+				defer cleanup()
+
+				conn, _ := findConnection(localAddr, remoteAddr, conns)
+				require.NotNil(collect, conn)
+				assert.Equal(collect, uint32(0), conn.TCPFailures[104], "expected 0 connection reset")
+				assert.Equal(collect, uint32(0), conn.TCPFailures[111], "expected 0 connection refused")
+				assert.Equal(collect, uint64(0), conn.Monotonic.SentBytes, "expected 0 bytes sent")
+				assert.Equal(collect, uint64(0), conn.Monotonic.RecvBytes, "expected 0 bytes received")
+
+				tc.checkConn(collect, conn)
+			}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
+
+		})
 	}
-	sfd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
-	require.NoError(t, err)
-	t.Cleanup(func() { syscall.Close(sfd) })
-
-	//syscall.TCP_USER_TIMEOUT is 18 but not defined in our linter. Set it to 500ms
-	err = syscall.SetsockoptInt(sfd, syscall.IPPROTO_TCP, 18, 500)
-	require.NoError(t, err)
-
-	err = syscall.Connect(sfd, &addr)
-	if err != nil {
-		var errno syscall.Errno
-		if errors.As(err, &errno) && errors.Is(err, syscall.ETIMEDOUT) {
-			t.Log("Connection timed out as expected")
-		} else {
-			require.NoError(t, err, "could not connect to server: ", err)
-		}
-	}
-
-	f := os.NewFile(uintptr(sfd), "")
-	defer f.Close()
-	c, err := net.FileConn(f)
-	require.NoError(t, err)
-	port = c.LocalAddr().(*net.TCPAddr).Port
-	// the addr here is 0.0.0.0, but the tracer sees it as 127.0.0.1
-	localAddr := fmt.Sprintf("127.0.0.1:%d", port)
-
-	// Check if the connection was recorded as failed due to timeout
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		conns, cleanup := getConnections(collect, tr)
-		defer cleanup()
-		// 110 is the errno for ETIMEDOUT
-		conn := findFailedConnection(t, localAddr, srvAddr, conns, 110)
-		require.NotNil(collect, conn)
-		assert.Equal(collect, uint32(0), conn.TCPFailures[104], "expected 0 connection reset")
-		assert.Equal(collect, uint32(0), conn.TCPFailures[111], "expected 0 connection refused")
-		assert.Equal(collect, uint32(1), conn.TCPFailures[110], "expected 1 connection timeout")
-		assert.Equal(collect, uint64(0), conn.Monotonic.SentBytes, "expected 0 bytes sent")
-		assert.Equal(collect, uint64(0), conn.Monotonic.RecvBytes, "expected 0 bytes received")
-	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
 }
 
 func (s *TracerSuite) TestTCPFailureConnectionResetWithDNAT() {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -277,6 +277,7 @@ func (s *TracerSuite) TestTCPShortLived() {
 	// Verify the short lived connection is accounting for both TCP_ESTABLISHED and TCP_CLOSED events
 	assert.Equal(t, uint16(1), m.TCPEstablished)
 	assert.Equal(t, uint16(1), m.TCPClosed)
+	assert.Empty(t, conn.TCPFailures, "connection should have no failures")
 
 	connections, cleanup := getConnections(t, tr)
 	defer cleanup()
@@ -439,6 +440,9 @@ func (s *TracerSuite) TestTCPConnsReported() {
 		require.Equal(collect, uint16(1), forward.Monotonic.TCPClosed)
 		require.Equal(collect, uint16(1), reverse.Monotonic.TCPEstablished)
 		require.Equal(collect, uint16(1), reverse.Monotonic.TCPClosed)
+
+		require.Empty(t, forward.TCPFailures, "forward should have no failures")
+		require.Empty(t, reverse.TCPFailures, "reverse should have no failures")
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 
 }
@@ -1176,6 +1180,7 @@ func (s *TracerSuite) TestTCPEstablished() {
 	require.True(t, ok)
 	assert.Equal(t, uint16(0), conn.Last.TCPEstablished)
 	assert.Equal(t, uint16(1), conn.Last.TCPClosed)
+	assert.Empty(t, conn.TCPFailures, "connection should have no failures")
 }
 
 func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
@@ -1213,6 +1218,7 @@ func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
 	m := conn.Monotonic
 	assert.Equal(t, uint16(0), m.TCPEstablished)
 	assert.Equal(t, uint16(1), m.TCPClosed)
+	assert.Empty(t, conn.TCPFailures, "connection should have no failures")
 }
 
 func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a new failed connection type, `ECANCELED` which isn't actually a kernel error but rather an indication that userspace closed the connection while the TCP handshake was still underway. Previously, these flows were invisible.

### Motivation
"Cancelled" connections occur whenever language runtimes that use nonblocking sockets (such as Go) time out. So essentially, we can't see many timeout failures unless we start looking at cancelled connections.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
How to run new tests:
```
PATH="$PATH" sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run 'TestTracerSuite/.*/TestTCPFailureConnectionTimeout.*'
```
I added a couple new tests for these timeout scenarios (the first one already existed):
```
TestTCPFailureConnectionTimeout/blocking_kernel_timeout
TestTCPFailureConnectionTimeout/nonblocking_kernel_timeout
TestTCPFailureConnectionTimeout/userspace_cancel
```


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->