### PR TITLE
Add link to SMP report UI

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -217,9 +217,10 @@ single-machine-performance-regression_detector:
     # be seen as a quality gates failure.
     - datadog-ci tag --level job --tags smp_quality_gates:"failed"
     - |
-      python3 <<'EOF'
+      CI_COMMIT_BRANCH="${CI_COMMIT_BRANCH}" python3 <<EOF
       import json
       import sys
+      import os
 
       try:
           with open('outputs/report.json') as f:
@@ -266,6 +267,11 @@ single-machine-performance-regression_detector:
           else:
               f.write('✅ **Passed.** All Quality Gates passed.\n\n')
               f.write('\n'.join(decision_record))
+
+          # This is a link to the SMP report UI
+          ci_commit_branch = os.environ.get('CI_COMMIT_BRANCH', 'unknown')
+          f.write("\n")
+          f.write(f'<sub>[Report UI | Preview](https://dd.datad0g.com/smp/report?team_name=agent&ci_commit_branch={ci_commit_branch})</sub>')
 
       if failed:
           print("Quality gate failed, see decision record")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- adds a link to the bottom of the SMP regression detector report to the report ui (in preview)

### Motivation

We want users to start exploring the UI and providing feedback to us. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

It's purely a CI change so I waited for CI to complete and to see the result of the PR comment.

### Possible Drawbacks / Trade-offs

None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A