### PR TITLE
Fix missing ContainerResources in WLM proto

### DIFF
--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -150,6 +150,7 @@ func protoContainerFromWorkloadmetaContainer(container *workloadmeta.Container) 
 		CollectorTags:              container.CollectorTags,
 		CgroupPath:                 container.CgroupPath,
 		ResolvedAllocatedResources: protoResolvedAllocatedResources,
+		Resources:                  toProtoContainerResources(container.Resources),
 	}, nil
 }
 
@@ -216,7 +217,6 @@ func toProtoEntityMetaFromContainer(container *workloadmeta.Container) *pb.Entit
 }
 
 func toProtoImage(image *workloadmeta.ContainerImage) *pb.ContainerImage {
-
 	return &pb.ContainerImage{
 		Id:         image.ID,
 		RawName:    image.RawName,
@@ -294,6 +294,22 @@ func toProtoResolvedAllocatedResources(resources []workloadmeta.ContainerAllocat
 	}
 
 	return protoResolvedAllocatedResources
+}
+
+func toProtoContainerResources(resources workloadmeta.ContainerResources) *pb.ContainerResources {
+	if resources.CPURequest == nil &&
+		resources.CPULimit == nil &&
+		resources.MemoryRequest == nil &&
+		resources.MemoryLimit == nil {
+		return nil
+	}
+
+	return &pb.ContainerResources{
+		CpuRequest:    resources.CPURequest,
+		CpuLimit:      resources.CPULimit,
+		MemoryRequest: resources.MemoryRequest,
+		MemoryLimit:   resources.MemoryLimit,
+	}
 }
 
 func toProtoContainerStatus(status workloadmeta.ContainerStatus) (pb.ContainerStatus, error) {
@@ -637,6 +653,7 @@ func toWorkloadmetaContainer(protoContainer *pb.Container) (*workloadmeta.Contai
 		CollectorTags:              protoContainer.CollectorTags,
 		CgroupPath:                 protoContainer.CgroupPath,
 		ResolvedAllocatedResources: resources,
+		Resources:                  toWorkloadmetaContainerResources(protoContainer.Resources),
 	}, nil
 }
 
@@ -658,6 +675,19 @@ func toWorkloadmetaResolvedAllocatedResources(protoResolvedAllocatedResources []
 	}
 
 	return resources
+}
+
+func toWorkloadmetaContainerResources(protoResources *pb.ContainerResources) workloadmeta.ContainerResources {
+	if protoResources == nil {
+		return workloadmeta.ContainerResources{}
+	}
+
+	return workloadmeta.ContainerResources{
+		CPURequest:    protoResources.CpuRequest,
+		CPULimit:      protoResources.CpuLimit,
+		MemoryRequest: protoResources.MemoryRequest,
+		MemoryLimit:   protoResources.MemoryLimit,
+	}
 }
 
 func toWorkloadmetaEntityID(protoEntityID *pb.WorkloadmetaEntityId) (workloadmeta.EntityID, error) {

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -16,6 +16,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // This function tests both the function that converts a workloadmeta.Event into
@@ -87,6 +88,12 @@ func TestConversions(t *testing.T) {
 					ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
 						{Name: "nvidia.com/gpu", ID: "gpu1"},
 					},
+					Resources: workloadmeta.ContainerResources{
+						CPURequest:    pointer.Ptr(0.5),
+						CPULimit:      pointer.Ptr(1.0),
+						MemoryRequest: pointer.Ptr[uint64](1024),
+						MemoryLimit:   pointer.Ptr[uint64](2048),
+					},
 				},
 			},
 			protoWorkloadmetaEvent: &pb.WorkloadmetaEvent{
@@ -143,6 +150,12 @@ func TestConversions(t *testing.T) {
 					},
 					ResolvedAllocatedResources: []*pb.ContainerAllocatedResource{
 						{Name: "nvidia.com/gpu", ID: "gpu1"},
+					},
+					Resources: &pb.ContainerResources{
+						CpuRequest:    pointer.Ptr(0.5),
+						CpuLimit:      pointer.Ptr(1.0),
+						MemoryRequest: pointer.Ptr[uint64](1024),
+						MemoryLimit:   pointer.Ptr[uint64](2048),
 					},
 				},
 			},
