### PR TITLE
Add IIS APM uninstallation script on windows

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -697,6 +697,7 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestMSIRollbackRemovesLibrary$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestMSISkipRollbackIfInstalled$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestUninstallKeepsLibrary$"
+      - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestUninstallScript$"
 
 new-e2e-installer-ansible:
   extends: .new_e2e_template

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -132,6 +132,8 @@ build do
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/agent.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/dist', "#{install_dir}/bin/agent"
+    mkdir "#{install_dir}/bin/scripts/"
+    copy "#{project_dir}/omnibus/windows-scripts/iis-instrumentation.bat", "#{install_dir}/bin/scripts/"
     mkdir Omnibus::Config.package_dir() unless Dir.exists?(Omnibus::Config.package_dir())
   end
 

--- a/omnibus/windows-scripts/iis-instrumentation.bat
+++ b/omnibus/windows-scripts/iis-instrumentation.bat
@@ -1,0 +1,51 @@
+:: Do not print commands
+@echo off
+:: Needed for the for loop, otherwise variables are expanded at parse time
+setlocal enabledelayedexpansion
+
+:: Parse command line arguments
+set "uninstall_flag="
+
+:: Try to get installer path from registry, fallback to default
+set "installerPath="
+for /f "tokens=2*" %%a in ('reg query "HKLM\SOFTWARE\Datadog\Datadog Agent" /v "InstallPath" 2^>nul') do (
+    set "installerPath=%%b\bin\datadog-installer.exe"
+)
+
+:: If registry lookup failed, use default path
+if not defined installerPath (
+    set "installerPath=C:\Program Files\Datadog\Datadog Agent\bin\datadog-installer.exe"
+)
+
+for %%A in (%*) do (
+    set "arg=%%A"
+    if /i "!arg!" == "-h" (
+        goto usage
+    )
+    if /i "!arg!" == "--help" (
+        goto usage
+    )
+    if /i "!arg!" == "--uninstall" (
+        set "uninstall_flag=true"
+    )
+)
+
+if defined uninstall_flag (
+    echo Running APM uninstall command...
+    "%installerPath%" remove datadog-apm-library-dotnet
+) else (
+    goto usage
+)
+exit /b 0
+
+:: Display usage/help
+:usage
+echo Datadog IIS Instrumentation
+echo.
+echo Usage: %0 [options]
+echo.
+echo Options:
+echo   --help^|-h         OPTIONAL Display this message
+echo   --uninstall        OPTIONAL Remove installation
+echo.
+goto :EOF

--- a/releasenotes/notes/add-iis-instrumentation-script-1baafc3f2b954fe2.yaml
+++ b/releasenotes/notes/add-iis-instrumentation-script-1baafc3f2b954fe2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a script to manage IIS .NET APM instrumentation on Windows

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
@@ -288,7 +288,7 @@ func (s *testAgentMSIInstallsDotnetLibrary) TestUninstallScript() {
 	oldLibraryPath := s.getLibraryPathFromInstrumentedIIS()
 	s.Require().Contains(oldLibraryPath, version.Version())
 
-	output, err := s.Env().RemoteHost.Execute(`C:\Program Files\Datadog\Datadog Agent\bin\scripts\iis-instrumentation.bat --uninstall`)
+	output, err := s.Env().RemoteHost.Execute(`&"C:\Program Files\Datadog\Datadog Agent\bin\scripts\iis-instrumentation.bat" --uninstall`)
 	s.Require().NoErrorf(err, "failed to run uninstall script: %s", output)
 
 	s.stopIISApp()

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
@@ -265,6 +265,39 @@ func (s *testAgentMSIInstallsDotnetLibrary) TestUninstallKeepsLibrary() {
 	s.Require().Contains(oldLibraryPath, version.Version())
 }
 
+// TestUninstallScript validates that instrumentation is disabled after we run the uninstall script
+func (s *testAgentMSIInstallsDotnetLibrary) TestUninstallScript() {
+	// Arrange
+	version := s.currentDotnetLibraryVersion
+
+	// Act
+	s.installCurrentAgentVersion(
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=iis"),
+		// TODO: remove override once image is published in prod
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com.internal.dda-testing.com"),
+		installerwindows.WithMSIArg(fmt.Sprintf("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:%s", version.PackageVersion())),
+		installerwindows.WithMSILogFile("install.log"),
+	)
+	// Start the IIS app to load the library
+	defer s.stopIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
+
+	// Assert
+	s.assertSuccessfulPromoteExperiment(version.Version())
+	// Check that the expected version of the library is loaded
+	oldLibraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Contains(oldLibraryPath, version.Version())
+
+	output, err := s.Env().RemoteHost.Execute(`C:\Program Files\Datadog\Datadog Agent\bin\scripts\iis-instrumentation.bat --uninstall`)
+	s.Require().NoErrorf(err, "failed to run uninstall script: %s", output)
+
+	s.stopIISApp()
+	defer s.stopIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
+	newLibraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Empty(newLibraryPath)
+}
+
 func (s *testAgentMSIInstallsDotnetLibrary) setAgentConfig() {
 	err := s.Env().RemoteHost.MkdirAll("C:\\ProgramData\\Datadog")
 	s.Require().NoError(err)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -573,6 +573,9 @@ namespace WixSetup.Datadog_Agent
                         AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     }
             );
+            var scriptsBinDir = new Dir(new Id("SCRIPTS"), "scripts",
+                 new Files($@"{InstallerSource}\bin\scripts\*")
+            );
             var securityAgentService = GenerateDependentServiceInstaller(
                 new Id("ddagentsecurityservice"),
                 Constants.SecurityAgentServiceName,
@@ -628,7 +631,8 @@ namespace WixSetup.Datadog_Agent
                         Account = "LocalSystem",
                         Vital = true
                     }
-                )
+                ),
+                scriptsBinDir
             );
 
             return targetBinFolder;


### PR DESCRIPTION
### What does this PR do?

This PR adds a script to manage IIS APM instrumentation on Windows hosts.

The script is installed in the bin/scripts directory of the agent installation directory and allows to uninstall .NET instrumentation without uninstalling the datadog agent.

### Motivation

Provide a more user friendly and stable abstraction on top of the datadog-installer command.

### Describe how you validated your changes

This change has been validated with a E2E test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->