### PR TITLE
dyninst/rcscrape: remove debug log line

### DIFF
--- a/pkg/dyninst/rcscrape/scraper.go
+++ b/pkg/dyninst/rcscrape/scraper.go
@@ -132,7 +132,6 @@ func (s *scraperSink) HandleEvent(ev output.Event) error {
 	switch d := d.(type) {
 	case *remoteConfigEventDecoder:
 		rcFile, err := d.decodeRemoteConfigFile(ev)
-		log.Infof("decodeRemoteConfigFile: %+v, %+v", rcFile, err)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This log line wasn't intended to be shipped.
