### PR TITLE
[EBPF-769] gpu: mark vectoradd test flaky on specific log

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1087,7 +1087,6 @@ workflow:
         - pkg/gpu/**/*
         - pkg/ebpf/**/*
         - pkg/util/kernel/**/*
-        - pkg/gpu/**/*
         - test/new-e2e/tests/gpu/**/*
         - pkg/collector/corechecks/gpu/**/*
         - comp/core/workloadmeta/collectors/internal/nvml/**/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1085,6 +1085,9 @@ workflow:
   - changes:
       paths:
         - pkg/gpu/**/*
+        - pkg/ebpf/**/*
+        - pkg/util/kernel/**/*
+        - pkg/gpu/**/*
         - test/new-e2e/tests/gpu/**/*
         - pkg/collector/corechecks/gpu/**/*
         - comp/core/workloadmeta/collectors/internal/nvml/**/*

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -351,7 +351,9 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 		v.T().Skip("skipping test as system does not support the system-probe component")
 	}
 
-	flake.Mark(v.T())
+	// Docker access to GPUs is flaky sometimes. We haven't been able to reproduce why this happens, but it
+	// seems it's always the same error code.
+	flake.MarkOnLog(v.T(), "error code no CUDA-capable device is detected")
 	_ = v.runCudaDockerWorkload()
 
 	v.EventuallyWithT(func(c *assert.CollectT) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Instead of marking the test as flaky all of the time, mark it as flaky only when we get the specific log showing an error with the CUDA device assignment in Docker.

### Motivation

Ensure failures due to other reasons are not masked.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->