### PR TITLE
reduce connection error log level

### DIFF
--- a/releasenotes/notes/reduce-system-probe-connection-error-log-level-393bc77751fa0c5c.yaml
+++ b/releasenotes/notes/reduce-system-probe-connection-error-log-level-393bc77751fa0c5c.yaml
@@ -1,0 +1,8 @@
+fixes:
+  - |
+    The Agent no longer logs an error each time it fails to connect to
+    system-probe through ``\\.\pipe\dd_system_probe``. This log message
+    was added in Agent 7.63.0.
+    The error is still logged if it persists long enough,
+    see [#35790](https://github.com/DataDog/datadog-agent/pull/35790).
+    Each failed connection attempt still logs the error at debug level to aid troubleshooting.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Reduce log level from ERROR to DEBUG when failing to connect to system probe named pipe.

Error message should still be logged by the caller after a delay, see https://github.com/DataDog/datadog-agent/pull/35790. This PR does not modify that, it only modifies this additional/extra log call.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1695

Remove unnecessary logs and alerts from the ERROR level log message
```
error connecting to named pipe "\\\\.\\pipe\\dd_system_probe": open \\.\pipe\dd_system_probe: The system cannot find the file specified.
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run with system-probe disabled (default configuration)
wait for inventoryagent log messages, or run status/flare to trigger it, they should be DEBUG instead of ERROR now.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Some code only tries to contact system-probe if it's enabled
- https://github.com/DataDog/datadog-agent/blob/875b01011e72bad8e9399203db096f46218455f5/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go#L49-L55

Other code contacts it regardless
- https://github.com/DataDog/datadog-agent/blob/875b01011e72bad8e9399203db096f46218455f5/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go#L293-L303

I think there might be some complexities in container environments regarding not having access to the config to determine what should be running, in these cases I think it's expected to try to reach the socket.