### PR TITLE
enable crash dumps and agent debug logs

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -47,6 +47,7 @@ type BaseSuite struct {
 	stableAgent        *AgentVersionManager
 	CreateCurrentAgent func() (*AgentVersionManager, error)
 	CreateStableAgent  func() (*AgentVersionManager, error)
+	dumpFolder         string
 }
 
 // Installer The Datadog Installer for testing.
@@ -108,6 +109,17 @@ func (s *BaseSuite) SetupSuite() {
 	s.T().Logf("current agent version: %s", s.CurrentAgentVersion())
 	s.createStableAgent()
 	s.T().Logf("stable agent version: %s", s.StableAgentVersion())
+
+	// Enable crash dumps
+	host := s.Env().RemoteHost
+	s.dumpFolder = `C:\dumps`
+	err := windowscommon.EnableWERGlobalDumps(host, s.dumpFolder)
+	s.Require().NoError(err, "should enable WER dumps")
+	// Set the environment variable at the machine level.
+	// The tests will be re-installing services so the per-service environment
+	// won't be persisted.
+	_, err = host.Execute(`[Environment]::SetEnvironmentVariable("GOTRACEBACK", "wer", "Machine")`)
+	s.Require().NoError(err, "should set GOTRACEBACK environment variable")
 }
 
 // createCurrentAgent sets the current agent version for the test suite.
@@ -261,6 +273,16 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 func (s *BaseSuite) AfterTest(suiteName, testName string) {
 	if afterTest, ok := any(&s.BaseSuite).(suite.AfterTest); ok {
 		afterTest.AfterTest(suiteName, testName)
+	}
+
+	// look for and download crashdumps
+	dumps, err := windowscommon.DownloadAllWERDumps(s.Env().RemoteHost, s.dumpFolder, s.SessionOutputDir())
+	s.Assert().NoError(err, "should download crash dumps")
+	if !s.Assert().Empty(dumps, "should not have crash dumps") {
+		s.T().Logf("Found crash dumps:")
+		for _, dump := range dumps {
+			s.T().Logf("  %s", dump)
+		}
 	}
 
 	if s.T().Failed() {

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -43,7 +43,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "true")
+		WithValueEqual("log_to_console", true)
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -51,7 +51,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_to_console": "false"}`),
+				Contents: json.RawMessage(`{"log_to_console": false}`),
 			},
 		},
 	}
@@ -61,14 +61,14 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
@@ -105,7 +105,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	// Config should be reverted to the stable config
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "true")
+		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -190,7 +190,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_to_console": "false"}`),
+				Contents: json.RawMessage(`{"log_to_console": false}`),
 			},
 		},
 	}
@@ -200,7 +200,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 
 	// Stop the agent service to trigger watchdog rollback
 	windowscommon.StopService(s.Env().RemoteHost, consts.ServiceName)
@@ -210,7 +210,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "true")
+		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -235,7 +235,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_to_console": "false"}`),
+				Contents: json.RawMessage(`{"log_to_console": false}`),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 
 	// wait for the timeout
 	s.WaitForDaemonToStop(func() {}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
@@ -255,7 +255,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "true")
+		WithValueEqual("log_to_console", true)
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -276,7 +276,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "true")
+		WithValueEqual("log_to_console", true)
 
 	// Set up a custom configuration
 	config := installerwindows.ConfigExperiment{
@@ -284,7 +284,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_to_console": "false"}`),
+				Contents: json.RawMessage(`{"log_to_console": false}`),
 			},
 		},
 	}
@@ -295,7 +295,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 
 	// Act - Perform a package upgrade to current version
 	s.MustStartExperimentCurrentVersion()
