### PR TITLE
[SMP] Fix expvar scraping of trace agent for `docker_containers_*` experiments

### DIFF
--- a/test/regression/cases/docker_containers_cpu/lading/lading.yaml
+++ b/test/regression/cases/docker_containers_cpu/lading/lading.yaml
@@ -51,7 +51,7 @@ target_metrics:
       tags:
         sub_agent: "process"
   - expvar: #trace agent telemetry
-      uri: "http://127.0.0.1:5012/debug/vars"
+      uri: "https://127.0.0.1:5012/debug/vars"
       vars:
         - "/Event"
         - "/ServiceCheck"

--- a/test/regression/cases/docker_containers_memory/lading/lading.yaml
+++ b/test/regression/cases/docker_containers_memory/lading/lading.yaml
@@ -51,7 +51,7 @@ target_metrics:
       tags:
         sub_agent: "process"
   - expvar: #trace agent telemetry
-      uri: "http://127.0.0.1:5012/debug/vars"
+      uri: "https://127.0.0.1:5012/debug/vars"
       vars:
         - "/Event"
         - "/ServiceCheck"


### PR DESCRIPTION
### What does this PR do?

Fixes the lading config for `docker_containers_cpu` and `docker_containers_memory`

### Motivation

Get rid of [these](https://app.datadoghq.com/logs?query=client_team%3Aagent%20%22client%20sent%20an%20HTTP%20request%20to%20an%20HTTPS%20server%22&agg_m=count&agg_m_source=base&agg_q=experiment&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&flat_group_bys=true&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&sort_m=count&sort_t=count&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1753942046474&to_ts=1754499594662&live=false) errors, and also properly ingest internal telemetry from trace agent for these two experiments. To see examples of experiments that have this properly configured, see `quality_gate_idle` and `quality_gate_idle_all_features`

### Describe how you validated your changes


### Possible Drawbacks / Trade-offs

### Additional Notes
