### PR TITLE
Narrow down cleanup in `embedded` Python distribution

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -40,11 +40,8 @@ build do
         end
 
         if linux_target? || osx_target?
-            # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will
-            # default to `pip2` if the default Python runtime is Python 2.
-            delete "#{install_dir}/embedded/bin/pip"
-            delete "#{install_dir}/embedded/bin/pip3"
-            delete "#{install_dir}/embedded/bin/python"
+            delete "#{install_dir}/embedded/bin/pip"  # copy of pip3.12
+            delete "#{install_dir}/embedded/bin/pip3"  # copy of pip3.12
             block 'create relative symlinks within embedded Python distribution' do
               Dir.chdir "#{install_dir}/embedded/bin" do
                 File.symlink 'pip3.12', 'pip3'


### PR DESCRIPTION
### What does this PR do?
This is a follow-up of #39368, since `python` is not created within the agent's embedded Python distribution so doesn't need to be removed.

### Additional Notes
Shebang lines happen to be wrong in most of the shell scripts:
```
./2to3-3.12 -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3.12
./ddtrace-run -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./echo_supervisord_conf -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./fastavro -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./idle3.12 -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3.12
./in-toto-keygen -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-match-products -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-mock -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-record -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-run -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-sign -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./in-toto-verify -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./jp.py -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./jsondiff -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./jsonpatch -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./jsonpointer -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./libtool -> #! /bin/sh
./libtoolize -> #! /usr/bin/env sh
./mibcopy -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./mibdump -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./normalizer -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./openstack-inventory -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pbr -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pidproxy -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pip3.12 -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pip3 -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pip -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pydoc3.12 -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3.12
./pyrsa-decrypt -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyrsa-encrypt -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyrsa-keygen -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyrsa-priv2pub -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyrsa-sign -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyrsa-verify -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pysemver -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./pyspnego-parse -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./python3.12-config -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3.12
./rethinkdb-dump -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./rethinkdb-export -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./rethinkdb-import -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./rethinkdb-index-rebuild -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./rethinkdb-repl -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./rethinkdb-restore -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./snowflake-dump-certs -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./snowflake-dump-ocsp-response-cache -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./snowflake-dump-ocsp-response -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./supervisorctl -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./supervisord -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
./wsdump -> #!/tmp/gitlabci/datadog-agent-build/bin/embedded/bin/python3
```