### PR TITLE
CXP-2500 [agent] add process collection interval config support + test refactor

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -156,7 +156,7 @@ func (c *collector) processCollectionIntervalConfig() time.Duration {
 	// service discovery data will be incorrect/empty if the process collection interval > service collection interval
 	// therefore, the service collection interval must be the max interval for process collection
 	if processCollectionInterval > serviceCollectionInterval {
-		log.Warnf("process collection interval %v cannot be larger than the service collection interval %v. falling back to service interval",
+		log.Warnf("process collection interval %v cannot be larger than the service collection interval %v. falling back to service collection interval",
 			processCollectionInterval, serviceCollectionInterval)
 		return serviceCollectionInterval
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -11,7 +11,6 @@ package process
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
@@ -663,15 +662,12 @@ func setUpCollectorTest(t *testing.T, configOverrides map[string]interface{}, sy
 		config.MockModule(),
 		fx.Replace(config.MockParams{Overrides: configOverrides}),
 	))
-	fmt.Printf("config %v\n", mockConfig.AllSettings())
 
 	// mock language detection system probe configOverrides
 	mockSystemProbeConfig := fxutil.Test[sysprobeconfig.Component](t, fx.Options(
 		sysprobeconfigimpl.MockModule(),
 		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysProbeConfigOverrides}),
 	))
-	fmt.Printf("system probe config %v\n", mockSystemProbeConfig.AllSettings())
-	fmt.Printf("system probe config overrides %v\n", sysProbeConfigOverrides)
 	processCollector := newProcessCollector(collectorID, workloadmeta.NodeAgent, mockClock, mockProbe, mockConfig, mockSystemProbeConfig)
 	processCollector.sysProbeClient = &http.Client{}
 	processCollector.containerProvider = mockContainerProvider


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- adds support to read process collection interval from configuration

### Motivation
- removing hardcoded values and allow them to be user configurable 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- unit tests
- vagrant ubuntu 24 vm testing

metrics look good on dddev
<img width="1343" height="641" alt="image" src="https://github.com/user-attachments/assets/5031dfb3-b229-41c7-894b-1f17276822aa" />
the gap was turning off the agent and changing the interval to 30 seconds
<img width="571" height="358" alt="image" src="https://github.com/user-attachments/assets/28d56e95-4644-4eaf-9470-fbeb2b6bd641" />
next data point appears 30 seconds later

Setting `process_config.intervals.process` to 100 leads to the expected warning log:

```
2025-08-06 14:13:06 CDT | CORE | WARN | (comp/core/workloadmeta/collectors/internal/process/process_collector.go:159 in processCollectionIntervalConfig) | process collection interval 1m40s cannot be larger than the service collection interval 1m0s. falling back to service collection interval
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->