### PR TITLE
add lambda tag to http header

### DIFF
--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -57,6 +57,9 @@ func (r *HTTPReceiver) pipelineStatsProxyHandler() http.Handler {
 		tag := fmt.Sprintf("orchestrator:fargate_%s", strings.ToLower(string(orch)))
 		tags = tags + "," + tag
 	}
+	if r.conf.LambdaFunctionName != "" {
+		tags = tags + "," + "_dd.origin:lambda"
+	}
 	return newPipelineStatsProxy(r.conf, urls, apiKeys, tags, r.statsd)
 }
 

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -180,4 +180,49 @@ func TestPipelineStatsProxyHandler(t *testing.T) {
 			t.Fatalf("invalid message: %q", slurp)
 		}
 	})
+	t.Run("lambda_function", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			v := req.Header.Get("X-Datadog-Additional-Tags")
+			if !strings.Contains(v, "_dd.origin:lambda") {
+				t.Fatalf("invalid X-Datadog-Additional-Tags header, should contain _dd.origin:lambda")
+			}
+			called = true
+		}))
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = srv.URL
+		conf.LambdaFunctionName = "my-function-name"
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.pipelineStatsProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
+
+	t.Run("not_lambda_function", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			v := req.Header.Get("X-Datadog-Additional-Tags")
+			if strings.Contains(v, "_dd.origin:lambda") {
+				t.Fatalf("invalid X-Datadog-Additional-Tags header, should not contain '_dd.origin:lambda' when LambdaFunctionName is empty")
+			}
+			called = true
+		}))
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = srv.URL
+		conf.LambdaFunctionName = ""
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.pipelineStatsProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds _dd.origin:lambda as a HTTP header tag to send to DSM backend if the data is coming from a lambda. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Wrote 2 unit tests, 1 where the tag should not be added if not a lambda and 1 test where the tag should be added if is a lambda. Tested with AWS Sandbox account, 
<img width="1407" height="393" alt="Screenshot 2025-08-05 at 3 40 13 PM" src="https://github.com/user-attachments/assets/de8df510-a74b-4aa5-9e61-b2cd8c410528" />
backend is capable of querying the metric despite having DD_EXTENSION_VERSION = compatibility. 

This is the same tag that the Lambda next-gen extension layer adds https://github.com/DataDog/datadog-lambda-extension/blob/main/bottlecap/src/traces/proxy_flusher.rs#L63-L65

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->