### PR TITLE
Migrate processes to WorkloadFilter

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -35,6 +35,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
 	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -168,6 +169,8 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		workloadmetafx.Module(workloadmeta.Params{
 			AgentType: workloadmeta.Remote,
 		}),
+
+		workloadfilterfx.Module(),
 
 		remoteTaggerfx.Module(tagger.RemoteParams{
 			RemoteTarget: func(c config.Component) (string, error) {

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -30,6 +30,8 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
 	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -70,10 +72,11 @@ type Dependencies struct {
 	// TODO: the tagger is used by the ContainerProvider, which is currently not a component so there is no direct
 	// dependency on it. The ContainerProvider needs to be componentized so it can be injected and have fx manage its
 	// lifecycle.
-	Tagger       tagger.Component
-	WorkloadMeta workloadmeta.Component
-	NpCollector  npcollector.Component
-	Checks       []types.CheckComponent `group:"check"`
+	Tagger         tagger.Component
+	WorkloadMeta   workloadmeta.Component
+	WorkloadFilter workloadfilter.Component
+	NpCollector    npcollector.Component
+	Checks         []types.CheckComponent `group:"check"`
 }
 
 func nextGroupID() func() int32 {
@@ -140,6 +143,7 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 				workloadmetafx.Module(workloadmeta.Params{
 					AgentType: workloadmeta.Remote,
 				}),
+				workloadfilterfx.Module(),
 
 				// Tagger must be initialized after agent config has been setup
 				remoteTaggerfx.Module(tagger.RemoteParams{

--- a/comp/core/workloadfilter/catalog/process.go
+++ b/comp/core/workloadfilter/catalog/process.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package catalog contains the implementation of the filtering catalogs.
+package catalog
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
+)
+
+// LegacyProcessDisallowlistProgram creates a program for filtering processes based on legacy disallowlist patterns
+func LegacyProcessDisallowlistProgram(config config.Component, logger log.Component) program.FilterProgram {
+	programName := "LegacyProcessDisallowlistProgram"
+	var initErrors []error
+
+	patterns := config.GetStringSlice("process_config.blacklist_patterns")
+
+	excludeProgram, excludeErr := createProgramFromOldFilters(patterns, workloadfilter.ProcessType)
+	if excludeErr != nil {
+		initErrors = append(initErrors, excludeErr)
+		logger.Warnf("Error creating exclude program for %s: %v", programName, excludeErr)
+	}
+
+	return program.CELProgram{
+		Name:                 programName,
+		Exclude:              excludeProgram,
+		InitializationErrors: initErrors,
+	}
+}

--- a/comp/core/workloadfilter/catalog/utils.go
+++ b/comp/core/workloadfilter/catalog/utils.go
@@ -38,7 +38,7 @@ func createCELProgram(rules string, objectType workloadfilter.ResourceType) (cel
 		return nil, nil
 	}
 	env, err := cel.NewEnv(
-		cel.Types(&workloadfilter.Container{}, &workloadfilter.Pod{}),
+		cel.Types(&workloadfilter.Container{}, &workloadfilter.Pod{}, &workloadfilter.Process{}),
 		cel.Variable(string(objectType), cel.ObjectType(convertTypeToProtoType(objectType))),
 	)
 	if err != nil {
@@ -88,9 +88,17 @@ func convertOldToNewFilter(oldFilters []string, objectType workloadfilter.Resour
 	legacyFieldMapping := getFieldMapping(objectType)
 
 	var newFilters []string
+	var processPatterns []string
+
 	for _, oldFilter := range oldFilters {
 
 		if oldFilter == "" {
+			continue
+		}
+
+		// Legacy process denylist patterns only support raw regex
+		if objectType == workloadfilter.ProcessType {
+			processPatterns = append(processPatterns, oldFilter)
 			continue
 		}
 
@@ -122,6 +130,16 @@ func convertOldToNewFilter(oldFilters []string, objectType workloadfilter.Resour
 			return "", fmt.Errorf("container filter %s:%s is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'", key, value)
 		}
 	}
+
+	// Combine process patterns into a single expression since they only support one field
+	if len(processPatterns) > 0 {
+		combinedPattern := strings.Join(processPatterns, "|")
+		newFilters = append(newFilters, fmt.Sprintf(
+			"process.cmdline.matches(%s)",
+			strconv.Quote(combinedPattern),
+		))
+	}
+
 	return strings.Join(newFilters, " || "), nil
 }
 
@@ -138,6 +156,8 @@ func convertTypeToProtoType(key workloadfilter.ResourceType) string {
 		return "datadog.filter.FilterKubeEndpoint"
 	case workloadfilter.ImageType:
 		return "datadog.filter.FilterImage"
+	case workloadfilter.ProcessType:
+		return "datadog.filter.FilterProcess"
 	default:
 		return ""
 	}

--- a/comp/core/workloadfilter/catalog/utils_test.go
+++ b/comp/core/workloadfilter/catalog/utils_test.go
@@ -87,6 +87,18 @@ func TestConvertOldToNewFilter_Success(t *testing.T) {
 			[]string{"image:nginx.*", "kube_namespace:foo", "name:bar"},
 			`image.name.matches("nginx.*")`,
 		},
+		{
+			"process raw regex pattern",
+			workloadfilter.ProcessType,
+			[]string{"java.*-jar.*app"},
+			`process.cmdline.matches("java.*-jar.*app")`,
+		},
+		{
+			"multiple process raw regex patterns",
+			workloadfilter.ProcessType,
+			[]string{"java.*", "python.*script", "node.*server"},
+			`process.cmdline.matches("java.*|python.*script|node.*server")`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/comp/core/workloadfilter/def/component.go
+++ b/comp/core/workloadfilter/def/component.go
@@ -22,6 +22,8 @@ type Component interface {
 	IsServiceExcluded(service *Service, serviceFilters [][]ServiceFilter) bool
 	// IsEndpointExcluded returns true if the endpoint is excluded by the selected endpoint filter keys.
 	IsEndpointExcluded(endpoint *Endpoint, endpointFilters [][]EndpointFilter) bool
+	// IsProcessExcluded returns true if the process is excluded by the selected process filter keys.
+	IsProcessExcluded(process *Process, processFilters [][]ProcessFilter) bool
 
 	// GetContainerFilterInitializationErrors returns a list of errors
 	// encountered during the initialization of the selected container filters.

--- a/comp/core/workloadfilter/def/proto/filter.pb.go
+++ b/comp/core/workloadfilter/def/proto/filter.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.6
 // 	protoc        v5.29.3
-// source: comp/core/workloadfilter/def/proto/filter.proto
+// source: filter.proto
 
 package proto
 
@@ -37,7 +37,7 @@ type FilterContainer struct {
 
 func (x *FilterContainer) Reset() {
 	*x = FilterContainer{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0]
+	mi := &file_filter_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -49,7 +49,7 @@ func (x *FilterContainer) String() string {
 func (*FilterContainer) ProtoMessage() {}
 
 func (x *FilterContainer) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0]
+	mi := &file_filter_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62,7 +62,7 @@ func (x *FilterContainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterContainer.ProtoReflect.Descriptor instead.
 func (*FilterContainer) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{0}
+	return file_filter_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *FilterContainer) GetId() string {
@@ -139,7 +139,7 @@ type FilterPod struct {
 
 func (x *FilterPod) Reset() {
 	*x = FilterPod{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[1]
+	mi := &file_filter_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -151,7 +151,7 @@ func (x *FilterPod) String() string {
 func (*FilterPod) ProtoMessage() {}
 
 func (x *FilterPod) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[1]
+	mi := &file_filter_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -164,7 +164,7 @@ func (x *FilterPod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterPod.ProtoReflect.Descriptor instead.
 func (*FilterPod) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{1}
+	return file_filter_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *FilterPod) GetId() string {
@@ -205,7 +205,7 @@ type FilterECSTask struct {
 
 func (x *FilterECSTask) Reset() {
 	*x = FilterECSTask{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[2]
+	mi := &file_filter_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -217,7 +217,7 @@ func (x *FilterECSTask) String() string {
 func (*FilterECSTask) ProtoMessage() {}
 
 func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[2]
+	mi := &file_filter_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -230,7 +230,7 @@ func (x *FilterECSTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterECSTask.ProtoReflect.Descriptor instead.
 func (*FilterECSTask) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{2}
+	return file_filter_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *FilterECSTask) GetId() string {
@@ -258,7 +258,7 @@ type FilterKubeService struct {
 
 func (x *FilterKubeService) Reset() {
 	*x = FilterKubeService{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[3]
+	mi := &file_filter_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -270,7 +270,7 @@ func (x *FilterKubeService) String() string {
 func (*FilterKubeService) ProtoMessage() {}
 
 func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[3]
+	mi := &file_filter_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -283,7 +283,7 @@ func (x *FilterKubeService) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeService.ProtoReflect.Descriptor instead.
 func (*FilterKubeService) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{3}
+	return file_filter_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *FilterKubeService) GetName() string {
@@ -318,7 +318,7 @@ type FilterKubeEndpoint struct {
 
 func (x *FilterKubeEndpoint) Reset() {
 	*x = FilterKubeEndpoint{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[4]
+	mi := &file_filter_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -330,7 +330,7 @@ func (x *FilterKubeEndpoint) String() string {
 func (*FilterKubeEndpoint) ProtoMessage() {}
 
 func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[4]
+	mi := &file_filter_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -343,7 +343,7 @@ func (x *FilterKubeEndpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterKubeEndpoint.ProtoReflect.Descriptor instead.
 func (*FilterKubeEndpoint) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{4}
+	return file_filter_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *FilterKubeEndpoint) GetName() string {
@@ -376,7 +376,7 @@ type FilterImage struct {
 
 func (x *FilterImage) Reset() {
 	*x = FilterImage{}
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[5]
+	mi := &file_filter_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -388,7 +388,7 @@ func (x *FilterImage) String() string {
 func (*FilterImage) ProtoMessage() {}
 
 func (x *FilterImage) ProtoReflect() protoreflect.Message {
-	mi := &file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[5]
+	mi := &file_filter_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -401,7 +401,7 @@ func (x *FilterImage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterImage.ProtoReflect.Descriptor instead.
 func (*FilterImage) Descriptor() ([]byte, []int) {
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP(), []int{5}
+	return file_filter_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *FilterImage) GetName() string {
@@ -411,11 +411,71 @@ func (x *FilterImage) GetName() string {
 	return ""
 }
 
-var File_comp_core_workloadfilter_def_proto_filter_proto protoreflect.FileDescriptor
+type FilterProcess struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Cmdline       string                 `protobuf:"bytes,2,opt,name=cmdline,proto3" json:"cmdline,omitempty"`
+	Args          []string               `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
 
-const file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc = "" +
+func (x *FilterProcess) Reset() {
+	*x = FilterProcess{}
+	mi := &file_filter_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FilterProcess) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FilterProcess) ProtoMessage() {}
+
+func (x *FilterProcess) ProtoReflect() protoreflect.Message {
+	mi := &file_filter_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FilterProcess.ProtoReflect.Descriptor instead.
+func (*FilterProcess) Descriptor() ([]byte, []int) {
+	return file_filter_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *FilterProcess) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *FilterProcess) GetCmdline() string {
+	if x != nil {
+		return x.Cmdline
+	}
+	return ""
+}
+
+func (x *FilterProcess) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+var File_filter_proto protoreflect.FileDescriptor
+
+const file_filter_proto_rawDesc = "" +
 	"\n" +
-	"/comp/core/workloadfilter/def/proto/filter.proto\x12\x0edatadog.filter\"\xbf\x01\n" +
+	"\ffilter.proto\x12\x0edatadog.filter\"\xbf\x01\n" +
 	"\x0fFilterContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -449,38 +509,43 @@ const file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"!\n" +
 	"\vFilterImage\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04nameB$Z\"comp/core/workloadfilter/def/protob\x06proto3"
+	"\x04name\x18\x01 \x01(\tR\x04name\"Q\n" +
+	"\rFilterProcess\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\acmdline\x18\x02 \x01(\tR\acmdline\x12\x12\n" +
+	"\x04args\x18\x03 \x03(\tR\x04argsB$Z\"comp/core/workloadfilter/def/protob\x06proto3"
 
 var (
-	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescOnce sync.Once
-	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData []byte
+	file_filter_proto_rawDescOnce sync.Once
+	file_filter_proto_rawDescData []byte
 )
 
-func file_comp_core_workloadfilter_def_proto_filter_proto_rawDescGZIP() []byte {
-	file_comp_core_workloadfilter_def_proto_filter_proto_rawDescOnce.Do(func() {
-		file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc), len(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc)))
+func file_filter_proto_rawDescGZIP() []byte {
+	file_filter_proto_rawDescOnce.Do(func() {
+		file_filter_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_filter_proto_rawDesc), len(file_filter_proto_rawDesc)))
 	})
-	return file_comp_core_workloadfilter_def_proto_filter_proto_rawDescData
+	return file_filter_proto_rawDescData
 }
 
-var file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-var file_comp_core_workloadfilter_def_proto_filter_proto_goTypes = []any{
+var file_filter_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_filter_proto_goTypes = []any{
 	(*FilterContainer)(nil),    // 0: datadog.filter.FilterContainer
 	(*FilterPod)(nil),          // 1: datadog.filter.FilterPod
 	(*FilterECSTask)(nil),      // 2: datadog.filter.FilterECSTask
 	(*FilterKubeService)(nil),  // 3: datadog.filter.FilterKubeService
 	(*FilterKubeEndpoint)(nil), // 4: datadog.filter.FilterKubeEndpoint
 	(*FilterImage)(nil),        // 5: datadog.filter.FilterImage
-	nil,                        // 6: datadog.filter.FilterPod.AnnotationsEntry
-	nil,                        // 7: datadog.filter.FilterKubeService.AnnotationsEntry
-	nil,                        // 8: datadog.filter.FilterKubeEndpoint.AnnotationsEntry
+	(*FilterProcess)(nil),      // 6: datadog.filter.FilterProcess
+	nil,                        // 7: datadog.filter.FilterPod.AnnotationsEntry
+	nil,                        // 8: datadog.filter.FilterKubeService.AnnotationsEntry
+	nil,                        // 9: datadog.filter.FilterKubeEndpoint.AnnotationsEntry
 }
-var file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs = []int32{
+var file_filter_proto_depIdxs = []int32{
 	1, // 0: datadog.filter.FilterContainer.pod:type_name -> datadog.filter.FilterPod
 	2, // 1: datadog.filter.FilterContainer.ecs_task:type_name -> datadog.filter.FilterECSTask
-	6, // 2: datadog.filter.FilterPod.annotations:type_name -> datadog.filter.FilterPod.AnnotationsEntry
-	7, // 3: datadog.filter.FilterKubeService.annotations:type_name -> datadog.filter.FilterKubeService.AnnotationsEntry
-	8, // 4: datadog.filter.FilterKubeEndpoint.annotations:type_name -> datadog.filter.FilterKubeEndpoint.AnnotationsEntry
+	7, // 2: datadog.filter.FilterPod.annotations:type_name -> datadog.filter.FilterPod.AnnotationsEntry
+	8, // 3: datadog.filter.FilterKubeService.annotations:type_name -> datadog.filter.FilterKubeService.AnnotationsEntry
+	9, // 4: datadog.filter.FilterKubeEndpoint.annotations:type_name -> datadog.filter.FilterKubeEndpoint.AnnotationsEntry
 	5, // [5:5] is the sub-list for method output_type
 	5, // [5:5] is the sub-list for method input_type
 	5, // [5:5] is the sub-list for extension type_name
@@ -488,12 +553,12 @@ var file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_comp_core_workloadfilter_def_proto_filter_proto_init() }
-func file_comp_core_workloadfilter_def_proto_filter_proto_init() {
-	if File_comp_core_workloadfilter_def_proto_filter_proto != nil {
+func init() { file_filter_proto_init() }
+func file_filter_proto_init() {
+	if File_filter_proto != nil {
 		return
 	}
-	file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes[0].OneofWrappers = []any{
+	file_filter_proto_msgTypes[0].OneofWrappers = []any{
 		(*FilterContainer_Pod)(nil),
 		(*FilterContainer_EcsTask)(nil),
 	}
@@ -501,17 +566,17 @@ func file_comp_core_workloadfilter_def_proto_filter_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc), len(file_comp_core_workloadfilter_def_proto_filter_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_filter_proto_rawDesc), len(file_filter_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_comp_core_workloadfilter_def_proto_filter_proto_goTypes,
-		DependencyIndexes: file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs,
-		MessageInfos:      file_comp_core_workloadfilter_def_proto_filter_proto_msgTypes,
+		GoTypes:           file_filter_proto_goTypes,
+		DependencyIndexes: file_filter_proto_depIdxs,
+		MessageInfos:      file_filter_proto_msgTypes,
 	}.Build()
-	File_comp_core_workloadfilter_def_proto_filter_proto = out.File
-	file_comp_core_workloadfilter_def_proto_filter_proto_goTypes = nil
-	file_comp_core_workloadfilter_def_proto_filter_proto_depIdxs = nil
+	File_filter_proto = out.File
+	file_filter_proto_goTypes = nil
+	file_filter_proto_depIdxs = nil
 }

--- a/comp/core/workloadfilter/def/proto/filter.proto
+++ b/comp/core/workloadfilter/def/proto/filter.proto
@@ -42,3 +42,9 @@ message FilterKubeEndpoint {
 message FilterImage {
   string name = 1;
 }
+
+message FilterProcess {
+  string name = 1;
+  string cmdline = 2;
+  repeated string args = 3;
+}

--- a/comp/core/workloadfilter/def/types.go
+++ b/comp/core/workloadfilter/def/types.go
@@ -6,7 +6,10 @@
 package workloadfilter
 
 import (
+	"strings"
+
 	typedef "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def/proto"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
 // Result is an enumeration that represents the possible results of a filter evaluation.
@@ -41,6 +44,7 @@ const (
 	ServiceType   ResourceType = "service"
 	EndpointType  ResourceType = "endpoint"
 	ImageType     ResourceType = "image"
+	ProcessType   ResourceType = "process"
 )
 
 //
@@ -217,4 +221,55 @@ const (
 	LegacyEndpointGlobal
 	EndpointADAnnotationsMetrics
 	EndpointADAnnotations
+)
+
+//
+// Process Definition
+//
+
+// Process represents a filterable process object.
+type Process struct {
+	*typedef.FilterProcess
+}
+
+// CreateProcess creates a Filterable Process object from a workloadmeta.Process.
+func CreateProcess(process *workloadmeta.Process) *Process {
+	if process == nil {
+		return nil
+	}
+
+	p := &typedef.FilterProcess{
+		Name:    process.Name,
+		Cmdline: strings.Join(process.Cmdline, " "),
+		Args:    process.Cmdline,
+	}
+
+	return &Process{
+		FilterProcess: p,
+	}
+}
+
+var _ Filterable = &Process{}
+
+// Serialize converts the Process object to a filterable object.
+func (p *Process) Serialize() any {
+	return p.FilterProcess
+}
+
+// Type returns the resource type of the process.
+func (p *Process) Type() ResourceType {
+	return ProcessType
+}
+
+// GetAnnotations returns the annotations of the process.
+func (p *Process) GetAnnotations() map[string]string {
+	return nil
+}
+
+// ProcessFilter defines the type of process filter.
+type ProcessFilter int
+
+// Defined Process filter kinds
+const (
+	LegacyProcessDisallowlist ProcessFilter = iota
 )

--- a/comp/core/workloadfilter/def/types_test.go
+++ b/comp/core/workloadfilter/def/types_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package workloadfilter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+func TestCreateProcess(t *testing.T) {
+	t.Run("nil process input", func(t *testing.T) {
+		result := CreateProcess(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("process with all fields populated", func(t *testing.T) {
+		process := &workloadmeta.Process{
+			Name:    "test-proc",
+			Cmdline: []string{"test-process", "--config", "/etc/config.yaml", "--verbose"},
+		}
+
+		result := CreateProcess(process)
+
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.FilterProcess)
+		assert.Equal(t, "test-proc", result.FilterProcess.Name)
+		assert.Equal(t, "test-process --config /etc/config.yaml --verbose", result.FilterProcess.Cmdline)
+		assert.Equal(t, []string{"test-process", "--config", "/etc/config.yaml", "--verbose"}, result.FilterProcess.Args)
+	})
+
+	t.Run("process with empty fields", func(t *testing.T) {
+		process := &workloadmeta.Process{}
+
+		result := CreateProcess(process)
+
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.FilterProcess)
+		assert.Empty(t, result.FilterProcess.Name)
+		assert.Empty(t, result.FilterProcess.Cmdline)
+		assert.Empty(t, result.FilterProcess.Args)
+	})
+}

--- a/comp/core/workloadfilter/impl/filter.go
+++ b/comp/core/workloadfilter/impl/filter.go
@@ -139,6 +139,9 @@ func newFilter(cfg config.Component, logger log.Component, telemetry coretelemet
 	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodADAnnotations), genericADProgramFactory)
 	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodADAnnotationsMetrics), genericADMetricsProgramFactory)
 
+	// Process Filters
+	filter.registerFactory(workloadfilter.ProcessType, int(workloadfilter.LegacyProcessDisallowlist), catalog.LegacyProcessDisallowlistProgram)
+
 	return filter, nil
 }
 
@@ -158,6 +161,10 @@ func (f *filter) IsServiceExcluded(service *workloadfilter.Service, serviceFilte
 
 func (f *filter) IsEndpointExcluded(endpoint *workloadfilter.Endpoint, endpointFilters [][]workloadfilter.EndpointFilter) bool {
 	return evaluateResource(f, endpoint, endpointFilters) == workloadfilter.Excluded
+}
+
+func (f *filter) IsProcessExcluded(process *workloadfilter.Process, processFilters [][]workloadfilter.ProcessFilter) bool {
+	return evaluateResource(f, process, processFilters) == workloadfilter.Excluded
 }
 
 // evaluateResource checks if a resource is excluded based on the provided filters.

--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -865,3 +865,123 @@ func TestPodFiltering(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessFiltering(t *testing.T) {
+	tests := []struct {
+		name             string
+		disallowPatterns []string
+		comm             string
+		cmdline          []string
+		filters          [][]workloadfilter.ProcessFilter
+		expected         workloadfilter.Result
+	}{
+		{
+			name:             "empty filters, empty process",
+			disallowPatterns: []string{},
+			filters:          [][]workloadfilter.ProcessFilter{},
+			expected:         workloadfilter.Unknown,
+		},
+		{
+			name:             "process excluded by cmdline pattern",
+			disallowPatterns: []string{"java.*", "systemd", "/usr/bin/.*"},
+			cmdline:          []string{"java", "-server", "-Xmx2g"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Excluded,
+		},
+		{
+			name:             "process excluded by systemd pattern in cmdline",
+			disallowPatterns: []string{"java.*", "systemd", "/usr/bin/.*"},
+			cmdline:          []string{"systemd", "--user"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Excluded,
+		},
+		{
+			name:             "process excluded by /usr/bin pattern in cmdline",
+			disallowPatterns: []string{"java.*", "systemd", "/usr/bin/.*"},
+			cmdline:          []string{"/usr/bin/python3", "script.py"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Excluded,
+		},
+		{
+			name:             "process not excluded",
+			disallowPatterns: []string{"java.*", "systemd", "/usr/bin/.*"},
+			cmdline:          []string{"nginx", "-g", "daemon off;"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Unknown,
+		},
+		{
+			name:             "pattern spanning multiple arguments - python script",
+			disallowPatterns: []string{"python.*script", "java.*-jar.*app", "node.*server"},
+			cmdline:          []string{"python3", "manage.py", "runserver", "script.py"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Excluded,
+		},
+		{
+			name:             "pattern spanning multiple arguments - java jar app",
+			disallowPatterns: []string{"python.*script", "java.*-jar.*app", "node.*server"},
+			cmdline:          []string{"java", "-Xmx2g", "-jar", "myapp.jar", "--port", "8080"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Excluded,
+		},
+		{
+			name:             "no patterns match",
+			disallowPatterns: []string{"python.*script", "java.*-jar.*app", "node.*server"},
+			cmdline:          []string{"nginx", "-g", "daemon off;"},
+			filters:          [][]workloadfilter.ProcessFilter{{workloadfilter.LegacyProcessDisallowlist}},
+			expected:         workloadfilter.Unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			if len(tt.disallowPatterns) > 0 {
+				mockConfig.SetWithoutSource("process_config.blacklist_patterns", tt.disallowPatterns)
+			}
+			f := newFilterObject(t, mockConfig)
+
+			var process *workloadfilter.Process
+			if tt.name == "empty filters, empty process" {
+				process = &workloadfilter.Process{}
+			} else {
+				process = workloadfilter.CreateProcess(
+					&workloadmeta.Process{
+						Comm:    tt.comm,
+						Cmdline: tt.cmdline,
+					},
+				)
+			}
+
+			res := evaluateResource(f, process, tt.filters)
+			assert.Equal(t, tt.expected, res)
+		})
+	}
+}
+
+func TestProcessFilterInitializationError(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("process_config.blacklist_patterns", []string{
+		"valid_pattern",
+		"[invalid_regex",
+	})
+	f := newFilterObject(t, mockConfig)
+
+	t.Run("Invalid regex patterns cause initialization errors", func(t *testing.T) {
+		errs := getFilterErrors(f, workloadfilter.ProcessType, []workloadfilter.ProcessFilter{workloadfilter.LegacyProcessDisallowlist})
+		assert.NotEmpty(t, errs, "Expected initialization errors for invalid regex patterns")
+
+		errStrings := make([]string, len(errs))
+		for i, err := range errs {
+			errStrings[i] = err.Error()
+		}
+
+		hasRegexError := false
+		for _, errStr := range errStrings {
+			if strings.Contains(errStr, "invalid_regex") || strings.Contains(errStr, "error parsing regexp") {
+				hasRegexError = true
+				break
+			}
+		}
+		assert.True(t, hasRegexError, "Expected error message to contain regex-related error. Got errors: %v", errStrings)
+	})
+}

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -25,6 +25,7 @@ import (
 	coreStatusImpl "github.com/DataDog/datadog-agent/comp/core/status/statusimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -50,6 +51,7 @@ func TestBundleDependencies(t *testing.T) {
 		fx.Provide(func() types.CheckComponent { return nil }),
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		workloadfilterfx.Module(),
 		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
 		coreStatusImpl.Module(),
 		settingsimpl.MockModule(),
@@ -104,6 +106,7 @@ func TestBundleOneShot(t *testing.T) {
 		}}),
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		workloadfilterfx.Module(),
 		fx.Provide(func() tagger.Component { return taggerfxmock.SetupFakeTagger(t) }),
 		eventplatformreceiverimpl.Module(),
 		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),

--- a/comp/process/processcheck/processcheckimpl/check.go
+++ b/comp/process/processcheck/processcheckimpl/check.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	gpusubscriber "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/def"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
@@ -36,12 +37,13 @@ type check struct {
 type dependencies struct {
 	fx.In
 
-	Config        config.Component
-	Sysconfig     sysprobeconfig.Component
-	WMmeta        workloadmeta.Component
-	GpuSubscriber gpusubscriber.Component
-	Statsd        statsd.ClientInterface
-	IPC           ipc.Component
+	Config         config.Component
+	Sysconfig      sysprobeconfig.Component
+	WMmeta         workloadmeta.Component
+	WorkloadFilter workloadfilter.Component
+	GpuSubscriber  gpusubscriber.Component
+	Statsd         statsd.ClientInterface
+	IPC            ipc.Component
 }
 
 type result struct {
@@ -53,7 +55,7 @@ type result struct {
 
 func newCheck(deps dependencies) result {
 	c := &check{
-		processCheck: checks.NewProcessCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.GpuSubscriber, deps.Statsd, deps.IPC.GetTLSServerConfig()),
+		processCheck: checks.NewProcessCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.WorkloadFilter, deps.GpuSubscriber, deps.Statsd, deps.IPC.GetTLSServerConfig()),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/processcheck/processcheckimpl/check_linux_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
@@ -60,6 +61,7 @@ func TestProcessCheckEnablementOnCoreAgent(t *testing.T) {
 				core.MockBundle(),
 				fx.Replace(config.MockParams{Overrides: configs}),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				workloadfilterfxmock.MockModule(),
 				gpusubscriberfxmock.MockModule(),
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}

--- a/comp/process/processcheck/processcheckimpl/check_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
@@ -95,6 +96,7 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 				fx.Replace(config.MockParams{Overrides: tc.configs}),
 				fx.Replace(sysprobeconfigimpl.MockParams{Overrides: tc.sysProbeConfigs}),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				workloadfilterfxmock.MockModule(),
 				gpusubscriberfxmock.MockModule(),
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add processes support to WorkloadFilter and migrate the one existing
configuration to use it.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-177

### Describe how you validated your changes

Tests added.
Existing process config tests minimally modified to use new infra.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
