### PR TITLE
Fix stabilization window implementation

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -332,9 +332,11 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 }
 
 func (c *Controller) handleScaling(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, podAutoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, target NamespacedPodOwner) (autoscaling.ProcessResult, error) {
+	currentTime := c.clock.Now()
+
 	// Update the scaling values based on the staleness of recommendations
-	desiredHorizontalScalingSource, desiredVerticalScalingSource := getActiveScalingSources(c.clock.Now(), podAutoscalerInternal)
-	podAutoscalerInternal.MergeScalingValues(desiredHorizontalScalingSource, desiredVerticalScalingSource)
+	desiredHorizontalScalingSource, desiredVerticalScalingSource := getActiveScalingSources(currentTime, podAutoscalerInternal)
+	podAutoscalerInternal.SetActiveScalingValues(currentTime, desiredHorizontalScalingSource, desiredVerticalScalingSource)
 	c.updateLocalFallbackEnabled(podAutoscalerInternal, desiredHorizontalScalingSource)
 
 	// TODO: While horizontal scaling is in progress we should not start vertical scaling

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -108,12 +109,7 @@ func (hr *horizontalController) performScaling(ctx context.Context, podAutoscale
 		autoscalerInternal.UpdateFromHorizontalAction(nil, err)
 		return autoscaling.NoRequeue, nil
 	}
-	// We are already scaled
-	if horizontalAction == nil {
-		autoscalerInternal.UpdateFromHorizontalAction(nil, nil)
-		return autoscaling.NoRequeue, nil
-	}
-	// Target replicas has not changed due to scaling rules
+	// Target replicas has not changed because we are already scaled or due to scaling rules
 	if horizontalAction.FromReplicas == horizontalAction.ToReplicas {
 		autoscalerInternal.UpdateFromHorizontalAction(horizontalAction, nil)
 		if nextEvalAfter > 0 {
@@ -176,22 +172,6 @@ func (hr *horizontalController) computeScaleAction(
 		outsideBoundaries = true
 	}
 
-	// Checking scale direction
-	scaleDirection := common.GetScaleDirection(currentDesiredReplicas, targetDesiredReplicas)
-
-	// No scaling needed
-	if scaleDirection == common.NoScale {
-		return nil, 0, nil
-	}
-
-	// Checking if scaling constraints allow this scaling
-	autoscalerSpec := autoscalerInternal.Spec()
-	allowed, reason := isScalingAllowed(autoscalerSpec, source, scaleDirection)
-	if !allowed {
-		log.Debugf("Scaling not allowed for autoscaler id: %s, scale direction: %s, scale reason: %s", autoscalerInternal.ID(), scaleDirection, reason)
-		return nil, 0, errors.New(reason)
-	}
-
 	// Going back inside requested boundaries in one shot.
 	// TODO: Should we apply scaling rules in this case?
 	if outsideBoundaries {
@@ -205,34 +185,9 @@ func (hr *horizontalController) computeScaleAction(
 		}, 0, nil
 	}
 
+	autoscalerSpec := autoscalerInternal.Spec()
 	var evalAfter time.Duration
 	var limitReason string
-
-	// Scaling is allowed, applying Min/Max replicas constraints from Spec
-	if targetDesiredReplicas > maxReplicas {
-		targetDesiredReplicas = maxReplicas
-		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to max replicas constraint", maxReplicas, originalTargetDesiredReplicas)
-	} else if targetDesiredReplicas < minReplicas {
-		targetDesiredReplicas = minReplicas
-		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to min replicas constraint", minReplicas, originalTargetDesiredReplicas)
-	}
-
-	// Applying scaling rules if any
-	var rulesLimitReason string
-	var rulesLimitedReplicas int32
-	var rulesNextEvalAfter time.Duration
-	if scaleDirection == common.ScaleUp && autoscalerSpec.ApplyPolicy != nil {
-		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleUpPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleUp, currentDesiredReplicas, targetDesiredReplicas)
-	} else if scaleDirection == common.ScaleDown && autoscalerSpec.ApplyPolicy != nil {
-		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleDownPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleDown, currentDesiredReplicas, targetDesiredReplicas)
-	}
-	// If rules had any effect, use values from rules
-	if rulesLimitReason != "" {
-		limitReason = rulesLimitReason
-		targetDesiredReplicas = rulesLimitedReplicas
-		// To make sure event has expired and not have sub-second requeue, will be rounded to the next second
-		evalAfter = rulesNextEvalAfter.Truncate(time.Second) + time.Second
-	}
 
 	// Stabilize recommendation
 	var stabilizationLimitReason string
@@ -249,10 +204,42 @@ func (hr *horizontalController) computeScaleAction(
 		}
 	}
 
