### PR TITLE
CAP-2756 Add container_instance_arn host tag

### DIFF
--- a/pkg/util/ec2/tags/container_instance_arn.go
+++ b/pkg/util/ec2/tags/container_instance_arn.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build ec2 && docker
+
+package tags
+
+import (
+	"context"
+	"fmt"
+
+	ecsmeta "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+)
+
+// getContainerInstanceARN fetches the ARN of the ECS container instance using the
+// ECS metadata introspection endpoint (metadata v1).
+func getContainerInstanceARN(ctx context.Context) (string, error) {
+	client, err := ecsmeta.V1()
+	if err != nil {
+		return "", fmt.Errorf("unable to initialize ECS metadata client: %w", err)
+	}
+
+	instance, err := client.GetInstance(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to query ECS metadata: %w", err)
+	}
+
+	return instance.ContainerInstanceARN, nil
+}

--- a/pkg/util/ec2/tags/container_instance_arn_nodocker.go
+++ b/pkg/util/ec2/tags/container_instance_arn_nodocker.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build ec2 && !docker
+
+package tags
+
+import (
+	"context"
+	"fmt"
+)
+
+// getContainerInstanceARN is a stub used when the `docker` build tag is not enabled.
+func getContainerInstanceARN(_ context.Context) (string, error) {
+	return "", fmt.Errorf("ECS metadata is not available without docker build tag")
+}

--- a/releasenotes/notes/add-container-instance-arn-tag-f6273f443db06ff5.yaml
+++ b/releasenotes/notes/add-container-instance-arn-tag-f6273f443db06ff5.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Add `container_instance_arn` as a host tag when running on ECS EC2.


### PR DESCRIPTION
### What does this PR do?
Adds `container_instance_arn` as a host tag when agent is running on ECS EC2. This tag is hidden behind the `DD_COLLECT_EC2_INSTANCE_INFO` configuration. 

### Motivation
Standardize ECS tagging to allow better correlation between ECS explorer and other products/features. Having `container_instance_arn` as a host tag allows agent telemetry to be tagged accordingly. This allows the possibility of pivoting from a container instance in the ecs explorer to other product pages using this tag.

### Describe how you validated your changes
Deployed agent on ECS EC2 instance using image `datadog/agent-dev:stzou-cap-2756-full` while setting `DD_COLLECT_EC2_INSTANCE_INFO=false`. With this configuration, I confirmed that the `container_instance_arn` tag was not present. 

Redeployed the agent again and  set `DD_COLLECT_EC2_INSTANCE_INFO=true` and saw that the agent started reporting `container_instance_arn` as a host tag:
<img width="1057" height="353" alt="image" src="https://github.com/user-attachments/assets/c743888a-064a-4cfd-b439-d324824bdef1" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->