### PR TITLE
Use resolved `git` hashes in Omnibus environment

### DIFF
--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -118,12 +118,28 @@ def get_omnibus_env(
     if go_mod_cache:
         env['OMNIBUS_GOMODCACHE'] = go_mod_cache
 
-    env_override = ['INTEGRATIONS_CORE_VERSION', 'OMNIBUS_RUBY_VERSION']
-    for key in env_override:
+    external_repos = {
+        "INTEGRATIONS_CORE_VERSION": "https://github.com/DataDog/integrations-core.git",
+        "OMNIBUS_RUBY_VERSION": "https://github.com/DataDog/omnibus-ruby.git",
+    }
+    for key, url in external_repos.items():
         value = os.environ.get(key)
         # Only overrides the env var if the value is a non-empty string.
         if value:
             env[key] = value
+        ref = env[key]
+        if not re.fullmatch(r"[0-9a-f]{4,40}", ref):  # resolve only "moving" refs, such as `own/branch`
+            candidates = [line.split() for line in ctx.run(f"git ls-remote --refs {url} '{ref}'").stdout.splitlines()]
+            if not candidates:
+                warnings.warn(f"No candidate for {url}@{ref} - leaving untouched", stacklevel=1)
+                continue
+            sha1, shortest_ref = min(candidates, key=lambda c: len(c[1]))
+            if len(candidates) > 1:  # happens when a branch name mimics its base or target, such as `my/own/branch`
+                warnings.warn(
+                    f"Multiple candidates for {url}@{ref}: {[c[1] for c in candidates]} - choosing shortest: {shortest_ref} -> {sha1}",
+                    stacklevel=1,
+                )
+            env[key] = sha1
 
     if sys.platform == 'darwin':
         env['MACOSX_DEPLOYMENT_TARGET'] = '11.0' if os.uname().machine == "arm64" else '10.12'


### PR DESCRIPTION
### What does this PR do? / Motivation
This is aimed at reducing the number of `Omnibus git cache mutation` alerts triggered when using a "floating" `git` ref such as a branch name.

### Describe how you validated your changes
I ran the script with hardcoded overrides denoting "moving" refs of external repositories (i.e. `main`, `master`, `datadog-5.5.0`): https://github.com/DataDog/datadog-agent/commit/727aa50ea4a01f1180f378441d5eb1ec22bc988f#diff-0a1a69df7ccd1e457863118f2c0908aec6b4b3ad15cf698562bdaeec824aba01R132
The behavior was as expected: ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1069081597))
```sh
$ dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --flavor "$FLAVOR" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR"
/go/src/github.com/DataDog/datadog-agent/tasks/omnibus.py:142: UserWarning: Multiple candidates for https://github.com/DataDog/integrations-core.git@master: ('refs/heads/external-pr/Yufeireal/master', 'refs/heads/external-pr/footprint-it-solutions/master', 'refs/heads/master') - choosing shortest: refs/heads/master
```

### Possible Drawbacks / Trade-offs
None foreseen.

### Additional Notes