### PR TITLE
dyninst/symdb: don't ignore packages that only have types

### DIFF
--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -510,7 +510,6 @@ Package: main
 		Arg: x: int (declared at line 0, available: [75-75])
 	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
 		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
 		Field: c: main.interfaceComplexityB
@@ -550,13 +549,11 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
 			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
-	Type: main.behavior
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
 		Field: val: int
 		Field: b: *main.node
-	Type: main.triggerVerifierErrorForTesting
 	Type: main.structWithTwoValues
 		Field: a: uint
 		Field: b: bool
@@ -577,7 +574,6 @@ Package: main
 	Type: main.spws
 		Field: a: int
 		Field: x: *string
-	Type: main.t
 	Type: main.threeStringStruct
 		Field: a: string
 		Field: b: string
@@ -643,7 +639,6 @@ Package: main
 	Type: main.deepStruct1
 		Field: a: int
 		Field: b: main.deepStruct2
-	Type: main.emptyStruct
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -510,7 +510,6 @@ Package: main
 		Arg: x: int (declared at line 0, available: [75-75])
 	Function: testInlinedSumArray (main.testInlinedSumArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go [70:71]
 		Arg: a: [5]int (declared at line 0, available: [71-71])
-	Type: main.typeAlias
 	Type: main.interfaceComplexityA
 		Field: b: int
 		Field: c: main.interfaceComplexityB
@@ -550,13 +549,11 @@ Package: main
 		Field: i: int
 		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
 			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
-	Type: main.behavior
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
 		Field: val: int
 		Field: b: *main.node
-	Type: main.triggerVerifierErrorForTesting
 	Type: main.structWithTwoValues
 		Field: a: uint
 		Field: b: bool
@@ -577,7 +574,6 @@ Package: main
 	Type: main.spws
 		Field: a: int
 		Field: x: *string
-	Type: main.t
 	Type: main.threeStringStruct
 		Field: a: string
 		Field: b: string
@@ -643,7 +639,6 @@ Package: main
 	Type: main.deepStruct1
 		Field: a: int
 		Field: b: main.deepStruct2
-	Type: main.emptyStruct
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8


### PR DESCRIPTION
Before this patch, we would not output information about types from packages that have no functions (e.g. packages that only contain exported structs).

Also this patch makes it so that we don't output empty types (types with no fields or methods), on the argument that they wouldn't be useful to either the backend or the UI.