### PR TITLE
Revert "Make agent-build team owners of various bazel config files"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,12 +23,6 @@
 /.pre-commit-config.yaml                @DataDog/agent-devx
 /.vscode/                               @DataDog/agent-devx
 
-/.bazel*                                @DataDog/agent-build
-/MODULE.bazel*                          @DataDog/agent-build
-# Temporary during Bazel migration
-/**/BUILD.bazel                         @DataDog/agent-build
-/**/*.bzl                               @DataDog/agent-build
-
 /CHANGELOG.rst                          @DataDog/agent-delivery
 /CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
 /CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery @DataDog/container-ecosystems


### PR DESCRIPTION
This reverts commit c0f2971cb3763f25aada1b4d88c6c402e1e9cd05.

The PR is fine, but it should have gone through CI.