### PR TITLE
[CIEXE-1103]Make vault read generalizable for omnibus tests

### DIFF
--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -10,4 +10,4 @@ invoke_unit_tests:
   script:
     - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
     - python3 -m dda self dep sync -f legacy-tasks
-    - POD_NAMESPACE=${POD_NAMESPACE} dda inv -- -e invoke-unit-tests.run
+    - dda inv -- -e invoke-unit-tests.run

--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -10,4 +10,4 @@ invoke_unit_tests:
   script:
     - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
     - python3 -m dda self dep sync -f legacy-tasks
-    - dda inv -- -e invoke-unit-tests.run
+    - POD_NAMESPACE=${POD_NAMESPACE} dda inv -- -e invoke-unit-tests.run

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -155,9 +155,6 @@ def _hash_paths(hasher, paths: list[str]):
 
 
 def get_dd_api_key(ctx):
-    print(f'sjain:sys.platform: {sys.platform}')
-    for key, value in os.environ.items():
-        print(f"{key}: {value}")
     if sys.platform == 'win32':
         cmd = f'aws.exe ssm get-parameter --region us-east-1 --name {os.environ["API_KEY_ORG2"]} --with-decryption --query "Parameter.Value" --out text'
     elif sys.platform == 'darwin':

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -160,7 +160,7 @@ def get_dd_api_key(ctx):
     elif sys.platform == 'darwin':
         cmd = f'vault kv get -field=token kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     else:
-        cmd = f'vault kv get -field=token kv/k8s/{os.environ["POD_NAMESPACE"]}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
+        cmd = f'vault kv get -field=token kv/k8s/{os.environ.get('POD_NAMESPACE', 'gitlab-runner')}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     return ctx.run(cmd, hide=True).stdout.strip()
 
 

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -156,6 +156,8 @@ def _hash_paths(hasher, paths: list[str]):
 
 def get_dd_api_key(ctx):
     print(f'sjain:sys.platform: {sys.platform}')
+    for key, value in os.environ.items():
+        print(f"{key}: {value}")
     if sys.platform == 'win32':
         cmd = f'aws.exe ssm get-parameter --region us-east-1 --name {os.environ["API_KEY_ORG2"]} --with-decryption --query "Parameter.Value" --out text'
     elif sys.platform == 'darwin':

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -155,6 +155,7 @@ def _hash_paths(hasher, paths: list[str]):
 
 
 def get_dd_api_key(ctx):
+    print(f'sjain:sys.platform: {sys.platform}')
     if sys.platform == 'win32':
         cmd = f'aws.exe ssm get-parameter --region us-east-1 --name {os.environ["API_KEY_ORG2"]} --with-decryption --query "Parameter.Value" --out text'
     elif sys.platform == 'darwin':

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -160,7 +160,7 @@ def get_dd_api_key(ctx):
     elif sys.platform == 'darwin':
         cmd = f'vault kv get -field=token kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     else:
-        cmd = f'vault kv get -field=token kv/k8s/gitlab-runner/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
+        cmd = f'vault kv get -field=token kv/k8s/{os.environ["POD_NAMESPACE"]}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     return ctx.run(cmd, hide=True).stdout.strip()
 
 

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -42,10 +42,10 @@ def _run_calls_to_string(mock_calls):
         'S3_OMNIBUS_GIT_CACHE_BUCKET': 'omnibus-cache',
         'API_KEY_ORG2': 'api-key',
         'AGENT_API_KEY_ORG2': 'agent-api-key',
-        'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
+        # 'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
 
     },
-    clear=True,
+    # clear=True,
 )
 class TestOmnibusCache(unittest.TestCase):
     def setUp(self):

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -42,6 +42,8 @@ def _run_calls_to_string(mock_calls):
         'S3_OMNIBUS_GIT_CACHE_BUCKET': 'omnibus-cache',
         'API_KEY_ORG2': 'api-key',
         'AGENT_API_KEY_ORG2': 'agent-api-key',
+        'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
+
     },
     clear=True,
 )

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -42,10 +42,9 @@ def _run_calls_to_string(mock_calls):
         'S3_OMNIBUS_GIT_CACHE_BUCKET': 'omnibus-cache',
         'API_KEY_ORG2': 'api-key',
         'AGENT_API_KEY_ORG2': 'agent-api-key',
-        # 'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
-
+        'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
     },
-    # clear=True,
+    clear=True,
 )
 class TestOmnibusCache(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation
CI team is creating dedicated gitlab runners for datadog-agent so that datadog-agents job dont get impacted by other repos. As part of this we would need to replace hardcoded vault path to be generalizable so we can smoothly migrate from shared gitlab runners to dedicated ones

It seems we are running `omnibus` unit tests mocked to be on linux in macos runners. They are also run on kubernetes runners. So this diff handles both cases. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

We can see the CI jobs ran fine and hence we can confirm that they could read the secret successfully from vault.

These tests especially : 
invoke_unit_tests
tests_macos_gitlab_amd64
tests_macos_gitlab_arm64


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->