### PR TITLE
Revert "Fix MacOS build conflicting with system Python 3"

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -163,7 +163,7 @@ def get_dd_api_key(ctx):
     elif sys.platform == 'darwin':
         cmd = f'vault kv get -field=token kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     else:
-        cmd = f'vault kv get -field=token kv/k8s/{os.environ.get('POD_NAMESPACE', 'gitlab-runner')}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
+        cmd = f'vault kv get -field=token kv/k8s/{os.environ["POD_NAMESPACE"]}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     return ctx.run(cmd, hide=True).stdout.strip()
 
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -36,14 +36,7 @@ def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info",
         if host_distribution:
             overrides_cmd += f" --override=host_distribution:{host_distribution}"
 
-        omnibus = "bundle exec omnibus"
-        if sys.platform == 'win32':
-            omnibus = "bundle exec omnibus.bat"
-        elif sys.platform == 'darwin':
-            # HACK: This is an ugly hack to fix another hack made by python3 on MacOS
-            # The full explanation is available on this PR: https://github.com/DataDog/datadog-agent/pull/5010.
-            omnibus = "unset __PYVENV_LAUNCHER__ && bundle exec omnibus"
-
+        omnibus = f"bundle exec {"omnibus.bat" if sys.platform == "win32" else "omnibus"}"
         cmd = "{omnibus} {task} {project_name} --log-level={log_level} {overrides}"
         args = {
             "omnibus": omnibus,

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -30,11 +30,11 @@ from tasks.libs.releasing.version import get_version, load_dependencies
 
 def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info", host_distribution=None):
     with ctx.cd("omnibus"):
-        overrides_cmd = ""
+        overrides = []
         if base_dir:
-            overrides_cmd = f"--override=base_dir:{base_dir}"
+            overrides.append(f"--override=base_dir:{base_dir}")
         if host_distribution:
-            overrides_cmd += f" --override=host_distribution:{host_distribution}"
+            overrides.append(f"--override=host_distribution:{host_distribution}")
 
         omnibus = f"bundle exec {"omnibus.bat" if sys.platform == "win32" else "omnibus"}"
         cmd = "{omnibus} {task} {project_name} --log-level={log_level} {overrides}"
@@ -43,7 +43,7 @@ def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info",
             "task": task,
             "project_name": target_project,
             "log_level": log_level,
-            "overrides": overrides_cmd,
+            "overrides": " ".join(overrides),
         }
 
         with gitlab_section(f"Running omnibus task {task}", collapsed=True):

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -87,11 +87,20 @@ class TestOmnibusCache(unittest.TestCase):
         """Assert the given line patterns appear in the given order in `msg`."""
         commands = _run_calls_to_string(self.mock_ctx.run.mock_calls)
         # Match patterns independently to avoid pitfalls of regex merging while enabling precise mismatch reporting
+        unmatched_patterns = []
+        pos = 0
         for pattern in line_patterns:
-            self.assertIsNotNone(
-                re.search(pattern, commands, re.MULTILINE),
-                f'Failed to match pattern `{pattern}` among {pformat(commands)}',
-            )
+            match = re.search(pattern, commands[pos:], re.MULTILINE)
+            if match:
+                pos += match.end()
+            else:
+                unmatched_patterns.append(pattern)
+        if unmatched_patterns:
+            self.fail(f"""Failed to match patterns in order:
+{pformat(unmatched_patterns)}
+... among commands:
+{pformat(commands)}
+""")
 
     @_for_each_platform
     def test_successful_cache_hit(self):

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -2,7 +2,6 @@ import functools
 import os
 import re
 import unittest
-from contextlib import nullcontext
 from unittest import mock
 
 from invoke.context import MockContext
@@ -49,25 +48,22 @@ class TestOmnibusCache(unittest.TestCase):
         self.mock_ctx = MockContextRaising(run={})
 
     @staticmethod
