### PR TITLE
Hash omnibus files instead of trying to guess where they last changed

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -222,7 +222,7 @@ def _hash_paths(hasher, paths: list[str]):
             for filepath in sorted(all_files_under(path)):
                 hash_file(filepath)
         else:
-            raise Exception("provided paths must exist and be either a folder or a regular file")
+            raise ValueError("provided paths must exist and be either a folder or a regular file")
 
 
 def get_dd_api_key(ctx):

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -253,6 +253,7 @@ def omnibus_compute_cache_key(ctx):
             'omnibus/omnibus.rb',
         ],
     )
+    print(f'Current hash value: {h.hexdigest()}')
     h.update(str.encode(os.getenv('CI_JOB_IMAGE', 'local_build')))
     # Some values can be forced through the environment so we need to read it
     # from there first, and fallback to release.json

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -206,6 +206,10 @@ def _hash_paths(hasher, paths: list[str]):
     """Update hashlib.hash object `hasher` by recursive hashing of the contents provided in `paths`."""
 
     def hash_file(filepath):
+        # Include the path to the file in the hash to account for file moves
+        hasher.update(filepath.encode())
+
+        # Hash the file contents
         with open(filepath, 'rb') as f:
             while chunk := f.read(4096):
                 hasher.update(chunk)


### PR DESCRIPTION
### What does this PR do?

It computes the hash of all the individual files that could impact an omnibus build as part of the git cache key computation, instead of trying to base it on the diff against the last detected changes. This is easier to reason about and easier to get right.

### Motivation

While working on #39342, and rebasing I got "[cacerts dirtied the cache](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1061788064/viewer#L499)" which matches a [recent change](https://github.com/DataDog/datadog-agent/commit/e3847e6711acc067f311f39308733967ff9d3234) (a change that happened between rebases). This means that the mechanism to account for changes in omnibus files when computing the git cache key is not working properly.

### Describe how you validated your changes

I validated manually via debug printing that all the expected files ran through the hasher (I could leave debug printing in if we think that would be helpful).

### Possible Drawbacks / Trade-offs

There's a chance that hashing all the contents is somewhat slower than doing the git thing that we were doing, but in practice it's not really noticeable.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->