### PR TITLE
dyninst/symdb: fix handling of types in packages with dots

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 87
           Type: 375 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd7f4a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd7faa", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -54,7 +54,7 @@ Probes:
       events:
         - ID: 52
           Type: 340 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -124,7 +124,7 @@ Probes:
       events:
         - ID: 68
           Type: 356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd7200", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7260", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -138,7 +138,7 @@ Probes:
       events:
         - ID: 66
           Type: 354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd6e20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd6e80", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -152,7 +152,7 @@ Probes:
       events:
         - ID: 76
           Type: 364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd75c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7620", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -166,7 +166,7 @@ Probes:
       events:
         - ID: 78
           Type: 366 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd7b00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7b60", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -180,7 +180,7 @@ Probes:
       events:
         - ID: 81
           Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7b60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7bc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -194,7 +194,7 @@ Probes:
       events:
         - ID: 95
           Type: 383 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd80e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - ID: 97
           Type: 385 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -532,7 +532,7 @@ Probes:
       events:
         - ID: 70
           Type: 358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd73e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7440", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -546,7 +546,7 @@ Probes:
       events:
         - ID: 50
           Type: 338 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -560,7 +560,7 @@ Probes:
       events:
         - ID: 56
           Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -574,7 +574,7 @@ Probes:
       events:
         - ID: 54
           Type: 342 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd55e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -588,7 +588,7 @@ Probes:
       events:
         - ID: 65
           Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5740", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -602,7 +602,7 @@ Probes:
       events:
         - ID: 64
           Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5720", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -616,7 +616,7 @@ Probes:
       events:
         - ID: 55
           Type: 343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd55a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -630,7 +630,7 @@ Probes:
       events:
         - ID: 63
           Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -644,7 +644,7 @@ Probes:
       events:
         - ID: 62
           Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd56e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -658,7 +658,7 @@ Probes:
       events:
         - ID: 48
           Type: 336 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd54c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -672,7 +672,7 @@ Probes:
       events:
         - ID: 49
           Type: 337 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd54e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5540", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -686,7 +686,7 @@ Probes:
       events:
         - ID: 47
           Type: 335 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5500", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -700,7 +700,7 @@ Probes:
       events:
         - ID: 57
           Type: 345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd55e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -714,7 +714,7 @@ Probes:
       events:
         - ID: 60
           Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd5640", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd56a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -728,7 +728,7 @@ Probes:
       events:
         - ID: 61
           Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd56c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -742,7 +742,7 @@ Probes:
       events:
         - ID: 58
           Type: 346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5660", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -756,7 +756,7 @@ Probes:
       events:
         - ID: 59
           Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd5620", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5680", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -770,7 +770,7 @@ Probes:
       events:
         - ID: 93
           Type: 381 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd80a0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -784,7 +784,7 @@ Probes:
       events:
         - ID: 67
           Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd6fe0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7040", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -798,7 +798,7 @@ Probes:
       events:
         - ID: 75
           Type: 363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd7580", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd75e0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - ID: 85
           Type: 373 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd7be0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7c40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -826,7 +826,7 @@ Probes:
       events:
         - ID: 82
           Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7b80", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7be0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -840,7 +840,7 @@ Probes:
       events:
         - ID: 84
           Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd7bc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7c20", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -854,7 +854,7 @@ Probes:
       events:
         - ID: 92
           Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -868,7 +868,7 @@ Probes:
       events:
         - ID: 71
           Type: 359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd7400", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -882,7 +882,7 @@ Probes:
       events:
         - ID: 53
           Type: 341 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd5560", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd55c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -896,7 +896,7 @@ Probes:
       events:
         - ID: 69
           Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd73c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7420", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - ID: 88
           Type: 376 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1148,7 +1148,7 @@ Probes:
       events:
         - ID: 79
           Type: 367 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd7b20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7b80", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1162,7 +1162,7 @@ Probes:
       events:
         - ID: 51
           Type: 339 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd5520", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd5580", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1190,7 +1190,7 @@ Probes:
       events:
         - ID: 74
           Type: 362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd7540", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd75a0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1204,7 +1204,7 @@ Probes:
       events:
         - ID: 83
           Type: 371 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd7ba0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7c00", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1218,7 +1218,7 @@ Probes:
       events:
         - ID: 96
           Type: 384 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd8300", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8360", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1232,7 +1232,7 @@ Probes:
       events:
         - ID: 80
           Type: 368 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd7b40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7ba0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1246,7 +1246,7 @@ Probes:
       events:
         - ID: 46
           Type: 334 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd5480", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd54e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1260,7 +1260,7 @@ Probes:
       events:
         - ID: 89
           Type: 377 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1274,7 +1274,7 @@ Probes:
       events:
         - ID: 90
           Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1288,7 +1288,7 @@ Probes:
       events:
         - ID: 91
           Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1386,7 +1386,7 @@ Probes:
       events:
         - ID: 73
           Type: 361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd74c0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1400,7 +1400,7 @@ Probes:
       events:
         - ID: 77
           Type: 365 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd7ae0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7b40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1414,7 +1414,7 @@ Probes:
       events:
         - ID: 94
           Type: 382 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd80c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1428,7 +1428,7 @@ Probes:
       events:
         - ID: 72
           Type: 360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd7420", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7480", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1456,7 +1456,7 @@ Probes:
       events:
         - ID: 86
           Type: 374 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd7c00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd7c60", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
