### PR TITLE
[SMP] Fixes duplicate `logs_config` for `docker_containers_*` experiments

### DIFF
--- a/test/regression/cases/docker_containers_cpu/datadog-agent/datadog.yaml
+++ b/test/regression/cases/docker_containers_cpu/datadog-agent/datadog.yaml
@@ -2,6 +2,7 @@ dd_url: http://127.0.0.1:9091
 logs_config:
   logs_dd_url: localhost:9092
   logs_no_ssl: true
+  container_collect_all: true
 process_config:
   process_dd_url: http://localhost:9093
 container_image:
@@ -16,8 +17,6 @@ dogstatsd_origin_detection: true
 dogstatsd_tag_cardinality: high
 log_enabled: true
 logs_enabled: true
-logs_config:
-  container_collect_all: true
 container_labels_as_tags:
   foo: label_foo
   bar: label_bar

--- a/test/regression/cases/docker_containers_memory/datadog-agent/datadog.yaml
+++ b/test/regression/cases/docker_containers_memory/datadog-agent/datadog.yaml
@@ -2,6 +2,7 @@ dd_url: http://127.0.0.1:9091
 logs_config:
   logs_dd_url: localhost:9092
   logs_no_ssl: true
+  container_collect_all: true
 process_config:
   process_dd_url: http://localhost:9093
 container_image:
@@ -16,8 +17,6 @@ dogstatsd_origin_detection: true
 dogstatsd_tag_cardinality: high
 log_enabled: true
 logs_enabled: true
-logs_config:
-  container_collect_all: true
 container_labels_as_tags:
   foo: label_foo
   bar: label_bar


### PR DESCRIPTION
### What does this PR do?

Fixes duplicate `logs_config` blocks in `datadog.yaml`

### Motivation

Fix [these](https://app.datadoghq.com/logs?query=client_team%3Aagent%20%22line%2020%3A%20key%20%5C%22logs_config%5C%22%20already%20set%20in%20map%22&agg_m=count&agg_m_source=base&agg_q=experiment&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&flat_group_bys=true&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&sort_m=count&sort_t=count&storage=hot&stream_sort=time%2Casc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1753256538793&to_ts=1754508242159&live=false) errors

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
