### PR TITLE
Autodiscovery Annotation Filter Precedence

### DIFF
--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -337,7 +337,7 @@ func processEndpoints(kep *v1.Endpoints, tags []string, filterStore workloadfilt
 	if filterStore != nil {
 		metricsExcluded = filterStore.IsEndpointExcluded(
 			workloadfilter.CreateEndpoint(kep.Name, kep.Namespace, kep.GetAnnotations()),
-			[][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotationsMetrics}, {workloadfilter.LegacyEndpointMetrics}},
+			[][]workloadfilter.EndpointFilter{{workloadfilter.EndpointADAnnotations, workloadfilter.EndpointADAnnotationsMetrics}, {workloadfilter.LegacyEndpointMetrics}},
 		)
 		globalExcluded = filterStore.IsEndpointExcluded(
 			workloadfilter.CreateEndpoint(kep.Name, kep.Namespace, kep.GetAnnotations()),

--- a/comp/core/autodiscovery/listeners/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints_test.go
@@ -702,6 +702,32 @@ func TestKubeEndpointsFiltering(t *testing.T) {
 			expectedMetricsExcl: true,
 			expectedGlobalExcl:  false,
 		},
+		{
+			name: "endpoint with AD annotations: metrics excluded",
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotation-excluded",
+					Namespace: "default",
+					UID:       types.UID("annotation-excluded-uid"),
+					Annotations: map[string]string{
+						"ad.datadoghq.com/service.check_names": "[\"http_check\"]",
+						"ad.datadoghq.com/exclude":             "true",
+					},
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{IP: "10.0.0.4"},
+						},
+						Ports: []v1.EndpointPort{
+							{Name: "http", Port: 80},
+						},
+					},
+				},
+			},
+			expectedMetricsExcl: true,
+			expectedGlobalExcl:  true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/comp/core/autodiscovery/listeners/kube_services.go
+++ b/comp/core/autodiscovery/listeners/kube_services.go
@@ -253,7 +253,7 @@ func processService(ksvc *v1.Service, filterStore workloadfilter.Component) *Kub
 
 	svc.metricsExcluded = filterStore.IsServiceExcluded(
 		workloadfilter.CreateService(ksvc.Name, ksvc.Namespace, ksvc.GetAnnotations()),
-		[][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotationsMetrics}, {workloadfilter.LegacyServiceMetrics}},
+		[][]workloadfilter.ServiceFilter{{workloadfilter.ServiceADAnnotations, workloadfilter.ServiceADAnnotationsMetrics}, {workloadfilter.LegacyServiceMetrics}},
 	)
 
 	svc.globalExcluded = filterStore.IsServiceExcluded(

--- a/comp/core/autodiscovery/listeners/kube_services_test.go
+++ b/comp/core/autodiscovery/listeners/kube_services_test.go
@@ -731,7 +731,7 @@ func TestKubeServiceFiltering(t *testing.T) {
 					},
 				},
 			},
-			expectedMetricsExcl: false,
+			expectedMetricsExcl: true,
 			expectedGlobalExcl:  true,
 		},
 	}

--- a/comp/core/workloadfilter/def/utils.go
+++ b/comp/core/workloadfilter/def/utils.go
@@ -73,7 +73,7 @@ func GetAutodiscoveryFilters(filterScope Scope) [][]ContainerFilter {
 			low = append(low, LegacyContainerACExclude)
 		}
 	case MetricsFilter:
-		low = append(low, LegacyContainerMetrics, ContainerADAnnotationsMetrics)
+		low = append(low, LegacyContainerMetrics)
 		high = append(high, ContainerADAnnotationsMetrics)
 	case LogsFilter:
 		low = append(low, LegacyContainerLogs)

--- a/comp/core/workloadfilter/def/utils.go
+++ b/comp/core/workloadfilter/def/utils.go
@@ -61,8 +61,7 @@ func GetAutodiscoveryFilters(filterScope Scope) [][]ContainerFilter {
 	flist := make([][]ContainerFilter, 2)
 
 	// TODO: Add config option for users to configure AD annotations to take lower priority
-	flist[highPrecedence] = []ContainerFilter{ContainerADAnnotations}
-
+	high := []ContainerFilter{ContainerADAnnotations}
 	low := []ContainerFilter{LegacyContainerGlobal}
 
 	switch filterScope {
@@ -75,10 +74,14 @@ func GetAutodiscoveryFilters(filterScope Scope) [][]ContainerFilter {
 		}
 	case MetricsFilter:
 		low = append(low, LegacyContainerMetrics, ContainerADAnnotationsMetrics)
+		high = append(high, ContainerADAnnotationsMetrics)
 	case LogsFilter:
-		low = append(low, LegacyContainerLogs, ContainerADAnnotationsLogs)
+		low = append(low, LegacyContainerLogs)
+		high = append(high, ContainerADAnnotationsLogs)
+	default:
 	}
 
+	flist[highPrecedence] = high
 	flist[lowPrecedence] = low
 
 	return flist


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Commit 1: Bumps the precedence of the metric/log AD annotation exclusion. This avoids cases in which workload owners may have explicitly added an exclusion annotation but it might conflict with an inclusion condition defined elsewhere. Traditionally, AD exclusion annotations always exclude a workload regardless of any other inclusion conditions and bumping the precedence to high in this PR maintains that behavior.

Below is the legacy filtering function that checks for all annotations first (highest precedence)
https://github.com/DataDog/datadog-agent/blob/e338a1844d9a1255bcf0bfca959882554d6cab4a/pkg/util/containers/filter.go#L329-L340

Commit 2: Uses the global AD exclusion annotation also for metric filtering use cases. Maintains backward compatibility with the previous system that checks for both the metric specific prefix and the global prefix.

`{workloadfilter.EndpointADAnnotations, workloadfilter.EndpointADAnnotationsMetrics}`

https://github.com/DataDog/datadog-agent/blob/e338a1844d9a1255bcf0bfca959882554d6cab4a/pkg/util/containers/filter.go#L398-L410

### Motivation

Maintain backwards compatibility with Autodiscovery filtering

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit Tests and CI