### PR TITLE
Don't explicitly download dependencies before Agent builds on windows

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -139,12 +139,6 @@ function Install-Deps() {
         Write-Error "Failed to install python requirements"
         exit 1
     }
-    Write-Host "Installing go dependencies"
-    dda inv -- -e deps
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to install dependencies"
-        exit 1
-    }
 }
 
 function Install-TestingDeps() {

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -139,6 +139,10 @@ function Install-Deps() {
         Write-Error "Failed to install python requirements"
         exit 1
     }
+    # Note on Go dependencies
+    # CI: downloaded in the CI via the modcache archive, see Expand-ModCache
+    # Locally: go automatically downloads deps when running go build/test.
+    #          if you want to pre-download everything, see `dda inv deps`
 }
 
 function Install-TestingDeps() {

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -300,8 +300,6 @@ function Invoke-BuildScript {
         Enable-DevEnv
 
         # Expand modcache
-        # TODO: Can these be moved inside the Install-Deps/Install-TestingDeps functions,
-        #       or is it important that they both be run before `dda inv deps` ?
         if ($InstallDeps) {
             Expand-ModCache -modcache modcache
         }


### PR DESCRIPTION
### What does this PR do?

It stops running `inv deps` before all Windows builds.

### Motivation

I noticed that a step [running go mod download and go mod tidy](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1062985858#L328) was taking a significant chunk of windows build times and that this doesn't appear in the linux build logs. Looking at [logs](https://app.datadoghq.com/logs?query=%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20service%3Agitlab-ci%20%22go%20mod%20download%20%26%26%20go%20mod%20tidy%20completed%20in%22%20%40ci.job.name%3Awindows_msi%2Aa7&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1753721646485&to_ts=1754326446485&live=true), it seems like this step alone takes 6-10 minutes of the build.

As expounded in more detail further below, this step is with high certainty unnecessary.

### Describe how you validated your changes

Green build, reduced build times, and no increase in time in `go build` commands (which may indicate that this is causing extra downloads to happen during build).

### Possible Drawbacks / Trade-offs

### Additional Notes

All build jobs depend on the [go_deps](https://github.com/DataDog/datadog-agent/blob/ad56cc27c43adb7f2a5d6d0952149cd80fed349b/.gitlab/deps_fetch/deps_fetch.yml#L35) job, which prefetches go modules needed in the Agent repo (with `inv deps`) into an artifact that build jobs can use to reduce redundant fetching of go dependencies.

Windows build jobs [depend](https://github.com/DataDog/datadog-agent/blob/ad56cc27c43adb7f2a5d6d0952149cd80fed349b/.gitlab/package_build/windows.yml#L5) on that go_deps job, and the archive is [extracted](https://github.com/DataDog/datadog-agent/blob/ad56cc27c43adb7f2a5d6d0952149cd80fed349b/tasks/winbuildscripts/common.ps1#L104) before the actual build runs. Therefore, these jobs should already be getting the result of `inv deps` via this artifact, making a new call to `inv deps` redundant — and in this case, quite costly.

Note that Linux omnibus build jobs don't explicitly call `inv deps` either, and that `inv omnibus.build` actually has [a place](https://github.com/DataDog/datadog-agent/blob/70658cb6dab750a857c00c55a91f8a90667bb9bd/tasks/omnibus.py#L209-L211) where `inv deps` would be called (which is inhibited via `--skip-deps`), making it even more clear that this shouldn't be necessary.

For more references based on what `go mod download` and `go mod tidy` do and why it should normally not make sense to run them (at least not `go mod download`) explicitly before the build:

https://go.dev/ref/mod#go-mod-download

> The go command will automatically download modules as needed during ordinary execution. The go mod download command is useful mainly for pre-filling the module cache or for loading data to be served by a [module proxy](https://go.dev/ref/mod#glos-module-proxy).

So for `go mod download`, it looks pretty clear that it makes no sense to run explicitly before `go build`, and only makes sense when pre-filling the cache (which is what we do in `go_deps`).

https://go.dev/ref/mod#go-mod-tidy

Whatever `go mod tidy` does that may involve downloading modules (as described in https://github.com/DataDog/datadog-agent/pull/29487) is not explicitly documented. But at any rate, there's:

> go mod tidy acts as if all build tags are enabled, so it will consider platform-specific source files and files that require custom build tags, even if those source files wouldn’t normally be built.

Which would mean that if we can skip this on linux builds we should be able to drop them for windows too.