### PR TITLE
Revert "Global Datadog() can only read/write config, not build it"

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -34,12 +34,11 @@ func CheckAndUpgradeConfig() error {
 		log.Debug("Previous config file not found, not upgrading")
 		return nil
 	}
-	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
-	ddcfg.AddConfigPath(defaultpaths.ConfPath)
-	_, err := pkgconfigsetup.LoadWithoutSecret(ddcfg, nil)
+	pkgconfigsetup.Datadog().AddConfigPath(defaultpaths.ConfPath)
+	_, err := pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil)
 	if err == nil {
 		// was able to read config, check for api key
-		if ddcfg.GetString("api_key") != "" {
+		if pkgconfigsetup.Datadog().GetString("api_key") != "" {
 			log.Debug("Datadog.yaml found, and API key present.  Not upgrading config")
 			return nil
 		}

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -52,16 +52,14 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// setup the configuration system
-	cfg := pkgconfigsetup.GlobalConfigBuilder()
-
-	cfg.AddConfigPath(newConfigDir)
-	_, err = pkgconfigsetup.LoadWithoutSecret(cfg, nil)
+	pkgconfigsetup.Datadog().AddConfigPath(newConfigDir)
+	_, err = pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil)
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}
 
 	// we won't overwrite the conf file if it contains a valid api_key
-	if cfg.GetString("api_key") != "" && !force {
+	if pkgconfigsetup.Datadog().GetString("api_key") != "" && !force {
 		return fmt.Errorf("%s seems to contain a valid configuration, run the command again with --force or -f to overwrite it",
 			datadogYamlPath)
 	}
@@ -138,7 +136,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// marshal the config object to YAML
-	b, err := yaml.Marshal(cfg.AllSettings())
+	b, err := yaml.Marshal(pkgconfigsetup.Datadog().AllSettings())
 	if err != nil {
 		return fmt.Errorf("unable to marshal config to YAML: %v", err)
 	}

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -97,10 +97,8 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 		return nil, err
 	}
 
-	// Get the global agent config, build on top of it some more
-	// NOTE: This pattern should not be used by other callsites, it is needed here
-	// specifically because of the unique requirements of OTel's configuration.
-	pkgconfig := pkgconfigsetup.Datadog().RevertFinishedBackToBuilder()
+	// Set the global agent config
+	pkgconfig := pkgconfigsetup.Datadog()
 
 	pkgconfig.SetConfigName("OTel")
 	pkgconfig.SetEnvPrefix("DD")
@@ -143,10 +141,6 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	// Override config read (if any) with Default values
 	pkgconfigsetup.InitConfig(pkgconfig)
 	pkgconfigmodel.ApplyOverrideFuncs(pkgconfig)