-	stabilizationLimitedReplicas, stabilizationLimitReason = stabilizeRecommendations(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), currentDesiredReplicas, targetDesiredReplicas, scaleUpStabilizationSeconds, scaleDownStabilizationSeconds, scaleDirection)
+	stabilizationLimitedReplicas, stabilizationLimitReason = stabilizeRecommendations(scalingTimestamp, autoscalerInternal.HorizontalLastRecommendations(), currentDesiredReplicas, targetDesiredReplicas, scaleUpStabilizationSeconds, scaleDownStabilizationSeconds)
 	if stabilizationLimitReason != "" {
 		limitReason = stabilizationLimitReason
 		targetDesiredReplicas = stabilizationLimitedReplicas
+	}
+
+	// Scaling is allowed, applying Min/Max replicas constraints from Spec
+	if targetDesiredReplicas > maxReplicas {
+		targetDesiredReplicas = maxReplicas
+		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to max replicas constraint", maxReplicas, originalTargetDesiredReplicas)
+	} else if targetDesiredReplicas < minReplicas {
+		targetDesiredReplicas = minReplicas
+		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to min replicas constraint", minReplicas, originalTargetDesiredReplicas)
+	}
+
+	// Now that we have applied all modifications to targetDesiredReplicas, we can compute the scale direction
+	scaleDirection := common.GetScaleDirection(currentDesiredReplicas, targetDesiredReplicas)
+
+	// If we need to scale, we apply scaling rules if any
+	if scaleDirection != common.NoScale {
+		// Applying scaling rules if any
+		var rulesLimitReason string
+		var rulesLimitedReplicas int32
+		var rulesNextEvalAfter time.Duration
+		if scaleDirection == common.ScaleUp && autoscalerSpec.ApplyPolicy != nil {
+			rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleUpPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleUp, currentDesiredReplicas, targetDesiredReplicas)
+		} else if scaleDirection == common.ScaleDown && autoscalerSpec.ApplyPolicy != nil {
+			rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleDownPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleDown, currentDesiredReplicas, targetDesiredReplicas)
+		}
+		// If rules had any effect, use values from rules
+		if rulesLimitReason != "" {
+			limitReason = rulesLimitReason
+			targetDesiredReplicas = rulesLimitedReplicas
+			// To make sure event has expired and not have sub-second requeue, will be rounded to the next second
+			evalAfter = rulesNextEvalAfter.Truncate(time.Second) + time.Second
+		}
 	}
 
 	horizontalAction := &datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
@@ -265,6 +252,14 @@ func (hr *horizontalController) computeScaleAction(
 		log.Debugf("Scaling limited for autoscaler id: %s, scale direction: %s, limit reason: %s", autoscalerInternal.ID(), scaleDirection, limitReason)
 		horizontalAction.LimitedReason = pointer.Ptr(limitReason)
 	}
+
+	// Finally checking if scaling is allowed
+	allowed, reason := isScalingAllowed(autoscalerSpec, source, scaleDirection)
+	if !allowed {
+		log.Debugf("Scaling not allowed for autoscaler id: %s, scale direction: %s, scale reason: %s (would have scaled to %d replicas)", autoscalerInternal.ID(), scaleDirection, reason, horizontalAction.ToReplicas)
+		return nil, 0, errors.New(reason)
+	}
+
 	return horizontalAction, evalAfter, nil
 }
 
@@ -304,6 +299,43 @@ func isScalingAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source
 
 	// No specific policy defined, defaulting to allow
 	return true, ""
