### PR TITLE
[CWS] fix missing embed files when combining btfhub constants

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -123,6 +123,11 @@ jobs:
 
       - name: Combine constants
         run: |
+          # fix amd64 missing embed files
+          touch pkg/ebpf/kernelbugs/c/uprobe-trigger.o
+          touch pkg/ebpf/kernelbugs/c/detect-seccomp-bug
+
+          # combine constants
           dda inv -- -e security-agent.combine-btfhub-constants --archive-path=./dev/dist/constants
           dda inv -- -e security-agent.split-btfhub-constants
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/39489 fixed only half of the issue in that it fixes the constant generation jobs but not the combine one making the job still fail. This PR fixes it.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->