-
-	// Finish building the config, required because the finished config was
-	// reverted earlier by the method "RevertFinishedBackToBuilder"
-	pkgconfig.BuildSchema()
 
 	ddc, err := getDDExporterConfig(cfg)
 	if err == ErrNoDDExporter {

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -393,10 +393,9 @@ func setupApiKey() bool {
 }
 
 func loadConfig() {
-	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
-	ddcfg.SetConfigFile(datadogConfigPath)
+	pkgconfigsetup.Datadog().SetConfigFile(datadogConfigPath)
 	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
-	if _, err := pkgconfigsetup.LoadWithoutSecret(ddcfg, nil); err != nil {
+	if _, err := pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil); err != nil {
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
 }

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -83,8 +83,7 @@ func newComponent(deps dependencies) (provides, error) {
 }
 
 func newConfig(deps dependencies) (*cfg, error) {
-	config := pkgconfigsetup.GlobalConfigBuilder()
-
+	config := pkgconfigsetup.Datadog()
 	warnings, err := setupConfig(config, deps)
 	returnErrFct := func(e error) (*cfg, error) {
 		if e != nil && deps.Params.ignoreErrors {

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -17,8 +17,8 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
-// setupConfig loads additional configuration data from yaml files, fleet policies, and command-line options
-func setupConfig(config pkgconfigmodel.BuildableConfig, deps configDependencies) (*pkgconfigmodel.Warnings, error) {
+// setupConfig is copied from cmd/agent/common/helpers.go.
+func setupConfig(config pkgconfigmodel.Config, deps configDependencies) (*pkgconfigmodel.Warnings, error) {
 	p := deps.getParams()
 
 	confFilePath := p.ConfFilePath

--- a/pkg/config/create/new.go
+++ b/pkg/config/create/new.go
@@ -18,7 +18,7 @@ import (
 
 // NewConfig returns a config with the given name. Implementation of the
 // config is chosen by an env var
-func NewConfig(name string) model.BuildableConfig {
+func NewConfig(name string) model.Config {
 	// Configure Datadog global configuration
 	envvar := os.Getenv("DD_CONF_NODETREEMODEL")
 	// Possible values for DD_CONF_NODETREEMODEL:

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -26,20 +26,20 @@ var (
 
 // mockConfig should only be used in tests
 type mockConfig struct {
-	model.BuildableConfig
+	model.Config
 }
 
 // New creates a mock for the config
-func New(t testing.TB) model.BuildableConfig {
+func New(t testing.TB) model.Config {
 	m.Lock()
 	defer m.Unlock()
 	if isConfigMocked {
 		// The configuration is already mocked.
-		return &mockConfig{setup.GlobalConfigBuilder()}
+		return &mockConfig{setup.Datadog()}
 	}
 
 	isConfigMocked = true
-	originalDatadogConfig := setup.GlobalConfigBuilder()
+	originalDatadogConfig := setup.Datadog()
 	t.Cleanup(func() {
 		m.Lock()
 		defer m.Unlock()
@@ -57,7 +57,7 @@ func New(t testing.TB) model.BuildableConfig {
 }
 
 // NewFromYAML creates a mock for the config and load the give YAML
-func NewFromYAML(t testing.TB, yamlData string) model.BuildableConfig {
+func NewFromYAML(t testing.TB, yamlData string) model.Config {
 	conf := New(t)
 	conf.SetConfigType("yaml")
 	err := conf.ReadConfig(bytes.NewBuffer([]byte(yamlData)))
@@ -66,7 +66,7 @@ func NewFromYAML(t testing.TB, yamlData string) model.BuildableConfig {
 }
 
 // NewFromFile creates a mock for the config and load the give YAML
-func NewFromFile(t testing.TB, yamlFilePath string) model.BuildableConfig {
+func NewFromFile(t testing.TB, yamlFilePath string) model.Config {
 	conf := New(t)
 	conf.SetConfigType("yaml")
 	conf.SetConfigFile(yamlFilePath)
@@ -76,7 +76,7 @@ func NewFromFile(t testing.TB, yamlFilePath string) model.BuildableConfig {
 }
 
 // NewSystemProbe creates a mock for the system-probe config
-func NewSystemProbe(t testing.TB) model.BuildableConfig {
+func NewSystemProbe(t testing.TB) model.Config {
 	// We only check isSystemProbeConfigMocked when registering a cleanup function. 'isSystemProbeConfigMocked'
 	// avoids nested calls to Mock to reset the config to a blank state. This way we have only one mock per test and
 	// test helpers can call Mock.
@@ -85,11 +85,11 @@ func NewSystemProbe(t testing.TB) model.BuildableConfig {
 		defer m.Unlock()
 		if isSystemProbeConfigMocked {
 			// The configuration is already mocked.
-			return &mockConfig{setup.GlobalSystemProbeConfigBuilder()}
+			return &mockConfig{setup.SystemProbe()}
 		}
 
 		isSystemProbeConfigMocked = true
-		originalConfig := setup.GlobalSystemProbeConfigBuilder()
+		originalConfig := setup.SystemProbe()
 		t.Cleanup(func() {
 			m.Lock()
 			defer m.Unlock()
@@ -101,9 +101,9 @@ func NewSystemProbe(t testing.TB) model.BuildableConfig {
 	// Configure Datadog global configuration
 	setup.SetSystemProbe(create.NewConfig("system-probe")) // nolint forbidigo legitimate use of SetSystemProbe
 	// Configuration defaults
-	setup.InitSystemProbeConfig(setup.GlobalSystemProbeConfigBuilder())
+	setup.InitSystemProbeConfig(setup.SystemProbe())
 	setup.SystemProbe().SetTestOnlyDynamicSchema(true)
-	return &mockConfig{setup.GlobalSystemProbeConfigBuilder()}
+	return &mockConfig{setup.SystemProbe()}
 }
 
 // SetDefaultConfigType sets the config type for the mock config in use

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -276,29 +276,15 @@ type Compound interface {
 	ReadConfig(in io.Reader) error
 	MergeConfig(in io.Reader) error
 	MergeFleetPolicy(configPath string) error
-
-	// Revert a finished configuration so that more can be build on top of it.
-	// When building is completed, the caller should call BuildSchema.
-	// NOTE: This method should not be used by any new callsites, it is needed
-	// currently because of the unique requirements of OTel's configuration.
-	RevertFinishedBackToBuilder() BuildableConfig
 }
 
-// Config is an interface that can read/write the config after it has been
-// build and initialized.
+// Config represents an object that can load and store configuration parameters
+// coming from different kind of sources:
+// - defaults
+// - files
+// - environment variables
+// - flags
 type Config interface {
-	ReaderWriter
-	Compound
-	// TODO: This method shouldn't be here, but it is depended upon by an external repository
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e7c3295769637e61558c6892be732398840dd5f5/pkg/datadog/agentcomponents/agentcomponents.go#L166
-	SetKnown(key string)
-}
-
-// BuildableConfig is the most-general interface for the Config, it can be
-// used both to build the config and also to read/write its values. It should
-// only be used when necessary, such as when constructing a new config object
-// from scratch.
-type BuildableConfig interface {
 	ReaderWriter
 	Setup
 	Compound

--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func constructBothConfigs(content string, dynamicSchema bool, setupFunc func(model.Setup)) (model.BuildableConfig, model.BuildableConfig) {
+func constructBothConfigs(content string, dynamicSchema bool, setupFunc func(model.Setup)) (model.Config, model.Config) {
 	viperConf := viperconfig.NewViperConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	ntmConf := NewNodeTreeConfig("datadog", "DD", strings.NewReplacer(".", "_"))            // nolint: forbidigo // legit use case
 

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -213,14 +213,6 @@ func (c *ntmConfig) SetTestOnlyDynamicSchema(allow bool) {
 	c.allowDynamicSchema.Store(allow)
 }
 
-// RevertFinishedBackToBuilder returns an interface that can build more on the current
-// config, instead of treating it as sealed
-// NOTE: Only used by OTel, no new uses please!
-func (c *ntmConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
-	c.ready.Store(false)
-	return c
-}
-
 // Set assigns the newValue to the given key and marks it as originating from the given source
 func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	c.maybeRebuild()
@@ -993,7 +985,7 @@ func (c *ntmConfig) Object() model.Reader {
 }
 
 // NewNodeTreeConfig returns a new Config object.
-func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.BuildableConfig {
+func NewNodeTreeConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.Config {
 	config := ntmConfig{
 		ready:               atomic.NewBool(false),
 		allowDynamicSchema:  atomic.NewBool(false),

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -34,7 +34,7 @@ network_devices:
     bind_host: ko
 `
 
-func setupDefault(_ *testing.T, cfg model.BuildableConfig) *ntmConfig {
+func setupDefault(_ *testing.T, cfg model.Config) *ntmConfig {
 	cfg.SetDefault("network_devices.snmp_traps.enabled", false)
 	cfg.SetDefault("network_devices.snmp_traps.port", 0)
 	cfg.SetDefault("network_devices.snmp_traps.bind_host", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -124,8 +124,8 @@ const (
 
 var (
 	// datadog is the global configuration object
-	datadog     pkgconfigmodel.BuildableConfig
-	systemProbe pkgconfigmodel.BuildableConfig
+	datadog     pkgconfigmodel.Config
+	systemProbe pkgconfigmodel.Config
 
 	datadogMutex     = sync.RWMutex{}
 	systemProbeMutex = sync.RWMutex{}
@@ -134,7 +134,7 @@ var (
 // SetDatadog sets the the reference to the agent configuration.
 // This is currently used by the legacy converter and config mocks and should not be user anywhere else. Once the
 // legacy converter and mock have been migrated we will remove this function.
-func SetDatadog(cfg pkgconfigmodel.BuildableConfig) {
+func SetDatadog(cfg pkgconfigmodel.Config) {
 	datadogMutex.Lock()
 	defer datadogMutex.Unlock()
 	datadog = cfg
@@ -143,7 +143,7 @@ func SetDatadog(cfg pkgconfigmodel.BuildableConfig) {
 // SetSystemProbe sets the the reference to the systemProbe configuration.
 // This is currently used by the config mocks and should not be user anywhere else. Once the mocks have been migrated we
 // will remove this function.
-func SetSystemProbe(cfg pkgconfigmodel.BuildableConfig) {
+func SetSystemProbe(cfg pkgconfigmodel.Config) {
 	systemProbeMutex.Lock()
 	defer systemProbeMutex.Unlock()
 	systemProbe = cfg

--- a/pkg/config/setup/config_accessor.go
+++ b/pkg/config/setup/config_accessor.go
@@ -18,15 +18,3 @@ func Datadog() pkgconfigmodel.Config {
 func SystemProbe() pkgconfigmodel.Config {
 	return systemProbe
 }
-
-// GlobalConfigBuilder returns a builder appropriate for initializing
-// the config. It should not be used in most places, except for code
-// that builds the config from scratch.
-func GlobalConfigBuilder() pkgconfigmodel.BuildableConfig {
-	return datadog
-}
-
-// GlobalSystemProbeConfigBuilder returns a builder for the system probe config
-func GlobalSystemProbeConfigBuilder() pkgconfigmodel.BuildableConfig {
-	return systemProbe
-}

--- a/pkg/config/setup/config_init.go
+++ b/pkg/config/setup/config_init.go
@@ -8,9 +8,6 @@
 package setup
 
 func initConfig() {
-	cfg := GlobalConfigBuilder()
-	InitConfig(cfg)
-
-	sysprobe := GlobalSystemProbeConfigBuilder()
-	InitSystemProbeConfig(sysprobe)
+	InitConfig(Datadog())
+	InitSystemProbeConfig(SystemProbe())
 }

--- a/pkg/config/setup/config_init_serverless.go
+++ b/pkg/config/setup/config_init_serverless.go
@@ -8,6 +8,5 @@
 package setup
 
 func initConfig() {
-	ddcfg := GlobalConfigBuilder()
-	initCommonWithServerless(ddcfg)
+	initCommonWithServerless(Datadog())
 }

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
-func confFromYAML(t *testing.T, yamlConfig string) pkgconfigmodel.BuildableConfig {
+func confFromYAML(t *testing.T, yamlConfig string) pkgconfigmodel.Config {
 	conf := newTestConf(t)
 	conf.SetConfigType("yaml")
 	err := conf.ReadConfig(strings.NewReader(yamlConfig))

--- a/pkg/config/setup/config_test_accessor.go
+++ b/pkg/config/setup/config_test_accessor.go
@@ -22,19 +22,3 @@ func SystemProbe() pkgconfigmodel.Config {
 	defer systemProbeMutex.RUnlock()
 	return systemProbe
 }
-
-// GlobalConfigBuilder returns a builder appropriate for initializing
-// the config. It should not be used in most places, except for code
-// that builds the config from scratch.
-func GlobalConfigBuilder() pkgconfigmodel.BuildableConfig {
-	datadogMutex.RLock()
-	defer datadogMutex.RUnlock()
-	return datadog
-}
-
-// GlobalSystemProbeConfigBuilder returns a builder for the system probe config
-func GlobalSystemProbeConfigBuilder() pkgconfigmodel.BuildableConfig {
-	systemProbeMutex.RLock()
-	defer systemProbeMutex.RUnlock()
-	return systemProbe
-}

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -69,7 +69,7 @@ var (
 )
 
 // InitSystemProbeConfig declares all the configuration values normally read from system-probe.yaml.
-func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
+func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), true)
@@ -473,7 +473,7 @@ func suffixHostEtc(suffix string) string {
 // eventMonitorBindEnvAndSetDefault is a helper function that generates both "DD_RUNTIME_SECURITY_CONFIG_" and "DD_EVENT_MONITORING_CONFIG_"
 // prefixes from a key. We need this helper function because the standard BindEnvAndSetDefault can only generate one prefix, but we want to
 // support both for backwards compatibility.
-func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, val interface{}) {
+func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Config, key string, val interface{}) {
 	// Uppercase, replace "." with "_" and add "DD_" prefix to key so that we follow the same environment
 	// variable convention as the core agent.
 	emConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
@@ -484,7 +484,7 @@ func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, v
 }
 
 // eventMonitorBindEnv is the same as eventMonitorBindEnvAndSetDefault, but without setting a default.
-func eventMonitorBindEnv(config pkgconfigmodel.Setup, key string) {
+func eventMonitorBindEnv(config pkgconfigmodel.Config, key string) {
 	emConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
 	runtimeSecKey := strings.Replace(emConfigKey, "EVENT_MONITORING_CONFIG", "RUNTIME_SECURITY_CONFIG", 1)
 

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 )
 
-func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
+func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// CWS - general config
 	// the following entries are platform specific
 	// - runtime_security_config.policies.dir

--- a/pkg/config/setup/system_probe_cws_notwin.go
+++ b/pkg/config/setup/system_probe_cws_notwin.go
@@ -13,7 +13,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-func platformCWSConfig(cfg pkgconfigmodel.Setup) {
+func platformCWSConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
 	cfg.BindEnvAndSetDefault("runtime_security_config.socket", filepath.Join(InstallPath, "run/runtime-security.sock"))
 }

--- a/pkg/config/setup/system_probe_cws_windows.go
+++ b/pkg/config/setup/system_probe_cws_windows.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
-func platformCWSConfig(cfg pkgconfigmodel.Setup) {
+func platformCWSConfig(cfg pkgconfigmodel.Config) {
 	programdata, err := winutil.GetProgramDataDir()
 	if err == nil {
 		cfg.BindEnvAndSetDefault("runtime_security_config.policies.dir", filepath.Join(programdata, "runtime-security.d"))

--- a/pkg/config/setup/test_helpers.go
+++ b/pkg/config/setup/test_helpers.go
@@ -17,7 +17,7 @@ import (
 // newEmptyMockConf returns an empty config appropriate for running tests
 // we can't use pkg/config/mock here because that package depends upon this one, so
 // this avoids a circular dependency
-func newEmptyMockConf(_ *testing.T) pkgconfigmodel.BuildableConfig {
+func newEmptyMockConf(_ *testing.T) pkgconfigmodel.Config {
 	cfg := create.NewConfig("test")
 	cfg.SetTestOnlyDynamicSchema(true)
 	return cfg
@@ -25,7 +25,7 @@ func newEmptyMockConf(_ *testing.T) pkgconfigmodel.BuildableConfig {
 
 // newTestConf generates and returns a new configuration that has been setup
 // by running the schema constructing code InitConfig found in setup/config.go
-func newTestConf(t *testing.T) pkgconfigmodel.BuildableConfig {
+func newTestConf(t *testing.T) pkgconfigmodel.Config {
 	conf := newEmptyMockConf(t)
 	InitConfig(conf)
 	conf.SetConfigFile("")

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -45,7 +45,7 @@ type trapsConfig struct {
 // newEmptyMockConf returns an empty config appropriate for running tests
 // we can't use pkg/config/mock here because that package depends upon this one, so
 // this avoids a circular dependency
-func newEmptyMockConf(_ *testing.T) model.BuildableConfig {
+func newEmptyMockConf(_ *testing.T) model.Config {
 	cfg := create.NewConfig("test")
 	cfg.SetTestOnlyDynamicSchema(true)
 	return cfg
@@ -53,7 +53,7 @@ func newEmptyMockConf(_ *testing.T) model.BuildableConfig {
 
 // We don't use config mock here to not create cycle dependencies (same reason why config mock are not used in
 // pkg/config/{setup/model})
-func newConfigFromYaml(t *testing.T, yaml string) model.BuildableConfig {
+func newConfigFromYaml(t *testing.T, yaml string) model.Config {
 	conf := newEmptyMockConf(t)
 	conf.SetConfigType("yaml")
 	err := conf.ReadConfig(bytes.NewBuffer([]byte(yaml)))

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -23,8 +23,8 @@ import (
 
 // teeConfig is a combination of two configs, both get written to but only baseline is read
 type teeConfig struct {
-	baseline model.BuildableConfig
-	compare  model.BuildableConfig
+	baseline model.Config
+	compare  model.Config
 }
 
 func getLocation(nbStack int) string {
@@ -34,17 +34,8 @@ func getLocation(nbStack int) string {
 }
 
 // NewTeeConfig constructs a new teeConfig
-func NewTeeConfig(baseline, compare model.BuildableConfig) model.BuildableConfig {
+func NewTeeConfig(baseline, compare model.Config) model.Config {
 	return &teeConfig{baseline: baseline, compare: compare}
-}
-
-// RevertFinishedBackToBuilder returns an interface that can build more on the
-// current config, instead of treating it as sealed
-// NOTE: Only used by OTel, no new uses please!
-func (t *teeConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
-	t.baseline.RevertFinishedBackToBuilder()
-	t.compare.RevertFinishedBackToBuilder()
-	return t
 }
 
 // OnUpdate adds a callback to the list receivers to be called each time a value is changed in the configuration

--- a/pkg/config/viperconfig/go.mod
+++ b/pkg/config/viperconfig/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/stretchr/testify v1.10.0
-	go.uber.org/atomic v1.11.0
 )
 
 require (
@@ -27,6 +26,7 @@ require (
 	github.com/spf13/cast v1.9.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -21,8 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/atomic"
-
 	"github.com/DataDog/viper"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mohae/deepcopy"
@@ -44,9 +42,6 @@ type safeConfig struct {
 	notificationReceivers []model.NotificationReceiver
 	notificationChannel   chan model.ConfigChangeNotification
 	sequenceID            uint64
-
-	// ready is whether the schema has been built, which marks the config as ready for use
-	ready *atomic.Bool
 
 	// Proxy settings
 	proxies *model.Proxy
@@ -224,7 +219,7 @@ func (c *safeConfig) GetKnownKeysLowercased() map[string]interface{} {
 
 // BuildSchema is a no-op for the viper based config
 func (c *safeConfig) BuildSchema() {
-	c.ready.Store(true)
+	// pass
 }
 
 func (c *safeConfig) setEnvTransformer(key string, fn func(string) interface{}) {
@@ -494,26 +489,11 @@ func (c *safeConfig) GetSource(key string) model.Source {
 	return source
 }
 
-func (c *safeConfig) isReady() bool {
-	return c.ready.Load()
-}
-
-// RevertFinishedBackToBuilder returns an interface that can build more on
-// the current config, instead of treating it as sealed
-// NOTE: Only used by OTel, no new uses please!
-func (c *safeConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
-	c.ready.Store(false)
-	return c
-}
-
 // SetEnvPrefix wraps Viper for concurrent access, and keeps the envPrefix for
 // future reference
 func (c *safeConfig) SetEnvPrefix(in string) {
 	c.Lock()
 	defer c.Unlock()
-	if c.isReady() {
-		panic("cannot SetEnvPrefix() once the config has been marked as ready for use")
-	}
 	c.configSources[model.SourceEnvVar].SetEnvPrefix(in)
 	c.Viper.SetEnvPrefix(in)
 	c.envPrefix = in
@@ -556,9 +536,6 @@ func (c *safeConfig) BindEnv(key string, envvars ...string) {
 func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
 	c.Lock()
 	defer c.Unlock()
-	if c.isReady() {
-		panic("cannot SetEnvPrefix() once the config has been marked as ready for use")
-	}
 	c.configSources[model.SourceEnvVar].SetEnvKeyReplacer(r)
 	c.Viper.SetEnvKeyReplacer(r)
 	c.envKeyReplacer = r
@@ -819,17 +796,16 @@ func (c *safeConfig) Object() model.Reader {
 
 // NewConfig returns a new viper config
 // Deprecated: instead use pkg/config/create.NewConfig or NewViperConfig
-func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.BuildableConfig {
+func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.Config {
 	return NewViperConfig(name, envPrefix, envKeyReplacer)
 }
 
 // NewViperConfig returns a new Config object.
-func NewViperConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.BuildableConfig {
+func NewViperConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) model.Config {
 	config := safeConfig{
 		Viper:               viper.New(),
 		configSources:       map[model.Source]*viper.Viper{},
 		sequenceID:          0,
-		ready:               atomic.NewBool(false),
 		configEnvVars:       map[string]struct{}{},
 		unknownKeys:         map[string]struct{}{},
 		notificationChannel: make(chan model.ConfigChangeNotification, 1000),

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -31,9 +31,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
-	ddcfg.SetConfigFile(*cfgpath)
-	if _, err := pkgconfigsetup.LoadWithoutSecret(ddcfg, nil); err != nil {
+	pkgconfigsetup.Datadog().SetConfigFile(*cfgpath)
+	if _, err := pkgconfigsetup.LoadWithoutSecret(pkgconfigsetup.Datadog(), nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -683,9 +683,8 @@ func TestClusterAgentSuite(t *testing.T) {
 	require.Nil(t, err, fmt.Errorf("%v", err))
 	defer os.Remove(f.Name())
 
-	cfg := configmock.New(t)
-	cfg.SetConfigFile(f.Name())
-	s := &clusterAgentSuite{config: cfg}
+	s := &clusterAgentSuite{config: configmock.New(t)}
+	s.config.SetConfigFile(f.Name())
 	s.authTokenPath = filepath.Join(fakeDir, clusterAgentAuthTokenFilename)
 	_, err = os.Stat(s.authTokenPath)
 	require.NotNil(t, err, fmt.Sprintf("%v", err))


### PR DESCRIPTION
Reverts DataDog/datadog-agent#39395

#incident-41756 (static quality gates violation)