### PR TITLE
Revert "[AMCC-85] dogstatsd: emit a signal on control reconfiguration."

### DIFF
--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -90,8 +90,6 @@ func (s *server) onBlocklistUpdateCallback(updates map[string]state.RawConfig, a
 		s.config.Set("statsd_metric_blocklist_match_prefix", false, model.SourceRC)
 
 		// apply this new blocklist to all the running workers
-		s.tlmFilterListUpdates.Inc()
-		s.tlmFilterListSize.Set(float64(len(metricNames)))
 		s.SetBlocklist(metricNames, false)
 
 	} else {

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -177,8 +177,6 @@ type server struct {
 	tlmProcessedOk          telemetry.SimpleCounter
 	tlmProcessedError       telemetry.SimpleCounter
 	tlmChannel              telemetry.Histogram
-	tlmFilterListUpdates    telemetry.SimpleCounter
-	tlmFilterListSize       telemetry.SimpleGauge
 	listernersTelemetry     *listeners.TelemetryStore
 	packetsTelemetry        *packets.TelemetryStore
 	stringInternerTelemetry *stringInternerTelemetry
@@ -333,12 +331,6 @@ func newServerCompat(cfg model.ReaderWriter, log log.Component, hostname hostnam
 		[]string{"shard", "message_type"},
 		"Time in nanosecond to push metrics to the aggregator input buffer",
 		buckets)
-	s.tlmFilterListUpdates = telemetrycomp.NewSimpleCounter("dogstatsd", "filterlist_updates",
-		"Incremented when a reconfiguration of the filterlist happened",
-	)
-	s.tlmFilterListSize = telemetrycomp.NewSimpleGauge("dogstatsd", "filterlist_size",
-		"Filter list size",
-	)
 
 	s.listernersTelemetry = listeners.NewTelemetryStore(getBuckets(cfg, log, "telemetry.dogstatsd.listeners_latency_buckets"), telemetrycomp)
 	s.packetsTelemetry = packets.NewTelemetryStore(getBuckets(cfg, log, "telemetry.dogstatsd.listeners_channel_latency_buckets"), telemetrycomp)
@@ -614,9 +606,6 @@ func (s *server) handleMessages() {
 
 func (s *server) restoreBlocklistFromLocalConfig() {
 	s.log.Debug("Restoring blocklist with local config.")
-
-	s.tlmFilterListUpdates.Inc()
-	s.tlmFilterListSize.Set(float64(len(s.localBlocklistConfig.metricNames)))
 
 	s.SetBlocklist(
 		s.localBlocklistConfig.metricNames,


### PR DESCRIPTION
Reverts DataDog/datadog-agent#39413

Attempting a revert since this PR violated the gates when it landed on main.