### PR TITLE
Pass canonical target to `swiftc` on AArch64/ARM64 (ABLD-28 follow-up)

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -258,7 +258,7 @@ build do
     systray_build_dir = "#{project_dir}/comp/core/gui/guiimpl/systray"
     # Target OSX 10.10 (it brings significant changes to Cocoa and Foundation APIs, and older versions of OSX are EOL'ed)
     # Add @executable_path/../Frameworks to rpath to find the swift libs in the Frameworks folder.
-    target = arm_target? ? 'arm64-apple-macosx11.0' : 'x86_64-apple-macosx10.10'
+    target = arm_target? ? 'arm64-apple-macos11.0' : 'x86_64-apple-macosx10.10'
     command "swiftc -O -swift-version \"5\" -target \"#{target}\" -Xlinker '-rpath' -Xlinker '@executable_path/../Frameworks' Sources/*.swift -o gui", cwd: systray_build_dir
     copy "#{systray_build_dir}/gui", "#{app_temp_dir}/MacOS/"
     copy "#{systray_build_dir}/agent.png", "#{app_temp_dir}/MacOS/"


### PR DESCRIPTION
### What does this PR do?
Pass a more canonical[^1] target to `swiftc` for AArch64/ARM64 on macOS:
```diff
-swiftc ... -target arm64-apple-macosx11.0 ...
+swiftc ... -target arm64-apple-macos11.0 ...
```

### Motivation
See:
- https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary#Update-the-Architecture-List-of-Custom-Makefiles
  ```
  arm_app: main.c
      $(CC) main.c -o arm_app -target arm64-apple-macos11
  ```
- https://github.com/DataDog/datadog-agent/pull/18173#issuecomment-3164974903
  ```
  command 'swiftc -O -swift-version "5" -target "arm64-apple-macos11" -Xlinker \'-rpath\' -Xlinker \'@executable_path/../Frameworks\' Sources/*.swift -o gui', cwd: systray_build_dir
  ```
- https://stackoverflow.com/a/73773711
  > **Is there a generic -target I can use that will work for all macOS versions (maybe even future versions)?**
  >
  > Yes. For example, if you are targeting macos 11, you can use `-target x86_64-apple-macos11.0` for intel CPUs and `arm64-apple-macos11.0` for apple silicon CPUs. By default, targeting macos 11 means you can run the binary in future macos version.

### Describe how you validated your changes
Successful build.

### Additional Notes
[^1]: preferred, if not recommended