+}
+
+func stabilizeRecommendations(currentTime time.Time, recHist []model.HorizontalScalingValues, currentReplicas int32, targetDesiredReplicas int32, stabilizationWindowScaleUpSeconds int32, stabilizationWindowScaleDownSeconds int32) (int32, string) {
+	limitReason := ""
+
+	upRecommendation := targetDesiredReplicas
+	upCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleUpSeconds) * time.Second)
+
+	downRecommendation := targetDesiredReplicas
+	downCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleDownSeconds) * time.Second)
+
+	for _, a := range slices.Backward(recHist) {
+		if a.Timestamp.After(upCutoff) {
+			upRecommendation = min(upRecommendation, a.Replicas)
+		}
+
+		if a.Timestamp.After(downCutoff) {
+			downRecommendation = max(downRecommendation, a.Replicas)
+		}
+
+		if a.Timestamp.Before(upCutoff) && a.Timestamp.Before(downCutoff) {
+			break
+		}
+	}
+
+	recommendation := currentReplicas
+	if recommendation < upRecommendation {
+		recommendation = upRecommendation
+	}
+	if recommendation > downRecommendation {
+		recommendation = downRecommendation
+	}
+	if recommendation != targetDesiredReplicas {
+		limitReason = fmt.Sprintf("desired replica count adjusted to %d (originally %d) due to stabilization window", recommendation, targetDesiredReplicas)
+	}
+
+	return recommendation, limitReason
 }
 
 func applyScaleUpPolicy(
@@ -456,45 +488,4 @@ func accumulateReplicasChange(currentTime time.Time, events []datadoghqcommon.Da
 		expireIn = periodDuration
 	}
 	return
-}
-
-func stabilizeRecommendations(currentTime time.Time, pastActions []datadoghqcommon.DatadogPodAutoscalerHorizontalAction, currentReplicas int32, originalTargetDesiredReplicas int32, stabilizationWindowScaleUpSeconds int32, stabilizationWindowScaleDownSeconds int32, scaleDirection common.ScaleDirection) (int32, string) {
-	limitReason := ""
-
-	if len(pastActions) == 0 {
-		return originalTargetDesiredReplicas, limitReason
-	}
-
-	upRecommendation := originalTargetDesiredReplicas
-	upCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleUpSeconds) * time.Second)
-
-	downRecommendation := originalTargetDesiredReplicas
-	downCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleDownSeconds) * time.Second)
-
-	for _, a := range pastActions {
-		if scaleDirection == common.ScaleUp && a.Time.Time.After(upCutoff) {
-			upRecommendation = min(upRecommendation, *a.RecommendedReplicas)
-		}
-
-		if scaleDirection == common.ScaleDown && a.Time.Time.After(downCutoff) {
-			downRecommendation = max(downRecommendation, *a.RecommendedReplicas)
-		}
-
-		if (scaleDirection == common.ScaleUp && a.Time.Time.Before(upCutoff)) || (scaleDirection == common.ScaleDown && a.Time.Time.Before(downCutoff)) {
-			break
-		}
-	}
-
-	recommendation := currentReplicas
-	if recommendation < upRecommendation {
-		recommendation = upRecommendation
-	}
-	if recommendation > downRecommendation {
-		recommendation = downRecommendation
-	}
-	if recommendation != originalTargetDesiredReplicas {
-		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to stabilization window", recommendation, originalTargetDesiredReplicas)
-	}
-
-	return recommendation, limitReason
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -79,15 +79,6 @@ func (f *horizontalControllerFixture) runSync(fakePai *model.FakePodAutoscalerIn
 	return autoscalerInternal, res, err
 }
 
-func newHorizontalAction(time time.Time, fromReplicas, toReplicas, recommendedReplicas int32) datadoghqcommon.DatadogPodAutoscalerHorizontalAction {
-	return datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
-		Time:                metav1.NewTime(time),
-		FromReplicas:        fromReplicas,
-		ToReplicas:          toReplicas,
-		RecommendedReplicas: pointer.Ptr[int32](recommendedReplicas),
-	}
-}
-
 type horizontalScalingTestArgs struct {
 	fakePai          *model.FakePodAutoscalerInternal
 	dataSource       datadoghqcommon.DatadogPodAutoscalerValueSource

--- a/pkg/clusteragent/autoscaling/workload/dump_test.go
+++ b/pkg/clusteragent/autoscaling/workload/dump_test.go
@@ -159,6 +159,13 @@ From Replicas: 2
 To Replicas: 3
 Recommended Replicas: 3
 --------------------------------
+Horizontal Last Recommendation: Source: Autoscaling
+Timestamp: %[1]s
+Replicas: 100
+Horizontal Last Recommendation: Source: Autoscaling
+Timestamp: %[1]s
+Replicas: 102
+--------------------------------
 Vertical Last Action Error: test vertical last action error
 Vertical Last Action: Timestamp: %[1]s
 Version: 1
@@ -377,6 +384,18 @@ func createFakePodAutoscaler(testTime time.Time) model.FakePodAutoscalerInternal
 				FromReplicas:        2,
 				ToReplicas:          3,
 				RecommendedReplicas: ptr.To(int32(3)),
+			},
+		},
+		HorizontalLastRecommendations: []model.HorizontalScalingValues{
+			{
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+				Timestamp: testTime,
+				Replicas:  100,
+			},
+			{
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+				Timestamp: testTime,
+				Replicas:  102,
 			},
 		},
 		VerticalLastAction: &datadoghqcommon.DatadogPodAutoscalerVerticalAction{

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
@@ -79,27 +79,21 @@ func TestAddHorizontalAction(t *testing.T) {
 	}, horizontalLastActions)
 }
 
