### PR TITLE
Don't ship unused processchecks subcommand for iot agent

### DIFF
--- a/cmd/iot-agent/main.go
+++ b/cmd/iot-agent/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/cmd/agent/subcommands"
+	"github.com/DataDog/datadog-agent/cmd/iot-agent/subcommands"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
@@ -20,7 +20,7 @@ func main() {
 	// Set the flavor
 	flavor.SetFlavor(flavor.IotAgent)
 
-	if err := command.MakeCommand(subcommands.AgentSubcommands()).Execute(); err != nil {
+	if err := command.MakeCommand(subcommands.IotAgentSubcommands()).Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/cmd/iot-agent/subcommands/subcommands.go
+++ b/cmd/iot-agent/subcommands/subcommands.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package subcommands defines the iot-agent subcommands.
+package subcommands
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	cmdanalyzelogs "github.com/DataDog/datadog-agent/cmd/agent/subcommands/analyzelogs"
+	cmdcheck "github.com/DataDog/datadog-agent/cmd/agent/subcommands/check"
+	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/subcommands/config"
+	cmdconfigcheck "github.com/DataDog/datadog-agent/cmd/agent/subcommands/configcheck"
+	cmdcontrolsvc "github.com/DataDog/datadog-agent/cmd/agent/subcommands/controlsvc"
+	cmdcoverage "github.com/DataDog/datadog-agent/cmd/agent/subcommands/coverage"
+	cmddiagnose "github.com/DataDog/datadog-agent/cmd/agent/subcommands/diagnose"
+	cmddogstatsd "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsd"
+	cmddogstatsdcapture "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdcapture"
+	cmddogstatsdreplay "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdreplay"
+	cmddogstatsdstats "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdstats"
+	cmdflare "github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare"
+	cmdhealth "github.com/DataDog/datadog-agent/cmd/agent/subcommands/health"
+	cmdhostname "github.com/DataDog/datadog-agent/cmd/agent/subcommands/hostname"
+	cmdimport "github.com/DataDog/datadog-agent/cmd/agent/subcommands/import"
+	cmdintegrations "github.com/DataDog/datadog-agent/cmd/agent/subcommands/integrations"
+	cmdjmx "github.com/DataDog/datadog-agent/cmd/agent/subcommands/jmx"
+	cmdlaunchgui "github.com/DataDog/datadog-agent/cmd/agent/subcommands/launchgui"
+	cmdremoteconfig "github.com/DataDog/datadog-agent/cmd/agent/subcommands/remoteconfig"
+	cmdrun "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run"
+	cmdsecret "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secret"
+	cmdsecrethelper "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secrethelper"
+	cmdsnmp "github.com/DataDog/datadog-agent/cmd/agent/subcommands/snmp"
+	cmdstatus "github.com/DataDog/datadog-agent/cmd/agent/subcommands/status"
+	cmdstop "github.com/DataDog/datadog-agent/cmd/agent/subcommands/stop"
+	cmdstreamep "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamep"
+	cmdstreamlogs "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamlogs"
+	cmdtaggerlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/taggerlist"
+	cmdversion "github.com/DataDog/datadog-agent/cmd/agent/subcommands/version"
+	cmdworkloadlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/workloadlist"
+)
+
+// IotAgentSubcommands returns SubcommandFactories for the subcommands supported
+// with the current build flags.
+func IotAgentSubcommands() []command.SubcommandFactory {
+	return []command.SubcommandFactory{
+		cmdcheck.Commands,
+		cmdconfigcheck.Commands,
+		cmdconfig.Commands,
+		cmddiagnose.Commands,
+		cmddogstatsd.Commands,
+		cmddogstatsdcapture.Commands,
+		cmddogstatsdreplay.Commands,
+		cmddogstatsdstats.Commands,
+		cmdflare.Commands,
+		cmdhealth.Commands,
+		cmdhostname.Commands,
+		cmdimport.Commands,
+		cmdlaunchgui.Commands,
+		cmdanalyzelogs.Commands,
+		cmdremoteconfig.Commands,
+		cmdrun.Commands,
+		cmdsecret.Commands,
+		cmdsnmp.Commands,
+		cmdstatus.Commands,
+		cmdstreamlogs.Commands,
+		cmdstreamep.Commands,
+		cmdtaggerlist.Commands,
+		cmdversion.Commands,
+		cmdworkloadlist.Commands,
+		cmdjmx.Commands,
+		cmdsecrethelper.Commands,
+		cmdintegrations.Commands,
+		cmdstop.Commands,
+		cmdcontrolsvc.Commands,
+		cmdcoverage.Commands,
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Removes imports to unused processchecks subcommand for the iot agent as the iot agent does not support live processes https://docs.datadoghq.com/agent/iot/?tab=deb#:~:text=image%20detection%20algorithms.-,Capabilities,-The%20IoT%20Agent

> The IoT Agent does not include the Python interpreter and other integrations pre-packaged with the standard Agent. It also doesn’t support tracing for APM, live process monitoring, or Cloud Network Monitoring.

### Motivation
- failing static quality gates on main due to iot agent size #incident-41581
- new processes and service discovery data consolidation https://github.com/DataDog/datadog-agent/pull/39354 will lead to ~60KB of size which will also cause this gate to fail so we want to reduce the iot agent size to give any possible headroom

dependency graph: `dda inv -e go-deps.graph -t github.com/DataDog/datadog-agent/cmd/agent/subcommands/processchecks/... -b agent -o linux -f iot
`
<img width="1501" height="66" alt="image" src="https://github.com/user-attachments/assets/f71e9e31-22e2-43e9-8c13-2534bb28882e" />


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- ci passing
- manual diff between core agent subcommands and iot agent subcommands lead to only 1 operational diff of not importing the processchecks commands

```
❯ diff cmd/iot-agent/subcommands/subcommands.go cmd/agent/subcommands/subcommands.go
6,8c6
< //go:build !windows
< 
< // Package subcommands defines the iot-agent subcommands.
---
> // Package subcommands defines the agent subcommands.
30a29
>       cmdprocesschecks "github.com/DataDog/datadog-agent/cmd/agent/subcommands/processchecks"
45c44
< // IotAgentSubcommands returns SubcommandFactories for the subcommands supported
---
> // AgentSubcommands returns SubcommandFactories for the subcommands supported
47c46
< func IotAgentSubcommands() []command.SubcommandFactory {
---
> func AgentSubcommands() []command.SubcommandFactory {
77a77
>               cmdprocesschecks.Commands,
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->