@@ -485,7 +498,6 @@ func TestConvertWorkloadEventToProtoWithUnpopulatedFields(t *testing.T) {
 }
 
 func TestProtobufFilterFromWorkloadmetaFilter(t *testing.T) {
-
 	filter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceRuntime).
 		SetEventType(workloadmeta.EventTypeSet).

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -100,6 +100,13 @@ message ContainerAllocatedResource {
   string ID = 2;
 }
 
+message ContainerResources {
+  optional double cpuRequest = 1;
+  optional double cpuLimit = 2;
+  optional uint64 memoryRequest = 3;
+  optional uint64 memoryLimit = 4;
+}
+
 message Container {
   WorkloadmetaEntityId entityId = 1;
   EntityMeta entityMeta = 2;
@@ -114,6 +121,7 @@ message Container {
   repeated string collectorTags = 11;
   string cgroupPath = 12;
   repeated ContainerAllocatedResource resolvedAllocatedResources = 13;
+  ContainerResources resources = 14;
 }
 
 message KubernetesPodOwner {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -897,6 +897,74 @@ func (x *ContainerAllocatedResource) GetID() string {
 	return ""
 }
 
+type ContainerResources struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CpuRequest    *float64               `protobuf:"fixed64,1,opt,name=cpuRequest,proto3,oneof" json:"cpuRequest,omitempty"`
+	CpuLimit      *float64               `protobuf:"fixed64,2,opt,name=cpuLimit,proto3,oneof" json:"cpuLimit,omitempty"`
+	MemoryRequest *uint64                `protobuf:"varint,3,opt,name=memoryRequest,proto3,oneof" json:"memoryRequest,omitempty"`
+	MemoryLimit   *uint64                `protobuf:"varint,4,opt,name=memoryLimit,proto3,oneof" json:"memoryLimit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ContainerResources) Reset() {
+	*x = ContainerResources{}
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerResources) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerResources) ProtoMessage() {}
+
+func (x *ContainerResources) ProtoReflect() protoreflect.Message {
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerResources.ProtoReflect.Descriptor instead.
+func (*ContainerResources) Descriptor() ([]byte, []int) {
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ContainerResources) GetCpuRequest() float64 {
+	if x != nil && x.CpuRequest != nil {
+		return *x.CpuRequest
+	}
+	return 0
+}
+
+func (x *ContainerResources) GetCpuLimit() float64 {
+	if x != nil && x.CpuLimit != nil {
+		return *x.CpuLimit
+	}
+	return 0
+}
+
+func (x *ContainerResources) GetMemoryRequest() uint64 {
+	if x != nil && x.MemoryRequest != nil {
+		return *x.MemoryRequest
+	}
+	return 0
+}
+
+func (x *ContainerResources) GetMemoryLimit() uint64 {
+	if x != nil && x.MemoryLimit != nil {
+		return *x.MemoryLimit
+	}
+	return 0
+}
+
 type Container struct {
 	state                      protoimpl.MessageState        `protogen:"open.v1"`
 	EntityId                   *WorkloadmetaEntityId         `protobuf:"bytes,1,opt,name=entityId,proto3" json:"entityId,omitempty"`
@@ -912,13 +980,14 @@ type Container struct {
 	CollectorTags              []string                      `protobuf:"bytes,11,rep,name=collectorTags,proto3" json:"collectorTags,omitempty"`
 	CgroupPath                 string                        `protobuf:"bytes,12,opt,name=cgroupPath,proto3" json:"cgroupPath,omitempty"`
 	ResolvedAllocatedResources []*ContainerAllocatedResource `protobuf:"bytes,13,rep,name=resolvedAllocatedResources,proto3" json:"resolvedAllocatedResources,omitempty"`
+	Resources                  *ContainerResources           `protobuf:"bytes,14,opt,name=resources,proto3" json:"resources,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
 	*x = Container{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[8]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -930,7 +999,7 @@ func (x *Container) String() string {
 func (*Container) ProtoMessage() {}
 
 func (x *Container) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[8]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -943,7 +1012,7 @@ func (x *Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Container.ProtoReflect.Descriptor instead.
 func (*Container) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{8}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Container) GetEntityId() *WorkloadmetaEntityId {
@@ -1037,6 +1106,13 @@ func (x *Container) GetResolvedAllocatedResources() []*ContainerAllocatedResourc
 	return nil
 }
 
+func (x *Container) GetResources() *ContainerResources {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
 type KubernetesPodOwner struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
@@ -1048,7 +1124,7 @@ type KubernetesPodOwner struct {
 
 func (x *KubernetesPodOwner) Reset() {
 	*x = KubernetesPodOwner{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[9]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1060,7 +1136,7 @@ func (x *KubernetesPodOwner) String() string {
 func (*KubernetesPodOwner) ProtoMessage() {}
 
 func (x *KubernetesPodOwner) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[9]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1073,7 +1149,7 @@ func (x *KubernetesPodOwner) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubernetesPodOwner.ProtoReflect.Descriptor instead.
 func (*KubernetesPodOwner) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{9}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *KubernetesPodOwner) GetKind() string {
@@ -1108,7 +1184,7 @@ type OrchestratorContainer struct {
 
 func (x *OrchestratorContainer) Reset() {
 	*x = OrchestratorContainer{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[10]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1120,7 +1196,7 @@ func (x *OrchestratorContainer) String() string {
 func (*OrchestratorContainer) ProtoMessage() {}
 
 func (x *OrchestratorContainer) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[10]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1133,7 +1209,7 @@ func (x *OrchestratorContainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OrchestratorContainer.ProtoReflect.Descriptor instead.
 func (*OrchestratorContainer) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{10}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *OrchestratorContainer) GetId() string {
@@ -1180,7 +1256,7 @@ type KubernetesPod struct {
 
 func (x *KubernetesPod) Reset() {
 	*x = KubernetesPod{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[11]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1192,7 +1268,7 @@ func (x *KubernetesPod) String() string {
 func (*KubernetesPod) ProtoMessage() {}
 
 func (x *KubernetesPod) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[11]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1205,7 +1281,7 @@ func (x *KubernetesPod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubernetesPod.ProtoReflect.Descriptor instead.
 func (*KubernetesPod) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{11}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *KubernetesPod) GetEntityId() *WorkloadmetaEntityId {
@@ -1333,7 +1409,7 @@ type ECSTask struct {
 
 func (x *ECSTask) Reset() {
 	*x = ECSTask{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[12]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1345,7 +1421,7 @@ func (x *ECSTask) String() string {
 func (*ECSTask) ProtoMessage() {}
 
 func (x *ECSTask) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[12]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1358,7 +1434,7 @@ func (x *ECSTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ECSTask.ProtoReflect.Descriptor instead.
 func (*ECSTask) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{12}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ECSTask) GetEntityId() *WorkloadmetaEntityId {
@@ -1457,7 +1533,7 @@ type WorkloadmetaEvent struct {
 
 func (x *WorkloadmetaEvent) Reset() {
 	*x = WorkloadmetaEvent{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[13]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1469,7 +1545,7 @@ func (x *WorkloadmetaEvent) String() string {
 func (*WorkloadmetaEvent) ProtoMessage() {}
 
 func (x *WorkloadmetaEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[13]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1482,7 +1558,7 @@ func (x *WorkloadmetaEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadmetaEvent.ProtoReflect.Descriptor instead.
 func (*WorkloadmetaEvent) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{13}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *WorkloadmetaEvent) GetType() WorkloadmetaEventType {
@@ -1522,7 +1598,7 @@ type WorkloadmetaStreamResponse struct {
 
 func (x *WorkloadmetaStreamResponse) Reset() {
 	*x = WorkloadmetaStreamResponse{}
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[14]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1534,7 +1610,7 @@ func (x *WorkloadmetaStreamResponse) String() string {
 func (*WorkloadmetaStreamResponse) ProtoMessage() {}
 
 func (x *WorkloadmetaStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[14]
+	mi := &file_datadog_workloadmeta_workloadmeta_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1547,7 +1623,7 @@ func (x *WorkloadmetaStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkloadmetaStreamResponse.ProtoReflect.Descriptor instead.
 func (*WorkloadmetaStreamResponse) Descriptor() ([]byte, []int) {
-	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{14}
+	return file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *WorkloadmetaStreamResponse) GetEvents() []*WorkloadmetaEvent {
@@ -1607,7 +1683,18 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\bexitCode\x18\a \x01(\x03R\bexitCode\"@\n" +
 	"\x1aContainerAllocatedResource\x12\x12\n" +
 	"\x04Name\x18\x01 \x01(\tR\x04Name\x12\x0e\n" +
-	"\x02ID\x18\x02 \x01(\tR\x02ID\"\xfb\x06\n" +
+	"\x02ID\x18\x02 \x01(\tR\x02ID\"\xea\x01\n" +
+	"\x12ContainerResources\x12#\n" +
+	"\n" +
+	"cpuRequest\x18\x01 \x01(\x01H\x00R\n" +
+	"cpuRequest\x88\x01\x01\x12\x1f\n" +
+	"\bcpuLimit\x18\x02 \x01(\x01H\x01R\bcpuLimit\x88\x01\x01\x12)\n" +
+	"\rmemoryRequest\x18\x03 \x01(\x04H\x02R\rmemoryRequest\x88\x01\x01\x12%\n" +
+	"\vmemoryLimit\x18\x04 \x01(\x04H\x03R\vmemoryLimit\x88\x01\x01B\r\n" +
+	"\v_cpuRequestB\v\n" +
+	"\t_cpuLimitB\x10\n" +
+	"\x0e_memoryRequestB\x0e\n" +
+	"\f_memoryLimit\"\xc3\a\n" +
 	"\tContainer\x12F\n" +
 	"\bentityId\x18\x01 \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\bentityId\x12@\n" +
 	"\n" +
@@ -1628,7 +1715,8 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\n" +
 	"cgroupPath\x18\f \x01(\tR\n" +
 	"cgroupPath\x12p\n" +
-	"\x1aresolvedAllocatedResources\x18\r \x03(\v20.datadog.workloadmeta.ContainerAllocatedResourceR\x1aresolvedAllocatedResources\x1a:\n" +
+	"\x1aresolvedAllocatedResources\x18\r \x03(\v20.datadog.workloadmeta.ContainerAllocatedResourceR\x1aresolvedAllocatedResources\x12F\n" +
+	"\tresources\x18\x0e \x01(\v2(.datadog.workloadmeta.ContainerResourcesR\tresources\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a=\n" +
@@ -1753,7 +1841,7 @@ func file_datadog_workloadmeta_workloadmeta_proto_rawDescGZIP() []byte {
 }
 
 var file_datadog_workloadmeta_workloadmeta_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_datadog_workloadmeta_workloadmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_datadog_workloadmeta_workloadmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_datadog_workloadmeta_workloadmeta_proto_goTypes = []any{
 	(WorkloadmetaKind)(0),              // 0: datadog.workloadmeta.WorkloadmetaKind
 	(WorkloadmetaSource)(0),            // 1: datadog.workloadmeta.WorkloadmetaSource
@@ -1770,20 +1858,21 @@ var file_datadog_workloadmeta_workloadmeta_proto_goTypes = []any{
 	(*ContainerPort)(nil),              // 12: datadog.workloadmeta.ContainerPort
 	(*ContainerState)(nil),             // 13: datadog.workloadmeta.ContainerState
 	(*ContainerAllocatedResource)(nil), // 14: datadog.workloadmeta.ContainerAllocatedResource
-	(*Container)(nil),                  // 15: datadog.workloadmeta.Container
-	(*KubernetesPodOwner)(nil),         // 16: datadog.workloadmeta.KubernetesPodOwner
-	(*OrchestratorContainer)(nil),      // 17: datadog.workloadmeta.OrchestratorContainer
-	(*KubernetesPod)(nil),              // 18: datadog.workloadmeta.KubernetesPod
-	(*ECSTask)(nil),                    // 19: datadog.workloadmeta.ECSTask
-	(*WorkloadmetaEvent)(nil),          // 20: datadog.workloadmeta.WorkloadmetaEvent
-	(*WorkloadmetaStreamResponse)(nil), // 21: datadog.workloadmeta.WorkloadmetaStreamResponse
-	nil,                                // 22: datadog.workloadmeta.EntityMeta.AnnotationsEntry
-	nil,                                // 23: datadog.workloadmeta.EntityMeta.LabelsEntry
-	nil,                                // 24: datadog.workloadmeta.Container.EnvVarsEntry
-	nil,                                // 25: datadog.workloadmeta.Container.NetworkIpsEntry
-	nil,                                // 26: datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
-	nil,                                // 27: datadog.workloadmeta.ECSTask.TagsEntry
-	nil,                                // 28: datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	(*ContainerResources)(nil),         // 15: datadog.workloadmeta.ContainerResources
+	(*Container)(nil),                  // 16: datadog.workloadmeta.Container
+	(*KubernetesPodOwner)(nil),         // 17: datadog.workloadmeta.KubernetesPodOwner
+	(*OrchestratorContainer)(nil),      // 18: datadog.workloadmeta.OrchestratorContainer
+	(*KubernetesPod)(nil),              // 19: datadog.workloadmeta.KubernetesPod
+	(*ECSTask)(nil),                    // 20: datadog.workloadmeta.ECSTask
+	(*WorkloadmetaEvent)(nil),          // 21: datadog.workloadmeta.WorkloadmetaEvent
+	(*WorkloadmetaStreamResponse)(nil), // 22: datadog.workloadmeta.WorkloadmetaStreamResponse
+	nil,                                // 23: datadog.workloadmeta.EntityMeta.AnnotationsEntry
+	nil,                                // 24: datadog.workloadmeta.EntityMeta.LabelsEntry
+	nil,                                // 25: datadog.workloadmeta.Container.EnvVarsEntry
+	nil,                                // 26: datadog.workloadmeta.Container.NetworkIpsEntry
+	nil,                                // 27: datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
+	nil,                                // 28: datadog.workloadmeta.ECSTask.TagsEntry
+	nil,                                // 29: datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
 }
 var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	0,  // 0: datadog.workloadmeta.WorkloadmetaFilter.kinds:type_name -> datadog.workloadmeta.WorkloadmetaKind
@@ -1791,43 +1880,44 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	2,  // 2: datadog.workloadmeta.WorkloadmetaFilter.eventType:type_name -> datadog.workloadmeta.WorkloadmetaEventType
 	7,  // 3: datadog.workloadmeta.WorkloadmetaStreamRequest.filter:type_name -> datadog.workloadmeta.WorkloadmetaFilter
 	0,  // 4: datadog.workloadmeta.WorkloadmetaEntityId.kind:type_name -> datadog.workloadmeta.WorkloadmetaKind
-	22, // 5: datadog.workloadmeta.EntityMeta.annotations:type_name -> datadog.workloadmeta.EntityMeta.AnnotationsEntry
-	23, // 6: datadog.workloadmeta.EntityMeta.labels:type_name -> datadog.workloadmeta.EntityMeta.LabelsEntry
+	23, // 5: datadog.workloadmeta.EntityMeta.annotations:type_name -> datadog.workloadmeta.EntityMeta.AnnotationsEntry
+	24, // 6: datadog.workloadmeta.EntityMeta.labels:type_name -> datadog.workloadmeta.EntityMeta.LabelsEntry
 	4,  // 7: datadog.workloadmeta.ContainerState.status:type_name -> datadog.workloadmeta.ContainerStatus
 	5,  // 8: datadog.workloadmeta.ContainerState.health:type_name -> datadog.workloadmeta.ContainerHealth
 	9,  // 9: datadog.workloadmeta.Container.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
 	10, // 10: datadog.workloadmeta.Container.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	24, // 11: datadog.workloadmeta.Container.envVars:type_name -> datadog.workloadmeta.Container.EnvVarsEntry
+	25, // 11: datadog.workloadmeta.Container.envVars:type_name -> datadog.workloadmeta.Container.EnvVarsEntry
 	11, // 12: datadog.workloadmeta.Container.image:type_name -> datadog.workloadmeta.ContainerImage
-	25, // 13: datadog.workloadmeta.Container.networkIps:type_name -> datadog.workloadmeta.Container.NetworkIpsEntry
+	26, // 13: datadog.workloadmeta.Container.networkIps:type_name -> datadog.workloadmeta.Container.NetworkIpsEntry
 	12, // 14: datadog.workloadmeta.Container.ports:type_name -> datadog.workloadmeta.ContainerPort
 	3,  // 15: datadog.workloadmeta.Container.runtime:type_name -> datadog.workloadmeta.Runtime
 	13, // 16: datadog.workloadmeta.Container.state:type_name -> datadog.workloadmeta.ContainerState
 	14, // 17: datadog.workloadmeta.Container.resolvedAllocatedResources:type_name -> datadog.workloadmeta.ContainerAllocatedResource
-	11, // 18: datadog.workloadmeta.OrchestratorContainer.image:type_name -> datadog.workloadmeta.ContainerImage
-	9,  // 19: datadog.workloadmeta.KubernetesPod.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
-	10, // 20: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	16, // 21: datadog.workloadmeta.KubernetesPod.owners:type_name -> datadog.workloadmeta.KubernetesPodOwner
-	17, // 22: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	26, // 23: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
-	17, // 24: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	17, // 25: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	9,  // 26: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
-	10, // 27: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	27, // 28: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
-	28, // 29: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
-	6,  // 30: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
-	17, // 31: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	2,  // 32: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
-	15, // 33: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
-	18, // 34: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
-	19, // 35: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
-	20, // 36: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	15, // 18: datadog.workloadmeta.Container.resources:type_name -> datadog.workloadmeta.ContainerResources
+	11, // 19: datadog.workloadmeta.OrchestratorContainer.image:type_name -> datadog.workloadmeta.ContainerImage
+	9,  // 20: datadog.workloadmeta.KubernetesPod.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	10, // 21: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
+	17, // 22: datadog.workloadmeta.KubernetesPod.owners:type_name -> datadog.workloadmeta.KubernetesPodOwner
+	18, // 23: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	27, // 24: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
+	18, // 25: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	18, // 26: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	9,  // 27: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	10, // 28: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
+	28, // 29: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
+	29, // 30: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	6,  // 31: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
+	18, // 32: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	2,  // 33: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
+	16, // 34: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
+	19, // 35: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
+	20, // 36: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
+	21, // 37: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadmeta_workloadmeta_proto_init() }
@@ -1835,13 +1925,14 @@ func file_datadog_workloadmeta_workloadmeta_proto_init() {
 	if File_datadog_workloadmeta_workloadmeta_proto != nil {
 		return
 	}
+	file_datadog_workloadmeta_workloadmeta_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datadog_workloadmeta_workloadmeta_proto_rawDesc), len(file_datadog_workloadmeta_workloadmeta_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   22,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
### What does this PR do?

### Motivation

Fix bug for Autoscaling when `process-agent` is still running separately since 7.67 (forced since https://github.com/DataDog/datadog-agent/pull/35954)

### Describe how you validated your changes

Run the `process-agent` separately, observe that Autoscaling metrics are missing.

### Possible Drawbacks / Trade-offs

### Additional Notes