-func TestGetHorizontalEventsRetention(t *testing.T) {
+func TestGetHorizontalRetentionValues(t *testing.T) {
 	tests := []struct {
-		name                   string
-		policy                 *datadoghq.DatadogPodAutoscalerApplyPolicy
-		longestLookbackAllowed time.Duration
-		expectedRetention      time.Duration
+		name                            string
+		policy                          *datadoghq.DatadogPodAutoscalerApplyPolicy
+		expectedEventsRetention         time.Duration
+		expectedRecommendationRetention time.Duration
 	}{
 		{
-			name:                   "No policy, no retention",
-			policy:                 nil,
-			longestLookbackAllowed: 0,
-			expectedRetention:      0,
+			name:                            "No policy, no retention",
+			policy:                          nil,
+			expectedEventsRetention:         0,
+			expectedRecommendationRetention: 0,
 		},
 		{
-			name:                   "No policy, 15 minutes retention",
-			policy:                 nil,
-			longestLookbackAllowed: 15 * time.Minute,
-			expectedRetention:      0,
-		},
-		{
-			name: "Scale up policy with rules, 30 minutes retention",
+			name: "Scale up policy with rules",
 			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
@@ -111,11 +105,11 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					},
 				},
 			},
-			longestLookbackAllowed: 30 * time.Minute,
-			expectedRetention:      15 * time.Minute,
+			expectedEventsRetention:         15 * time.Minute,
+			expectedRecommendationRetention: 0,
 		},
 		{
-			name: "Scale up policy with rules, 10 minutes max retention",
+			name: "Scale up policy with rules",
 			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
@@ -127,36 +121,11 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					},
 				},
 			},
-			longestLookbackAllowed: 10 * time.Minute,
-			expectedRetention:      10 * time.Minute,
+			expectedEventsRetention:         15 * time.Minute,
+			expectedRecommendationRetention: 0,
 		},
 		{
-			name: "Scale up and scale down policy with rules, 30 minutes retention",
-			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
-				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
-					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
-						{
-							Type:          "Pods",
-							PeriodSeconds: 900,
-							Value:         2,
-						},
-					},
-				},
-				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
-					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
-						{
-							Type:          "Pods",
-							PeriodSeconds: 960,
-							Value:         2,
-						},
-					},
-				},
-			},
-			longestLookbackAllowed: 30 * time.Minute,
-			expectedRetention:      16 * time.Minute,
-		},
-		{
-			name: "Scale up and scale down policy with rules, 10 minutes max retention",
+			name: "Scale up and scale down policy with rules",
 			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
@@ -177,11 +146,36 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					},
 				},
 			},
-			longestLookbackAllowed: 10 * time.Minute,
-			expectedRetention:      10 * time.Minute,
+			expectedEventsRetention:         16 * time.Minute,
+			expectedRecommendationRetention: 0,
 		},
 		{
-			name: "Scale up stabilization window 5 minutes",
+			name: "Scale up and scale down policy with rules longer than allowed",
+			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
+						{
+							Type:          "Pods",
+							PeriodSeconds: 90000,
+							Value:         2,
+						},
+					},
+				},
+				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
+						{
+							Type:          "Pods",
+							PeriodSeconds: 960000,
+							Value:         2,
+						},
+					},
+				},
+			},
+			expectedEventsRetention:         longestScalingRulePeriodAllowed,
+			expectedRecommendationRetention: 0,
+		},
+		{
+			name: "Scale up stabilization window",
 			policy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
@@ -203,8 +197,8 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					},
 				},
 			},
