### PR TITLE
Alleviate temporary file conflicts in JUnit uploads

### DIFF
--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -35,7 +35,7 @@
       -e AWS_NETWORKING=true
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
-      -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME}.tgz"
+      -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME_SLUG}.tgz"
       -e PIP_INDEX_URL="${PIP_INDEX_URL}"
       -e TEST_OUTPUT_FILE="${TEST_OUTPUT_FILE}"
       -e EXTRA_OPTS="${FAST_TESTS_FLAG}"
@@ -63,6 +63,7 @@
 
 tests_windows-x64:
   extends: .tests_windows_base
+  #parallel: 10
   variables:
     ARCH: "x64"
 


### PR DESCRIPTION
### What does this PR *NOT* do?
This is **not** to address deep concurrency issues. In particular, it won't prevent locking issues stemming from shared access to `git` metadata.
The change doesn't tackle _potential causes_ like:
1. not-so-unique temporary directories?
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/dsyms/utils.ts#L20
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/git-metadata/gitdb.ts#L306
2. underlying temporary directory removal cycling forever?
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/dsyms/utils.ts#L28
3. using the current working directory, whether as a fallback or primary?
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/git-metadata/gitdb.ts#L323
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/git-metadata/git.ts#L24
4. the way `git pack-objects` is invoked?
   - https://github.com/DataDog/datadog-ci/blob/3b5f3729119d88c2a4e7a3077bcebac73b7d83b9/src/commands/git-metadata/gitdb.ts#L293

### What does this PR do?
This is instead to alleviate issues caused by a tool that likely reuses temporary paths across invocations by assigning each subprocess a dedicated temporary directory via `TEMP`, `TMP`, and `TMPDIR` environment variables.
    
Using `tempfile.TemporaryDirectory` ensures _sufficient entropy_ in the paths and automatic cleanup, avoiding collisions during concurrent JUnit uploads.
    
This change also renames the JUnit tarball using `CI_JOB_NAME_SLUG` in lieu of `CI_JOB_NAME`, ensuring compatibility with GitLab's `parallel` feature when experimenting with concurrent test job runs, in which case `CI_JOB_NAME` includes annoying spaces and, more importantly, filesystem-incompatible slashes, which result in invalid paths:
- `c:\mnt\junit-tests_windows-x64 3/10.tgz: No such file or directory` because `c:\mnt\junit-tests_windows-x64 3` is then expected to be an existing _directory_ where to find the `10.tgz` archive,
- `c:\mnt\junit-tests-windows-x64-3-10.tgz` works. (`-3-10` is of course absent when not leveraging `parallel`)
    
### Motivation
**Reduce occurrences of hanging jobs killed after a 2-hour timeout**, with the console output flooded by loops around:
```
Error: EPERM: operation not permitted, lstat '\\?\C:\Users\ContainerAdministrator\AppData\Local\Temp\pkg-UKhsg3\f6db2f7790c415a4726371e606fb3a9b4677c1226d9dfb63fd4798b687ee1579'
    at lstatSync (node:fs:1574:3)
    at rimrafSync (node:internal/fs/rimraf:180:13)
    at node:internal/fs/rimraf:253:9
    at Array.forEach (<anonymous>)
    at _rmdirSync (node:internal/fs/rimraf:250:7)
    at fixWinEPERMSync (node:internal/fs/rimraf:304:5)
    at rimrafSync (node:internal/fs/rimraf:200:14)
    at Object.rmSync (node:fs:1274:10)
    at removeTemporaryFolderAndContent (pkg/prelude/bootstrap.js:704:10)
    at process.<anonymous> (pkg/prelude/bootstrap.js:711:5) {
  errno: -4048,
  syscall: 'lstat',
  code: 'EPERM',
  path: '\\\\?\\C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\pkg-UKhsg3\\f6db2f7790c415a4726371e606fb3a9b4677c1226d9dfb63fd4798b687ee1579'
}
```
Examples:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066313948
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066455969
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1068186062

References:
- #39460
- [ACIX-968]

### Describe how you validated your changes
Temporarily set `parallel: 10`:
1. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554790 succeeded _despite shared access to `git` metadata errors_:
    ```
    Internal Error: warning: unable to access 'C:/Users/ContainerAdministrator/.gitconfig': Permission denied
    ```
2. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554791 succeeded _despite shared access to `git` metadata errors_:
    ```
    Internal Error: warning: unable to access 'C:/Users/ContainerAdministrator/.gitconfig': Permission denied
    ```
3. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554792 succeeded
4. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554793 succeeded _despite shared access to `git` metadata errors_:
    ```
    Internal Error: warning: unable to access 'C:/Users/ContainerAdministrator/.gitconfig': Permission denied
    ```
5. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554794 succeeded
6. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554795 succeeded _despite shared access to `git` metadata errors_:
    ```
    Internal Error: warning: unable to access 'C:/Users/ContainerAdministrator/.gitconfig': Permission denied
    ```
7. run twice:
    - https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554796 failed, but for another reason:
    ```
    Reinitialized existing Git repository in C:/gitlab-ci/builds/CXNwiBkBi/2/DataDog/datadog-agent/.git/
    error: cannot lock ref 'refs/tags/comp/otelcol/otlp/components/statsprocessor/v0.64.2-rc.1': Unable to create 'C:/gitlab-ci/builds/CXNwiBkBi/2/DataDog/datadog-agent/.git/refs/tags/comp/otelcol/otlp/components/statsprocessor/v0.64.2-rc.1.lock': File exists.
    Another git process seems to be running in this repository, e.g.
    an editor opened by 'git commit'. Please make sure all processes
    are terminated then try again. If it still fails, a git process
    may have crashed in this repository earlier:
    remove the file manually to continue.
    ```
    - https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066594420 succeeded
8. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554797 succeeded
9. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554798 succeeded
10. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1066554799 succeeded

:dart: **No job hanged**. (nor killed by timeout)

### Possible Drawbacks / Trade-offs
Of course, the ideal would be to fix the root cause(s) of all these problems, which is(are) yet to be determined.

### Additional Notes
[ACIX-968]: https://datadoghq.atlassian.net/browse/ACIX-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