### PR TITLE
Skip the Windows exec command test

### DIFF
--- a/comp/core/secrets/secretsimpl/fetch_secret_test.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret_test.go
@@ -91,6 +91,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestExecCommandError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip this test on Windows")
+	}
+
 	inputPayload := "{\"version\": \"1.0\" , \"secrets\": [\"sec1\", \"sec2\"]}"
 	tel := fxutil.Test[telemetry.Component](t, nooptelemetry.Module())
 


### PR DESCRIPTION
### What does this PR do?

Skip the Windows exec command test

### Motivation

This test has gotten more flaky lately. Disable it until we have time to investigate more closely.

Incident 41507

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
