### PR TITLE
Update Data Streams messages log format

### DIFF
--- a/pkg/datastreams/live_messages.go
+++ b/pkg/datastreams/live_messages.go
@@ -24,7 +24,10 @@ import (
 
 const (
 	kafkaConsumerIntegrationName = "kafka_consumer"
-	logsConfig                   = "[{\"type\":\"integration\",\"service\":\"kafka_consumer\",\"source\":\"kafka_consumer\"}]"
+	logsConfig                   = `logs:
+  - type: integration
+    service: kafka_consumer
+    source: kafka_consumer`
 )
 
 type kafkaConfig struct {

--- a/pkg/datastreams/live_messages_test.go
+++ b/pkg/datastreams/live_messages_test.go
@@ -156,7 +156,7 @@ func TestController(t *testing.T) {
 		Name:       kafkaConsumerIntegrationName,
 		Instances:  []integration.Data{integration.Data(modifiedConfig)},
 		InitConfig: integration.Data{},
-		LogsConfig: integration.Data("[{\"type\":\"integration\",\"service\":\"kafka_consumer\",\"source\":\"kafka_consumer\"}]"),
+		LogsConfig: integration.Data(logsConfig),
 	}
 	assert.Equal(t, expectedUnscheduled, cfg.Unschedule[0])
 	assert.Equal(t, expectedScheduled, cfg.Schedule[0])

--- a/releasenotes/notes/kafka-messages-log-format-7bea9792c59b294d.yaml
+++ b/releasenotes/notes/kafka-messages-log-format-7bea9792c59b294d.yaml
@@ -1,0 +1,1 @@
+fixes: The Kafka messages feature is not working in some cases when using K8s labels because config is translated to yaml.


### PR DESCRIPTION
### What does this PR do?

### Motivation

I'm getting an error in kubernetes:
```
2025-08-01 20:08:56 UTC | CORE | WARN | (pkg/logs/schedulers/ad/scheduler.go:77 in Schedule) | Invalid configuration: could not parse logs config as JSON or YAML: could not decode YAML logs config: yaml: unmarshal errors:
  line 1: cannot unmarshal !!seq into config.yamlLogsConfigsWrapper
```

It looks like the logs pipeline is transforming the logs config into a yaml config somewhere. But without adding the `logs:` prefix.
So I'm updating it to use a correctly formatted Yaml instead.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->