### PR TITLE
[SINT-3833] dd-octo-sts: onboard 4 workflows

### DIFF
--- a/.github/workflows/code_review_complexity.yml
+++ b/.github/workflows/code_review_complexity.yml
@@ -10,12 +10,11 @@ on:
   pull_request_review_comment:
     types: [created, deleted]
 
-permissions: {}
 jobs:
   codereview-complexity:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      id-token: write # This is required for getting the required OIDC token from GitHub
     if: github.event.pull_request.head.repo.full_name == github.repository # Run only on non-fork PRs
     steps:
       - name: Checkout repository
@@ -26,8 +25,13 @@ jobs:
         uses: ./.github/actions/install-dda
         with:
           features: legacy-tasks
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.code-review-complexity.modify-pr
       - name: Check code review complexity
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: dda inv -- -e github.assign-codereview-label --pr-id="$PR_NUMBER"

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -9,18 +9,30 @@ on:
       - "[0-9]+.[0-9]+.x"
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPO: ${{ github.repository }}
 
-permissions: {}
-
 jobs:
+  dd-octo-sts:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.dd-octo-sts.outputs.token }}
+    permissions:
+      id-token: write # Needed to federate tokens with dd-octo-sts
+    name: Get access token from dd-octo-sts
+    steps:
+      - name: Get access token from dd-octo-sts
+        id: dd-octo-sts
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.label-analysis.modify-pr
+
   assign-team-label:
     if: github.triggering_actor != 'dd-devflow[bot]' && github.event.pull_request.head.repo.full_name == github.repository # Run only on non-fork PRs
     runs-on: ubuntu-latest
+    needs: dd-octo-sts
     permissions:
-      pull-requests: write
+      id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -33,10 +45,13 @@ jobs:
       - name: Auto assign team label
         env:
           PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
+          GH_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
         run: dda inv -- -e github.assign-team-label --pr-id="$PR_ID"
   release-note-check:
     if: github.triggering_actor != 'dd-devflow[bot]'
     runs-on: ubuntu-latest
+    needs: dd-octo-sts
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -51,6 +66,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
         run: dda inv -- -e linter.releasenote
   fetch-labels:
     needs: assign-team-label
@@ -111,6 +127,7 @@ jobs:
   agenttelemetry-list-change-ack-check:
     if: github.triggering_actor != 'dd-devflow[bot]' && github.event.pull_request.head.repo.full_name == github.repository # Run only on non-fork PRs
     runs-on: ubuntu-latest
+    needs: dd-octo-sts
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -122,10 +139,13 @@ jobs:
           features: legacy-tasks
       - name: Check agent telemetry metric list
         run: dda inv -- -e github.agenttelemetry-list-change-ack-check --pr-id=${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
 
   ask-reviews:
     if: github.triggering_actor != 'dd-devflow[bot]' && github.event.action == 'labeled' && github.event.label.name == 'ask-review'
     runs-on: ubuntu-latest
+    needs: dd-octo-sts
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -138,4 +158,6 @@ jobs:
       - name: Ask for code reviews
         env:
           SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          GH_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
+          GITHUB_TOKEN: "${{ needs.dd-octo-sts.outputs.token }}"
         run: dda inv -- -e issue.ask-reviews -p ${{ github.event.pull_request.number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,18 +6,20 @@ on:
       - main
       - "[0-9]+.[0-9]+.x"
 
-permissions: {}
-
 jobs:
   label:
     permissions:
-      contents: read
-      pull-requests: write
+      id-token: write # This is required for getting the required OIDC token from GitHub
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository # Run only on non-fork PRs
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.labeler.modify-pr
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ steps.octo-sts.outputs.token }}"
           # currently doesn't work
           sync-labels: true

--- a/.github/workflows/serverless-benchmarks.yml
+++ b/.github/workflows/serverless-benchmarks.yml
@@ -14,8 +14,6 @@ concurrency:
   group: ${{ github.workflow }}/PR#${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions: {}
-
 jobs:
   baseline:
     name: Baseline
@@ -98,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [baseline, current]
     permissions:
-      pull-requests: write
+      id-token: write # This is required for getting the required OIDC token from GitHub
 
     steps:
       - name: Install Go
@@ -130,9 +128,16 @@ jobs:
           cat analyze.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.serverless-benchmarks.modify-pr
+
       - name: Post comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           header: serverless-benchmarks
           recreate: true
           message: |


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Follow-up of https://github.com/DataDog/datadog-agent/pull/39538.

On-boards the 4 following workflows to dd-octo-sts:
- code_review_complexity.yml
- label-analysis.yml
- labeler.yml
- serverless-benchmarks.yml

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->