### PR TITLE
workloadmeta: add support for container owner in protobuf (and remote collector)

### DIFF
--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -136,6 +136,18 @@ func protoContainerFromWorkloadmetaContainer(container *workloadmeta.Container) 
 
 	protoResolvedAllocatedResources := toProtoResolvedAllocatedResources(container.ResolvedAllocatedResources)
 
+	var ownerEntityID *pb.WorkloadmetaEntityId
+	if container.Owner != nil {
+		kind, err := toProtoKind(container.Owner.Kind)
+		if err != nil {
+			return nil, err
+		}
+		ownerEntityID = &pb.WorkloadmetaEntityId{
+			Kind: kind,
+			Id:   container.Owner.ID,
+		}
+	}
+
 	return &pb.Container{
 		EntityId:                   protoEntityID,
 		EntityMeta:                 toProtoEntityMetaFromContainer(container),
@@ -151,6 +163,7 @@ func protoContainerFromWorkloadmetaContainer(container *workloadmeta.Container) 
 		CgroupPath:                 container.CgroupPath,
 		ResolvedAllocatedResources: protoResolvedAllocatedResources,
 		Resources:                  toProtoContainerResources(container.Resources),
+		Owner:                      ownerEntityID,
 	}, nil
 }
 
@@ -639,6 +652,15 @@ func toWorkloadmetaContainer(protoContainer *pb.Container) (*workloadmeta.Contai
 
 	resources := toWorkloadmetaResolvedAllocatedResources(protoContainer.ResolvedAllocatedResources)
 
+	var owner *workloadmeta.EntityID
+	if protoContainer.Owner != nil {
+		ownerEntityID, err := toWorkloadmetaEntityID(protoContainer.Owner)
+		if err != nil {
+			return nil, err
+		}
+		owner = &ownerEntityID
+	}
+
 	return &workloadmeta.Container{
 		EntityID:                   entityID,
 		EntityMeta:                 toWorkloadmetaEntityMeta(protoContainer.EntityMeta),
@@ -654,6 +676,7 @@ func toWorkloadmetaContainer(protoContainer *pb.Container) (*workloadmeta.Contai
 		CgroupPath:                 protoContainer.CgroupPath,
 		ResolvedAllocatedResources: resources,
 		Resources:                  toWorkloadmetaContainerResources(protoContainer.Resources),
+		Owner:                      owner,
 	}, nil
 }
 

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -162,6 +162,132 @@ func TestConversions(t *testing.T) {
 			expectsError: false,
 		},
 		{
+			name: "event with a container with an owner",
+			workloadmetaEvent: workloadmeta.Event{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.Container{
+					EntityID: workloadmeta.EntityID{
+						Kind: workloadmeta.KindContainer,
+						ID:   "123",
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:      "abc",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"an_annotation": "an_annotation_value",
+						},
+						Labels: map[string]string{
+							"a_label": "a_label_value",
+						},
+					},
+					EnvVars: map[string]string{
+						"an_env": "an_env_val",
+					},
+					Hostname: "test_host",
+					Image: workloadmeta.ContainerImage{
+						ID:        "123",
+						RawName:   "datadog/agent:7",
+						Name:      "datadog/agent",
+						ShortName: "agent",
+						Tag:       "7",
+					},
+					NetworkIPs: map[string]string{
+						"net1": "10.0.0.1",
+						"net2": "192.168.0.1",
+					},
+					PID: 0,
+					Ports: []workloadmeta.ContainerPort{
+						{
+							Port:     2000,
+							Protocol: "tcp",
+						},
+					},
+					Runtime: workloadmeta.ContainerRuntimeContainerd,
+					State: workloadmeta.ContainerState{
+						Running:    true,
+						Status:     workloadmeta.ContainerStatusRunning,
+						Health:     workloadmeta.ContainerHealthHealthy,
+						CreatedAt:  createdAt,
+						StartedAt:  createdAt,
+						FinishedAt: time.Time{},
+						ExitCode:   nil,
+					},
+					CollectorTags: []string{
+						"tag1",
+					},
+					ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+						{Name: "nvidia.com/gpu", ID: "gpu1"},
+					},
+					Owner: &workloadmeta.EntityID{
+						Kind: workloadmeta.KindKubernetesPod,
+						ID:   "pod123",
+					},
+				},
+			},
+			protoWorkloadmetaEvent: &pb.WorkloadmetaEvent{
+				Type: pb.WorkloadmetaEventType_EVENT_TYPE_SET,
+				Container: &pb.Container{
+					EntityId: &pb.WorkloadmetaEntityId{
+						Kind: pb.WorkloadmetaKind_CONTAINER,
+						Id:   "123",
+					},
+					EntityMeta: &pb.EntityMeta{
+						Name:      "abc",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"an_annotation": "an_annotation_value",
+						},
+						Labels: map[string]string{
+							"a_label": "a_label_value",
+						},
+					},
+					EnvVars: map[string]string{
+						"an_env": "an_env_val",
+					},
+					Hostname: "test_host",
+					Image: &pb.ContainerImage{
+						Id:        "123",
+						RawName:   "datadog/agent:7",
+						Name:      "datadog/agent",
+						ShortName: "agent",
+						Tag:       "7",
+					},
+					NetworkIps: map[string]string{
+						"net1": "10.0.0.1",
+						"net2": "192.168.0.1",
+					},
+					Pid: 0,
+					Ports: []*pb.ContainerPort{
+						{
+							Port:     2000,
+							Protocol: "tcp",
+						},
+					},
+					Runtime: pb.Runtime_CONTAINERD,
+					State: &pb.ContainerState{
+						Running:    true,
+						Status:     pb.ContainerStatus_CONTAINER_STATUS_RUNNING,
+						Health:     pb.ContainerHealth_CONTAINER_HEALTH_HEALTHY,
+						CreatedAt:  createdAt.Unix(),
+						StartedAt:  createdAt.Unix(),
+						FinishedAt: time.Time{}.Unix(),
+						ExitCode:   0,
+					},
+					CollectorTags: []string{
+						"tag1",
+					},
+					ResolvedAllocatedResources: []*pb.ContainerAllocatedResource{
+						{Name: "nvidia.com/gpu", ID: "gpu1"},
+					},
+					Owner: &pb.WorkloadmetaEntityId{
+						Kind: pb.WorkloadmetaKind_KUBERNETES_POD,
+						Id:   "pod123",
+					},
+				},
+			},
+			expectsError: false,
+		},
+		{
 			name: "event with a Kubernetes pod",
 			workloadmetaEvent: workloadmeta.Event{
 				Type: workloadmeta.EventTypeSet,

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -122,6 +122,7 @@ message Container {
   string cgroupPath = 12;
   repeated ContainerAllocatedResource resolvedAllocatedResources = 13;
   ContainerResources resources = 14;
+  WorkloadmetaEntityId owner = 15;
 }
 
 message KubernetesPodOwner {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -981,6 +981,7 @@ type Container struct {
 	CgroupPath                 string                        `protobuf:"bytes,12,opt,name=cgroupPath,proto3" json:"cgroupPath,omitempty"`
 	ResolvedAllocatedResources []*ContainerAllocatedResource `protobuf:"bytes,13,rep,name=resolvedAllocatedResources,proto3" json:"resolvedAllocatedResources,omitempty"`
 	Resources                  *ContainerResources           `protobuf:"bytes,14,opt,name=resources,proto3" json:"resources,omitempty"`
+	Owner                      *WorkloadmetaEntityId         `protobuf:"bytes,15,opt,name=owner,proto3" json:"owner,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1109,6 +1110,13 @@ func (x *Container) GetResolvedAllocatedResources() []*ContainerAllocatedResourc
 func (x *Container) GetResources() *ContainerResources {
 	if x != nil {
 		return x.Resources
+	}
+	return nil
+}
+
+func (x *Container) GetOwner() *WorkloadmetaEntityId {
+	if x != nil {
+		return x.Owner
 	}
 	return nil
 }
@@ -1694,7 +1702,7 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\v_cpuRequestB\v\n" +
 	"\t_cpuLimitB\x10\n" +
 	"\x0e_memoryRequestB\x0e\n" +
-	"\f_memoryLimit\"\xc3\a\n" +
+	"\f_memoryLimit\"\x85\b\n" +
 	"\tContainer\x12F\n" +
 	"\bentityId\x18\x01 \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\bentityId\x12@\n" +
 	"\n" +
@@ -1716,7 +1724,8 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"cgroupPath\x18\f \x01(\tR\n" +
 	"cgroupPath\x12p\n" +
 	"\x1aresolvedAllocatedResources\x18\r \x03(\v20.datadog.workloadmeta.ContainerAllocatedResourceR\x1aresolvedAllocatedResources\x12F\n" +
-	"\tresources\x18\x0e \x01(\v2(.datadog.workloadmeta.ContainerResourcesR\tresources\x1a:\n" +
+	"\tresources\x18\x0e \x01(\v2(.datadog.workloadmeta.ContainerResourcesR\tresources\x12@\n" +
+	"\x05owner\x18\x0f \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\x05owner\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a=\n" +
@@ -1894,30 +1903,31 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	13, // 16: datadog.workloadmeta.Container.state:type_name -> datadog.workloadmeta.ContainerState
 	14, // 17: datadog.workloadmeta.Container.resolvedAllocatedResources:type_name -> datadog.workloadmeta.ContainerAllocatedResource
 	15, // 18: datadog.workloadmeta.Container.resources:type_name -> datadog.workloadmeta.ContainerResources
-	11, // 19: datadog.workloadmeta.OrchestratorContainer.image:type_name -> datadog.workloadmeta.ContainerImage
-	9,  // 20: datadog.workloadmeta.KubernetesPod.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
-	10, // 21: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	17, // 22: datadog.workloadmeta.KubernetesPod.owners:type_name -> datadog.workloadmeta.KubernetesPodOwner
-	18, // 23: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	27, // 24: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
-	18, // 25: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	18, // 26: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	9,  // 27: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
-	10, // 28: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
-	28, // 29: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
-	29, // 30: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
-	6,  // 31: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
-	18, // 32: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
-	2,  // 33: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
-	16, // 34: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
-	19, // 35: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
-	20, // 36: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
-	21, // 37: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
-	38, // [38:38] is the sub-list for method output_type
-	38, // [38:38] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	9,  // 19: datadog.workloadmeta.Container.owner:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	11, // 20: datadog.workloadmeta.OrchestratorContainer.image:type_name -> datadog.workloadmeta.ContainerImage
+	9,  // 21: datadog.workloadmeta.KubernetesPod.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	10, // 22: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
+	17, // 23: datadog.workloadmeta.KubernetesPod.owners:type_name -> datadog.workloadmeta.KubernetesPodOwner
+	18, // 24: datadog.workloadmeta.KubernetesPod.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	27, // 25: datadog.workloadmeta.KubernetesPod.namespaceLabels:type_name -> datadog.workloadmeta.KubernetesPod.NamespaceLabelsEntry
+	18, // 26: datadog.workloadmeta.KubernetesPod.InitContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	18, // 27: datadog.workloadmeta.KubernetesPod.ephemeralContainers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	9,  // 28: datadog.workloadmeta.ECSTask.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
+	10, // 29: datadog.workloadmeta.ECSTask.entityMeta:type_name -> datadog.workloadmeta.EntityMeta
+	28, // 30: datadog.workloadmeta.ECSTask.tags:type_name -> datadog.workloadmeta.ECSTask.TagsEntry
+	29, // 31: datadog.workloadmeta.ECSTask.containerInstanceTags:type_name -> datadog.workloadmeta.ECSTask.ContainerInstanceTagsEntry
+	6,  // 32: datadog.workloadmeta.ECSTask.launchType:type_name -> datadog.workloadmeta.ECSLaunchType
+	18, // 33: datadog.workloadmeta.ECSTask.containers:type_name -> datadog.workloadmeta.OrchestratorContainer
+	2,  // 34: datadog.workloadmeta.WorkloadmetaEvent.type:type_name -> datadog.workloadmeta.WorkloadmetaEventType
+	16, // 35: datadog.workloadmeta.WorkloadmetaEvent.container:type_name -> datadog.workloadmeta.Container
+	19, // 36: datadog.workloadmeta.WorkloadmetaEvent.kubernetesPod:type_name -> datadog.workloadmeta.KubernetesPod
+	20, // 37: datadog.workloadmeta.WorkloadmetaEvent.ecsTask:type_name -> datadog.workloadmeta.ECSTask
+	21, // 38: datadog.workloadmeta.WorkloadmetaStreamResponse.events:type_name -> datadog.workloadmeta.WorkloadmetaEvent
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_datadog_workloadmeta_workloadmeta_proto_init() }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support for the container owner field in the protobuf format allowing the remote workloadmeta store to access this information. The main goal of this is to allow remote consumers to go from the container to the owning pod and read some pod specific data (like pod annotations or namespace).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->