### PR TITLE
Don't ships systemd headers

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -296,6 +296,12 @@ resources_path "#{Omnibus::Config.project_root}/resources/agent"
 exclude '\.git*'
 exclude 'bundler\/git'
 
+# Exclude headers that are not needed in the final package
+# TODO(alopezz): figure out the right way to write these patterns
+exclude "**/embedded/include/systemd"
+exclude "**/embedded/include/systemd/*"
+exclude "**/embedded/include/systemd/**/*"
+
 if windows_target?
   FORBIDDEN_SYMBOLS = [
     "github.com/golang/glog"

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -230,6 +230,12 @@ end
 exclude '\.git*'
 exclude 'bundler\/git'
 
+# Exclude headers that are not needed in the final package
+# TODO(alopezz): figure out the right way to write these patterns
+exclude "**/embedded/include/systemd"
+exclude "**/embedded/include/systemd/*"
+exclude "**/embedded/include/systemd/**/*"
+
 if linux_target? or windows_target?
   strip_build windows_target? || !do_package
   debug_path ".debug"


### PR DESCRIPTION
### What does this PR do?

It excludes systemd headers from final Agent (including iot-agent) packages.

### Motivation

#incident-41581

These files are only used for building components of the Agent, and customers are not meant to use them in any way. Therefore, they're dead weight that we can remove.

### Describe how you validated your changes

CI passing, size reduction, manual check that the files are no longer present.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->