@@ -2247,66 +2247,30 @@ Subprograms:
           IsReturn: false
     - ID: 52
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd5480..0xcd5481]
+      OutOfLinePCRanges: [0xcd54e0..0xcd54e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 77 StructureType main.structWithMap
           Locations:
-            - Range: 0xcd5480..0xcd5481
+            - Range: 0xcd54e0..0xcd54e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 53
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
+      OutOfLinePCRanges: [0xcd5500..0xcd5501]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcd54a0..0xcd54a1
+            - Range: 0xcd5500..0xcd5501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 54
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd54c0..0xcd54c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd54c0..0xcd54c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd54e0..0xcd54e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd54e0..0xcd54e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd5500..0xcd5501]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 124 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0xcd5500..0xcd5501
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd5520..0xcd5521]
       InlinePCRanges: []
       Variables:
@@ -2317,237 +2281,273 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
-      Name: main.testArrayOfMaps
+    - ID: 55
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd5540..0xcd5541]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 ArrayType [2]map[string]int
+          Type: 112 GoMapType map[string][]string
           Locations:
             - Range: 0xcd5540..0xcd5541
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
-      Name: main.testPointerToMap
+    - ID: 56
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd5560..0xcd5561]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 PointerType *map[string]int
+          Type: 124 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd5560..0xcd5561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
-      Name: main.testMapIntToInt
+    - ID: 57
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd5580..0xcd5581]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 78 GoMapType map[int]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcd5580..0xcd5581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
-      Name: main.testMapMassive
+    - ID: 58
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd55a0..0xcd55a1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 136 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd55a0..0xcd55a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
+    - ID: 59
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd55c0..0xcd55c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 137 PointerType *map[string]int
           Locations:
             - Range: 0xcd55c0..0xcd55c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
+    - ID: 60
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd55e0..0xcd55e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[bool]main.node
+          Type: 78 GoMapType map[int]int
           Locations:
             - Range: 0xcd55e0..0xcd55e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
+    - ID: 61
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd5600..0xcd5601]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]uint8
+        - Name: redactMyEntries
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5600..0xcd5601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
+    - ID: 62
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd5620..0xcd5621]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
+        - Name: m
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5620..0xcd5621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 63
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd5640..0xcd5641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 151 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd5640..0xcd5641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 64
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd5660..0xcd5661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5660..0xcd5661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
+    - ID: 65
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd5680..0xcd5681]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5680..0xcd5681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 66
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcd56a0..0xcd56a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[uint8][4]int
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd56a0..0xcd56a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcd56c0..0xcd56c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd56c0..0xcd56c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 68
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcd56e0..0xcd56e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd56e0..0xcd56e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd5700..0xcd5701]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd5700..0xcd5701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd5720..0xcd5721]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd5720..0xcd5721
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd5740..0xcd5741]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd5740..0xcd5741
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd6e20..0xcd6e21]
+      OutOfLinePCRanges: [0xcd6e80..0xcd6e81]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd6e20..0xcd6e21
+            - Range: 0xcd6e80..0xcd6e81
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd6e20..0xcd6e21
+            - Range: 0xcd6e80..0xcd6e81
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0xcd6e20..0xcd6e21
+            - Range: 0xcd6e80..0xcd6e81
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd6fe0..0xcd6fe1]
+      OutOfLinePCRanges: [0xcd7040..0xcd7041]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
+            - Range: 0xcd7040..0xcd7041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
+            - Range: 0xcd7040..0xcd7041
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
+            - Range: 0xcd7040..0xcd7041
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
+            - Range: 0xcd7040..0xcd7041
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd6fe0..0xcd6fe1
+            - Range: 0xcd7040..0xcd7041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2557,37 +2557,37 @@ Subprograms:
           IsReturn: false
     - ID: 74
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd7200..0xcd7201]
+      OutOfLinePCRanges: [0xcd7260..0xcd7261]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0xcd7200..0xcd7201
+            - Range: 0xcd7260..0xcd7261
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd73c0..0xcd73c1]
+      OutOfLinePCRanges: [0xcd7420..0xcd7421]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd73c0..0xcd73c1
+            - Range: 0xcd7420..0xcd7421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 76
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd73e0..0xcd73e1]
+      OutOfLinePCRanges: [0xcd7440..0xcd7441]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 StructureType main.node
           Locations:
-            - Range: 0xcd73e0..0xcd73e1
+            - Range: 0xcd7440..0xcd7441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2597,92 +2597,92 @@ Subprograms:
           IsReturn: false
     - ID: 77
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd7400..0xcd7401]
+      OutOfLinePCRanges: [0xcd7460..0xcd7461]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *main.node
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 78
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd7420..0xcd7421]
+      OutOfLinePCRanges: [0xcd7480..0xcd7481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd7420..0xcd7421
+            - Range: 0xcd7480..0xcd7481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 79
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd7460..0xcd7461]
+      OutOfLinePCRanges: [0xcd74c0..0xcd74c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 223 PointerType *uint
           Locations:
-            - Range: 0xcd7460..0xcd7461
+            - Range: 0xcd74c0..0xcd74c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 80
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd7540..0xcd7541]
+      OutOfLinePCRanges: [0xcd75a0..0xcd75a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0xcd7540..0xcd7541
+            - Range: 0xcd75a0..0xcd75a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 81
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd7580..0xcd7581]
+      OutOfLinePCRanges: [0xcd75e0..0xcd75e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 224 PointerType *bool
           Locations:
-            - Range: 0xcd7580..0xcd7581
+            - Range: 0xcd75e0..0xcd75e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd7580..0xcd7581
+            - Range: 0xcd75e0..0xcd75e1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 82
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd75c0..0xcd75c1]
+      OutOfLinePCRanges: [0xcd7620..0xcd7621]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 225 PointerType *main.t
           Locations:
-            - Range: 0xcd75c0..0xcd75c1
+            - Range: 0xcd7620..0xcd7621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 83
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd7ae0..0xcd7ae1]
+      OutOfLinePCRanges: [0xcd7b40..0xcd7b41]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd7ae0..0xcd7ae1
+            - Range: 0xcd7b40..0xcd7b41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2694,13 +2694,13 @@ Subprograms:
           IsReturn: false
     - ID: 84
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd7b00..0xcd7b01]
+      OutOfLinePCRanges: [0xcd7b60..0xcd7b61]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd7b00..0xcd7b01
+            - Range: 0xcd7b60..0xcd7b61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2712,13 +2712,13 @@ Subprograms:
           IsReturn: false
     - ID: 85
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd7b20..0xcd7b21]
+      OutOfLinePCRanges: [0xcd7b80..0xcd7b81]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcd7b20..0xcd7b21
+            - Range: 0xcd7b80..0xcd7b81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2730,86 +2730,11 @@ Subprograms:
           IsReturn: false
     - ID: 86
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd7b40..0xcd7b41]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7b40..0xcd7b41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7b40..0xcd7b41
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd7b60..0xcd7b61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7b60..0xcd7b61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7b60..0xcd7b61
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 88
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd7b80..0xcd7b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7b80..0xcd7b81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7b80..0xcd7b81
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testStringSlice
       OutOfLinePCRanges: [0xcd7ba0..0xcd7ba1]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 123 GoSliceHeaderType []string
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7ba0..0xcd7ba1
               Pieces:
@@ -2821,22 +2746,97 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7ba0..0xcd7ba1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd7bc0..0xcd7bc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd7bc0..0xcd7bc1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7bc0..0xcd7bc1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd7be0..0xcd7be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd7be0..0xcd7be1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7be0..0xcd7be1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd7c00..0xcd7c01]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 123 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd7c00..0xcd7c01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
     - ID: 90
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd7bc0..0xcd7bc1]
+      OutOfLinePCRanges: [0xcd7c20..0xcd7c21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xcd7bc0..0xcd7bc1
+            - Range: 0xcd7c20..0xcd7c21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd7bc0..0xcd7bc1
+            - Range: 0xcd7c20..0xcd7c21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -2849,19 +2849,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd7bc0..0xcd7bc1
+            - Range: 0xcd7c20..0xcd7c21
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd7be0..0xcd7be1]
+      OutOfLinePCRanges: [0xcd7c40..0xcd7c41]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd7be0..0xcd7be1
+            - Range: 0xcd7c40..0xcd7c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2873,13 +2873,13 @@ Subprograms:
           IsReturn: false
     - ID: 92
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd7c00..0xcd7c01]
+      OutOfLinePCRanges: [0xcd7c60..0xcd7c61]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd7c00..0xcd7c01
+            - Range: 0xcd7c60..0xcd7c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2891,23 +2891,23 @@ Subprograms:
           IsReturn: false
     - ID: 93
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd7f40..0xcd7f92]
+      OutOfLinePCRanges: [0xcd7fa0..0xcd7ff2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0xcd7f40..0xcd7f92, Pieces: []}]
+          Locations: [{Range: 0xcd7fa0..0xcd7ff2, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 94
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd7fa0..0xcd7fa1]
+      OutOfLinePCRanges: [0xcd8000..0xcd8001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7fa0..0xcd7fa1
+            - Range: 0xcd8000..0xcd8001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd7fc0..0xcd7fc1]
+      OutOfLinePCRanges: [0xcd8020..0xcd8021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7fc0..0xcd7fc1
+            - Range: 0xcd8020..0xcd8021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2934,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7fc0..0xcd7fc1
+            - Range: 0xcd8020..0xcd8021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2945,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7fc0..0xcd7fc1
+            - Range: 0xcd8020..0xcd8021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2955,13 +2955,13 @@ Subprograms:
           IsReturn: false
     - ID: 96
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd7fe0..0xcd7fff]
+      OutOfLinePCRanges: [0xcd8040..0xcd805f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd7fe0..0xcd7fff
+            - Range: 0xcd8040..0xcd805f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2979,37 +2979,37 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd8000..0xcd8001]
+      OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd8000..0xcd8001
+            - Range: 0xcd8060..0xcd8061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 98
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd8020..0xcd8021]
+      OutOfLinePCRanges: [0xcd8080..0xcd8081]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd8020..0xcd8021
+            - Range: 0xcd8080..0xcd8081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 99
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd8040..0xcd8041]
+      OutOfLinePCRanges: [0xcd80a0..0xcd80a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8040..0xcd8041
+            - Range: 0xcd80a0..0xcd80a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3019,13 +3019,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd8060..0xcd8061]
+      OutOfLinePCRanges: [0xcd80c0..0xcd80c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8060..0xcd8061
+            - Range: 0xcd80c0..0xcd80c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3035,13 +3035,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd8080..0xcd8081]
+      OutOfLinePCRanges: [0xcd80e0..0xcd80e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8080..0xcd8081
+            - Range: 0xcd80e0..0xcd80e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3051,13 +3051,13 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd8300..0xcd8323]
+      OutOfLinePCRanges: [0xcd8360..0xcd8383]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0xcd8300..0xcd8323
+            - Range: 0xcd8360..0xcd8383
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3077,12 +3077,12 @@ Subprograms:
           IsReturn: false
     - ID: 103
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd8480..0xcd8481]
+      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 242 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd8480..0xcd8481, Pieces: []}]
+          Locations: [{Range: 0xcd84e0..0xcd84e1, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 87
           Type: 375 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84c85c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c89c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -54,7 +54,7 @@ Probes:
       events:
         - ID: 52
           Type: 340 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84a830", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a870", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -124,7 +124,7 @@ Probes:
       events:
         - ID: 68
           Type: 356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84be80", Frameless: true}]
+          InjectionPoints: [{PC: "0x84bec0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -138,7 +138,7 @@ Probes:
       events:
         - ID: 66
           Type: 354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
+          InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -152,7 +152,7 @@ Probes:
       events:
         - ID: 76
           Type: 364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84c120", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c160", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -166,7 +166,7 @@ Probes:
       events:
         - ID: 78
           Type: 366 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84c500", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c540", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -180,7 +180,7 @@ Probes:
       events:
         - ID: 81
           Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c570", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -194,7 +194,7 @@ Probes:
       events:
         - ID: 95
           Type: 383 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84c940", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c980", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - ID: 97
           Type: 385 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84cc50", Frameless: true}]
+          InjectionPoints: [{PC: "0x84cc90", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -532,7 +532,7 @@ Probes:
       events:
         - ID: 70
           Type: 358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84c030", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c070", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -546,7 +546,7 @@ Probes:
       events:
         - ID: 50
           Type: 338 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84a810", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a850", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -560,7 +560,7 @@ Probes:
       events:
         - ID: 56
           Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84a870", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8b0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -574,7 +574,7 @@ Probes:
       events:
         - ID: 54
           Type: 342 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84a850", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a890", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -588,7 +588,7 @@ Probes:
       events:
         - ID: 65
           Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84a900", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a940", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -602,7 +602,7 @@ Probes:
       events:
         - ID: 64
           Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84a8f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a930", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -616,7 +616,7 @@ Probes:
       events:
         - ID: 55
           Type: 343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84a860", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8a0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -630,7 +630,7 @@ Probes:
       events:
         - ID: 63
           Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84a8e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a920", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -644,7 +644,7 @@ Probes:
       events:
         - ID: 62
           Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84a8d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a910", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -658,7 +658,7 @@ Probes:
       events:
         - ID: 48
           Type: 336 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84a7f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a830", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -672,7 +672,7 @@ Probes:
       events:
         - ID: 49
           Type: 337 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84a800", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a840", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -686,7 +686,7 @@ Probes:
       events:
         - ID: 47
           Type: 335 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84a7e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a820", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -700,7 +700,7 @@ Probes:
       events:
         - ID: 57
           Type: 345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84a880", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -714,7 +714,7 @@ Probes:
       events:
         - ID: 60
           Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84a8b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -728,7 +728,7 @@ Probes:
       events:
         - ID: 61
           Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a900", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -742,7 +742,7 @@ Probes:
       events:
         - ID: 58
           Type: 346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84a890", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -756,7 +756,7 @@ Probes:
       events:
         - ID: 59
           Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84a8a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a8e0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -770,7 +770,7 @@ Probes:
       events:
         - ID: 93
           Type: 381 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84c920", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c960", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -784,7 +784,7 @@ Probes:
       events:
         - ID: 67
           Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84bce0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84bd20", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -798,7 +798,7 @@ Probes:
       events:
         - ID: 75
           Type: 363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84c100", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c140", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - ID: 85
           Type: 373 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84c570", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c5b0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -826,7 +826,7 @@ Probes:
       events:
         - ID: 82
           Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84c540", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c580", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -840,7 +840,7 @@ Probes:
       events:
         - ID: 84
           Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84c560", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c5a0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -854,7 +854,7 @@ Probes:
       events:
         - ID: 92
           Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84c910", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c950", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -868,7 +868,7 @@ Probes:
       events:
         - ID: 71
           Type: 359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84c040", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c080", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -882,7 +882,7 @@ Probes:
       events:
         - ID: 53
           Type: 341 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84a840", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a880", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -896,7 +896,7 @@ Probes:
       events:
         - ID: 69
           Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84c020", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c060", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - ID: 88
           Type: 376 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84c8c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c900", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1148,7 +1148,7 @@ Probes:
       events:
         - ID: 79
           Type: 367 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84c510", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c550", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1162,7 +1162,7 @@ Probes:
       events:
         - ID: 51
           Type: 339 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84a820", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a860", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1190,7 +1190,7 @@ Probes:
       events:
         - ID: 74
           Type: 362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84c0e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c120", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1204,7 +1204,7 @@ Probes:
       events:
         - ID: 83
           Type: 371 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84c550", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c590", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1218,7 +1218,7 @@ Probes:
       events:
         - ID: 96
           Type: 384 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84cb50", Frameless: true}]
+          InjectionPoints: [{PC: "0x84cb90", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1232,7 +1232,7 @@ Probes:
       events:
         - ID: 80
           Type: 368 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84c520", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c560", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1246,7 +1246,7 @@ Probes:
       events:
         - ID: 46
           Type: 334 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84a7d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a810", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1260,7 +1260,7 @@ Probes:
       events:
         - ID: 89
           Type: 377 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84c8d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c910", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1274,7 +1274,7 @@ Probes:
       events:
         - ID: 90
           Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84c8e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c920", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1288,7 +1288,7 @@ Probes:
       events:
         - ID: 91
           Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84c900", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c940", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1386,7 +1386,7 @@ Probes:
       events:
         - ID: 73
           Type: 361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84c070", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c0b0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1400,7 +1400,7 @@ Probes:
       events:
         - ID: 77
           Type: 365 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84c4f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1414,7 +1414,7 @@ Probes:
       events:
         - ID: 94
           Type: 382 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84c930", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c970", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1428,7 +1428,7 @@ Probes:
       events:
         - ID: 72
           Type: 360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84c050", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c090", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1456,7 +1456,7 @@ Probes:
       events:
         - ID: 86
           Type: 374 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84c580", Frameless: true}]
+          InjectionPoints: [{PC: "0x84c5c0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
@@ -2247,307 +2247,307 @@ Subprograms:
           IsReturn: false
     - ID: 52
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84a7d0..0x84a7e0]
+      OutOfLinePCRanges: [0x84a810..0x84a820]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 77 StructureType main.structWithMap
           Locations:
-            - Range: 0x84a7d0..0x84a7e0
+            - Range: 0x84a810..0x84a820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 53
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84a7e0..0x84a7f0]
+      OutOfLinePCRanges: [0x84a820..0x84a830]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84a7e0..0x84a7f0
+            - Range: 0x84a820..0x84a830
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 54
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84a7f0..0x84a800]
+      OutOfLinePCRanges: [0x84a830..0x84a840]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x84a7f0..0x84a800
+            - Range: 0x84a830..0x84a840
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 55
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84a800..0x84a810]
+      OutOfLinePCRanges: [0x84a840..0x84a850]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 112 GoMapType map[string][]string
           Locations:
-            - Range: 0x84a800..0x84a810
+            - Range: 0x84a840..0x84a850
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 56
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84a810..0x84a820]
+      OutOfLinePCRanges: [0x84a850..0x84a860]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 124 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84a810..0x84a820
+            - Range: 0x84a850..0x84a860
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 57
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84a820..0x84a830]
+      OutOfLinePCRanges: [0x84a860..0x84a870]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 101 GoMapType map[string]int
           Locations:
-            - Range: 0x84a820..0x84a830
+            - Range: 0x84a860..0x84a870
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 58
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84a830..0x84a840]
+      OutOfLinePCRanges: [0x84a870..0x84a880]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 136 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84a830..0x84a840
+            - Range: 0x84a870..0x84a880
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 59
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84a840..0x84a850]
+      OutOfLinePCRanges: [0x84a880..0x84a890]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 137 PointerType *map[string]int
           Locations:
-            - Range: 0x84a840..0x84a850
+            - Range: 0x84a880..0x84a890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 60
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84a850..0x84a860]
+      OutOfLinePCRanges: [0x84a890..0x84a8a0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 78 GoMapType map[int]int
           Locations:
-            - Range: 0x84a850..0x84a860
+            - Range: 0x84a890..0x84a8a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 61
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84a860..0x84a870]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84a860..0x84a870
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84a870..0x84a880]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84a870..0x84a880
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84a880..0x84a890]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 151 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x84a880..0x84a890
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84a890..0x84a8a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x84a890..0x84a8a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84a8a0..0x84a8b0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84a8a0..0x84a8b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 62
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84a8b0..0x84a8c0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84a8b0..0x84a8c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 63
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 151 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84a8c0..0x84a8d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
+    - ID: 64
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84a8d0..0x84a8e0]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0x84a8d0..0x84a8e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 65
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84a8e0..0x84a8f0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 186 GoMapType map[uint8][4]int
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0x84a8e0..0x84a8f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 66
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84a8f0..0x84a900]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84a8f0..0x84a900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x84a900..0x84a910]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84a900..0x84a910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 68
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84a910..0x84a920]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84a910..0x84a920
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84a920..0x84a930]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x84a920..0x84a930
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84a930..0x84a940]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x84a930..0x84a940
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84a940..0x84a950]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84a940..0x84a950
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84bc00..0x84bc10]
+      OutOfLinePCRanges: [0x84bc40..0x84bc50]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84bc00..0x84bc10
+            - Range: 0x84bc40..0x84bc50
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84bc00..0x84bc10
+            - Range: 0x84bc40..0x84bc50
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0x84bc00..0x84bc10
+            - Range: 0x84bc40..0x84bc50
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84bce0..0x84bcf0]
+      OutOfLinePCRanges: [0x84bd20..0x84bd30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0x84bce0..0x84bcf0
+            - Range: 0x84bd20..0x84bd30
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84bce0..0x84bcf0
+            - Range: 0x84bd20..0x84bd30
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x84bce0..0x84bcf0
+            - Range: 0x84bd20..0x84bd30
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84bce0..0x84bcf0
+            - Range: 0x84bd20..0x84bd30
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84bce0..0x84bcf0
+            - Range: 0x84bd20..0x84bd30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2557,37 +2557,37 @@ Subprograms:
           IsReturn: false
     - ID: 74
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84be80..0x84be90]
+      OutOfLinePCRanges: [0x84bec0..0x84bed0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0x84be80..0x84be90
+            - Range: 0x84bec0..0x84bed0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 75
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84c020..0x84c030]
+      OutOfLinePCRanges: [0x84c060..0x84c070]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84c020..0x84c030
+            - Range: 0x84c060..0x84c070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 76
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84c030..0x84c040]
+      OutOfLinePCRanges: [0x84c070..0x84c080]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 StructureType main.node
           Locations:
-            - Range: 0x84c030..0x84c040
+            - Range: 0x84c070..0x84c080
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2597,92 +2597,92 @@ Subprograms:
           IsReturn: false
     - ID: 77
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84c040..0x84c050]
+      OutOfLinePCRanges: [0x84c080..0x84c090]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *main.node
           Locations:
-            - Range: 0x84c040..0x84c050
+            - Range: 0x84c080..0x84c090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 78
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84c050..0x84c060]
+      OutOfLinePCRanges: [0x84c090..0x84c0a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84c050..0x84c060
+            - Range: 0x84c090..0x84c0a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 79
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84c070..0x84c080]
+      OutOfLinePCRanges: [0x84c0b0..0x84c0c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 223 PointerType *uint
           Locations:
-            - Range: 0x84c070..0x84c080
+            - Range: 0x84c0b0..0x84c0c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 80
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84c0e0..0x84c0f0]
+      OutOfLinePCRanges: [0x84c120..0x84c130]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0x84c0e0..0x84c0f0
+            - Range: 0x84c120..0x84c130
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 81
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84c100..0x84c110]
+      OutOfLinePCRanges: [0x84c140..0x84c150]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 224 PointerType *bool
           Locations:
-            - Range: 0x84c100..0x84c110
+            - Range: 0x84c140..0x84c150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c100..0x84c110
+            - Range: 0x84c140..0x84c150
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 82
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84c120..0x84c130]
+      OutOfLinePCRanges: [0x84c160..0x84c170]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 225 PointerType *main.t
           Locations:
-            - Range: 0x84c120..0x84c130
+            - Range: 0x84c160..0x84c170
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 83
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84c4f0..0x84c500]
+      OutOfLinePCRanges: [0x84c530..0x84c540]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c4f0..0x84c500
+            - Range: 0x84c530..0x84c540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2694,13 +2694,13 @@ Subprograms:
           IsReturn: false
     - ID: 84
       Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84c500..0x84c510]
+      OutOfLinePCRanges: [0x84c540..0x84c550]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c500..0x84c510
+            - Range: 0x84c540..0x84c550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2712,104 +2712,11 @@ Subprograms:
           IsReturn: false
     - ID: 85
       Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84c510..0x84c520]
+      OutOfLinePCRanges: [0x84c550..0x84c560]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x84c510..0x84c520
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 86
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84c520..0x84c530]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84c520..0x84c530
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x84c520..0x84c530
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84c530..0x84c540]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84c530..0x84c540
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x84c530..0x84c540
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 88
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84c540..0x84c550]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84c540..0x84c550
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x84c540..0x84c550
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84c550..0x84c560]
-      InlinePCRanges: []
-      Variables:
-        - Name: s
-          Type: 123 GoSliceHeaderType []string
           Locations:
             - Range: 0x84c550..0x84c560
               Pieces:
@@ -2821,22 +2728,115 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
+    - ID: 86
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84c560..0x84c570]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84c560..0x84c570
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84c560..0x84c570
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 87
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84c570..0x84c580]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84c570..0x84c580
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84c570..0x84c580
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84c580..0x84c590]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84c580..0x84c590
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84c580..0x84c590
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84c590..0x84c5a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 123 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84c590..0x84c5a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
     - ID: 90
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84c560..0x84c570]
+      OutOfLinePCRanges: [0x84c5a0..0x84c5b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x84c560..0x84c570
+            - Range: 0x84c5a0..0x84c5b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84c560..0x84c570
+            - Range: 0x84c5a0..0x84c5b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -2849,19 +2849,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c560..0x84c570
+            - Range: 0x84c5a0..0x84c5b0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 91
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84c570..0x84c580]
+      OutOfLinePCRanges: [0x84c5b0..0x84c5c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84c570..0x84c580
+            - Range: 0x84c5b0..0x84c5c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2873,13 +2873,13 @@ Subprograms:
           IsReturn: false
     - ID: 92
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84c580..0x84c590]
+      OutOfLinePCRanges: [0x84c5c0..0x84c5d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c580..0x84c590
+            - Range: 0x84c5c0..0x84c5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2891,23 +2891,23 @@ Subprograms:
           IsReturn: false
     - ID: 93
       Name: main.stackC
-      OutOfLinePCRanges: [0x84c850..0x84c8c0]
+      OutOfLinePCRanges: [0x84c890..0x84c900]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0x84c850..0x84c8c0, Pieces: []}]
+          Locations: [{Range: 0x84c890..0x84c900, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 94
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84c8c0..0x84c8d0]
+      OutOfLinePCRanges: [0x84c900..0x84c910]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c8c0..0x84c8d0
+            - Range: 0x84c900..0x84c910
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2917,13 +2917,13 @@ Subprograms:
           IsReturn: false
     - ID: 95
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84c8d0..0x84c8e0]
+      OutOfLinePCRanges: [0x84c910..0x84c920]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c8d0..0x84c8e0
+            - Range: 0x84c910..0x84c920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2934,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c8d0..0x84c8e0
+            - Range: 0x84c910..0x84c920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2945,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c8d0..0x84c8e0
+            - Range: 0x84c910..0x84c920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2955,13 +2955,13 @@ Subprograms:
           IsReturn: false
     - ID: 96
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84c8e0..0x84c900]
+      OutOfLinePCRanges: [0x84c920..0x84c940]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84c8e0..0x84c900
+            - Range: 0x84c920..0x84c940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2979,37 +2979,37 @@ Subprograms:
           IsReturn: false
     - ID: 97
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84c900..0x84c910]
+      OutOfLinePCRanges: [0x84c940..0x84c950]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84c900..0x84c910
+            - Range: 0x84c940..0x84c950
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 98
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84c910..0x84c920]
+      OutOfLinePCRanges: [0x84c950..0x84c960]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84c910..0x84c920
+            - Range: 0x84c950..0x84c960
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 99
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84c920..0x84c930]
+      OutOfLinePCRanges: [0x84c960..0x84c970]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c920..0x84c930
+            - Range: 0x84c960..0x84c970
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3019,13 +3019,13 @@ Subprograms:
           IsReturn: false
     - ID: 100
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84c930..0x84c940]
+      OutOfLinePCRanges: [0x84c970..0x84c980]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c930..0x84c940
+            - Range: 0x84c970..0x84c980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3035,13 +3035,13 @@ Subprograms:
           IsReturn: false
     - ID: 101
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84c940..0x84c950]
+      OutOfLinePCRanges: [0x84c980..0x84c990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c940..0x84c950
+            - Range: 0x84c980..0x84c990
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3051,13 +3051,13 @@ Subprograms:
           IsReturn: false
     - ID: 102
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84cb50..0x84cb70]
+      OutOfLinePCRanges: [0x84cb90..0x84cbb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0x84cb50..0x84cb70
+            - Range: 0x84cb90..0x84cbb0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3077,12 +3077,12 @@ Subprograms:
           IsReturn: false
     - ID: 103
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84cc50..0x84cc60]
+      OutOfLinePCRanges: [0x84cc90..0x84cca0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 242 StructureType main.emptyStruct
-          Locations: [{Range: 0x84cc50..0x84cc60, Pieces: []}]
+          Locations: [{Range: 0x84cc90..0x84cca0, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1

--- a/pkg/dyninst/symdb/func_name.go
+++ b/pkg/dyninst/symdb/func_name.go
@@ -10,7 +10,9 @@ package symdb
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Utilities for parsing Go function names.
@@ -212,4 +214,124 @@ func parseFuncName(qualifiedName string) (parseFuncNameResult, error) {
 			QualifiedName: qualifiedName,
 		},
 	}, nil
+}
+
+// splitPkg splits a full linker symbol name into package (full import path) and
+// local symbol name.
+//
+// Copied from
+// https://github.com/golang/go/blob/c0025d5e0b3f6fca7117e9b8f4593a95e37a9fa5/src/cmd/compile/internal/ir/func.go#L367
+func splitPkg(name string) (pkgpath, sym string) {
+	// package-sym split is at first dot after last the / that comes before
+	// any characters illegal in a package path.
+
+	lastSlashIdx := 0
+	for i, r := range name {
+		// Catches cases like:
+		// * example.foo[sync/atomic.Uint64].
+		// * example%2ecom.foo[sync/atomic.Uint64].
+		//
+		// Note that name is still escaped; unescape occurs after splitPkg.
+		if !escapedImportPathOK(r) {
+			break
+		}
+		if r == '/' {
+			lastSlashIdx = i
+		}
+	}
+	for i := lastSlashIdx; i < len(name); i++ {
+		r := name[i]
+		if r == '.' {
+			return name[:i], name[i+1:]
+		}
+	}
+
+	return "", name
+}
+
+// parseLinkFuncName parsers a symbol name (such as a type or function name) as
+// it appears in DWARF to the package path and local identifier name. The
+// returned package name is unescaped. If the package name contained escape
+// sequences, wasEscaped is returned true. Otherwise, name == <pkg>.<sym>
+//
+// This and related functions were adapted from
+// https://github.com/golang/go/blob/7a1679d7ae32dd8a01bd355413ee77ba517f5f43/src/cmd/internal/objabi/path.go#L18
+func parseLinkFuncName(name string) (pkg, sym string, wasEscaped bool, err error) {
+	pkg, sym = splitPkg(name)
+	if pkg == "" {
+		return "", sym, false, nil
+	}
+
+	pkg, wasEscaped, err = prefixToPath(pkg) // unescape
+	if err != nil {
+		return "", "", false, fmt.Errorf("malformed package path: %v", err)
+	}
+
+	return pkg, sym, wasEscaped, nil
+}
+
+// unescapeSymbol takes a symbol name as it appears in DWARF (i.e. package
+// import path + identifier) and unescapes the package import path, returning
+// the full symbol name with the unescaped package path.
+func unescapeSymbol(name string) (string, error) {
+	pkg, sym, wasEscaped, err := parseLinkFuncName(name)
+	if err != nil {
+		return "", err
+	}
+	if !wasEscaped {
+		// Avoid allocation on the common case.
+		return name, nil
+	}
+	return pkg + "." + sym, nil
+}
+
+// prefixToPath unescapes package import paths, replacing escape sequences with
+// the original character.
+//
+// The bool return value is true if any escape sequences were found and
+// replaced.
+func prefixToPath(s string) (string, bool, error) {
+	// Short-circuit the common case.
+	percent := strings.IndexByte(s, '%')
+	if percent == -1 {
+		return s, false, nil
+	}
+
+	p := make([]byte, 0, len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '%' {
+			p = append(p, s[i])
+			i++
+			continue
+		}
+		if i+2 >= len(s) {
+			// Not enough characters remaining to be a valid escape
+			// sequence.
+			return "", false, fmt.Errorf("malformed prefix %q: escape sequence must contain two hex digits", s)
+		}
+
+		b, err := strconv.ParseUint(s[i+1:i+3], 16, 8)
+		if err != nil {
+			// Not a valid escape sequence.
+			return "", false, fmt.Errorf("malformed prefix %q: escape sequence %q must contain two hex digits", s, s[i:i+3])
+		}
+
+		p = append(p, byte(b))
+		i += 3
+	}
+	return string(p), true, nil
+}
+
+func modPathOK(r rune) bool {
+	if r < utf8.RuneSelf {
+		return r == '-' || r == '.' || r == '_' || r == '~' ||
+			'0' <= r && r <= '9' ||
+			'A' <= r && r <= 'Z' ||
+			'a' <= r && r <= 'z'
+	}
+	return false
+}
+
+func escapedImportPathOK(r rune) bool {
+	return modPathOK(r) || r == '+' || r == '/' || r == '%'
 }

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -377,23 +376,17 @@ type typesCollection struct {
 	packages map[string][]*Type
 }
 
-var (
-	// The parsing goes as follows:
-	// - optionally one or more starting '*', for pointer types. We discard these.
-	// - consume eagerly up to the last slash, if any. This is part of the
-	// package path.
-	// - after the last slash, consume up to the next dot. This completes the
-	// package name.
-	parsePkgFromTypeNameRE = regexp.MustCompile(`^(\*)*(?P<pkg>(.*\/)?[^.]*)\.`)
-	typePkgIdx             = parsePkgFromTypeNameRE.SubexpIndex("pkg")
-)
-
 func (c *typesCollection) resolveType(offset dwarf.Offset) (typeInfo, error) {
 	typ, err := c.typesCache.FindTypeByOffset(offset)
 	if err != nil {
 		return typeInfo{}, err
 	}
-	typeName := typ.Common().Name
+	// The package import path in the type name might be escaped. We want
+	// unescaped paths for SymDB.
+	typeName, err := unescapeSymbol(typ.Common().Name)
+	if err != nil {
+		return typeInfo{}, fmt.Errorf("failed to unescape type name %q: %w", typ.Common().Name, err)
+	}
 	size := typ.Common().Size()
 
 	// Unwrap pointer types and typedefs.
@@ -426,23 +419,19 @@ func (c *typesCollection) getType(name string) *Type {
 // addType adds a type to the collection if it is not already present.
 // Unsupported types are ignored and no error is returned.
 func (c *typesCollection) addType(t godwarf.Type) error {
-	name := t.Common().Name
-	{
-		// If the last element of the package's import path contains dots, they
-		// are replaced with %2e in DWARF to differentiate them from the dot
-		// that separates the package path from the type name. Undo this
-		// escaping so that our cache key matches the actual package name.
-		escapedDot := "%2e"
-		i := strings.LastIndex(name, escapedDot)
-		if i >= 0 {
-			// Replace %2e with '.' in the type name. This is how DWARF encodes
-			// dots in package names.
-			name = name[:i] + "." + name[i+len(escapedDot):]
-		}
+	pkg, sym, wasEscaped, err := parseLinkFuncName(t.Common().Name)
+	if err != nil {
+		return fmt.Errorf("failed to split package for %s : %w", t.Common().Name, err)
+	}
+	var unescapedName string
+	if wasEscaped {
+		unescapedName = pkg + "." + sym
+	} else {
+		unescapedName = t.Common().Name
 	}
 
 	// Check if the type is already present.
-	if _, ok := c.types[name]; ok {
+	if _, ok := c.types[unescapedName]; ok {
 		return nil
 	}
 
@@ -453,31 +442,20 @@ func (c *typesCollection) addType(t godwarf.Type) error {
 
 	// Assert that we were not given a pointer type.
 	if _, ok := t.(*godwarf.PtrType); ok {
-		return fmt.Errorf("ptr type expected to have been unwrapped: %s", name)
+		return fmt.Errorf("ptr type expected to have been unwrapped: %s", unescapedName)
 	}
-	if strings.HasPrefix(name, "*") {
-		return fmt.Errorf("type name for non-pointer unexpectedly starting with '*': %s", name)
+	if strings.HasPrefix(unescapedName, "*") {
+		return fmt.Errorf("type unescapedName for non-pointer unexpectedly starting with '*': %s", unescapedName)
 	}
 
 	// Skip anonymous types, generic types, array types and structs
 	// corresponding to slices.
-	if strings.ContainsAny(name, "{<[") {
+	if strings.ContainsAny(unescapedName, "{<[") {
 		return nil
 	}
 
-	// Figure out the type's package.
-	groups := parsePkgFromTypeNameRE.FindStringSubmatch(name)
-	if groups == nil {
-		// Base types like "int" don't have a package. We don't care about these
-		// types anyway.
-		return nil
-	}
-	pkg := groups[typePkgIdx]
-	if pkg == "" {
-		return fmt.Errorf("failed to parse package from type %s (type: %s)", name, t)
-	}
 	typ := &Type{
-		Name:   name,
+		Name:   unescapedName,
 		Fields: nil,
 		// Methods will be populated later, as we discover them in DWARF.
 		Methods: nil,
@@ -491,7 +469,7 @@ func (c *typesCollection) addType(t godwarf.Type) error {
 		}
 	}
 
-	c.types[name] = typ
+	c.types[unescapedName] = typ
 	c.packages[pkg] = append(c.packages[pkg], typ)
 	return nil
 }

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -165,7 +165,8 @@ Package: main
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
 		Arg: e: error (declared at line 60, available: [60-60])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:46]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -676,4 +677,7 @@ Package: main
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [15:16]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -165,7 +165,8 @@ Package: main
 	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
 		Arg: e: error (declared at line 60, available: [60-60])
 	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:46]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
@@ -676,4 +677,7 @@ Package: main
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
-	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [15:16]
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayOfMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 46
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 41
+            "lineNumber": 43
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 41
+            "lineNumber": 43
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 44
+            "lineNumber": 46
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapArrayToArray.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapEmbeddedMaps.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapIntToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapLargeKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeyLargeValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapSmallKeySmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToInt.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToSlice.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapStringToStruct.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithLinkedList.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallKeyAndValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValue.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMapWithSmallValueMassive.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerToMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSmallMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithMap.json
@@ -28,7 +28,7 @@
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 43
+            "lineNumber": 45
           },
           {
             "function": "runtime.main",

--- a/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go
@@ -8,9 +8,17 @@
 // gets escaped in DWARF, making this useful for our tests.
 package lib_v2
 
+import "fmt"
+
 var dummy int
 
 //go:noinline
 func FooV2() {
 	dummy++
+}
+
+type V2Type struct{}
+
+func (v *V2Type) MyMethod() {
+	fmt.Println("")
 }

--- a/pkg/dyninst/testprogs/progs/sample/main.go
+++ b/pkg/dyninst/testprogs/progs/sample/main.go
@@ -36,6 +36,8 @@ func main() {
 	executeComplexFuncs()
 	lib.Foo()
 	lib_v2.FooV2()
+	var t lib_v2.V2Type
+	t.MyMethod()
 
 	// unsupported for MVP, should not cause failures
 	executeEsoteric()


### PR DESCRIPTION
Fix a bug where types from packages containing a dot in the component of
the import path where added to the wrong package, or sometimes not added
at all. We were using the unescaped import patch when parsing out the
type's package, which made the regex we use for parsing incorrect. Now
we use unescaping utilities copied from the compiler, which are more
robust.

Also apply unescaping to the type names of variables; before, we were
producing variables with escaped type names in the output.