-			longestLookbackAllowed: 30 * time.Minute,
-			expectedRetention:      5 * time.Minute,
+			expectedEventsRetention:         3 * time.Minute,
+			expectedRecommendationRetention: 5 * time.Minute,
 		},
 		{
 			name: "Scale down stabilization window 5 minutes",
@@ -229,8 +223,8 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					StabilizationWindowSeconds: 300,
 				},
 			},
-			longestLookbackAllowed: 30 * time.Minute,
-			expectedRetention:      5 * time.Minute,
+			expectedEventsRetention:         3 * time.Minute,
+			expectedRecommendationRetention: 5 * time.Minute,
 		},
 		{
 			name: "Stabilization, rules, max retention",
@@ -243,7 +237,7 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 							Value:         2,
 						},
 					},
-					StabilizationWindowSeconds: 300,
+					StabilizationWindowSeconds: 3600,
 				},
 				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
@@ -256,15 +250,16 @@ func TestGetHorizontalEventsRetention(t *testing.T) {
 					StabilizationWindowSeconds: 180,
 				},
 			},
-			longestLookbackAllowed: 30 * time.Minute,
-			expectedRetention:      7 * time.Minute,
+			expectedEventsRetention:         7 * time.Minute,
+			expectedRecommendationRetention: 1 * time.Hour,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			horizontalEventsRetention := getHorizontalEventsRetention(tt.policy, tt.longestLookbackAllowed)
-			assert.Equal(t, tt.expectedRetention, horizontalEventsRetention)
+			eventsRetention, recommendationRetention := getHorizontalRetentionValues(tt.policy)
+			assert.Equal(t, tt.expectedEventsRetention, eventsRetention)
+			assert.Equal(t, tt.expectedRecommendationRetention, recommendationRetention)
 		})
 	}
 }

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -25,53 +25,57 @@ import (
 
 // FakePodAutoscalerInternal is a fake PodAutoscalerInternal object.
 type FakePodAutoscalerInternal struct {
-	Namespace                      string
-	Name                           string
-	Generation                     int64
-	Spec                           *datadoghq.DatadogPodAutoscalerSpec
-	SettingsTimestamp              time.Time
-	CreationTimestamp              time.Time
-	ScalingValues                  ScalingValues
-	MainScalingValues              ScalingValues
-	FallbackScalingValues          ScalingValues
-	HorizontalLastActions          []datadoghqcommon.DatadogPodAutoscalerHorizontalAction
-	HorizontalLastLimitReason      string
-	HorizontalLastActionError      error
-	HorizontalEventsRetention      time.Duration
-	VerticalLastAction             *datadoghqcommon.DatadogPodAutoscalerVerticalAction
-	VerticalLastActionError        error
-	CurrentReplicas                *int32
-	ScaledReplicas                 *int32
-	Error                          error
-	Deleted                        bool
-	TargetGVK                      schema.GroupVersionKind
-	CustomRecommenderConfiguration *RecommenderConfiguration
+	Namespace                          string
+	Name                               string
+	Generation                         int64
+	Spec                               *datadoghq.DatadogPodAutoscalerSpec
+	SettingsTimestamp                  time.Time
+	CreationTimestamp                  time.Time
+	ScalingValues                      ScalingValues
+	MainScalingValues                  ScalingValues
+	FallbackScalingValues              ScalingValues
+	HorizontalLastActions              []datadoghqcommon.DatadogPodAutoscalerHorizontalAction
+	HorizontalLastRecommendations      []HorizontalScalingValues
+	HorizontalLastLimitReason          string
+	HorizontalLastActionError          error
+	HorizontalEventsRetention          time.Duration
+	HorizontalRecommendationsRetention time.Duration
+	VerticalLastAction                 *datadoghqcommon.DatadogPodAutoscalerVerticalAction
+	VerticalLastActionError            error
+	CurrentReplicas                    *int32
+	ScaledReplicas                     *int32
+	Error                              error
+	Deleted                            bool
+	TargetGVK                          schema.GroupVersionKind
+	CustomRecommenderConfiguration     *RecommenderConfiguration
 }
 
 // Build creates a PodAutoscalerInternal object from the FakePodAutoscalerInternal.
 func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 	return PodAutoscalerInternal{
-		namespace:                      f.Namespace,
-		name:                           f.Name,
-		generation:                     f.Generation,
-		spec:                           f.Spec,
-		settingsTimestamp:              f.SettingsTimestamp,
-		creationTimestamp:              f.CreationTimestamp,
-		scalingValues:                  f.ScalingValues,
-		mainScalingValues:              f.MainScalingValues,
-		fallbackScalingValues:          f.FallbackScalingValues,
-		horizontalLastActions:          f.HorizontalLastActions,
-		horizontalLastLimitReason:      f.HorizontalLastLimitReason,
-		horizontalLastActionError:      f.HorizontalLastActionError,
-		horizontalEventsRetention:      f.HorizontalEventsRetention,
-		verticalLastAction:             f.VerticalLastAction,
-		verticalLastActionError:        f.VerticalLastActionError,
-		currentReplicas:                f.CurrentReplicas,
-		scaledReplicas:                 f.ScaledReplicas,
-		error:                          f.Error,
-		deleted:                        f.Deleted,
-		targetGVK:                      f.TargetGVK,
-		customRecommenderConfiguration: f.CustomRecommenderConfiguration,
+		namespace:                          f.Namespace,
+		name:                               f.Name,
+		generation:                         f.Generation,
+		spec:                               f.Spec,
+		settingsTimestamp:                  f.SettingsTimestamp,
+		creationTimestamp:                  f.CreationTimestamp,
+		scalingValues:                      f.ScalingValues,
+		mainScalingValues:                  f.MainScalingValues,
+		fallbackScalingValues:              f.FallbackScalingValues,
+		horizontalLastActions:              f.HorizontalLastActions,
+		horizontalLastRecommendations:      f.HorizontalLastRecommendations,
+		horizontalLastLimitReason:          f.HorizontalLastLimitReason,
+		horizontalLastActionError:          f.HorizontalLastActionError,
+		horizontalEventsRetention:          f.HorizontalEventsRetention,
+		horizontalRecommendationsRetention: f.HorizontalRecommendationsRetention,
+		verticalLastAction:                 f.VerticalLastAction,
+		verticalLastActionError:            f.VerticalLastActionError,
+		currentReplicas:                    f.CurrentReplicas,
+		scaledReplicas:                     f.ScaledReplicas,
+		error:                              f.Error,
+		deleted:                            f.Deleted,
+		targetGVK:                          f.TargetGVK,
+		customRecommenderConfiguration:     f.CustomRecommenderConfiguration,
 	}
 }
 