-    def _for_each_platform(calls_get_dd_api_key: bool = False):
-        def decorator(test_func):
-            @functools.wraps(test_func)
-            def wrapper(self, *args, **kwargs):
-                for platform, get_dd_api_key_env in {
-                    "darwin": {"AGENT_API_KEY_ORG2": "agent-api-key"},
-                    "linux": {"AGENT_API_KEY_ORG2": "agent-api-key", "POD_NAMESPACE": "pod-ns"},
-                    "win32": {"API_KEY_ORG2": "api-key"},
-                }.items():
-                    with (
-                        self.subTest(platform=platform),
-                        mock.patch("sys.platform", platform),
-                        mock.patch.dict(os.environ, get_dd_api_key_env) if calls_get_dd_api_key else nullcontext(),
-                    ):
-                        test_func(self, *args, **kwargs)
+    def _for_each_platform(test_func):
+        @functools.wraps(test_func)
+        def wrapper(self, *args, **kwargs):
+            for platform, get_dd_api_key_env in {
+                "darwin": {"AGENT_API_KEY_ORG2": "agent-api-key"},
+                "linux": {"AGENT_API_KEY_ORG2": "agent-api-key", "POD_NAMESPACE": "pod-ns"},
+                "win32": {"API_KEY_ORG2": "api-key"},
+            }.items():
+                with (
+                    self.subTest(platform=platform),
+                    mock.patch("sys.platform", platform),
+                    mock.patch.dict(os.environ, get_dd_api_key_env),
+                ):
+                    test_func(self, *args, **kwargs)
 
-            return wrapper
-
-        return decorator
+        return wrapper
 
     def _set_up_default_command_mocks(self):
         # This should allow to postpone the setting up of these broadly catching patterns
@@ -95,7 +91,7 @@ class TestOmnibusCache(unittest.TestCase):
             f'Failed to match pattern {line_patterns}.',
         )
 
-    @_for_each_platform()
+    @_for_each_platform
     def test_successful_cache_hit(self):
         self.mock_ctx.set_result_for(
             'run',
@@ -129,7 +125,7 @@ class TestOmnibusCache(unittest.TestCase):
         for line in lines:
             self.assertIsNone(re.search(line, commands))
 
-    @_for_each_platform(calls_get_dd_api_key=True)
+    @_for_each_platform
     def test_cache_miss(self):
         self.mock_ctx.set_result_for(
             'run',
@@ -170,7 +166,7 @@ class TestOmnibusCache(unittest.TestCase):
             ],
         )
 
-    @_for_each_platform()
+    @_for_each_platform
     def test_cache_hit_with_corruption(self):
         # Case where we get a bundle from S3 but git finds it to be corrupted
 
@@ -187,7 +183,7 @@ class TestOmnibusCache(unittest.TestCase):
         # We're satisfied if we ran the build despite that failure
         self.assertRunLines([r'bundle exec omnibus build agent'])
 
-    @_for_each_platform()
+    @_for_each_platform
     def test_cache_is_disabled_by_unsetting_env_var(self):
         self._set_up_default_command_mocks()
 
@@ -200,7 +196,7 @@ class TestOmnibusCache(unittest.TestCase):
         commands = _run_calls_to_string(self.mock_ctx.run.mock_calls)
         self.assertNotIn('omnibus-git-cache', commands)
 
-    @_for_each_platform(calls_get_dd_api_key=True)
+    @_for_each_platform
     def test_mutated_cache(self):
         self.mock_ctx.set_result_for(
             'run',


### PR DESCRIPTION
### What does this PR do? / Motivation
The present change is a follow-up of #39563, where it was found that:
> We need to have a default value here because these unit tests are also called from `macos` runners  but [`system` is patched as `linux`](https://github.com/DataDog/datadog-agent/pull/39563/files#diff-407acb07e932b50660fc4999612d12a05d6046a1716a53125e1010050c898cebR33). So even though the unit tests are run in macos runners(run on EC2) they try to access vault and dont have K8 `POD_NAMESPACE` env var set.

It turns out the temporary fix introduced by #5010 in 2020 is no longer needed:
- upstream bug report: https://github.com/pypa/virtualenv/issues/1643
- upstream fix: https://github.com/pypa/virtualenv/pull/1648
- released with `virtualenv` v20.0.5: https://virtualenv.pypa.io/en/latest/changelog.html#v20-0-5-2020-02-21

This therefore reverts commit d16a8a4da3baadc1ada4636513476e5b3df169cb: "[omnibus] Fix MacOS build conflicting with system Python 3 (#5010)", and adjusts consequences accordingly:
 - the `POD_NAMESPACE` environment variable must be present (no default) for `linux`, and only for `linux`,
- patches in tests get tailored to the very needs, with 3 `platforms` to cover implying 3 "sub" tests,
- covering `win32` unearthes unmatched command patterns due to suffixes (`.bat`, `.exe`) being used for certain commands (like `aws.exe` and `omnibus.bat`, unlike `git`) which requires further adaptation, especially to understand which patterns are not found.