### PR TITLE
dyninst/symdb: introduce a streaming api

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -12,6 +12,7 @@ import (
 	"debug/dwarf"
 	"errors"
 	"fmt"
+	"iter"
 	"math"
 	"runtime/debug"
 	"slices"
@@ -310,8 +311,8 @@ type SymDBBuilder struct {
 	loclistReader *loclist.Reader
 	// The size of pointers for the binary's architecture, in bytes.
 	pointerSize int
-	// Filtering mode.
-	scopeFilter ExtractScope
+	options     ExtractOptions
+
 	// The module path of the Go module containing the main function. Empty if
 	// unknown.
 	mainModule string
@@ -323,10 +324,15 @@ type SymDBBuilder struct {
 
 	// The compile unit currently being processed by explore* functions.
 	currentCompileUnit        *dwarf.Entry
+	currentCompileUnitName    string
 	filesInCurrentCompileUnit []string
 
 	abstractFunctions map[dwarf.Offset]*abstractFunction
-	types             typesCollection
+
+	// typesCache will accumulate types as we look them up to resolve variables
+	// and functions. The cache is indexed by DWARF offset.
+	typesCache *dwarfutils.TypeFinder
+	types      typesCollection
 
 	// Stack of blocks currently being explored. Variable location lists can
 	// make references to the current block and its PC ranges; they will look at
@@ -367,10 +373,6 @@ type typesCollection struct {
 	mainModule          string
 	firstPartyPkgPrefix string
 
-	// typesCache will accumulate types as we look them up to resolve variables
-	// and functions. The cache is indexed by DWARF offset.
-	typesCache *dwarfutils.TypeFinder
-
 	// Map from the type's name, as it appears in DWARF, to the type info. Only
 	// some of the types from typesCache are to be exported to SymDB and thus
 	// are present here -- we ignore some types we don't support, and we
@@ -381,8 +383,8 @@ type typesCollection struct {
 	packages map[string][]*Type
 }
 
-func (c *typesCollection) resolveType(offset dwarf.Offset) (typeInfo, error) {
-	typ, err := c.typesCache.FindTypeByOffset(offset)
+func (b *SymDBBuilder) resolveType(offset dwarf.Offset) (typeInfo, error) {
+	typ, err := b.typesCache.FindTypeByOffset(offset)
 	if err != nil {
 		return typeInfo{}, err
 	}
@@ -407,7 +409,15 @@ func (c *typesCollection) resolveType(offset dwarf.Offset) (typeInfo, error) {
 		break
 	}
 
-	if err := c.maybeAddType(typ); err != nil {
+	pkgFilter := ""
+	if !b.options.IncludeInlinedFunctions {
+		// Only add types from the current package; we're accumulating types for
+		// the purpose of adding methods to them and, if we ignore inlined
+		// functions, this compile unit only contains methods for types in the
+		// current package.
+		pkgFilter = b.currentCompileUnitName
+	}
+	if err := b.types.maybeAddType(typ, pkgFilter); err != nil {
 		return typeInfo{}, err
 	}
 
@@ -423,8 +433,9 @@ func (c *typesCollection) getType(name string) *Type {
 
 // maybeAddType adds a type to the collection if it is not already present and
 // if it's from a package that's not filtered. Unsupported types are ignored and
-// no error is returned.
-func (c *typesCollection) maybeAddType(t godwarf.Type) error {
+// no error is returned. If pkgFilter is not
+// empty, then only types from that package are added.
+func (c *typesCollection) maybeAddType(t godwarf.Type, pkgFilter string) error {
 	pkg, sym, wasEscaped, err := parseLinkFuncName(t.Common().Name)
 	if err != nil {
 		return fmt.Errorf("failed to split package for %s : %w", t.Common().Name, err)
@@ -462,6 +473,10 @@ func (c *typesCollection) maybeAddType(t godwarf.Type) error {
 	// Skip anonymous types, generic types, array types and structs
 	// corresponding to slices.
 	if strings.ContainsAny(unescapedName, "{<[") {
+		return nil
+	}
+
+	if pkgFilter != "" && pkg != pkgFilter {
 		return nil
 	}
 
@@ -584,7 +599,7 @@ const (
 // NewSymDBBuilder creates a new SymDBBuilder for the given ELF file. The
 // SymDBBuilder takes ownership of the ELF file.
 // Close() needs to be called .
-func NewSymDBBuilder(binaryPath string, opt ExtractScope) (*SymDBBuilder, error) {
+func NewSymDBBuilder(binaryPath string, opt ExtractOptions) (*SymDBBuilder, error) {
 	obj, err := object.OpenElfFile(binaryPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
@@ -646,7 +661,7 @@ func NewSymDBBuilder(binaryPath string, opt ExtractScope) (*SymDBBuilder, error)
 		if len(parts) >= 3 && (parts[0] == "github.com" || parts[0] == "gitlab.com") {
 			firstPartyPkgPrefix = parts[0] + "/" + parts[1] + "/"
 		}
-	} else if opt == ExtractScopeMainModuleOnly || opt == ExtractScopeModulesFromSameOrg {
+	} else if opt.Scope == ExtractScopeMainModuleOnly || opt.Scope == ExtractScopeModulesFromSameOrg {
 		filesFilter = []string{"external/", "GOROOT/"}
 	}
 
@@ -655,16 +670,16 @@ func NewSymDBBuilder(binaryPath string, opt ExtractScope) (*SymDBBuilder, error)
 		sym:                 symTable,
 		loclistReader:       obj.LoclistReader(),
 		pointerSize:         int(obj.PointerSize()),
-		scopeFilter:         opt,
+		options:             opt,
 		mainModule:          mainModule,
 		firstPartyPkgPrefix: firstPartyPkgPrefix,
 		filesFilter:         filesFilter,
 		abstractFunctions:   make(map[dwarf.Offset]*abstractFunction),
+		typesCache:          dwarfutils.NewTypeFinder(obj.DwarfData()),
 		types: typesCollection{
-			scopeFilter:         opt,
+			scopeFilter:         opt.Scope,
 			mainModule:          mainModule,
 			firstPartyPkgPrefix: firstPartyPkgPrefix,
-			typesCache:          dwarfutils.NewTypeFinder(obj.DwarfData()),
 			types:               make(map[string]*Type),
 			packages:            make(map[string][]*Type),
 		},
@@ -683,42 +698,30 @@ func (b *SymDBBuilder) Close() {
 // ExtractSymbols walks the DWARF data and accumulates the symbols to send to
 // SymDB.
 func (b *SymDBBuilder) ExtractSymbols() (Symbols, error) {
-	entryReader := b.dwarfData.Reader()
 	packages := make(map[string]*Package)
-
-	// Recognize compile units, which are the top-level entries in the DWARF
-	// data corresponding to Go packages.
-	for entry, err := entryReader.Next(); entry != nil; entry, err = entryReader.Next() {
+	for pkg, err := range b.packagesIteratorInner() {
 		if err != nil {
 			return Symbols{}, err
 		}
-
-		if entry.Tag != dwarf.TagCompileUnit {
-			entryReader.SkipChildren()
-			continue
-		}
-
-		pkg, err := b.exploreCompileUnit(entry, entryReader)
-		if err != nil {
-			return Symbols{}, err
-		}
-		if pkg.Name != "" {
-			if existingPkg, ok := packages[pkg.Name]; ok {
-				existingPkg.Functions = append(existingPkg.Functions, pkg.Functions...)
-				existingPkg.Types = append(existingPkg.Types, pkg.Types...)
-			} else {
-				packages[pkg.Name] = &pkg
-			}
+		if existingPkg, ok := packages[pkg.Name]; ok {
+			existingPkg.Functions = append(existingPkg.Functions, pkg.Functions...)
+			existingPkg.Types = append(existingPkg.Types, pkg.Types...)
+		} else {
+			packages[pkg.Name] = &pkg
 		}
 	}
-	err := b.addAbstractFunctions(packages)
-	if err != nil {
-		return Symbols{}, err
-	}
+
 	res := Symbols{
 		MainModule: b.mainModule,
 		Packages:   nil,
 	}
+	if b.options.IncludeInlinedFunctions {
+		err := b.addAbstractFunctions(packages)
+		if err != nil {
+			return Symbols{}, err
+		}
+	}
+
 	for pkgName, types := range b.types.packages {
 		anyNonEmpty := slices.ContainsFunc(types, func(t *Type) bool {
 			return len(t.Fields) > 0 || len(t.Methods) > 0
@@ -754,6 +757,101 @@ func (b *SymDBBuilder) ExtractSymbols() (Symbols, error) {
 		return res.Packages[i].Name < res.Packages[j].Name
 	})
 	return res, nil
+}
+
+// PackagesIterator returns an iterator over the packages in the binary.
+//
+// PackagesIterator can only be used if the SymDBBuilder was configured with
+// ExtractOptions.IncludeInlinedFunctions=false (i.e. if we're ignoring inlined
+// functions), since inlined functions can appear in different compile units
+// than their package.
+func (b *SymDBBuilder) PackagesIterator() iter.Seq2[Package, error] {
+	if b.options.IncludeInlinedFunctions {
+		return func(yield func(Package, error) bool) {
+			yield(Package{}, fmt.Errorf("cannot overate over packages when IncludeInlinedFunctions is set"))
+		}
+	}
+	return b.packagesIteratorInner()
+}
+
+func (b *SymDBBuilder) packagesIteratorInner() iter.Seq2[Package, error] {
+	var err error
+	return func(yield func(pkg Package, err error) bool) {
+		entryReader := b.dwarfData.Reader()
+
+		// Recognize compile units, which are the top-level entries in the DWARF
+		// data corresponding to Go packages.
+		var entry *dwarf.Entry
+		for entry, err = entryReader.Next(); entry != nil; entry, err = entryReader.Next() {
+			if err != nil {
+				break
+			}
+
+			if entry.Tag != dwarf.TagCompileUnit {
+				entryReader.SkipChildren()
+				continue
+			}
+
+			var pkg Package
+			pkg, err = b.exploreCompileUnit(entry, entryReader)
+			if err != nil {
+				break
+			}
+			if pkg.Name == "" {
+				continue
+			}
+
+			// If we're not dealing with inlined functions, then move all
+			// accumulated types to the output package. If we are dealing with
+			// inlined functions, then this will happen later, once we've
+			// discovered all the abstract functions and their inlined
+			// instances, both of which can be in different compile units.
+			if !b.options.IncludeInlinedFunctions {
+				numPkgs := len(b.types.packages)
+				if numPkgs > 1 {
+					pkgNames := make([]string, 0, 2)
+					for k := range b.types.packages {
+						pkgNames = append(pkgNames, k)
+						if len(pkgNames) == 2 {
+							break
+						}
+					}
+					err = fmt.Errorf(
+						"types from multiple packages in compile unit %s (0x%x); examples: %v",
+						pkg.Name, entry.Offset, pkgNames)
+					break
+				}
+
+				var types []*Type
+				if pkg.Name != "main" {
+					types = b.types.packages[pkg.Name]
+				} else {
+					for _, v := range b.types.packages {
+						types = v
+						break
+					}
+				}
+				if numPkgs == 1 && len(types) == 0 {
+					err = fmt.Errorf(
+						"types from unexpected package in compile unit: 0x%x",
+						entry.Offset)
+					break
+				}
+				for _, t := range types {
+					pkg.Types = append(pkg.Types, *t)
+				}
+				clear(b.types.packages)
+				clear(b.types.types)
+			}
+
+			if !yield(pkg, nil) {
+				break
+			}
+		}
+		if err != nil {
+			yield(Package{}, err)
+		}
+	}
 }
 
 func interestingPackage(pkgName string, mainModule string, firstPartyPkgPrefix string, scopeFilter ExtractScope) bool {
@@ -854,11 +952,22 @@ type typeInfo struct {
 	size int
 }
 
+// ExtractOptions contains knobs controlling what symbols collected from a
+// binary.
+type ExtractOptions struct {
+	Scope ExtractScope
+	// If set, abstract functions and their inlined instances are not explored.
+	// The produced
+	IncludeInlinedFunctions bool
+}
+
 // exploreCompileUnit processes a compile unit entry (entry's tag is
 // TagCompileUnit).
 //
 // Returns a zero value if the compile unit is not a Go package.
-func (b *SymDBBuilder) exploreCompileUnit(entry *dwarf.Entry, reader *dwarf.Reader) (Package, error) {
+func (b *SymDBBuilder) exploreCompileUnit(
+	entry *dwarf.Entry, reader *dwarf.Reader,
+) (Package, error) {
 	if entry.Tag != dwarf.TagCompileUnit {
 		return Package{}, fmt.Errorf("expected TagCompileUnit, got %s", entry.Tag)
 	}
@@ -867,7 +976,7 @@ func (b *SymDBBuilder) exploreCompileUnit(entry *dwarf.Entry, reader *dwarf.Read
 	if !ok {
 		return Package{}, errors.New("compile unit without name")
 	}
-	if !interestingPackage(name, b.mainModule, b.firstPartyPkgPrefix, b.scopeFilter) {
+	if !interestingPackage(name, b.mainModule, b.firstPartyPkgPrefix, b.options.Scope) {
 		reader.SkipChildren()
 		return Package{}, nil
 	}
@@ -891,8 +1000,10 @@ func (b *SymDBBuilder) exploreCompileUnit(entry *dwarf.Entry, reader *dwarf.Read
 	}
 
 	b.currentCompileUnit = entry
+	b.currentCompileUnitName = name
 	defer func() {
 		b.currentCompileUnit = nil
+		b.currentCompileUnitName = ""
 		b.filesInCurrentCompileUnit = nil
 	}()
 
@@ -1126,9 +1237,18 @@ func (b *SymDBBuilder) exploreInlinedInstance(
 	reader *dwarf.Reader,
 	lines map[string]gosym.FunctionLines,
 ) error {
+	earlyExit := func() error {
+		reader.SkipChildren()
+		return nil
+	}
+
 	origin, ok := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset)
 	if !ok {
 		return fmt.Errorf("inlined instance without abstract origin at 0x%x", entry.Offset)
+	}
+
+	if !b.options.IncludeInlinedFunctions {
+		return earlyExit()
 	}
 
 	// Parse the abstract definition eagerly, and cache it.
@@ -1148,8 +1268,7 @@ func (b *SymDBBuilder) exploreInlinedInstance(
 		}
 	}
 	if !af.interesting {
-		reader.SkipChildren()
-		return nil
+		return earlyExit()
 	}
 
 	// Update file and endLine which are not present on abstract definition.
@@ -1368,7 +1487,7 @@ func (b *SymDBBuilder) parseAbstractFunction(reader *dwarf.Reader, offset dwarf.
 	if err != nil {
 		return nil, err
 	}
-	if !recognized || !interestingPackage(funcName.Package, b.mainModule, b.firstPartyPkgPrefix, b.scopeFilter) {
+	if !recognized || !interestingPackage(funcName.Package, b.mainModule, b.firstPartyPkgPrefix, b.options.Scope) {
 		return &abstractFunction{
 			interesting: false,
 		}, nil
@@ -1430,7 +1549,7 @@ func (b *SymDBBuilder) parseAbstractVariable(entry *dwarf.Entry) (Variable, type
 	if !ok {
 		return Variable{}, typeInfo{}, fmt.Errorf("variable without type at 0x%x", entry.Offset)
 	}
-	typ, err := b.types.resolveType(typeOffset)
+	typ, err := b.resolveType(typeOffset)
 	if err != nil {
 		return Variable{}, typeInfo{}, err
 	}

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -33,13 +33,11 @@ func TestSymDB(t *testing.T) {
 			binaryPath, err := testprogs.GetBinary("simple", cfg)
 			require.NoError(t, err)
 			t.Logf("exploring binary: %s", binaryPath)
-			symBuilder, err := symdb.NewSymDBBuilder(binaryPath,
+			symbols, err := symdb.ExtractSymbols(binaryPath,
 				symdb.ExtractOptions{
 					Scope:                   symdb.ExtractScopeAllSymbols,
 					IncludeInlinedFunctions: true,
 				})
-			require.NoError(t, err)
-			symbols, err := symBuilder.ExtractSymbols()
 			require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
 			require.NotEmpty(t, symbols.Packages)
 
@@ -83,12 +81,10 @@ func TestSymDBSnapshot(t *testing.T) {
 							defer sem.Acquire()()
 							binaryPath := testprogs.MustGetBinary(t, prog, cfg)
 							t.Logf("exploring binary: %s", binaryPath)
-							symBuilder, err := symdb.NewSymDBBuilder(binaryPath, symdb.ExtractOptions{
+							symbols, err := symdb.ExtractSymbols(binaryPath, symdb.ExtractOptions{
 								Scope:                   symdb.ExtractScopeMainModuleOnly,
 								IncludeInlinedFunctions: !streaming,
 							})
-							require.NoError(t, err)
-							symbols, err := symBuilder.ExtractSymbols()
 							require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
 							require.NotEmpty(t, symbols.Packages)
 

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -9,6 +9,7 @@ package symdb_test
 
 import (
 	"flag"
+	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"path"
@@ -32,7 +33,11 @@ func TestSymDB(t *testing.T) {
 			binaryPath, err := testprogs.GetBinary("simple", cfg)
 			require.NoError(t, err)
 			t.Logf("exploring binary: %s", binaryPath)
-			symBuilder, err := symdb.NewSymDBBuilder(binaryPath, symdb.ExtractScopeAllSymbols)
+			symBuilder, err := symdb.NewSymDBBuilder(binaryPath,
+				symdb.ExtractOptions{
+					Scope:                   symdb.ExtractScopeAllSymbols,
+					IncludeInlinedFunctions: true,
+				})
 			require.NoError(t, err)
 			symbols, err := symBuilder.ExtractSymbols()
 			require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
@@ -69,37 +74,49 @@ func TestSymDBSnapshot(t *testing.T) {
 	sem := dyninsttest.MakeSemaphore()
 	for _, prog := range progs {
 		t.Run(prog, func(t *testing.T) {
-			t.Parallel()
-			for _, cfg := range cfgs {
-				t.Run(cfg.String(), func(t *testing.T) {
+			for _, streaming := range []bool{false, true} {
+				t.Run(fmt.Sprintf("stream=%t", streaming), func(t *testing.T) {
 					t.Parallel()
-					defer sem.Acquire()()
-					binaryPath := testprogs.MustGetBinary(t, prog, cfg)
-					t.Logf("exploring binary: %s", binaryPath)
-					symBuilder, err := symdb.NewSymDBBuilder(binaryPath, symdb.ExtractScopeMainModuleOnly)
-					require.NoError(t, err)
-					symbols, err := symBuilder.ExtractSymbols()
-					require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
-					require.NotEmpty(t, symbols.Packages)
+					for _, cfg := range cfgs {
+						t.Run(cfg.String(), func(t *testing.T) {
+							t.Parallel()
+							defer sem.Acquire()()
+							binaryPath := testprogs.MustGetBinary(t, prog, cfg)
+							t.Logf("exploring binary: %s", binaryPath)
+							symBuilder, err := symdb.NewSymDBBuilder(binaryPath, symdb.ExtractOptions{
+								Scope:                   symdb.ExtractScopeMainModuleOnly,
+								IncludeInlinedFunctions: !streaming,
+							})
+							require.NoError(t, err)
+							symbols, err := symBuilder.ExtractSymbols()
+							require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
+							require.NotEmpty(t, symbols.Packages)
 
-					var sb strings.Builder
-					symbols.Serialize(symdbutil.MakePanickingWriter(&sb))
-					out := sb.String()
+							var sb strings.Builder
+							symbols.Serialize(symdbutil.MakePanickingWriter(&sb))
+							out := sb.String()
 
-					outputFile := path.Join(snapshotDir, prog+"."+cfg.String()+".out")
-					if *rewrite {
-						tmpFile, err := os.CreateTemp(snapshotDir, ".out")
-						require.NoError(t, err)
-						name := tmpFile.Name()
-						defer func() { _ = os.Remove(name) }()
-						_, err = tmpFile.WriteString(out)
-						require.NoError(t, err)
-						require.NoError(t, tmpFile.Close())
-						require.NoError(t, os.Rename(name, outputFile))
-					} else {
-						expected, err := os.ReadFile(outputFile)
-						require.NoError(t, err)
-						require.Equal(t, string(expected), out)
+							var outputFile string
+							if !streaming {
+								outputFile = path.Join(snapshotDir, prog+"."+cfg.String()+".out")
+							} else {
+								outputFile = path.Join(snapshotDir, prog+".streaming."+cfg.String()+".out")
+							}
+							if *rewrite {
+								tmpFile, err := os.CreateTemp(snapshotDir, ".out")
+								require.NoError(t, err)
+								name := tmpFile.Name()
+								defer func() { _ = os.Remove(name) }()
+								_, err = tmpFile.WriteString(out)
+								require.NoError(t, err)
+								require.NoError(t, tmpFile.Close())
+								require.NoError(t, os.Rename(name, outputFile))
+							} else {
+								expected, err := os.ReadFile(outputFile)
+								require.NoError(t, err)
+								require.Equal(t, string(expected), out)
+							}
+						})
 					}
 				})
 			}

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/busyloop.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,36 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: noop (main.noop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [19:19]
+	Function: busyloop (main.busyloop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [21:56]
+		Arg: concurrency: int (declared at line 21, available: [21-56])
+		Arg: duration: time.Duration (declared at line 21, available: [21-56])
+		Arg: ~r0: float64 (declared at line 21, available: )
+		Var: ready: chan struct {} (declared at line 22, available: [21-56])
+		Var: start: chan struct {} (declared at line 23, available: [21-56])
+		Var: stop: chan struct {} (declared at line 24, available: [21-56])
+		Var: counts: chan int (declared at line 25, available: [21-56])
+		Var: total: int (declared at line 52, available: [21-56])
+		Scope: 22-46
+			Var: i: int (declared at line 26, available: [26-46])
+		Scope: 26-54
+			Var: i: int (declared at line 46, available: [46-54])
+		Scope: 46-56
+			Var: i: int (declared at line 53, available: [53-56])
+	Function: busyloop.func1 (main.busyloop.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [27:44]
+		Var: ready: chan struct {} (declared at line 30, available: [30-31])
+		Var: start: chan struct {} (declared at line 31, available: [27-44])
+		Var: stop: chan struct {} (declared at line 35, available: [27-44])
+		Var: counts: chan int (declared at line 43, available: [27-44])
+		Var: iters: int (declared at line 28, available: [27-44])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/busyloop/main.go [59:96]
+		Var: round_cnt: int (declared at line 65, available: [59-96])
+		Var: round_sec: int (declared at line 69, available: [61-96])
+		Var: concurrency: int (declared at line 73, available: [61-96])
+		Var: stddev: float64 (declared at line 89, available: [90-95])
+		Var: avg: float64 (declared at line 82, available: [83-86], [88-95])
+		Var: err: error (declared at line 65, available: [66-67], [70-71], [74-75], [78-79])
+		Var: results: []float64 (declared at line 81, available: [61-96])
+		Scope: 61-88
+			Var: i: int (declared at line 83, available: [83-86], [88-88])
+		Scope: 90-93
+			Var: i: int (declared at line 90, available: [90-95])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,58 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [26:80]
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-80])
+		Var: mux: *github.com/DataDog/dd-trace-go/contrib/net/http/v2/internal/wrap.ServeMux (declared at line 69, available: [66-80])
+		Var: port: int (declared at line 66, available: [67-67])
+		Var: s: *net/http.Server (declared at line 71, available: [66-80])
+		Var: ctx: context.Context (declared at line 27, available: [26-80])
+		Var: ln: net.Listener (declared at line 60, available: [26-80])
+		Var: err: error (declared at line 60, available: [61-62])
+		Var: .autotmp_38: context.backgroundCtx (declared at line 216, available: [26-80])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-64
+			Var: ddAgentHost: string (declared at line 40, available: [41-64])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+			Var: err: error (declared at line 53, available: [54-55])
+	Function: main.Println.func5 (main.main.Println.func5) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.Printf.func4 (main.main.Printf.func4) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [1003:1008]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 1003, available: [1003-1008])
+		Var: addr: string (declared at line 1006, available: [1003-1008])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [82:91]
+		Arg: w: net/http.ResponseWriter (declared at line 82, available: [82-91])
+		Arg: r: *net/http.Request (declared at line 82, available: [82-91])
+		Var: span: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span (declared at line 83, available: [84-85])
+		Var: &buf: *bytes.Buffer (declared at line 88, available: [82-91])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [82-91])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [94:96]
+		Arg: path: string (declared at line 94, available: [94-95])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [54-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [54-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [54-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [54-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/rc_tester_v1.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,52 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [26:77]
+		Var: mux: *gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http/internal/wrap.ServeMux (declared at line 66, available: [63-77])
+		Var: port: int (declared at line 63, available: [64-64])
+		Var: stop: context.CancelFunc (declared at line 27, available: [28-33])
+		Var: tracerEnabled: bool (declared at line 33, available: [26-77])
+		Var: s: *net/http.Server (declared at line 68, available: [63-77])
+		Var: ctx: context.Context (declared at line 27, available: [26-77])
+		Var: ln: net.Listener (declared at line 57, available: [26-77])
+		Var: err: error (declared at line 57, available: [58-59])
+		Var: .autotmp_35: context.backgroundCtx (declared at line 216, available: [26-77])
+		Var: ~r0.ptr: *uint8 (declared at line 236, available: )
+		Var: ~r0.len: int (declared at line 236, available: )
+		Scope: 40-61
+			Var: ddAgentHost: string (declared at line 40, available: [41-61])
+			Var: ddAgentPort: string (declared at line 44, available: [41-53])
+			Var: opts: []gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.StartOption (declared at line 48, available: [53-53])
+	Function: main.Println.func4 (main.main.Println.func4) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: main.WithAgentAddr.func3 (main.main.WithAgentAddr.func3) in gopkg.in/DataDog/dd-trace-go.v1@v1.73.1/ddtrace/tracer/option.go [1009:1014]
+		Arg: c: *gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.config (declared at line 1009, available: [1009-1014])
+		Var: addr: string (declared at line 1012, available: [1009-1014])
+	Function: main.Println.func2 (main.main.Println.func2) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])
+	Function: HandleHTTP (main.HandleHTTP) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [79:88]
+		Arg: w: net/http.ResponseWriter (declared at line 79, available: [79-88])
+		Arg: r: *net/http.Request (declared at line 79, available: [79-88])
+		Var: &buf: *bytes.Buffer (declared at line 85, available: [79-88])
+		Var: span: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span (declared at line 80, available: [81-82])
+		Var: .autotmp_14: context.backgroundCtx (declared at line 216, available: [79-88])
+	Function: HandleHTTP.Printf.func1 (main.HandleHTTP.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: LookAtTheRequest (main.LookAtTheRequest) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [91:93]
+		Arg: path: string (declared at line 91, available: [91-92])
+	Function: LookAtTheRequest.Printf.func1 (main.LookAtTheRequest.Printf.func1) in log/log.go [397:398]
+		Arg: b: []uint8 (declared at line 397, available: [397-398])
+		Arg: ~r0: []uint8 (declared at line 397, available: )
+		Var: format: string (declared at line 398, available: [398-398])
+		Var: v: []interface {} (declared at line 398, available: [398-398])
+	Function: main.func1 (main.main.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/rc_tester_v1/main.go [29:31]
+	Function: main.func1.Println.1 (main.main.func1.Println.1) in log/log.go [405:406]
+		Arg: b: []uint8 (declared at line 405, available: [405-406])
+		Arg: ~r0: []uint8 (declared at line 405, available: )
+		Var: v: []interface {} (declared at line 406, available: [406-406])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,662 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: current: *main.node (declared at line 141, available: [142-143], [147-147])
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-199], [200-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: )
+		Arg: k: uint8 (declared at line 16, available: )
+		Arg: l: uint8 (declared at line 16, available: )
+		Arg: m: uint8 (declared at line 16, available: )
+		Arg: n: uint8 (declared at line 16, available: )
+		Arg: o: uint8 (declared at line 17, available: )
+		Arg: p: uint8 (declared at line 17, available: )
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.t
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,662 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
+		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
+	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18]
+		Arg: x: [2]int32 (declared at line 18, available: [18-18])
+	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22]
+		Arg: x: [2]string (declared at line 22, available: [22-22])
+	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
+		Arg: x: [2]bool (declared at line 26, available: [26-26])
+	Function: testIntArray (main.testIntArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [30:30]
+		Arg: x: [2]int (declared at line 30, available: [30-30])
+	Function: testInt8Array (main.testInt8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [34:34]
+		Arg: x: [2]int8 (declared at line 34, available: [34-34])
+	Function: testInt16Array (main.testInt16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [38:38]
+		Arg: x: [2]int16 (declared at line 38, available: [38-38])
+	Function: testInt32Array (main.testInt32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [42:42]
+		Arg: x: [2]int32 (declared at line 42, available: [42-42])
+	Function: testInt64Array (main.testInt64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [46:46]
+		Arg: x: [2]int64 (declared at line 46, available: [46-46])
+	Function: testUintArray (main.testUintArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [50:50]
+		Arg: x: [2]uint (declared at line 50, available: [50-50])
+	Function: testUint8Array (main.testUint8Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [54:54]
+		Arg: x: [2]uint8 (declared at line 54, available: [54-54])
+	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58]
+		Arg: x: [2]uint16 (declared at line 58, available: [58-58])
+	Function: testUint32Array (main.testUint32Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [62:62]
+		Arg: x: [2]uint32 (declared at line 62, available: [62-62])
+	Function: testUint64Array (main.testUint64Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [66:66]
+		Arg: x: [2]uint64 (declared at line 66, available: [66-66])
+	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70]
+		Arg: a: [2][2]int (declared at line 70, available: [70-70])
+	Function: testArrayOfStrings (main.testArrayOfStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [74:74]
+		Arg: a: [2]string (declared at line 74, available: [74-74])
+	Function: testArrayOfArraysOfArrays (main.testArrayOfArraysOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [78:78]
+		Arg: b: [2][2][2]int (declared at line 78, available: [78-78])
+	Function: testArrayOfStructs (main.testArrayOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [83:83]
+		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
+	Function: testOverLimitArrayParameters (main.testOverLimitArrayParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [91:91]
+		Arg: a: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: b: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: c: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: d: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: e: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: f: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: g: [3]uint32 (declared at line 88, available: [91-91])
+		Arg: h: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: i: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: j: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: k: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: l: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: m: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: n: [3]uint32 (declared at line 89, available: [91-91])
+		Arg: o: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: p: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: q: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: r: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: s: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: t: [3]uint32 (declared at line 90, available: [91-91])
+		Arg: u: [3]uint32 (declared at line 90, available: [91-91])
+	Function: testVeryLargeArray (main.testVeryLargeArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [95:95]
+		Arg: a: [100]uint (declared at line 95, available: [95-95])
+	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
+	Function: testSingleByte (main.testSingleByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [11:11]
+		Arg: x: uint8 (declared at line 11, available: [11-11])
+	Function: testSingleRune (main.testSingleRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [15:15]
+		Arg: x: int32 (declared at line 15, available: [15-15])
+	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19]
+		Arg: x: bool (declared at line 19, available: [19-19])
+	Function: testSingleInt (main.testSingleInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [23:23]
+		Arg: x: int (declared at line 23, available: [23-23])
+	Function: testSingleInt8 (main.testSingleInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [27:27]
+		Arg: x: int8 (declared at line 27, available: [27-27])
+	Function: testSingleInt16 (main.testSingleInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [31:31]
+		Arg: x: int16 (declared at line 31, available: [31-31])
+	Function: testSingleInt32 (main.testSingleInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [35:35]
+		Arg: x: int32 (declared at line 35, available: [35-35])
+	Function: testSingleInt64 (main.testSingleInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [39:39]
+		Arg: x: int64 (declared at line 39, available: [39-39])
+	Function: testSingleUint (main.testSingleUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [43:43]
+		Arg: x: uint (declared at line 43, available: [43-43])
+	Function: testSingleUint8 (main.testSingleUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [47:47]
+		Arg: x: uint8 (declared at line 47, available: [47-47])
+	Function: testSingleUint16 (main.testSingleUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [51:51]
+		Arg: x: uint16 (declared at line 51, available: [51-51])
+	Function: testSingleUint32 (main.testSingleUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [55:55]
+		Arg: x: uint32 (declared at line 55, available: [55-55])
+	Function: testSingleUint64 (main.testSingleUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [59:59]
+		Arg: x: uint64 (declared at line 59, available: [59-59])
+	Function: testSingleFloat32 (main.testSingleFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [63:63]
+		Arg: x: float32 (declared at line 63, available: [63-63])
+	Function: testSingleFloat64 (main.testSingleFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [67:67]
+		Arg: x: float64 (declared at line 67, available: [67-67])
+	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73]
+		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
+	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
+		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
+		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
+		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
+		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
+		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
+		Arg: a: int (declared at line 93, available: [93-93])
+		Arg: b: error (declared at line 93, available: [93-93])
+		Arg: c: uint (declared at line 93, available: [93-93])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [96:146]
+		Var: s: []*string (declared at line 108, available: )
+		Var: str: string (declared at line 107, available: [96-146])
+		Var: circ: main.circularReferenceType (declared at line 129, available: [96-146])
+	Function: testEsotericStack (main.testEsotericStack) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [42:44]
+		Arg: e: main.esotericStack (declared at line 42, available: [42-43])
+	Function: testEsotericHeap (main.testEsotericHeap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [47:49]
+		Arg: e: *main.esotericHeap (declared at line 47, available: [47-48])
+	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
+		Var: &capture: *int (declared at line 52, available: [51-69])
+		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
+		Var: esotericStack: main.esotericStack (declared at line 53, available: [51-69])
+	Function: executeEsoteric.func1 (main.executeEsoteric.func1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [58:58]
+		Var: &capture: *int (declared at line 58, available: )
+	Function: executeGenericFuncs (main.executeGenericFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/generics.go [19:25]
+		Var: y: main.typeWithGenerics[int] (declared at line 23, available: )
+		Var: x: main.typeWithGenerics[string] (declared at line 20, available: )
+	Function: testInlinedA (main.testInlinedA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [17:19]
+		Arg: x: int (declared at line 17, available: [17-18])
+		Arg: y: int (declared at line 17, available: [17-18])
+	Function: testInlinedB (main.testInlinedB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [21:25]
+		Arg: x: int (declared at line 21, available: [21-25])
+		Arg: y: int (declared at line 21, available: [21-25])
+	Function: forceOutOfLine (main.forceOutOfLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [28:30]
+		Arg: f: func(int) (declared at line 28, available: [28-29])
+	Function: testInlinedBA (main.testInlinedBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [32:35]
+		Arg: x: int (declared at line 32, available: [32-34])
+	Function: testInlinedBB (main.testInlinedBB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [37:42]
+		Arg: x: int (declared at line 37, available: [37-38])
+		Arg: y: int (declared at line 37, available: [37-39])
+		Var: z: int (declared at line 38, available: [37-42])
+	Function: testInlinedBBA (main.testInlinedBBA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [44:46]
+		Arg: x: int (declared at line 44, available: [44-45])
+	Function: testInlinedBC (main.testInlinedBC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [52:60]
+		Var: s: int (declared at line 54, available: [55-58])
+		Scope: 55-58
+			Var: i: int (declared at line 55, available: [55-58])
+	Function: testFrameless (main.testFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [79:80]
+		Arg: x: int (declared at line 79, available: [79-80])
+		Arg: ~r0: int (declared at line 79, available: )
+	Function: testFramelessArray (main.testFramelessArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [92:93]
+		Arg: a: [5]int (declared at line 92, available: [92-93])
+		Arg: ~r0: int (declared at line 92, available: )
+	Function: executeInlined (main.executeInlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [97:106]
+		Var: x: int (declared at line 99, available: )
+		Var: y: int (declared at line 100, available: [97-106])
+		Var: a: [5]int (declared at line 98, available: [97-106])
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
+		Arg: b: main.behavior (declared at line 48, available: [48-51])
+		Arg: ~r0: string (declared at line 48, available: )
+		Var: hash: string (declared at line 51, available: [48-55])
+		Var: inter: string (declared at line 52, available: [48-55])
+		Var: iType: string (declared at line 53, available: [48-55])
+		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
+		Arg: e: error (declared at line 60, available: [60-60])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
+		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
+	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.3.0-dev/ddtrace/tracer/option.go [986:989]
+		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
+		Var: name: string (declared at line 987, available: [987-989])
+	Function: testStructWithMap (main.testStructWithMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [18:18]
+		Arg: s: main.structWithMap (declared at line 18, available: [18-18])
+	Function: testMapStringToStruct (main.testMapStringToStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [22:22]
+		Arg: m: map[string]main.nestedStruct (declared at line 22, available: [22-22])
+	Function: testMapStringToInt (main.testMapStringToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [26:26]
+		Arg: m: map[string]int (declared at line 26, available: [26-26])
+	Function: testMapStringToSlice (main.testMapStringToSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [30:30]
+		Arg: m: map[string][]string (declared at line 30, available: [30-30])
+	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
+		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
+	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38]
+		Arg: m: map[string]int (declared at line 38, available: [38-38])
+	Function: testArrayOfMaps (main.testArrayOfMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [42:42]
+		Arg: m: [2]map[string]int (declared at line 42, available: [42-42])
+	Function: testPointerToMap (main.testPointerToMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [46:46]
+		Arg: m: *map[string]int (declared at line 46, available: [46-46])
+	Function: testMapIntToInt (main.testMapIntToInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [50:50]
+		Arg: m: map[int]int (declared at line 50, available: [50-50])
+	Function: testMapMassive (main.testMapMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [54:54]
+		Arg: redactMyEntries: map[string][]main.structWithMap (declared at line 54, available: [54-54])
+	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58]
+		Arg: m: map[string][]main.structWithMap (declared at line 58, available: [58-58])
+	Function: testMapWithLinkedList (main.testMapWithLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [62:62]
+		Arg: m: map[bool]main.node (declared at line 62, available: [62-62])
+	Function: testMapWithSmallValue (main.testMapWithSmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [66:66]
+		Arg: m: map[int]uint8 (declared at line 66, available: [66-66])
+	Function: testMapWithSmallValueMassive (main.testMapWithSmallValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [70:70]
+		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
+	Function: testMapWithSmallKeyAndValue (main.testMapWithSmallKeyAndValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [74:74]
+		Arg: m: map[uint8]uint8 (declared at line 74, available: [74-74])
+	Function: testMapWithSmallKeyAndValueMassive (main.testMapWithSmallKeyAndValueMassive) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [78:78]
+		Arg: m: map[uint8]uint8 (declared at line 78, available: [78-78])
+	Function: testMapSmallKeySmallValue (main.testMapSmallKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [82:82]
+		Arg: m: map[uint8]uint8 (declared at line 82, available: [82-82])
+	Function: testMapSmallKeyLargeValue (main.testMapSmallKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [86:86]
+		Arg: m: map[uint8][4]int (declared at line 86, available: [86-86])
+	Function: testMapLargeKeySmallValue (main.testMapLargeKeySmallValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [90:90]
+		Arg: m: map[[4]int]uint8 (declared at line 90, available: [90-90])
+	Function: testMapLargeKeyLargeValue (main.testMapLargeKeyLargeValue) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [94:94]
+		Arg: m: map[[4]int][4]int (declared at line 94, available: [94-94])
+	Function: generateEmbeddedMaps (main.generateEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [97:107]
+		Arg: entriesCount: int (declared at line 97, available: [97-107])
+		Arg: ~r0: map[string][]main.structWithMap (declared at line 97, available: )
+		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
+		Scope: 97-107
+			Var: i: int (declared at line 99, available: [97-107])
+	Function: executeMapFuncs (main.executeMapFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [111:204]
+		Var: m: map[string]int (declared at line 114, available: [111-204])
+		Var: j: map[string]int (declared at line 115, available: [111-204])
+		Var: current: *main.node (declared at line 141, available: [142-142], [143-143], [147-147])
+		Scope: 127-130
+			Var: v: int (declared at line 127, available: [127-127], [128-128])
+			Var: k: string (declared at line 127, available: [128-128])
+		Scope: 142-147
+			Var: i: int (declared at line 142, available: [142-143], [147-147])
+		Scope: 162-165
+			Var: i: int (declared at line 162, available: [162-162], [163-163])
+		Scope: 165-168
+			Var: i: int (declared at line 165, available: [165-165], [166-166], [168-168])
+		Scope: 173-176
+			Var: i: int (declared at line 173, available: [173-173], [174-174])
+		Scope: 176-179
+			Var: i: int (declared at line 176, available: [176-176], [177-177], [179-179])
+		Scope: 184-187
+			Var: i: int (declared at line 184, available: [184-184], [185-185], [187-187])
+		Scope: 190-195
+			Var: i: int (declared at line 190, available: [190-190], [191-193], [195-195])
+		Scope: 198-202
+			Var: i: int (declared at line 198, available: [198-198], [199-200], [202-202])
+	Function: testOverLimitParameters (main.testOverLimitParameters) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [18:18]
+		Arg: a: uint8 (declared at line 15, available: [18-18])
+		Arg: b: uint8 (declared at line 15, available: [18-18])
+		Arg: c: uint8 (declared at line 15, available: [18-18])
+		Arg: d: uint8 (declared at line 15, available: [18-18])
+		Arg: e: uint8 (declared at line 15, available: [18-18])
+		Arg: f: uint8 (declared at line 15, available: [18-18])
+		Arg: g: uint8 (declared at line 15, available: [18-18])
+		Arg: h: uint8 (declared at line 16, available: [18-18])
+		Arg: i: uint8 (declared at line 16, available: [18-18])
+		Arg: j: uint8 (declared at line 16, available: [18-18])
+		Arg: k: uint8 (declared at line 16, available: [18-18])
+		Arg: l: uint8 (declared at line 16, available: [18-18])
+		Arg: m: uint8 (declared at line 16, available: [18-18])
+		Arg: n: uint8 (declared at line 16, available: [18-18])
+		Arg: o: uint8 (declared at line 17, available: [18-18])
+		Arg: p: uint8 (declared at line 17, available: [18-18])
+		Arg: q: uint8 (declared at line 17, available: )
+		Arg: r: uint8 (declared at line 17, available: )
+		Arg: s: uint8 (declared at line 17, available: )
+		Arg: t: uint8 (declared at line 17, available: )
+		Arg: u: uint8 (declared at line 17, available: )
+	Function: testCombinedByte (main.testCombinedByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [22:22]
+		Arg: w: uint8 (declared at line 22, available: [22-22])
+		Arg: x: uint8 (declared at line 22, available: [22-22])
+		Arg: y: float32 (declared at line 22, available: [22-22])
+	Function: testCombinedRune (main.testCombinedRune) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [26:26]
+		Arg: w: uint8 (declared at line 26, available: [26-26])
+		Arg: x: int32 (declared at line 26, available: [26-26])
+		Arg: y: float32 (declared at line 26, available: [26-26])
+	Function: testCombinedString (main.testCombinedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [30:30]
+		Arg: w: uint8 (declared at line 30, available: [30-30])
+		Arg: x: string (declared at line 30, available: [30-30])
+		Arg: y: float32 (declared at line 30, available: [30-30])
+	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
+		Arg: w: uint8 (declared at line 34, available: [34-34])
+		Arg: x: bool (declared at line 34, available: [34-34])
+		Arg: y: float32 (declared at line 34, available: [34-34])
+	Function: testCombinedInt (main.testCombinedInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [38:38]
+		Arg: w: uint8 (declared at line 38, available: [38-38])
+		Arg: x: int (declared at line 38, available: [38-38])
+		Arg: y: float32 (declared at line 38, available: [38-38])
+	Function: testCombinedInt8 (main.testCombinedInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [42:42]
+		Arg: w: uint8 (declared at line 42, available: [42-42])
+		Arg: x: int8 (declared at line 42, available: [42-42])
+		Arg: y: float32 (declared at line 42, available: [42-42])
+	Function: testCombinedInt16 (main.testCombinedInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [46:46]
+		Arg: w: uint8 (declared at line 46, available: [46-46])
+		Arg: x: int16 (declared at line 46, available: [46-46])
+		Arg: y: float32 (declared at line 46, available: [46-46])
+	Function: testCombinedInt32 (main.testCombinedInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [50:50]
+		Arg: w: uint8 (declared at line 50, available: [50-50])
+		Arg: x: int32 (declared at line 50, available: [50-50])
+		Arg: y: float32 (declared at line 50, available: [50-50])
+	Function: testCombinedInt64 (main.testCombinedInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [54:54]
+		Arg: w: uint8 (declared at line 54, available: [54-54])
+		Arg: x: int64 (declared at line 54, available: [54-54])
+		Arg: y: float32 (declared at line 54, available: [54-54])
+	Function: testCombinedUint (main.testCombinedUint) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [58:58]
+		Arg: w: uint8 (declared at line 58, available: [58-58])
+		Arg: x: uint (declared at line 58, available: [58-58])
+		Arg: y: float32 (declared at line 58, available: [58-58])
+	Function: testCombinedUint8 (main.testCombinedUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [62:62]
+		Arg: w: uint8 (declared at line 62, available: [62-62])
+		Arg: x: uint8 (declared at line 62, available: [62-62])
+		Arg: y: float32 (declared at line 62, available: [62-62])
+	Function: testCombinedUint16 (main.testCombinedUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [66:66]
+		Arg: w: uint8 (declared at line 66, available: [66-66])
+		Arg: x: uint16 (declared at line 66, available: [66-66])
+		Arg: y: float32 (declared at line 66, available: [66-66])
+	Function: testCombinedUint32 (main.testCombinedUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [70:70]
+		Arg: w: uint8 (declared at line 70, available: [70-70])
+		Arg: x: uint32 (declared at line 70, available: [70-70])
+		Arg: y: float32 (declared at line 70, available: [70-70])
+	Function: testCombinedUint64 (main.testCombinedUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [74:74]
+		Arg: w: uint8 (declared at line 74, available: [74-74])
+		Arg: x: uint64 (declared at line 74, available: [74-74])
+		Arg: y: float32 (declared at line 74, available: [74-74])
+	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78]
+		Arg: a: bool (declared at line 78, available: [78-78])
+		Arg: b: uint8 (declared at line 78, available: [78-78])
+		Arg: c: int32 (declared at line 78, available: [78-78])
+		Arg: d: uint (declared at line 78, available: [78-78])
+		Arg: e: string (declared at line 78, available: [78-78])
+	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118]
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
+		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34]
+		Arg: ~r0: uint64 (declared at line 28, available: )
+		Var: n: uint64 (declared at line 33, available: [32-34])
+		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44]
+		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: testPointerToSimpleStruct (main.testPointerToSimpleStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [38:38]
+		Arg: a: *main.structWithTwoValues (declared at line 38, available: [38-38])
+	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
+		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testPointerLoop (main.testPointerLoop) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [51:51]
+		Arg: a: *main.node (declared at line 51, available: [51-51])
+	Function: testUnsafePointer (main.testUnsafePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [55:55]
+		Arg: x: unsafe.Pointer (declared at line 55, available: [55-55])
+	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
+		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testUintPointer (main.testUintPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [63:63]
+		Arg: x: *uint (declared at line 63, available: [63-63])
+	Function: testStructPointer (main.testStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [67:67]
+		Arg: x: *main.nStruct (declared at line 67, available: [67-67])
+	Function: testNilStructPointer (main.testNilStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [71:71]
+		Arg: z: uint (declared at line 71, available: [71-71])
+		Arg: x: *main.nStruct (declared at line 71, available: [71-71])
+		Arg: a: int (declared at line 71, available: [71-71])
+	Function: testComplexType (main.testComplexType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [75:75]
+		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
+	Function: testStructWithPointer (main.testStructWithPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [79:79]
+		Arg: x: main.structWithPointer (declared at line 79, available: [79-79])
+	Function: testStructWithStructPointer (main.testStructWithStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [83:83]
+		Arg: b: main.swsp (declared at line 83, available: [83-83])
+	Function: testStructWithStringPointer (main.testStructWithStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [87:87]
+		Arg: z: main.spws (declared at line 87, available: [87-87])
+	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91]
+		Arg: z: *string (declared at line 91, available: [91-91])
+	Function: testStringSlicePointer (main.testStringSlicePointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [95:95]
+		Arg: a: *[]string (declared at line 95, available: [95-95])
+	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99]
+		Arg: z: *bool (declared at line 99, available: [99-99])
+		Arg: a: uint (declared at line 99, available: [99-99])
+	Function: testPointerToPointer (main.testPointerToPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [103:103]
+		Arg: u: **int (declared at line 103, available: [103-103])
+	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
+		Arg: t: *main.t (declared at line 109, available: [109-109])
+	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178]
+		Var: self: *main.node (declared at line 172, available: [173-177])
+		Var: z: main.spws (declared at line 118, available: )
+		Var: r: string (declared at line 117, available: [112-178])
+		Var: ssaw: main.swsp (declared at line 126, available: [112-178])
+		Var: rct: main.reallyComplexType (declared at line 137, available: [112-178])
+		Var: b: main.node (declared at line 145, available: [112-178])
+		Var: stringSlice: []string (declared at line 162, available: [112-178])
+		Var: up: *int (declared at line 168, available: [112-178])
+		Var: aruint: [2]uint (declared at line 159, available: )
+		Var: n: main.nStruct (declared at line 123, available: )
+		Var: u: int (declared at line 167, available: )
+		Var: u64F: uint64 (declared at line 113, available: )
+		Var: uintToPointTo: uint (declared at line 120, available: )
+		Var: x: main.structWithTwoValues (declared at line 134, available: )
+	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12]
+		Arg: x: []int (declared at line 12, available: [12-12])
+	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17]
+		Arg: x: []int (declared at line 16, available: [16-17])
+		Arg: ~r0: string (declared at line 16, available: )
+	Function: expandSlice (main.expandSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [22:25]
+		Arg: x: []int (declared at line 22, available: [22-25])
+	Function: testUintSlice (main.testUintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [29:29]
+		Arg: u: []uint (declared at line 29, available: [29-29])
+	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
+		Arg: u: []uint (declared at line 33, available: [33-33])
+	Function: testSliceOfSlices (main.testSliceOfSlices) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [37:37]
+		Arg: u: [][]uint (declared at line 37, available: [37-37])
+	Function: testStructSlice (main.testStructSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [41:41]
+		Arg: xs: []main.structWithNoStrings (declared at line 41, available: [41-41])
+		Arg: a: int (declared at line 41, available: [41-41])
+	Function: testEmptySliceOfStructs (main.testEmptySliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [45:45]
+		Arg: xs: []main.structWithNoStrings (declared at line 45, available: [45-45])
+		Arg: a: int (declared at line 45, available: [45-45])
+	Function: testNilSliceOfStructs (main.testNilSliceOfStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [49:49]
+		Arg: xs: []main.structWithNoStrings (declared at line 49, available: [49-49])
+		Arg: a: int (declared at line 49, available: [49-49])
+	Function: testStringSlice (main.testStringSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [53:53]
+		Arg: s: []string (declared at line 53, available: [53-53])
+	Function: testNilSliceWithOtherParams (main.testNilSliceWithOtherParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [57:57]
+		Arg: a: int8 (declared at line 57, available: [57-57])
+		Arg: s: []bool (declared at line 57, available: [57-57])
+		Arg: x: uint (declared at line 57, available: [57-57])
+	Function: testNilSlice (main.testNilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [61:61]
+		Arg: xs: []uint16 (declared at line 61, available: [61-61])
+	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65]
+		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [68:92]
+		Var: originalSlice: []int (declared at line 69, available: )
+		Var: s: []uint (declared at line 78, available: )
+		Scope: 79-82
+			Var: i: int (declared at line 79, available: [82-82])
+	Function: stackA (main.stackA) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [12:14]
+	Function: stackB (main.stackB) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [18:20]
+	Function: stackC (main.stackC) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/stacktraces.go [24:25]
+		Arg: ~r0: string (declared at line 24, available: )
+	Function: testSingleString (main.testSingleString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [12:12]
+		Arg: x: string (declared at line 12, available: [12-12])
+	Function: testThreeStrings (main.testThreeStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [16:16]
+		Arg: x: string (declared at line 16, available: [16-16])
+		Arg: y: string (declared at line 16, available: [16-16])
+		Arg: z: string (declared at line 16, available: [16-16])
+	Function: testThreeStringsInStruct (main.testThreeStringsInStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [30:30]
+		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
+	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34]
+		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
+	Function: testOneStringInStructPointer (main.testOneStringInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [38:38]
+		Arg: a: *main.oneStringStruct (declared at line 38, available: [38-38])
+	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
+		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testUnitializedString (main.testUnitializedString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [46:46]
+		Arg: x: string (declared at line 46, available: [46-46])
+	Function: testEmptyString (main.testEmptyString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [50:50]
+		Arg: x: string (declared at line 50, available: [50-50])
+	Function: executeStringFuncs (main.executeStringFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [53:64]
+		Var: uninitializedString: string (declared at line 61, available: )
+	Function: testStructWithUnsupportedFields (main.testStructWithUnsupportedFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [20:20]
+		Arg: a: main.hasUnsupportedFields (declared at line 20, available: [20-20])
+	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [32:32]
+		Arg: a: main.structWithAnArray (declared at line 32, available: [32-32])
+	Function: testStructWithASlice (main.testStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [36:36]
+		Arg: s: main.structWithASlice (declared at line 36, available: [36-36])
+	Function: testStructWithAnEmptySlice (main.testStructWithAnEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [40:40]
+		Arg: s: main.structWithASlice (declared at line 40, available: [40-40])
+	Function: testStructWithANilSlice (main.testStructWithANilSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44]
+		Arg: s: main.structWithASlice (declared at line 44, available: [44-44])
+	Function: testPointerToStructWithASlice (main.testPointerToStructWithASlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [48:48]
+		Arg: s: *main.structWithASlice (declared at line 48, available: [48-48])
+	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [52:52]
+		Arg: s: *main.structWithAString (declared at line 52, available: [52-52])
+	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [56:56]
+		Arg: x: main.aStruct (declared at line 56, available: [56-56])
+	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60]
+		Arg: s: main.structWithTwoArrays (declared at line 60, available: [60-60])
+	Function: testNonembeddedStruct (main.testNonembeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [64:64]
+		Arg: x: main.nStruct (declared at line 64, available: [64-64])
+	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [68:68]
+		Arg: b: main.bStruct (declared at line 68, available: [68-68])
+	Function: testNoStringStruct (main.testNoStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [72:72]
+		Arg: c: main.cStruct (declared at line 72, available: [72-72])
+	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [76:76]
+		Arg: w: uint8 (declared at line 76, available: [76-76])
+		Arg: x: main.aStruct (declared at line 76, available: [76-76])
+	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80]
+		Arg: x: *main.anotherStruct (declared at line 80, available: [80-80])
+	Function: testTenStrings (main.testTenStrings) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
+		Arg: x: main.tenStrings (declared at line 84, available: [84-84])
+	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88]
+		Arg: t: main.threestrings (declared at line 88, available: [88-88])
+	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [92:92]
+		Arg: t: main.deepStruct1 (declared at line 92, available: [92-92])
+	Function: testEmptyStruct (main.testEmptyStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
+		Arg: e: main.emptyStruct (declared at line 96, available: )
+	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [100:100]
+		Arg: l: main.lotsOfFields (declared at line 100, available: [100-100])
+	Function: executeStructFuncs (main.executeStructFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [103:182]
+		Var: n: main.nStruct (declared at line 107, available: )
+		Var: ns: main.structWithNoStrings (declared at line 116, available: )
+		Var: cs: main.cStruct (declared at line 117, available: )
+		Var: rcvr: main.receiver (declared at line 164, available: )
+		Var: ts: main.threestrings (declared at line 104, available: [103-182])
+		Var: s: main.aStruct (declared at line 110, available: [103-182])
+		Var: b: main.bStruct (declared at line 113, available: [103-182])
+		Var: tenStr: main.tenStrings (declared at line 130, available: [103-182])
+		Var: deep: main.deepStruct1 (declared at line 144, available: [103-182])
+		Var: fields: main.lotsOfFields (declared at line 161, available: [103-182])
+		Var: sta: main.structWithTwoArrays (declared at line 170, available: [103-182])
+		Var: .autotmp_13: [0]uint8 (declared at line 125, available: [103-182])
+		Var: .autotmp_33: main.emptyStruct (declared at line 158, available: [103-182])
+	Type: main.typeAlias
+	Type: main.interfaceComplexityA
+		Field: b: int
+		Field: c: main.interfaceComplexityB
+	Type: main.tierA
+		Field: a: int
+		Field: b: main.tierB
+	Type: main.outer
+		Field: A: *main.middle
+	Type: main.bigStruct
+		Field: x: []*string
+		Field: z: int
+		Field: writer: io.Writer
+	Type: main.circularReferenceType
+		Field: t: *main.circularReferenceType
+	Type: main.somethingImpl
+		Function: Do (main.(*somethingImpl).Do) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [21:21]
+			Arg: s: *main.somethingImpl (declared at line 21, available: [21-21])
+	Type: main.esotericStack
+		Field: _: int32
+		Field: _valid: int32
+		Field: c: chan struct {}
+		Field: val: interface {}
+		Field: _: uint64
+		Field: work: main.something
+		Field: foo: func()
+	Type: main.esotericHeap
+		Field: esotericStack: main.esotericStack
+		Field: mu: sync.Mutex
+		Field: once: sync.Once
+		Field: wg: sync.WaitGroup
+		Field: a: sync/atomic.Int32
+	Type: main.behavior
+	Type: main.structWithMap
+		Field: m: map[int]int
+	Type: main.node
+		Field: val: int
+		Field: b: *main.node
+	Type: main.triggerVerifierErrorForTesting
+	Type: main.structWithTwoValues
+		Field: a: uint
+		Field: b: bool
+	Type: main.nStruct
+		Field: aBool: bool
+		Field: aInt: int
+		Field: aInt16: int16
+	Type: main.reallyComplexType
+		Field: pointerToStructWithAPointerToAStruct: *main.swsp
+		Field: anArray: [1]main.nStruct
+		Field: aString: string
+		Field: aStringPtr: *string
+	Type: main.structWithPointer
+		Field: a: *uint64
+	Type: main.swsp
+		Field: a: int
+		Field: b: *main.nStruct
+	Type: main.spws
+		Field: a: int
+		Field: x: *string
+	Type: main.t
+	Type: main.threeStringStruct
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.oneStringStruct
+		Field: a: string
+	Type: main.hasUnsupportedFields
+		Field: b: int
+		Field: c: float32
+		Field: d: []uint8
+	Type: main.receiver
+		Field: u: uint
+		Function: testPointerMethodReceiver (main.(*receiver).testPointerMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [24:24]
+			Arg: r: *main.receiver (declared at line 24, available: [24-24])
+			Arg: a: int (declared at line 24, available: [24-24])
+		Function: testMethodReceiver (main.receiver.testMethodReceiver) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [28:28]
+			Arg: r: main.receiver (declared at line 28, available: [28-28])
+			Arg: a: int (declared at line 28, available: [28-28])
+	Type: main.structWithAnArray
+		Field: arr: [5]uint8
+	Type: main.structWithASlice
+		Field: x: int
+		Field: slice: []uint8
+		Field: z: uint64
+	Type: main.structWithAString
+		Field: x: int
+		Field: s: string
+	Type: main.aStruct
+		Field: aBool: bool
+		Field: aString: string
+		Field: aNumber: int
+		Field: nested: main.nestedStruct
+	Type: main.structWithTwoArrays
+		Field: a: [3]uint64
+		Field: b: uint8
+		Field: c: [5]int64
+	Type: main.bStruct
+		Field: aInt16: int16
+		Field: nested: main.aStruct
+		Field: aBool: bool
+		Field: aInt32: int32
+	Type: main.cStruct
+		Field: aInt32: int32
+		Field: aUint: uint
+		Field: nested: main.structWithNoStrings
+	Type: main.anotherStruct
+		Field: nested: *main.nestedStruct
+	Type: main.tenStrings
+		Field: first: string
+		Field: second: string
+		Field: third: string
+		Field: fourth: string
+		Field: fifth: string
+		Field: sixth: string
+		Field: seventh: string
+		Field: eighth: string
+		Field: ninth: string
+		Field: tenth: string
+	Type: main.threestrings
+		Field: a: string
+		Field: b: string
+		Field: c: string
+	Type: main.deepStruct1
+		Field: a: int
+		Field: b: main.deepStruct2
+	Type: main.emptyStruct
+	Type: main.lotsOfFields
+		Field: a: uint8
+		Field: b: uint8
+		Field: c: uint8
+		Field: d: uint8
+		Field: e: uint8
+		Field: f: uint8
+		Field: g: uint8
+		Field: h: uint8
+		Field: i: uint8
+		Field: j: uint8
+		Field: k: uint8
+		Field: l: uint8
+		Field: m: uint8
+		Field: n: uint8
+		Field: o: uint8
+		Field: p: uint8
+		Field: q: uint8
+		Field: r: uint8
+		Field: s: uint8
+		Field: t: uint8
+		Field: u: uint8
+		Field: v: uint8
+		Field: w: uint8
+		Field: x: uint8
+		Field: y: uint8
+		Field: z: uint8
+	Type: main.structWithNoStrings
+		Field: aUint8: uint8
+		Field: aBool: bool
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
+Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
+	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,0 +1,30 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,0 +1,30 @@
+Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
+Package: main
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:39]
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &val: *int (declared at line 31, available: [14-39])
+		Var: &ptr1: **int (declared at line 32, available: [14-39])
+		Var: &ptr2: ***int (declared at line 33, available: [14-39])
+		Var: &ptr3: ****int (declared at line 34, available: [14-39])
+		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: err: error (declared at line 15, available: [16-17])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [42:44]
+		Arg: x: int (declared at line 42, available: [42-43])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [47:49]
+		Arg: s: string (declared at line 47, available: [47-48])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [52:54]
+		Arg: s: []int (declared at line 52, available: [52-53])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [57:59]
+		Arg: s: [3]int (declared at line 57, available: [57-59])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [62:64]
+		Arg: s: []string (declared at line 62, available: [62-63])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [67:69]
+		Arg: s: [3]string (declared at line 67, available: [67-69])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [73:73]
+		Arg: s: [3]string (declared at line 72, available: [73-73])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [80:82]
+		Arg: f: func(int) (declared at line 80, available: [80-81])
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [85:87]
+		Arg: m: map[string]int (declared at line 85, available: [85-86])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [102:108]
+		Arg: m: map[string]main.bigStruct (declared at line 102, available: [102-108])


### PR DESCRIPTION
Introduce an iterator over a binary's packages so that the symbols can
be streamed out without accumulating them all in memory. For now this
implies configuring the extraction process to ignore abstract functions
and inlined instances, since they can appear in compile units
corresponding to other packages.

Even when using this streaming API, there is still a types cache that
accumulates types across packages (populated when resolving variables).
We'll see if that's a problem for memory use.