@@ -100,8 +104,8 @@ func ComparePodAutoscalers(expected any, actual any) string {
 			return t == reflect.TypeOf(PodAutoscalerInternal{})
 		}),
 		cmp.FilterValues(
-			func(x, y interface{}) bool {
-				for _, v := range []interface{}{x, y} {
+			func(x, y any) bool {
+				for _, v := range []any{x, y} {
 					switch v.(type) {
 					case FakePodAutoscalerInternal:
 					case PodAutoscalerInternal:
@@ -121,8 +125,8 @@ func ComparePodAutoscalers(expected any, actual any) string {
 			}),
 		),
 		cmp.FilterValues(
-			func(x, y interface{}) bool {
-				for _, v := range []interface{}{x, y} {
+			func(x, y any) bool {
+				for _, v := range []any{x, y} {
 					switch v.(type) {
 					case []FakePodAutoscalerInternal:
 					case []PodAutoscalerInternal:


### PR DESCRIPTION
### What does this PR do?

Fix the stabilization window implementation. 3 issues were detected in the current implementation:
- The major one, using only actions data does not work as we need actual recommendation history to make the correct decision
- The second one is that we were applying stabilization window after applying scaling speed rules
- The third one is that we were restricting the set of recommendations we were looking at to determine `min` and `max` boundaries, disappears as we're now looking at raw recommendations instead of actions.

### Motivation

Provide accurate results when using stabilization window.

### Describe how you validated your changes

The change can be validated by using workloads that have flapping replica calculations and verifying the expected behaviour (which is greatly explained in this issue: https://github.com/kubernetes/kubernetes/issues/96671).

### Possible Drawbacks / Trade-offs

This PR does not implement the serialization of recommendation history in the CR, as no field is available for it.
As a best effort, we read from the past actions to get _some_ of the past recommendations.

On a leader change or Cluster Agent restart, the stabilization window will reset. Note that old data may be present in the followers when they were once leader, it's not an issue as data are discarded based on timestamp.

### Additional Notes