@@ -311,7 +311,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 	// Verify the runtime config values are still preserved after upgrade
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_to_console", "false")
+		WithValueEqual("log_to_console", false)
 }
 
 func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows.ConfigExperiment) {

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -122,6 +122,9 @@ func (s *testAgentConfigSuite) TestConfigUpgradeNewAgents() {
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
 
+	// assert that setup was successful
+	s.AssertSuccessfulConfigPromoteExperiment("empty")
+
 	// Assert that the non-default services are not running
 	err := s.WaitForServicesWithBackoff("Stopped", &backoff.StopBackOff{},
 		"datadog-system-probe",
@@ -274,6 +277,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 	s.setAgentConfig()
 	s.installPreviousAgentVersion()
 
+	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
 		WithValueEqual("log_to_console", true)
@@ -315,6 +319,8 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 }
 
 func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows.ConfigExperiment) {
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().StartConfigExperiment(consts.AgentPackage, config)
 		s.Require().NoError(err, "daemon should stop cleanly")
@@ -324,6 +330,8 @@ func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows
 }
 
 func (s *testAgentConfigSuite) mustPromoteConfigExperiment(config installerwindows.ConfigExperiment) {
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+
 	s.WaitForDaemonToStop(func() {
 		_, err := s.Installer().PromoteConfigExperiment(consts.AgentPackage)
 		s.Require().NoError(err, "daemon should stop cleanly")

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/config_test.go
@@ -43,7 +43,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 	s.AssertSuccessfulConfigPromoteExperiment("empty")
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "info")
+		WithValueEqual("log_to_console", "true")
 
 	// Act
 	config := installerwindows.ConfigExperiment{
@@ -51,7 +51,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_level": "debug"}`),
+				Contents: json.RawMessage(`{"log_to_console": "false"}`),
 			},
 		},
 	}
@@ -61,14 +61,14 @@ func (s *testAgentConfigSuite) TestConfigUpgradeSuccessful() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 
 	// Promote config experiment
 	s.mustPromoteConfigExperiment(config)
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 }
 
 // TestConfigUpgradeFailure tests that the Agent's config can be rolled back
@@ -84,7 +84,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_level": "ENC[hi]"}`), // Invalid config
+				Contents: json.RawMessage(`{"log_to_console": "ENC[hi]"}`), // Invalid config
 			},
 		},
 	}
@@ -105,7 +105,7 @@ func (s *testAgentConfigSuite) TestConfigUpgradeFailure() {
 	// Config should be reverted to the stable config
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "info")
+		WithValueEqual("log_to_console", "true")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -190,7 +190,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_level": "debug"}`),
+				Contents: json.RawMessage(`{"log_to_console": "false"}`),
 			},
 		},
 	}
@@ -200,7 +200,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 
 	// Stop the agent service to trigger watchdog rollback
 	windowscommon.StopService(s.Env().RemoteHost, consts.ServiceName)
@@ -210,7 +210,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenServiceDies() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "info")
+		WithValueEqual("log_to_console", "true")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -235,7 +235,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_level": "debug"}`),
+				Contents: json.RawMessage(`{"log_to_console": "false"}`),
 			},
 		},
 	}
@@ -245,7 +245,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 
 	// wait for the timeout
 	s.WaitForDaemonToStop(func() {}, backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10))
@@ -255,7 +255,7 @@ func (s *testAgentConfigSuite) TestRevertsConfigExperimentWhenTimeout() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "info")
+		WithValueEqual("log_to_console", "true")
 
 	// backend will send stop experiment now
 	s.assertDaemonStaysRunning(func() {
@@ -276,7 +276,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "info")
+		WithValueEqual("log_to_console", "true")
 
 	// Set up a custom configuration
 	config := installerwindows.ConfigExperiment{
@@ -284,7 +284,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 		Files: []installerwindows.ConfigExperimentFile{
 			{
 				Path:     "/datadog.yaml",
-				Contents: json.RawMessage(`{"log_level": "debug"}`),
+				Contents: json.RawMessage(`{"log_to_console": "false"}`),
 			},
 		},
 	}
@@ -295,7 +295,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 
 	// Act - Perform a package upgrade to current version
 	s.MustStartExperimentCurrentVersion()
@@ -311,7 +311,7 @@ func (s *testAgentConfigSuite) TestManagedConfigActiveAfterUpgrade() {
 	// Verify the runtime config values are still preserved after upgrade
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().RuntimeConfig().
-		WithValueEqual("log_level", "debug")
+		WithValueEqual("log_to_console", "false")
 }
 
 func (s *testAgentConfigSuite) mustStartConfigExperiment(config installerwindows.ConfigExperiment) {

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -603,6 +603,7 @@ func (s *testAgentUpgradeSuite) setAgentConfigWithAltDir(path string) {
 api_key: `+apiKey+`
 site: datadoghq.com
 remote_updates: true
+log_level: debug
 `))
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
enable crash dumps and debug logging in fleet automation e2e tests on Windows

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1707
try to get more information from our test that's failing once every couple weeks

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
n/a, test change

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->