### PR TITLE
[Dynamic Instrumentation] Symbols Upload

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -180,6 +180,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(diNS, "probes_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
 	cfg.BindEnvAndSetDefault(join(diNS, "snapshot_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_SNAPSHOT_FILE_PATH")
 	cfg.BindEnvAndSetDefault(join(diNS, "diagnostics_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_DIAGNOSTICS_FILE_PATH")
+	cfg.BindEnvAndSetDefault(join(diNS, "symdb_upload_enabled"), false, "DD_SYMBOL_DATABASE_UPLOAD_ENABLED")
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "enabled"), true)
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "dir"), defaultDynamicInstrumentationDebugInfoDir)
 	cfg.BindEnvAndSetDefault(join(diNS, "debug_info_disk_cache", "max_total_bytes"), int64(2<<30 /* 2GiB */))

--- a/pkg/dyninst/actuator/process.go
+++ b/pkg/dyninst/actuator/process.go
@@ -35,10 +35,6 @@ type ProcessUpdate struct {
 	// If a previous update contained a different set of probes, they
 	// will be wholly replaced by the new set.
 	Probes []ir.ProbeDefinition
-
-	// ShouldUploadSymDB is whether the process should upload its symbol
-	// database.
-	ShouldUploadSymDB bool
 }
 
 // Executable forwards the definition from procmon.

--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -74,11 +74,13 @@ func TestDecoderErrorHandling(t *testing.T) {
 	diagURL, err := url.Parse(backendServer.URL + "/diags")
 	require.NoError(t, err)
 
+	symdbURL, err := url.Parse("http://dummy-symdb-url")
+	require.NoError(t, err)
 	c := module.NewController(
 		actuator,
 		uploader.NewLogsUploaderFactory(uploader.WithURL(logsURL)),
 		uploader.NewDiagnosticsUploader(uploader.WithURL(diagURL)),
-		nil,
+		symdbURL,
 		scraper,
 		&failOnceDecoderFactory{
 			underlying: module.DefaultDecoderFactory{},

--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -78,6 +78,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 		actuator,
 		uploader.NewLogsUploaderFactory(uploader.WithURL(logsURL)),
 		uploader.NewDiagnosticsUploader(uploader.WithURL(diagURL)),
+		nil,
 		scraper,
 		&failOnceDecoderFactory{
 			underlying: module.DefaultDecoderFactory{},

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -179,12 +179,6 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		makeTargetStatus(uploader.StatusInstalled, expectedProbeIDs...),
 	)
 
-	// If we added symdb, make sure we detect that it's enabled.
-	if cfg.addSymdb {
-		updates := ts.takeProcessesUpdates()
-		require.True(t, updates[len(updates)-1].Processes[0].ShouldUploadSymDB)
-	}
-
 	const numRequests = 3
 	sendTestRequests(t, serverPort, numRequests)
 	waitForLogMessages(
@@ -206,10 +200,6 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		// Assert that we've removed the probes regardless of whether we're
 		// adding the symdb.
 		assert.Empty(c, updates[len(updates)-1].Processes[0].Probes)
-		// If we added symdb, make sure we detect that it's gone.
-		if cfg.addSymdb {
-			assert.False(c, updates[len(updates)-1].Processes[0].ShouldUploadSymDB)
-		}
 	}, 10*time.Second, 100*time.Millisecond, "probes should be removed")
 }
 

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -603,6 +603,7 @@ func (ts *testState) initializeModule(t *testing.T) {
 	))
 	require.NoError(t, err)
 
+	cfg.SymDBUploadEnabled = true
 	cfg.LogUploaderURL = ts.backendServer.URL + "/logs"
 	cfg.DiagsUploaderURL = ts.backendServer.URL + "/diags"
 	cfg.SymDBUploaderURL = ts.symdbURL

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,7 +43,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	di_module "github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 )
@@ -55,6 +58,9 @@ type testState struct {
 
 	backend       *mockBackend
 	backendServer *httptest.Server
+	// A mock backend for uploading SymDB data to.
+	symdbServer *httptest.Server
+	symdbURL    string
 
 	module     *di_module.Module
 	subscriber *mockSubscriber
@@ -98,11 +104,15 @@ func TestEndToEnd(t *testing.T) {
 
 	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
 	useDocker := dockerIsEnabled(t)
-	for _, binary := range []string{
-		"rc_tester",
-		"rc_tester_v1",
-	} {
-		t.Run(binary, func(t *testing.T) {
+	testCases := []struct {
+		program       string
+		supportsSymDB bool
+	}{
+		{"rc_tester", true},
+		{"rc_tester_v1", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.program, func(t *testing.T) {
 			t.Parallel()
 			t.Run("docker", func(t *testing.T) {
 				if rewrite {
@@ -117,20 +127,20 @@ func TestEndToEnd(t *testing.T) {
 				t.Parallel()
 				runE2ETest(t, e2eTestConfig{
 					cfg:       cfg,
-					binary:    binary,
+					binary:    tc.program,
 					rewrite:   rewrite,
 					useDocker: true,
-					addSymdb:  binary == "rc_tester",
+					addSymdb:  tc.supportsSymDB,
 				})
 			})
 			t.Run("direct", func(t *testing.T) {
 				t.Parallel()
 				runE2ETest(t, e2eTestConfig{
 					cfg:       cfg,
-					binary:    binary,
+					binary:    tc.program,
 					rewrite:   rewrite,
 					useDocker: false,
-					addSymdb:  binary == "rc_tester",
+					addSymdb:  tc.supportsSymDB,
 				})
 			})
 		})
@@ -163,6 +173,14 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 	t.Cleanup(ts.rcServer.Close)
 	t.Cleanup(ts.rc.Close)
 
+	symDBRequests := atomic.Uint64{}
+	ts.symdbServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		symDBRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.symdbServer.Close)
+	ts.symdbURL = ts.symdbServer.URL
+
 	probes := testprogs.MustGetProbeDefinitions(t, cfg.binary)
 	rcs := makeRemoteConfigUpdate(t, probes, cfg.addSymdb)
 	ts.rc.UpdateRemoteConfig(rcs)
@@ -170,7 +188,14 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 	serverPort := ts.startSampleService(t, sampleServicePath)
 
 	ts.initializeModule(t)
-
+	symdbProcStates := make(map[procmon.ProcessID]bool)
+	if cfg.addSymdb {
+		ts.module.Controller().SetScraperUpdatesCallback(
+			func(updates []rcscrape.ProcessUpdate) {
+				u := updates[0]
+				symdbProcStates[u.ProcessID] = u.ShouldUploadSymDB
+			})
+	}
 	ts.subscriber.NotifyExec(ts.servicePID)
 
 	expectedProbeIDs := []string{"look_at_the_request", "http_handler"}
@@ -178,6 +203,16 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		t, ts.backend.diagPayloadCh,
 		makeTargetStatus(uploader.StatusInstalled, expectedProbeIDs...),
 	)
+
+	// If we added symdb, make sure we detect that it's enabled.
+	if cfg.addSymdb {
+		updates := ts.takeProcessesUpdates()
+		require.Len(t, updates, 1)
+		require.True(t, symdbProcStates[updates[0].Processes[0].ProcessID])
+		require.Eventually(t, func() bool {
+			return symDBRequests.Load() > 0
+		}, 10*time.Second, 100*time.Millisecond, "SymDB server should be hit")
+	}
 
 	const numRequests = 3
 	sendTestRequests(t, serverPort, numRequests)
@@ -189,17 +224,22 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 		t, ts.backend.diagPayloadCh,
 		makeTargetStatus(uploader.StatusEmitting, expectedProbeIDs...),
 	)
-	// Clear the remote config and make sure that we detect that we no longer
-	// are supposed to upload the symbol database.
+	// Clear the remote config.
 	ts.rc.UpdateRemoteConfig(nil)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		updates := ts.takeProcessesUpdates()
 		if !assert.NotEmpty(c, updates) {
 			return
 		}
-		// Assert that we've removed the probes regardless of whether we're
-		// adding the symdb.
-		assert.Empty(c, updates[len(updates)-1].Processes[0].Probes)
+		require.Len(t, updates, 1)
+		proc := updates[0].Processes[0]
+		// Assert that we've removed the probes.
+		assert.Empty(c, proc.Probes)
+		// If we previously added the SymDB key, make sure we detect that it's
+		// gone.
+		if cfg.addSymdb {
+			assert.False(t, symdbProcStates[proc.ProcessID])
+		}
 	}, 10*time.Second, 100*time.Millisecond, "probes should be removed")
 }
 
@@ -267,6 +307,8 @@ func getRcTesterEnv(rcHost string, rcPort int, tmpDir string) []string {
 		"DD_REMOTE_CONFIGURATION_ENABLED=true",
 		"DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=.01",
 		"DD_SERVICE=rc_tester",
+		"DD_ENV=test",
+		"DD_VERSION=1.0.0",
 		"DD_REMOTE_CONFIG_TUF_NO_VERIFICATION=true",
 		fmt.Sprintf("%s=%s", e2eTmpDirEnv, tmpDir),
 	}
@@ -504,6 +546,7 @@ type interceptingActuator struct {
 	mu    struct {
 		sync.Mutex
 		tenants map[string]*interceptingTenant
+		updates []actuator.ProcessesUpdate
 	}
 }
 
@@ -562,6 +605,7 @@ func (ts *testState) initializeModule(t *testing.T) {
 
 	cfg.LogUploaderURL = ts.backendServer.URL + "/logs"
 	cfg.DiagsUploaderURL = ts.backendServer.URL + "/diags"
+	cfg.SymDBUploaderURL = ts.symdbURL
 
 	ts.module, err = di_module.NewModule(cfg, ts.subscriber)
 	require.NoError(t, err)

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -85,7 +85,7 @@ func (a actuatorConstructor[A, T]) apply(c *Config) {
 // WithActuatorConstructor is an option that allows the user to provide a
 // custom actuator constructor.
 func WithActuatorConstructor[
-A Actuator[T], T ActuatorTenant,
+	A Actuator[T], T ActuatorTenant,
 ](
 	f actuatorConstructor[A, T],
 ) Option {

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	DynamicInstrumentationEnabled bool
 	LogUploaderURL                string
 	DiagsUploaderURL              string
+	SymDBUploadEnabled            bool
 	SymDBUploaderURL              string
 
 	// DiskCacheEnabled enables the disk cache for debug info.  If this is
@@ -109,11 +110,13 @@ func NewConfig(spConfig *sysconfigtypes.Config, opts ...Option) (*Config, error)
 	if err != nil {
 		return nil, err
 	}
+
 	c := &Config{
 		Config:                        *ebpf.NewConfig(),
 		DynamicInstrumentationEnabled: diEnabled,
 		LogUploaderURL:                withPath(traceAgentURL, logUploaderPath),
 		DiagsUploaderURL:              withPath(traceAgentURL, diagsUploaderPath),
+		SymDBUploadEnabled:            pkgconfigsetup.SystemProbe().GetBool("dynamic_instrumentation.symdb_upload_enabled"),
 		SymDBUploaderURL:              withPath(traceAgentURL, symdbUploaderPath),
 		DiskCacheEnabled:              cacheEnabled,
 		DiskCacheConfig:               cacheConfig,

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	DynamicInstrumentationEnabled bool
 	LogUploaderURL                string
 	DiagsUploaderURL              string
+	SymDBUploaderURL              string
 
 	// DiskCacheEnabled enables the disk cache for debug info.  If this is
 	// false, no disk cache will be used and the debug info will be stored in
@@ -84,7 +85,7 @@ func (a actuatorConstructor[A, T]) apply(c *Config) {
 // WithActuatorConstructor is an option that allows the user to provide a
 // custom actuator constructor.
 func WithActuatorConstructor[
-	A Actuator[T], T ActuatorTenant,
+A Actuator[T], T ActuatorTenant,
 ](
 	f actuatorConstructor[A, T],
 ) Option {
@@ -113,6 +114,7 @@ func NewConfig(spConfig *sysconfigtypes.Config, opts ...Option) (*Config, error)
 		DynamicInstrumentationEnabled: diEnabled,
 		LogUploaderURL:                withPath(traceAgentURL, logUploaderPath),
 		DiagsUploaderURL:              withPath(traceAgentURL, diagsUploaderPath),
+		SymDBUploaderURL:              withPath(traceAgentURL, symdbUploaderPath),
 		DiskCacheEnabled:              cacheEnabled,
 		DiskCacheConfig:               cacheConfig,
 		actuatorConstructor:           defaultActuatorConstructor,
@@ -174,6 +176,7 @@ const (
 
 	logUploaderPath   = "/debugger/v1/input"
 	diagsUploaderPath = "/debugger/v1/diagnostics"
+	symdbUploaderPath = "/symdb/v1/input"
 )
 
 var errSchemeRequired = fmt.Errorf("scheme is required")

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -10,6 +10,7 @@ package module
 import (
 	"context"
 	"math/rand"
+	"net/url"
 	"sync"
 	"time"
 
@@ -47,7 +48,7 @@ func NewController[AT ActuatorTenant, LU LogsUploader](
 	a Actuator[AT],
 	logUploader LogsUploaderFactory[LU],
 	diagUploader DiagnosticsUploader,
-	symdbUploader SymDBUploader,
+	symdbUploaderURL *url.URL,
 	rcScraper Scraper,
 	decoderFactory DecoderFactory,
 	irGenerator actuator.IRGenerator,
@@ -59,7 +60,7 @@ func NewController[AT ActuatorTenant, LU LogsUploader](
 		rcScraper:      rcScraper,
 		store:          store,
 		diagnostics:    newDiagnosticsManager(diagUploader),
-		symdb:          newSymdbManager(symdbUploader, store),
+		symdb:          newSymdbManager(symdbUploaderURL, store),
 		decoderFactory: decoderFactory,
 	}
 	c.actuator = a.NewTenant(

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -52,6 +52,8 @@ type Controller struct {
 }
 
 // NewController creates a new Controller.
+//
+// symdbUploaderURL can be nil, in which case there will be no SymDB uploads.
 func NewController[AT ActuatorTenant, LU LogsUploader](
 	a Actuator[AT],
 	logUploader LogsUploaderFactory[LU],

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -107,6 +107,9 @@ func (c *Controller) handleRemovals(removals []procmon.ProcessID) {
 			Removals: removals,
 		})
 	}
+	for _, pid := range removals {
+		c.symdb.removeUploadByPID(pid)
+	}
 }
 
 func (c *Controller) checkForUpdates() {

--- a/pkg/dyninst/module/controller_test.go
+++ b/pkg/dyninst/module/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"io"
 	"maps"
+	"net/url"
 	"slices"
 	"testing"
 
@@ -202,7 +203,7 @@ func TestController_HappyPathEndToEnd(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -249,7 +250,7 @@ func TestController_ProgramLifecycleFlow(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -299,7 +300,7 @@ func TestController_IRGenerationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 	require.NotNil(t, controller)
 	require.NotNil(t, a.tenant)
@@ -340,7 +341,7 @@ func TestController_AttachmentFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -384,7 +385,7 @@ func TestController_LoadingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -427,7 +428,7 @@ func TestController_DecoderCreationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 	controller.CheckForUpdates()
 
@@ -456,7 +457,7 @@ func TestController_EventDecodingSuccess(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -510,7 +511,7 @@ func TestController_EventDecodingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -550,7 +551,7 @@ func TestController_ProcessRemoval(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 	at := a.tenant
 
@@ -573,6 +574,14 @@ func TestController_ProcessRemoval(t *testing.T) {
 		Removals: removals,
 	})
 }
+
+var symdbURL = func() *url.URL {
+	u, err := url.Parse("http://dummy-symdb-url")
+	if err != nil {
+		panic(err)
+	}
+	return u
+}()
 
 // TestController_MultipleProcesses verifies that the controller can handle
 // multiple processes in a single update, generating diagnostics for all probes
@@ -598,7 +607,7 @@ func TestController_MultipleProcesses(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		actuator, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		actuator, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -647,7 +656,7 @@ func TestController_ProbeIssueReporting(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -693,7 +702,7 @@ func TestController_NoSuccessfulProbesError(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()

--- a/pkg/dyninst/module/controller_test.go
+++ b/pkg/dyninst/module/controller_test.go
@@ -202,7 +202,7 @@ func TestController_HappyPathEndToEnd(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -249,7 +249,7 @@ func TestController_ProgramLifecycleFlow(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -299,7 +299,7 @@ func TestController_IRGenerationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 	require.NotNil(t, controller)
 	require.NotNil(t, a.tenant)
@@ -340,7 +340,7 @@ func TestController_AttachmentFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -384,7 +384,7 @@ func TestController_LoadingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -427,7 +427,7 @@ func TestController_DecoderCreationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 	controller.CheckForUpdates()
 
@@ -456,7 +456,7 @@ func TestController_EventDecodingSuccess(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -510,7 +510,7 @@ func TestController_EventDecodingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -550,7 +550,7 @@ func TestController_ProcessRemoval(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 	at := a.tenant
 
@@ -598,7 +598,7 @@ func TestController_MultipleProcesses(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		actuator, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		actuator, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -647,7 +647,7 @@ func TestController_ProbeIssueReporting(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -693,7 +693,7 @@ func TestController_NoSuccessfulProbesError(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, nil, scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -68,6 +68,12 @@ func NewModule(
 	}
 	diagsUploader := uploader.NewDiagnosticsUploader(uploader.WithURL(diagsUploaderURL))
 
+	symdbUploaderURL, err := url.Parse(config.SymDBUploaderURL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing SymDB uploader URL: %w", err)
+	}
+	symdbUploader := uploader.NewSymDBUploader(uploader.WithURL(symdbUploaderURL))
+
 	loader, err := loader.NewLoader()
 	if err != nil {
 		return nil, fmt.Errorf("error creating loader: %w", err)
@@ -86,7 +92,7 @@ func NewModule(
 	rcScraper := rcscrape.NewScraper(actuator)
 	irGenerator := irgen.NewGenerator(irgen.WithObjectLoader(objectLoader))
 	controller := NewController(
-		actuator, logUploader, diagsUploader, rcScraper, DefaultDecoderFactory{}, irGenerator,
+		actuator, logUploader, diagsUploader, symdbUploader, rcScraper, DefaultDecoderFactory{}, irGenerator,
 	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
 		scraperHandler: rcScraper.AsProcMonHandler(),

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -72,7 +72,6 @@ func NewModule(
 	if err != nil {
 		return nil, fmt.Errorf("error parsing SymDB uploader URL: %w", err)
 	}
-	symdbUploader := uploader.NewSymDBUploader(uploader.WithURL(symdbUploaderURL))
 
 	loader, err := loader.NewLoader()
 	if err != nil {
@@ -92,7 +91,7 @@ func NewModule(
 	rcScraper := rcscrape.NewScraper(actuator)
 	irGenerator := irgen.NewGenerator(irgen.WithObjectLoader(objectLoader))
 	controller := NewController(
-		actuator, logUploader, diagsUploader, symdbUploader, rcScraper, DefaultDecoderFactory{}, irGenerator,
+		actuator, logUploader, diagsUploader, symdbUploaderURL, rcScraper, DefaultDecoderFactory{}, irGenerator,
 	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
 		scraperHandler: rcScraper.AsProcMonHandler(),

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -168,5 +168,6 @@ func (m *Module) Close() {
 		if err := m.actuator.Shutdown(); err != nil {
 			log.Errorf("error shutting down actuator: %v", err)
 		}
+		m.controller.symdb.stop()
 	})
 }

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -68,9 +68,12 @@ func NewModule(
 	}
 	diagsUploader := uploader.NewDiagnosticsUploader(uploader.WithURL(diagsUploaderURL))
 
-	symdbUploaderURL, err := url.Parse(config.SymDBUploaderURL)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing SymDB uploader URL: %w", err)
+	var symdbUploaderURL *url.URL
+	if config.SymDBUploadEnabled {
+		symdbUploaderURL, err = url.Parse(config.SymDBUploaderURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing SymDB uploader URL: %w", err)
+		}
 	}
 
 	loader, err := loader.NewLoader()

--- a/pkg/dyninst/module/state.go
+++ b/pkg/dyninst/module/state.go
@@ -21,12 +21,11 @@ import (
 
 type processState struct {
 	procRuntimeID
-	executable         actuator.Executable
-	symbolicator       symbol.Symbolicator
-	symbolicatorFile   io.Closer
-	symbolicatorErr    error
-	gitInfo            procmon.GitInfo
-	symdbUploadStarted bool
+	executable       actuator.Executable
+	symbolicator     symbol.Symbolicator
+	symbolicatorFile io.Closer
+	symbolicatorErr  error
+	gitInfo          procmon.GitInfo
 }
 
 type processStore struct {
@@ -144,17 +143,4 @@ func (ps *processStore) getRuntimeID(procID actuator.ProcessID) (procRuntimeID, 
 		return procRuntimeID{}, false
 	}
 	return p.procRuntimeID, true
-}
-
-func (ps *processStore) markSymdbUploadStarted(pid actuator.ProcessID) bool {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-
-	proc, ok := ps.processes[pid]
-	if !ok || proc.symdbUploadStarted {
-		return false // Process gone or already started
-	}
-
-	proc.symdbUploadStarted = true
-	return true
 }

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// SymDBUploader interface for uploading SymDB data
+type SymDBUploader interface {
+	Enqueue(eventMetadata *uploader.EventMetadata, symdbRoot *uploader.SymDBRoot) error
+}
+
+type symdbManager struct {
+	uploader SymDBUploader
+	store    *processStore
+}
+
+func newSymdbManager(uploader SymDBUploader, store *processStore) *symdbManager {
+	return &symdbManager{
+		uploader: uploader,
+		store:    store,
+	}
+}
+
+func (m *symdbManager) requestUpload(runtimeID procRuntimeID, executable actuator.Executable) {
+	if !m.store.markSymdbUploadStarted(runtimeID.ProcessID) {
+		return
+	}
+
+	go m.performUpload(runtimeID, executable)
+}
+
+func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuator.Executable) {
+	symbols, err := symdb.ExtractSymbols(executable.Path, symdb.ExtractOptions{
+		Scope:                   symdb.ExtractScopeModulesFromSameOrg,
+		IncludeInlinedFunctions: false,
+	})
+	if err != nil {
+		log.Errorf("SymDB: Failed to extract symbols for process %v (executable: %s): %v",
+			runtimeID.ProcessID, executable.Path, err)
+		return
+	}
+
+	eventMetadata := uploader.NewEventMetadata(runtimeID.service, runtimeID.runtimeID)
+	symdbRoot := uploader.NewSymDBRoot(runtimeID.service, runtimeID.environment, runtimeID.version, symbols)
+	if err := m.uploader.Enqueue(eventMetadata, symdbRoot); err != nil {
+		log.Errorf("SymDB: Failed to enqueue symbols for process %v (executable: %s): %v",
+			runtimeID.ProcessID, executable.Path, err)
+		return
+	}
+
+	log.Tracef("SymDB: Successfully enqueued symbols for process %v (executable: %s), main module: %s, packages: %d",
+		runtimeID.ProcessID, executable.Path, symbols.MainModule, len(symbols.Packages))
+}

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -8,6 +8,8 @@
 package module
 
 import (
+	"net/url"
+
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
@@ -16,18 +18,18 @@ import (
 
 // SymDBUploader interface for uploading SymDB data
 type SymDBUploader interface {
-	Enqueue(eventMetadata *uploader.EventMetadata, symdbRoot *uploader.SymDBRoot) error
+	Enqueue(pkg symdb.Package) error
 }
 
 type symdbManager struct {
-	uploader SymDBUploader
-	store    *processStore
+	uploadURL *url.URL
+	store     *processStore
 }
 
-func newSymdbManager(uploader SymDBUploader, store *processStore) *symdbManager {
+func newSymdbManager(uploadURL *url.URL, store *processStore) *symdbManager {
 	return &symdbManager{
-		uploader: uploader,
-		store:    store,
+		uploadURL: uploadURL,
+		store:     store,
 	}
 }
 
@@ -40,24 +42,33 @@ func (m *symdbManager) requestUpload(runtimeID procRuntimeID, executable actuato
 }
 
 func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuator.Executable) {
-	symbols, err := symdb.ExtractSymbols(executable.Path, symdb.ExtractOptions{
-		Scope:                   symdb.ExtractScopeModulesFromSameOrg,
-		IncludeInlinedFunctions: false,
-	})
+	it, err := symdb.PackagesIterator(executable.Path,
+		symdb.ExtractOptions{
+			Scope:                   symdb.ExtractScopeModulesFromSameOrg,
+			IncludeInlinedFunctions: false,
+		})
 	if err != nil {
-		log.Errorf("SymDB: Failed to extract symbols for process %v (executable: %s): %v",
+		log.Errorf("SymDB: failed to read symbols for process %v (executable: %s): %v",
 			runtimeID.ProcessID, executable.Path, err)
 		return
 	}
 
-	eventMetadata := uploader.NewEventMetadata(runtimeID.service, runtimeID.runtimeID)
-	symdbRoot := uploader.NewSymDBRoot(runtimeID.service, runtimeID.environment, runtimeID.version, symbols)
-	if err := m.uploader.Enqueue(eventMetadata, symdbRoot); err != nil {
-		log.Errorf("SymDB: Failed to enqueue symbols for process %v (executable: %s): %v",
-			runtimeID.ProcessID, executable.Path, err)
-		return
+	up := uploader.NewSymDBUploader(
+		runtimeID.service, runtimeID.environment, runtimeID.version, runtimeID.runtimeID,
+		uploader.WithURL(m.uploadURL))
+	for pkg, err := range it {
+		if err != nil {
+			log.Errorf("SymDB: Failed to iterate packages for process %v (executable: %s): %v",
+				runtimeID.ProcessID, executable.Path, err)
+			return
+		}
+		if err := up.Enqueue(pkg); err != nil {
+			log.Errorf("SymDB: Failed to enqueue symbols for process %v (executable: %s): %v",
+				runtimeID.ProcessID, executable.Path, err)
+			return
+		}
 	}
 
-	log.Tracef("SymDB: Successfully enqueued symbols for process %v (executable: %s), main module: %s, packages: %d",
-		runtimeID.ProcessID, executable.Path, symbols.MainModule, len(symbols.Packages))
+	log.Tracef("SymDB: Successfully enqueued symbols for process %v (executable: %s)",
+		runtimeID.ProcessID, executable.Path)
 }

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -8,66 +8,242 @@
 package module
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// symdbManager deals with uploading symbols to the SymDB backend.
 type symdbManager struct {
 	uploadURL *url.URL
-	store     *processStore
+	cfg       symdbManagerConfig
+	mu        struct {
+		sync.Mutex
+		queuedUploads []uploadRequest
+		cond          *sync.Cond
+		currentUpload *uploadRequest // nil if no upload is in progress
+		currentCancel context.CancelCauseFunc
+		currentDone   chan struct{} // closed when current upload finishes
+		stopped       bool
+	}
+	workerWg     sync.WaitGroup
+	workerCancel context.CancelCauseFunc
 }
 
-func newSymdbManager(uploadURL *url.URL, store *processStore) *symdbManager {
-	return &symdbManager{
-		uploadURL: uploadURL,
-		store:     store,
-	}
+type uploadRequest struct {
+	runtimeID      procRuntimeID
+	executablePath string
 }
 
-func (m *symdbManager) requestUpload(runtimeID procRuntimeID, executable actuator.Executable) {
-	if !m.store.markSymdbUploadStarted(runtimeID.ProcessID) {
-		return
+// newSymdbManager creates a new symdbManager and starts the upload worker.
+func newSymdbManager(uploadURL *url.URL, opts ...option) *symdbManager {
+	cfg := symdbManagerConfig{
+		maxBufferFuncs: 10000,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
+	workerCtx, cancel := context.WithCancelCause(context.Background())
+	m := &symdbManager{
+		uploadURL:    uploadURL,
+		cfg:          cfg,
+		workerCancel: cancel,
+	}
+	m.mu.cond = sync.NewCond(&m.mu.Mutex)
+
+	// Start the worker goroutine with tracking.
+	m.workerWg.Add(1)
 	go func() {
-		err := m.performUpload(runtimeID, executable)
-		if err != nil {
-			log.Errorf("SymDB: failed to upload symbols for process %v (executable: %s): %v",
-				runtimeID.ProcessID, executable.Path, err)
-		}
+		m.worker(workerCtx)
+		m.workerWg.Done()
 	}()
+	return m
 }
 
-func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuator.Executable) error {
-	it, err := symdb.PackagesIterator(executable.Path,
+type symdbManagerConfig struct {
+	maxBufferFuncs int
+}
+
+type option func(config *symdbManagerConfig)
+
+func withMaxBufferFuncs(maxBufferFuncs int) option {
+	return func(c *symdbManagerConfig) {
+		c.maxBufferFuncs = maxBufferFuncs
+	}
+}
+
+// stop gracefully shuts down the symdbManager, cancelling any ongoing uploads
+// and waiting for the worker goroutine to exit.
+func (m *symdbManager) stop() {
+	// Cancel the worker context to signal shutdown
+	m.workerCancel(errors.New("SymDB manager shutting down"))
+
+	// Signal the worker in case it's waiting on the condition variable
+	m.mu.Lock()
+	m.mu.stopped = true
+	m.mu.cond.Signal()
+	m.mu.Unlock()
+
+	// Wait for the worker to terminate.
+	m.workerWg.Wait()
+}
+
+// queueUpload queues a new upload request. The upload will be performed
+// asynchronously. A single upload can be in progress at a time.
+// Returns an error if the manager has been stopped.
+func (m *symdbManager) queueUpload(runtimeID procRuntimeID, executablePath string) error {
+	// Queue the upload request. The worker will pick it up.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Reject calls after Stop() has been called.
+	if m.mu.stopped {
+		return errors.New("symdbManager has been stopped")
+	}
+
+	m.mu.queuedUploads = append(m.mu.queuedUploads, uploadRequest{
+		runtimeID:      runtimeID,
+		executablePath: executablePath,
+	})
+	// Signal the worker that a new request is available.
+	m.mu.cond.Signal()
+	return nil
+}
+
+// removeUpload removes any queued upload for the given process ID. If the
+// upload is currently being processed, it will be cancelled and the call will
+// block until the upload stops. If no upload for the respective process is in
+// progress or queued, the call is a no-op.
+func (m *symdbManager) removeUpload(runtimeID procRuntimeID) {
+	m.mu.Lock()
+
+	// Remove future uploads from queue.
+	filtered := m.mu.queuedUploads[:0]
+	for _, req := range m.mu.queuedUploads {
+		if req.runtimeID.ProcessID != runtimeID.ProcessID {
+			filtered = append(filtered, req)
+		}
+	}
+	m.mu.queuedUploads = filtered
+
+	// Deal with the case where the current upload is being removed: cancel and
+	// wait for it to terminate.
+	var doneCh chan struct{}
+	if m.mu.currentUpload != nil && m.mu.currentUpload.runtimeID.ProcessID == runtimeID.ProcessID {
+		log.Infof("Cancelling symbols upload for process %v", runtimeID.ProcessID)
+		// Cancel the upload first.
+		if m.mu.currentCancel != nil {
+			m.mu.currentCancel(errors.New("symbols upload no longer required"))
+		}
+		// We'll wait for the upload to finish (or, rather, to respond to the
+		// cancellation) without holding the lock.
+		doneCh = m.mu.currentDone
+	}
+	m.mu.Unlock()
+
+	// Wait for upload to finish.
+	if doneCh != nil {
+		<-doneCh
+	}
+}
+
+func (m *symdbManager) queueSize() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	inProgress := 0
+	if m.mu.currentUpload != nil {
+		inProgress = 1
+	}
+	return len(m.mu.queuedUploads) + inProgress
+}
+
+// worker processes upload requests from the queue one by one.
+func (m *symdbManager) worker(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for {
+		// Check if we should shutdown
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Wait for work.
+		for len(m.mu.queuedUploads) == 0 {
+			// Check for shutdown before waiting
+			if ctx.Err() != nil {
+				return
+			}
+			m.mu.cond.Wait()
+		}
+
+		// Take the first request from the queue.
+		req := m.mu.queuedUploads[0]
+		m.mu.queuedUploads = m.mu.queuedUploads[1:]
+
+		uploadCtx, cancel := context.WithCancelCause(ctx)
+		m.mu.currentUpload = &req
+		m.mu.currentCancel = cancel
+		m.mu.currentDone = make(chan struct{})
+
+		// Unlock while processing the upload.
+		m.mu.Unlock()
+		err := m.performUpload(uploadCtx, req.runtimeID, req.executablePath)
+		if err != nil {
+			if uploadCtx.Err() != nil {
+				log.Infof("SymDB: upload cancelled for process %v (executable: %s): %v",
+					req.runtimeID.ProcessID, req.executablePath, context.Cause(uploadCtx))
+			} else {
+				log.Errorf("SymDB: failed to upload symbols for process %v (executable: %s): %v",
+					req.runtimeID.ProcessID, req.executablePath, err)
+			}
+		}
+
+		// Re-acquire lock and clear current upload.
+		m.mu.Lock()
+		m.mu.currentUpload = nil
+		m.mu.currentCancel = nil
+		close(m.mu.currentDone)
+		m.mu.currentDone = nil
+	}
+}
+
+func (m *symdbManager) performUpload(ctx context.Context, runtimeID procRuntimeID, executablePath string) error {
+	it, err := symdb.PackagesIterator(executablePath,
 		symdb.ExtractOptions{
 			Scope:                   symdb.ExtractScopeModulesFromSameOrg,
 			IncludeInlinedFunctions: false,
 		})
 	if err != nil {
 		return fmt.Errorf("failed to read symbols for process %v (executable: %s): %w",
-			runtimeID.ProcessID, executable.Path, err)
+			runtimeID.ProcessID, executablePath, err)
 	}
 
 	sender := uploader.NewSymDBUploader(
 		m.uploadURL.String(),
 		runtimeID.service, runtimeID.environment, runtimeID.version, runtimeID.runtimeID,
 	)
-	uploadBuffer := make([]uploader.Scope, 100)
+	uploadBuffer := make([]uploader.Scope, 0, 100)
 	bufferFuncs := 0
-	// Flush every 10k functions to not store too many scopes in memory.
-	const maxBufferFuncs = 10000
+	// Flush every so ofter in order to not store too many scopes in memory.
 	maybeFlush := func(force bool) error {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+
 		if len(uploadBuffer) == 0 {
 			return nil
 		}
-		if force || bufferFuncs >= maxBufferFuncs {
-			if err := sender.Upload(uploadBuffer); err != nil {
+		if force || bufferFuncs >= m.cfg.maxBufferFuncs {
+			log.Tracef("Uploading symbols chunk: %d packages, %d functions", len(uploadBuffer), bufferFuncs)
+			if err := sender.Upload(ctx, uploadBuffer); err != nil {
 				return fmt.Errorf("upload failed: %w", err)
 			}
 			uploadBuffer = uploadBuffer[:0]
@@ -78,7 +254,11 @@ func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuato
 	for pkg, err := range it {
 		if err != nil {
 			return fmt.Errorf("failed to iterate packages for process %v (executable: %s): %w",
-				runtimeID.ProcessID, executable.Path, err)
+				runtimeID.ProcessID, executablePath, err)
+		}
+
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
 		}
 
 		scope := uploader.ConvertPackageToScope(pkg)
@@ -92,7 +272,7 @@ func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuato
 		return err
 	}
 
-	log.Tracef("SymDB: Successfully uploaded symbols for process %v (executable: %s)",
-		runtimeID.ProcessID, executable.Path)
+	log.Infof("SymDB: Successfully uploaded symbols for process %v (executable: %s)",
+		runtimeID.ProcessID, executablePath)
 	return nil
 }

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -8,18 +8,14 @@
 package module
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-// SymDBUploader interface for uploading SymDB data
-type SymDBUploader interface {
-	Enqueue(pkg symdb.Package) error
-}
 
 type symdbManager struct {
 	uploadURL *url.URL
@@ -38,37 +34,65 @@ func (m *symdbManager) requestUpload(runtimeID procRuntimeID, executable actuato
 		return
 	}
 
-	go m.performUpload(runtimeID, executable)
+	go func() {
+		err := m.performUpload(runtimeID, executable)
+		if err != nil {
+			log.Errorf("SymDB: failed to upload symbols for process %v (executable: %s): %v",
+				runtimeID.ProcessID, executable.Path, err)
+		}
+	}()
 }
 
-func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuator.Executable) {
+func (m *symdbManager) performUpload(runtimeID procRuntimeID, executable actuator.Executable) error {
 	it, err := symdb.PackagesIterator(executable.Path,
 		symdb.ExtractOptions{
 			Scope:                   symdb.ExtractScopeModulesFromSameOrg,
 			IncludeInlinedFunctions: false,
 		})
 	if err != nil {
-		log.Errorf("SymDB: failed to read symbols for process %v (executable: %s): %v",
+		return fmt.Errorf("failed to read symbols for process %v (executable: %s): %w",
 			runtimeID.ProcessID, executable.Path, err)
-		return
 	}
 
-	up := uploader.NewSymDBUploader(
+	sender := uploader.NewSymDBUploader(
+		m.uploadURL.String(),
 		runtimeID.service, runtimeID.environment, runtimeID.version, runtimeID.runtimeID,
-		uploader.WithURL(m.uploadURL))
+	)
+	uploadBuffer := make([]uploader.Scope, 100)
+	bufferFuncs := 0
+	// Flush every 10k functions to not store too many scopes in memory.
+	const maxBufferFuncs = 10000
+	maybeFlush := func(force bool) error {
+		if len(uploadBuffer) == 0 {
+			return nil
+		}
+		if force || bufferFuncs >= maxBufferFuncs {
+			if err := sender.Upload(uploadBuffer); err != nil {
+				return fmt.Errorf("upload failed: %w", err)
+			}
+			uploadBuffer = uploadBuffer[:0]
+			bufferFuncs = 0
+		}
+		return nil
+	}
 	for pkg, err := range it {
 		if err != nil {
-			log.Errorf("SymDB: Failed to iterate packages for process %v (executable: %s): %v",
+			return fmt.Errorf("failed to iterate packages for process %v (executable: %s): %w",
 				runtimeID.ProcessID, executable.Path, err)
-			return
 		}
-		if err := up.Enqueue(pkg); err != nil {
-			log.Errorf("SymDB: Failed to enqueue symbols for process %v (executable: %s): %v",
-				runtimeID.ProcessID, executable.Path, err)
-			return
+
+		scope := uploader.ConvertPackageToScope(pkg)
+		uploadBuffer = append(uploadBuffer, scope)
+		bufferFuncs += pkg.Stats().NumFunctions
+		if err := maybeFlush(false /* force */); err != nil {
+			return err
 		}
 	}
+	if err := maybeFlush(true /* force */); err != nil {
+		return err
+	}
 
-	log.Tracef("SymDB: Successfully enqueued symbols for process %v (executable: %s)",
+	log.Tracef("SymDB: Successfully uploaded symbols for process %v (executable: %s)",
 		runtimeID.ProcessID, executable.Path)
+	return nil
 }

--- a/pkg/dyninst/module/symdb_test.go
+++ b/pkg/dyninst/module/symdb_test.go
@@ -1,0 +1,197 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+func TestSymdbManagerUpload(t *testing.T) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	cfg := cfgs[0] // use first config
+	binPath := testprogs.MustGetBinary(t, "rc_tester", cfg)
+
+	// Set up mock SymDB backend.
+	uploadCount := atomic.Int64{}
+	var lastUploadData []byte
+	symdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Read the uploaded data
+		data := make([]byte, r.ContentLength)
+		_, err := r.Body.Read(data)
+		if err != nil && err.Error() != "EOF" {
+			t.Errorf("Failed to read upload data: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		lastUploadData = data
+		uploadCount.Add(1)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer symdbServer.Close()
+
+	// Parse server URL for manager
+	symdbURL, err := url.Parse(symdbServer.URL)
+	require.NoError(t, err)
+
+	// Create process store and symdb manager
+	manager := newSymdbManager(symdbURL)
+
+	// Create runtime ID for testing
+	runtimeID := procRuntimeID{
+		ProcessID:   procmon.ProcessID{PID: 12345},
+		service:     "test_service",
+		environment: "test_env",
+		version:     "1.0.0",
+		runtimeID:   "dummy-runtime-id",
+	}
+
+	// Request an upload.
+	err = manager.queueUpload(runtimeID, binPath)
+	require.NoError(t, err)
+
+	// Wait for upload to complete, as reported by the manager.
+	require.Eventually(t, func() bool {
+		return manager.queueSize() == 0
+	}, 10*time.Second, 100*time.Millisecond, "expected upload to complete")
+
+	// Verify upload occurred.
+	require.Greater(t, uploadCount.Load(), int64(0), "No uploads received")
+	require.NotEmpty(t, lastUploadData, "No upload data received")
+
+	// Upload again.
+	initialCount := uploadCount.Load()
+	err = manager.queueUpload(runtimeID, binPath)
+	require.NoError(t, err)
+
+	// Wait for upload to complete.
+	require.Eventually(t, func() bool {
+		return manager.queueSize() == 0
+	}, 10*time.Second, 100*time.Millisecond, "expected upload to complete")
+
+	require.Greater(t, uploadCount.Load(), initialCount, "second upload did not occur")
+}
+
+func TestSymdbManagerCancellation(t *testing.T) {
+	t.Run("CancelViaRemoveUpload", func(t *testing.T) {
+		testSymdbManagerCancellation(t, false /* useStop */)
+	})
+
+	t.Run("CancelViaStop", func(t *testing.T) {
+		testSymdbManagerCancellation(t, true /* useStop */)
+	})
+}
+
+func testSymdbManagerCancellation(t *testing.T, useStop bool) {
+	cfgs := testprogs.MustGetCommonConfigs(t)
+	cfg := cfgs[0] // use first config
+	binPath := testprogs.MustGetBinary(t, "rc_tester", cfg)
+
+	uploadSemaphore := make(chan struct{})
+	blockUpload := false
+	uploadCount := 0
+	symdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if blockUpload {
+			// Notify that the upload started, and block until notified.
+			uploadSemaphore <- struct{}{}
+			<-uploadSemaphore
+		}
+		uploadCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer symdbServer.Close()
+
+	symdbURL, err := url.Parse(symdbServer.URL)
+	require.NoError(t, err)
+
+	manager := newSymdbManager(symdbURL,
+		// Use a small buffer (which will force a flush after every package)
+		// in order to have an opportunity to cancel the uploads in between
+		// flushes.
+		withMaxBufferFuncs(1),
+	)
+
+	// Create a dummy runtime ID
+	runtimeID := procRuntimeID{
+		ProcessID:   procmon.ProcessID{PID: 12345},
+		service:     "test_service",
+		environment: "test_env",
+		version:     "1.0.0",
+		runtimeID:   "dummy-runtime-id",
+	}
+
+	// First perform an upload, which we won't block or cancel, to see how many
+	// HTTP requests we get. We need to make sure that we get more than one, in
+	// order for the cancellation we perform afterward to make sense.
+	err = manager.queueUpload(runtimeID, binPath)
+	require.NoError(t, err)
+
+	// Wait for upload to complete, as reported by the manager.
+	require.Eventually(t, func() bool {
+		return manager.queueSize() == 0
+	}, 10*time.Second, 100*time.Millisecond, "expected upload to complete")
+	// We expect each package to be uploaded as a separate HTTP request. There
+	// should be a bunch of packages; the second part of this test only makes
+	// sense if there is more than one package.
+	require.Greater(t, uploadCount, 1, "multiple HTTP requests were expected")
+	uploadCount = 0
+
+	// Now perform another upload, which we'll block and then cancel.
+	blockUpload = true
+	err = manager.queueUpload(runtimeID, binPath)
+	require.NoError(t, err)
+
+	// Wait for upload to start.
+	select {
+	case <-uploadSemaphore:
+		// Good, upload started. We'll unblock it below.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Upload did not start in time")
+	}
+
+	// Now cancel the upload using the specified method.
+	if useStop {
+		manager.stop()
+	} else {
+		manager.removeUpload(runtimeID)
+	}
+	// Unblock the first HTTP request. There should be no more HTTP requests.
+	uploadSemaphore <- struct{}{}
+	// Wait a little bit to make sure there are no more requests.
+	select {
+	case <-uploadSemaphore:
+		t.Fatal("Upload was not cancelled")
+	case <-time.After(100 * time.Millisecond):
+		// Good, no more requests.
+	}
+
+	if useStop {
+		// Check that the manager actually stopped and doesn't process more
+		// uploads. Try to queue another upload after stop - it should be
+		// rejected.
+		err := manager.queueUpload(runtimeID, binPath)
+		require.ErrorContains(t, err, "stopped")
+	}
+}

--- a/pkg/dyninst/module/test_utils.go
+++ b/pkg/dyninst/module/test_utils.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package module
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
+)
+
+// SetScraperUpdatesCallback installs a callback that will be called when the
+// Controller gets updates from the rcscrape.Scraper.
+func (c *Controller) SetScraperUpdatesCallback(
+	callback func(updates []rcscrape.ProcessUpdate),
+) {
+	c.testingKnobs.scraperUpdatesCallback = callback
+}
+
+// Controller gives tests access to the inner Controller.
+func (m *Module) Controller() *Controller {
+	return m.controller
+}

--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -131,7 +131,7 @@ func analyzeProcess(
 			"failed to analyze environ", err,
 		)
 	}
-	if ddEnv.serviceName == "" || !ddEnv.diEnabled {
+	if ddEnv.serviceName == "" && !ddEnv.diEnabled {
 		log.Tracef(
 			"process %d is not interesting: service name is %q, %s=%t",
 			pid, ddEnv.serviceName, ddDynInstEnabledEnvVar, ddEnv.diEnabled,
@@ -150,6 +150,8 @@ func analyzeProcess(
 
 	return processAnalysis{
 		service:     ddEnv.serviceName,
+		version:     ddEnv.serviceVersion,
+		environment: ddEnv.environmentName,
 		exe:         Executable{Path: exePath, Key: fileKey},
 		interesting: true,
 		gitInfo: GitInfo{
@@ -162,12 +164,16 @@ func analyzeProcess(
 
 type ddEnvVars struct {
 	serviceName      string
+	serviceVersion   string
+	environmentName  string
 	diEnabled        bool
 	gitCommitSha     string
 	gitRepositoryURL string
 }
 
 const ddServiceEnvVar = "DD_SERVICE"
+const ddVersionEnvVar = "DD_VERSION"
+const ddEnvironmentEnvVar = "DD_ENV"
 const ddDynInstEnabledEnvVar = "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
 const ddGitCommitShaEnvVar = "DD_GIT_COMMIT_SHA"
 const ddGitRepositoryURLEnvVar = "DD_GIT_REPOSITORY_URL"
@@ -204,6 +210,10 @@ func analyzeEnviron(pid int32, procfsRoot string) (ddEnvVars, error) {
 		switch unsafe.String(unsafe.SliceData(envVar), len(envVar)) {
 		case ddServiceEnvVar:
 			ddEnv.serviceName = string(val)
+		case ddVersionEnvVar:
+			ddEnv.serviceVersion = string(val)
+		case ddEnvironmentEnvVar:
+			ddEnv.environmentName = string(val)
 		case ddDynInstEnabledEnvVar:
 			ddEnv.diEnabled, _ = strconv.ParseBool(string(val))
 		case ddGitCommitShaEnvVar:

--- a/pkg/dyninst/procmon/analyze_test.go
+++ b/pkg/dyninst/procmon/analyze_test.go
@@ -53,6 +53,8 @@ func TestAnalyzeProcess(t *testing.T) {
 	envTrue := makeEnviron(t,
 		ddDynInstEnabledEnvVar, "true",
 		ddServiceEnvVar, "foo",
+		ddEnvironmentEnvVar, "test",
+		ddVersionEnvVar, "1.0.0",
 	)
 	envFalse := makeEnviron(t,
 		"FOO", "bar",
@@ -304,6 +306,8 @@ func BenchmarkAnalyzeProcess(b *testing.B) {
 									env: []string{
 										"DD_DYNAMIC_INSTRUMENTATION_ENABLED=true",
 										"DD_SERVICE=foo",
+										"DD_ENV=test",
+										"DD_VERSION=1.0.0",
 									},
 								},
 							} {

--- a/pkg/dyninst/procmon/process_monitor.go
+++ b/pkg/dyninst/procmon/process_monitor.go
@@ -36,11 +36,13 @@ type ProcessesUpdate struct {
 
 // ProcessUpdate is an update to a process's instrumentation configuration.
 type ProcessUpdate struct {
-	ProcessID  ProcessID
-	Executable Executable
-	Service    string
-	GitInfo    GitInfo
-	Container  ContainerInfo
+	ProcessID   ProcessID
+	Executable  Executable
+	Service     string
+	Version     string
+	Environment string
+	GitInfo     GitInfo
+	Container   ContainerInfo
 }
 
 // ContainerInfo is information about the container the process is running in.

--- a/pkg/dyninst/procmon/state.go
+++ b/pkg/dyninst/procmon/state.go
@@ -29,6 +29,8 @@ type processEvent struct {
 
 type processAnalysis struct {
 	service       string
+	version       string
+	environment   string
 	exe           Executable
 	interesting   bool
 	gitInfo       GitInfo
@@ -90,10 +92,12 @@ func (s *state) handleAnalysisResult(e analysisResult) {
 			ProcessID: ProcessID{
 				PID: int32(e.pid),
 			},
-			Executable: e.exe,
-			Service:    e.service,
-			GitInfo:    e.gitInfo,
-			Container:  e.containerInfo,
+			Executable:  e.exe,
+			Service:     e.service,
+			Version:     e.version,
+			Environment: e.environment,
+			GitInfo:     e.gitInfo,
+			Container:   e.containerInfo,
 		})
 	}
 }

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -127,25 +127,21 @@ func run(binaryPath string) error {
 }
 
 type symbolStats struct {
-	numPackages    int
-	numTypes       int
-	numFunctions   int
-	numSourceFiles int
+	numPackages  int
+	numTypes     int
+	numFunctions int
 }
 
 func statsFromSymbols(s symdb.Symbols) symbolStats {
 	stats := symbolStats{
-		numPackages:    len(s.Packages),
-		numTypes:       0,
-		numFunctions:   0,
-		numSourceFiles: 0,
+		numPackages:  len(s.Packages),
+		numTypes:     0,
+		numFunctions: 0,
 	}
-	sourceFiles := make(map[string]struct{})
 	for _, pkg := range s.Packages {
-		s := pkg.Stats(sourceFiles)
+		s := pkg.Stats()
 		stats.numTypes += s.NumTypes
 		stats.numFunctions += s.NumFunctions
 	}
-	stats.numSourceFiles = len(sourceFiles)
 	return stats
 }

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -145,46 +145,27 @@ type PackageStats struct {
 	// collected symbols.
 	NumTypes int
 	// NumFunctions is the number of functions in this package represented in
-	// the collected symbols.
+	// the collected symbols. This includes methods.
 	NumFunctions int
-	// NumSourceFiles is the number of source files that contain functions in
-	// this package.
-	NumSourceFiles int
 }
 
 func (s PackageStats) String() string {
-	return fmt.Sprintf("Types: %d, Functions: %d, Source files: %d",
-		s.NumTypes, s.NumFunctions, s.NumSourceFiles)
+	return fmt.Sprintf("Types: %d, Functions: %d", s.NumTypes, s.NumFunctions)
 }
 
 // Stats computes statistics about the package's symbols.
 //
-// sourceFiles will be populated with files encoutered while going through this
+// sourceFiles will be populated with files encountered while going through this
 // package's compile unit. Nil can be passed if the caller is not interested.
 // Note that it's possible for multiple compile units to reference the same file
 // due to inlined functions; in such cases, the file will arbitrarily count
 // towards the stats of the first package that adds it to the map.
-func (p Package) Stats(sourceFiles map[string]struct{}) PackageStats {
+func (p Package) Stats() PackageStats {
 	var res PackageStats
-	if sourceFiles == nil {
-		sourceFiles = make(map[string]struct{})
-	}
 	res.NumTypes += len(p.Types)
 	res.NumFunctions += len(p.Functions)
-	recordFile := func(file string) {
-		if _, ok := sourceFiles[file]; !ok {
-			sourceFiles[file] = struct{}{}
-			res.NumSourceFiles++
-		}
-	}
 	for _, t := range p.Types {
 		res.NumFunctions += len(t.Methods)
-		for _, f := range t.Methods {
-			recordFile(f.File)
-		}
-	}
-	for _, f := range p.Functions {
-		recordFile(f.File)
 	}
 	return res
 }
@@ -1095,7 +1076,7 @@ func (b *packagesIterator) exploreCompileUnit(
 	}
 	duration := time.Since(start)
 	if duration > 5*time.Second {
-		log.Warnf("Processing package %s took %s: %s", name, duration, res.Stats(nil))
+		log.Warnf("Processing package %s took %s: %s", name, duration, res.Stats())
 	}
 
 	return res, nil

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -89,7 +89,6 @@ type LineRange struct {
 type SymDBUploader struct {
 	url       string
 	service   string
-	env       string
 	version   string
 	runtimeID string
 }
@@ -98,14 +97,12 @@ type SymDBUploader struct {
 func NewSymDBUploader(
 	urlStr string,
 	service string,
-	env string,
 	version string,
 	runtimeID string,
 ) *SymDBUploader {
 	return &SymDBUploader{
 		url:       urlStr,
 		service:   service,
-		env:       env,
 		version:   version,
 		runtimeID: runtimeID,
 	}
@@ -117,7 +114,6 @@ func (s *SymDBUploader) Upload(ctx context.Context, packages []Scope) error {
 	var buf bytes.Buffer
 	buf.WriteString(`{
 "service": "` + s.service + `",
-"env": "` + s.env + `",
 "version": "` + s.version + `",
 "language": "go",
 "scopes": `)

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -31,6 +31,8 @@ const (
 	ScopeTypePackage ScopeType = "package"
 	// ScopeTypeStruct represents Go structs (or other types with methods).
 	ScopeTypeStruct ScopeType = "struct"
+	// ScopeTypeFunction represents Go functions.
+	ScopeTypeFunction ScopeType = "function"
 	// ScopeTypeMethod represents Go methods (i.e. functions with a receiver).
 	ScopeTypeMethod ScopeType = "method"
 	// ScopeTypeLocal represents lexical scopes (pairs of {} brackets) inside go
@@ -248,7 +250,7 @@ func ConvertPackageToScope(pkg symdb.Package) Scope {
 func convertFunctionToScope(fn symdb.Function, isMethod bool) Scope {
 	scopeType := ScopeTypeMethod
 	if !isMethod {
-		scopeType = ScopeTypeMethod // Functions are treated as methods in the schema
+		scopeType = ScopeTypeFunction
 	}
 
 	scope := Scope{

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -110,7 +110,7 @@ func NewSymDBUploader(
 }
 
 // Upload uploads a batch of packages to SymDB.
-func (s *SymDBUploader) Upload(packages []Scope) error {
+func (s *SymDBUploader) Upload(ctx context.Context, packages []Scope) error {
 	// Wrap the data in an envelope expected by the debugger backend.
 	var buf bytes.Buffer
 	buf.WriteString(`{
@@ -127,14 +127,14 @@ func (s *SymDBUploader) Upload(packages []Scope) error {
 	buf.Write(jsonBytes)
 	buf.WriteString("}")
 
-	if err := s.uploadInner(buf.Bytes()); err != nil {
+	if err := s.uploadInner(ctx, buf.Bytes()); err != nil {
 		return fmt.Errorf("failed to send individual SymDB: %w", err)
 	}
 
 	return nil
 }
 
-func (s *SymDBUploader) uploadInner(symdbData []byte) error {
+func (s *SymDBUploader) uploadInner(ctx context.Context, symdbData []byte) error {
 	// The upload is a multipart containing metadata expected by the event platform
 	// and the gzipped SymDB data.
 
@@ -181,7 +181,7 @@ func (s *SymDBUploader) uploadInner(symdbData []byte) error {
 		return fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.url, &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, &buf)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
 	}

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -245,7 +245,6 @@ func TestSymDBUploader(t *testing.T) {
 			uploader := NewSymDBUploader(
 				ts.serverURL.String(),
 				"service1",
-				"env",
 				"1.0.0",
 				"dummy-runtime-id",
 			)

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -1,0 +1,278 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package uploader
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SymDBRoot models the root structure for SymDB uploads, following the JSON
+// schema produced by the uploader and expected by the backend.
+type SymDBRoot struct {
+	Service  string  `json:"service,omitempty"`
+	Env      string  `json:"env,omitempty"`
+	Version  string  `json:"version,omitempty"`
+	Language string  `json:"language"`
+	Scopes   []Scope `json:"scopes"`
+}
+
+type EventMetadata struct {
+	DDSource  string `json:"ddsource"`
+	Service   string `json:"service"`
+	RuntimeID string `json:"runtimeId"`
+}
+
+type testServer struct {
+	requests  <-chan receivedRequest
+	server    *httptest.Server
+	serverURL *url.URL
+	close     chan struct{}
+}
+
+func (s *testServer) Close() {
+	close(s.close)
+	s.server.Close()
+}
+
+type receivedRequest struct {
+	w    http.ResponseWriter
+	r    *http.Request
+	done chan struct{}
+}
+
+func newTestServer() *testServer {
+	requestsC := make(chan receivedRequest)
+	closeC := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		doneC := make(chan struct{})
+		select {
+		case requestsC <- receivedRequest{w: w, r: r, done: doneC}:
+		case <-closeC:
+		case <-r.Context().Done():
+			return
+		}
+		select {
+		case <-doneC:
+		case <-closeC:
+		case <-r.Context().Done():
+			return
+		}
+	}))
+	serverURL, _ := url.Parse(server.URL)
+	ts := &testServer{
+		server:    server,
+		serverURL: serverURL,
+		requests:  requestsC,
+		close:     closeC,
+	}
+	return ts
+}
+func validateSymDBRequest(
+	t *testing.T, expectedService, expectedRuntimeID string, req *http.Request,
+) {
+	contentType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "multipart/form-data", contentType)
+
+	// No additional custom headers expected (consistent with other uploaders)
+
+	reader := multipart.NewReader(req.Body, params["boundary"])
+
+	// We expect 2 parts: "file" and "event"
+	var filePart, eventPart *multipart.Part
+	var fileData, eventData []byte
+
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(part)
+		require.NoError(t, err)
+
+		switch part.FormName() {
+		case "file":
+			filePart = part
+			fileData = data
+		case "event":
+			eventPart = part
+			eventData = data
+		default:
+			t.Errorf("unexpected form part: %s", part.FormName())
+		}
+	}
+
+	// Validate both parts are present
+	require.NotNil(t, filePart, "missing 'file' part in multipart request")
+	require.NotNil(t, eventPart, "missing 'event' part in multipart request")
+
+	// Validate event part metadata
+	require.Equal(t, "event.json", eventPart.FileName())
+	require.Equal(t, "application/json", eventPart.Header.Get("Content-Type"))
+
+	var eventMetadata EventMetadata
+	require.NoError(t, json.Unmarshal(eventData, &eventMetadata))
+	require.Equal(t, "dd_debugger", eventMetadata.DDSource)
+	require.Equal(t, expectedService, eventMetadata.Service)
+	require.Equal(t, expectedRuntimeID, eventMetadata.RuntimeID)
+
+	// Validate file part - it should always be compressed as file.gz
+	require.Equal(t, "file.gz", filePart.FileName())
+	require.Equal(t, "application/gzip", filePart.Header.Get("Content-Type"))
+
+	// Decompress the data to validate the SymDB content
+	gzReader, err := gzip.NewReader(bytes.NewReader(fileData))
+	require.NoError(t, err)
+	defer gzReader.Close()
+
+	actualSymDBData, err := io.ReadAll(gzReader)
+	require.NoError(t, err)
+
+	// Validate the SymDB JSON structure
+	var symdbRoot SymDBRoot
+	require.NoError(t, json.Unmarshal(actualSymDBData, &symdbRoot))
+
+	// Validate service matches
+	require.Equal(t, expectedService, symdbRoot.Service)
+	require.Equal(t, "go", symdbRoot.Language)
+
+	// Validate basic structure exists
+	require.NotEmpty(t, symdbRoot.Scopes)
+	require.Equal(t, "main", symdbRoot.Scopes[0].Name)
+}
+
+func TestSymDBUploader(t *testing.T) {
+	createPackageScopes := func() []Scope {
+		return []Scope{
+			{
+				ScopeType: ScopeTypePackage,
+				Name:      "main",
+				StartLine: 0,
+				EndLine:   0,
+				Scopes: []Scope{
+					{
+						ScopeType:  ScopeTypeMethod,
+						Name:       "testFunction",
+						SourceFile: "/test/main.go",
+						StartLine:  10,
+						EndLine:    20,
+						Symbols: []Symbol{
+							{
+								Name:       "testVar",
+								Type:       "string",
+								SymbolType: SymbolTypeLocal,
+								Line:       &[]int{12}[0],
+							},
+							{
+								Name:       "arg1",
+								Type:       "int",
+								SymbolType: SymbolTypeArg,
+								Line:       &[]int{10}[0],
+							},
+						},
+					},
+					{
+						ScopeType: ScopeTypeStruct,
+						Name:      "main.TestStruct",
+						StartLine: 0,
+						EndLine:   0,
+						Symbols: []Symbol{
+							{
+								Name:       "field1",
+								Type:       "string",
+								SymbolType: SymbolTypeField,
+							},
+							{
+								Name:       "field2",
+								Type:       "int",
+								SymbolType: SymbolTypeField,
+							},
+						},
+						Scopes: []Scope{
+							{
+								ScopeType:  ScopeTypeMethod,
+								Name:       "method1",
+								SourceFile: "/test/main.go",
+								StartLine:  25,
+								EndLine:    30,
+								Symbols: []Symbol{
+									{
+										Name:       "receiver",
+										Type:       "*main.TestStruct",
+										SymbolType: SymbolTypeArg,
+										Line:       &[]int{25}[0],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	for _, injectError := range []bool{false, true} {
+		testName := "success"
+		if injectError {
+			testName = "failure"
+		}
+
+		t.Run(testName, func(t *testing.T) {
+			ts := newTestServer()
+			defer ts.Close()
+
+			uploader := NewSymDBUploader(
+				ts.serverURL.String(),
+				"service1",
+				"env",
+				"1.0.0",
+				"dummy-runtime-id",
+			)
+
+			// Do a (blocking) upload in a goroutine so that the test goroutine can
+			// intercept the request.
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				scopes := createPackageScopes()
+				err := uploader.Upload(scopes)
+				if injectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			}()
+
+			req := <-ts.requests
+			validateSymDBRequest(t, "service1", "dummy-runtime-id", req.r)
+			if injectError {
+				req.w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				req.w.WriteHeader(http.StatusOK)
+			}
+			close(req.done)
+			wg.Wait()
+		})
+	}
+}

--- a/pkg/dyninst/symdb/uploader/uploader_test.go
+++ b/pkg/dyninst/symdb/uploader/uploader_test.go
@@ -10,6 +10,7 @@ package uploader
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"mime"
@@ -256,7 +257,7 @@ func TestSymDBUploader(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				scopes := createPackageScopes()
-				err := uploader.Upload(scopes)
+				err := uploader.Upload(context.Background(), scopes)
 				if injectError {
 					assert.Error(t, err)
 				} else {

--- a/pkg/dyninst/testprogs/progs/go.mod
+++ b/pkg/dyninst/testprogs/progs/go.mod
@@ -11,7 +11,8 @@ require (
 	github.com/DataDog/dd-trace-go/v2 v2.2.3-rc.1
 
 	// This is the last version of dd-trace-go that isn't just a wrapper around
-	// the v2 package.
+	// the v2 package. Note that this tracer does not have support for the
+	// remote config key controlling the SymDB upload.
 	gopkg.in/DataDog/dd-trace-go.v1 v1.73.1
 )
 

--- a/pkg/dyninst/uploader/symdb.go
+++ b/pkg/dyninst/uploader/symdb.go
@@ -149,18 +149,19 @@ func newSymDBSender(
 func (s *symdbSender) send(batch []json.RawMessage) error {
 	// Wrap the data in an envelope expected by the debugger backend.
 	var buf bytes.Buffer
-	buf.WriteString(`
-service: "` + s.service + `",
-env: "` + s.env + `",
-version: "` + s.version + `",
-language: "go",
-scopes: [`)
+	buf.WriteString(`{
+"service": "` + s.service + `",
+"env": "` + s.env + `",
+"version": "` + s.version + `",
+"language": "go",
+"scopes": [`)
 	for i, msgData := range batch {
 		if i > 0 {
 			buf.WriteString(",")
 		}
 		buf.Write(msgData)
 	}
+	buf.WriteString("]}")
 
 	if err := s.upload(buf.Bytes()); err != nil {
 		return fmt.Errorf("failed to send individual SymDB: %w", err)

--- a/pkg/dyninst/uploader/symdb.go
+++ b/pkg/dyninst/uploader/symdb.go
@@ -25,7 +25,7 @@ import (
 type ScopeType string
 
 const (
-	ScopeTypePackage ScopeType = "module"
+	ScopeTypePackage ScopeType = "package"
 	ScopeTypeStruct  ScopeType = "struct"
 	ScopeTypeMethod  ScopeType = "method"
 	ScopeTypeClosure ScopeType = "closure"
@@ -149,12 +149,11 @@ func newSymDBSender(
 func (s *symdbSender) send(batch []json.RawMessage) error {
 	// Wrap the data in an envelope expected by the debugger backend.
 	var buf bytes.Buffer
-	// !!! switch language to go
 	buf.WriteString(`
 service: "` + s.service + `",
 env: "` + s.env + `",
 version: "` + s.version + `",
-language: "python",
+language: "go",
 scopes: [`)
 	for i, msgData := range batch {
 		if i > 0 {

--- a/pkg/dyninst/uploader/symdb.go
+++ b/pkg/dyninst/uploader/symdb.go
@@ -1,0 +1,404 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package uploader
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
+)
+
+// SymDBRoot represents the root structure for SymDB uploads, following the JSON schema
+type SymDBRoot struct {
+	Service  string  `json:"service,omitempty"`
+	Env      string  `json:"env,omitempty"`
+	Version  string  `json:"version,omitempty"`
+	Language string  `json:"language"`
+	Scopes   []Scope `json:"scopes"`
+}
+
+// ScopeType represents the type of scope in the SymDB schema
+type ScopeType string
+
+const (
+	ScopeTypePackage ScopeType = "module"
+	ScopeTypeStruct  ScopeType = "struct"
+	ScopeTypeMethod  ScopeType = "method"
+	ScopeTypeClosure ScopeType = "closure"
+	ScopeTypeLocal   ScopeType = "local"
+)
+
+// Scope represents a lexical scope in the SymDB schema
+type Scope struct {
+	ScopeType         ScopeType          `json:"scope_type"`
+	Name              string             `json:"name"`
+	SourceFile        string             `json:"source_file,omitempty"`
+	StartLine         int                `json:"start_line"`
+	EndLine           int                `json:"end_line"`
+	LanguageSpecifics *LanguageSpecifics `json:"language_specifics,omitempty"`
+	Symbols           []Symbol           `json:"symbols,omitempty"`
+	Scopes            []Scope            `json:"scopes,omitempty"`
+}
+
+// SymbolType represents the type of symbol in the SymDB schema
+type SymbolType string
+
+const (
+	SymbolTypeField       SymbolType = "field"
+	SymbolTypeStaticField SymbolType = "static_field"
+	SymbolTypeArg         SymbolType = "arg"
+	SymbolTypeLocal       SymbolType = "local"
+)
+
+// Symbol represents a variable, parameter, or field in the SymDB schema
+type Symbol struct {
+	Name              string             `json:"name"`
+	Type              string             `json:"type"`
+	SymbolType        SymbolType         `json:"symbol_type"`
+	Line              *int               `json:"line,omitempty"`
+	LanguageSpecifics *LanguageSpecifics `json:"language_specifics,omitempty"`
+}
+
+type LanguageSpecifics struct {
+	AvailableLineRanges []LineRange `json:"available_line_ranges,omitempty"`
+}
+
+type LineRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type EventMetadata struct {
+	DDSource  string `json:"ddsource"`
+	Service   string `json:"service"`
+	RuntimeID string `json:"runtimeId"`
+}
+
+type SymDBUploader struct {
+	*batcher
+}
+
+func NewSymDBUploader(opts ...Option) *SymDBUploader {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	sender := newSymDBSender(cfg.client, cfg.url.String())
+	return &SymDBUploader{
+		batcher: newBatcher("symdb", sender, cfg.batcherConfig),
+	}
+}
+
+// Enqueue adds a SymDB root object to the uploader's queue
+func (u *SymDBUploader) Enqueue(eventMetadata *EventMetadata, symdbRoot *SymDBRoot) error {
+	msg := map[string]interface{}{
+		"metadata": eventMetadata,
+		"symdb":    symdbRoot,
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %w", err)
+	}
+
+	u.enqueue(data)
+	return nil
+}
+
+func (u *SymDBUploader) Stop() {
+	u.stop()
+}
+
+type symdbSender struct {
+	client *http.Client
+	url    string
+}
+
+func newSymDBSender(client *http.Client, urlStr string) *symdbSender {
+	return &symdbSender{
+		client: client,
+		url:    urlStr,
+	}
+}
+
+func (s *symdbSender) send(batch []json.RawMessage) error {
+	for _, msgData := range batch {
+		var msg map[string]interface{}
+		if err := json.Unmarshal(msgData, &msg); err != nil {
+			return fmt.Errorf("failed to unmarshal message: %w", err)
+		}
+
+		// Marshal both parts separately for multipart upload
+		symdbData, err := json.Marshal(msg["symdb"])
+		if err != nil {
+			return fmt.Errorf("failed to marshal SymDB data: %w", err)
+		}
+
+		metadataData, err := json.Marshal(msg["metadata"])
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata: %w", err)
+		}
+
+		if err := s.upload(symdbData, metadataData); err != nil {
+			return fmt.Errorf("failed to send individual SymDB: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *symdbSender) upload(symdbData []byte, eventMetadata []byte) error {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	compressedData, err := compressSymDBData(symdbData)
+	if err != nil {
+		return fmt.Errorf("failed to compress SymDB data: %w", err)
+	}
+
+	fileHeader := make(textproto.MIMEHeader)
+	fileHeader.Set("Content-Disposition", `form-data; name="file"; filename="file.gz"`)
+	fileHeader.Set("Content-Type", "application/gzip")
+
+	filePart, err := writer.CreatePart(fileHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create file part: %w", err)
+	}
+
+	if _, err := filePart.Write(compressedData); err != nil {
+		return fmt.Errorf("failed to write compressed SymDB data: %w", err)
+	}
+
+	eventHeader := make(textproto.MIMEHeader)
+	eventHeader.Set("Content-Disposition", `form-data; name="event"; filename="event.json"`)
+	eventHeader.Set("Content-Type", "application/json")
+
+	eventPart, err := writer.CreatePart(eventHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create event part: %w", err)
+	}
+
+	if _, err := eventPart.Write(eventMetadata); err != nil {
+		return fmt.Errorf("failed to write event data: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.url, &buf)
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("uploader received error response: status=%d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func compressSymDBData(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gzWriter := gzip.NewWriter(&buf)
+
+	if _, err := gzWriter.Write(data); err != nil {
+		return nil, fmt.Errorf("failed to write to gzip writer: %w", err)
+	}
+
+	if err := gzWriter.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func cleanString(s string) string {
+	return strings.ReplaceAll(s, " ", "")
+}
+
+// NewSymDBRoot converts symdb.Symbols to the SymDB JSON schema format
+func NewSymDBRoot(service, env, version string, symbols symdb.Symbols) *SymDBRoot {
+	root := SymDBRoot{
+		Service:  service,
+		Env:      env,
+		Version:  version,
+		Language: "python",
+		Scopes:   make([]Scope, 0, len(symbols.Packages)),
+	}
+
+	for _, pkg := range symbols.Packages {
+		packageScope := convertPackageToScope(pkg)
+		root.Scopes = append(root.Scopes, packageScope)
+	}
+
+	return &root
+}
+
+// NewEventMetadata creates a new EventMetadata with the given service
+// and runtimeID.
+func NewEventMetadata(service, runtimeID string) *EventMetadata {
+	return &EventMetadata{
+		DDSource:  "dd_debugger",
+		Service:   service,
+		RuntimeID: runtimeID,
+	}
+}
+
+// convertPackageToScope converts a symdb.Package to a Scope
+func convertPackageToScope(pkg symdb.Package) Scope {
+	scope := Scope{
+		ScopeType: ScopeTypePackage,
+		Name:      pkg.Name,
+		StartLine: 0,
+		EndLine:   0,
+		Scopes:    make([]Scope, 0, len(pkg.Functions)+len(pkg.Types)),
+	}
+
+	// Add functions as method scopes
+	for _, fn := range pkg.Functions {
+		fnScope := convertFunctionToScope(fn, false)
+		scope.Scopes = append(scope.Scopes, fnScope)
+	}
+
+	// Add types as struct scopes
+	for _, typ := range pkg.Types {
+		typeScope := convertTypeToScope(typ)
+		scope.Scopes = append(scope.Scopes, typeScope)
+	}
+
+	return scope
+}
+
+// convertFunctionToScope converts a symdb.Function to a Scope
+func convertFunctionToScope(fn symdb.Function, isMethod bool) Scope {
+	scopeType := ScopeTypeMethod
+	if !isMethod {
+		scopeType = ScopeTypeMethod // Functions are treated as methods in the schema
+	}
+
+	scope := Scope{
+		ScopeType:  scopeType,
+		Name:       fn.Name,
+		SourceFile: fn.File,
+		StartLine:  fn.StartLine,
+		EndLine:    fn.EndLine,
+		Symbols:    make([]Symbol, 0, len(fn.Variables)),
+		Scopes:     make([]Scope, 0, len(fn.Scopes)),
+	}
+
+	for _, variable := range fn.Variables {
+		symbol := convertVariableToSymbol(variable)
+		scope.Symbols = append(scope.Symbols, symbol)
+	}
+
+	for _, nestedScope := range fn.Scopes {
+		localScope := convertScopeToScope(nestedScope, fn.File)
+		scope.Scopes = append(scope.Scopes, localScope)
+	}
+
+	return scope
+}
+
+// convertTypeToScope converts a symdb.Type to a Scope
+func convertTypeToScope(typ symdb.Type) Scope {
+	scope := Scope{
+		ScopeType: ScopeTypeStruct,
+		Name:      typ.Name,
+		StartLine: 0,
+		EndLine:   0,
+		Symbols:   make([]Symbol, 0, len(typ.Fields)),
+		Scopes:    make([]Scope, 0, len(typ.Methods)),
+	}
+
+	for _, field := range typ.Fields {
+		symbol := Symbol{
+			Name:       field.Name,
+			Type:       cleanString(field.Type),
+			SymbolType: SymbolTypeField,
+		}
+		scope.Symbols = append(scope.Symbols, symbol)
+	}
+
+	for _, method := range typ.Methods {
+		methodScope := convertFunctionToScope(method, true)
+		scope.Scopes = append(scope.Scopes, methodScope)
+	}
+
+	return scope
+}
+
+// convertScopeToScope converts a symdb.Scope to a Scope
+func convertScopeToScope(s symdb.Scope, sourceFile string) Scope {
+	scope := Scope{
+		ScopeType:  ScopeTypeLocal,
+		SourceFile: sourceFile,
+		StartLine:  s.StartLine,
+		EndLine:    s.EndLine,
+		Symbols:    make([]Symbol, 0, len(s.Variables)),
+		Scopes:     make([]Scope, 0, len(s.Scopes)),
+	}
+
+	for _, variable := range s.Variables {
+		symbol := convertVariableToSymbol(variable)
+		scope.Symbols = append(scope.Symbols, symbol)
+	}
+
+	for _, nestedScope := range s.Scopes {
+		localScope := convertScopeToScope(nestedScope, sourceFile)
+		scope.Scopes = append(scope.Scopes, localScope)
+	}
+
+	return scope
+}
+
+// convertVariableToSymbol converts a symdb.Variable to a Symbol
+func convertVariableToSymbol(variable symdb.Variable) Symbol {
+	symbolType := SymbolTypeLocal
+	if variable.FunctionArgument {
+		symbolType = SymbolTypeArg
+	}
+
+	symbol := Symbol{
+		Name:       variable.Name,
+		Type:       cleanString(variable.TypeName),
+		SymbolType: symbolType,
+		Line:       &variable.DeclLine,
+	}
+
+	// Add language specifics for line ranges if available
+	if len(variable.AvailableLineRanges) > 0 {
+		ranges := make([]LineRange, len(variable.AvailableLineRanges))
+		for i, r := range variable.AvailableLineRanges {
+			ranges[i] = LineRange{
+				Start: r[0],
+				End:   r[1],
+			}
+		}
+		/*symbol.LanguageSpecifics = &LanguageSpecifics{
+			AvailableLineRanges: ranges,
+		}*/
+	}
+
+	return symbol
+}

--- a/pkg/dyninst/uploader/symdb.go
+++ b/pkg/dyninst/uploader/symdb.go
@@ -56,15 +56,15 @@ const (
 
 // Symbol represents a variable, parameter, or field in the SymDB schema
 type Symbol struct {
-	Name              string             `json:"name"`
-	Type              string             `json:"type"`
-	SymbolType        SymbolType         `json:"symbol_type"`
-	Line              *int               `json:"line,omitempty"`
-	LanguageSpecifics *LanguageSpecifics `json:"language_specifics,omitempty"`
-}
+	Name       string     `json:"name"`
+	Type       string     `json:"type"`
+	SymbolType SymbolType `json:"symbol_type"`
+	Line       *int       `json:"line,omitempty"`
+}x
 
 type LanguageSpecifics struct {
 	AvailableLineRanges []LineRange `json:"available_line_ranges,omitempty"`
+	GoQualifiedName     string      `json:"go_qualified_name,omitempty"`
 }
 
 type LineRange struct {
@@ -295,6 +295,9 @@ func convertFunctionToScope(fn symdb.Function, isMethod bool) Scope {
 		EndLine:    fn.EndLine,
 		Symbols:    make([]Symbol, 0, len(fn.Variables)),
 		Scopes:     make([]Scope, 0, len(fn.Scopes)),
+		LanguageSpecifics: &LanguageSpecifics{
+			GoQualifiedName: fn.QualifiedName,
+		},
 	}
 
 	for _, variable := range fn.Variables {

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -24,6 +24,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// SymDBRoot models the root structure for SymDB uploads, following the JSON
+// schema produced by the uploader and expected by the backend.
+type SymDBRoot struct {
+	Service  string  `json:"service,omitempty"`
+	Env      string  `json:"env,omitempty"`
+	Version  string  `json:"version,omitempty"`
+	Language string  `json:"language"`
+	Scopes   []Scope `json:"scopes"`
+}
+
+type EventMetadata struct {
+	DDSource  string `json:"ddsource"`
+	Service   string `json:"service"`
+	RuntimeID string `json:"runtimeId"`
+}
+
 type testServer struct {
 	requests  <-chan receivedRequest
 	server    *httptest.Server

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -8,8 +8,6 @@
 package uploader
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"io"
 	"mime"
@@ -23,22 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// SymDBRoot models the root structure for SymDB uploads, following the JSON
-// schema produced by the uploader and expected by the backend.
-type SymDBRoot struct {
-	Service  string  `json:"service,omitempty"`
-	Env      string  `json:"env,omitempty"`
-	Version  string  `json:"version,omitempty"`
-	Language string  `json:"language"`
-	Scopes   []Scope `json:"scopes"`
-}
-
-type EventMetadata struct {
-	DDSource  string `json:"ddsource"`
-	Service   string `json:"service"`
-	RuntimeID string `json:"runtimeId"`
-}
 
 type testServer struct {
 	requests  <-chan receivedRequest
@@ -122,82 +104,6 @@ func validateLogsRequest(t *testing.T, expectedMessages []json.RawMessage, req *
 	for i, msg := range expectedMessages {
 		assert.Equal(t, string(msg), string(batch[i]))
 	}
-}
-
-func validateSymDBRequest(
-	t *testing.T, expectedService, expectedRuntimeID string, req *http.Request,
-) {
-	contentType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
-	require.NoError(t, err)
-	require.Equal(t, "multipart/form-data", contentType)
-
-	// No additional custom headers expected (consistent with other uploaders)
-
-	reader := multipart.NewReader(req.Body, params["boundary"])
-
-	// We expect 2 parts: "file" and "event"
-	var filePart, eventPart *multipart.Part
-	var fileData, eventData []byte
-
-	for {
-		part, err := reader.NextPart()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(t, err)
-
-		data, err := io.ReadAll(part)
-		require.NoError(t, err)
-
-		switch part.FormName() {
-		case "file":
-			filePart = part
-			fileData = data
-		case "event":
-			eventPart = part
-			eventData = data
-		default:
-			t.Errorf("unexpected form part: %s", part.FormName())
-		}
-	}
-
-	// Validate both parts are present
-	require.NotNil(t, filePart, "missing 'file' part in multipart request")
-	require.NotNil(t, eventPart, "missing 'event' part in multipart request")
-
-	// Validate event part metadata
-	require.Equal(t, "event.json", eventPart.FileName())
-	require.Equal(t, "application/json", eventPart.Header.Get("Content-Type"))
-
-	var eventMetadata EventMetadata
-	require.NoError(t, json.Unmarshal(eventData, &eventMetadata))
-	require.Equal(t, "dd_debugger", eventMetadata.DDSource)
-	require.Equal(t, expectedService, eventMetadata.Service)
-	require.Equal(t, expectedRuntimeID, eventMetadata.RuntimeID)
-
-	// Validate file part - it should always be compressed as file.gz
-	require.Equal(t, "file.gz", filePart.FileName())
-	require.Equal(t, "application/gzip", filePart.Header.Get("Content-Type"))
-
-	// Decompress the data to validate the SymDB content
-	gzReader, err := gzip.NewReader(bytes.NewReader(fileData))
-	require.NoError(t, err)
-	defer gzReader.Close()
-
-	actualSymDBData, err := io.ReadAll(gzReader)
-	require.NoError(t, err)
-
-	// Validate the SymDB JSON structure
-	var symdbRoot SymDBRoot
-	require.NoError(t, json.Unmarshal(actualSymDBData, &symdbRoot))
-
-	// Validate service matches
-	require.Equal(t, expectedService, symdbRoot.Service)
-	require.Equal(t, "go", symdbRoot.Language)
-
-	// Validate basic structure exists
-	require.NotEmpty(t, symdbRoot.Scopes)
-	require.Equal(t, "main", symdbRoot.Scopes[0].Name)
 }
 
 func TestDiagnosticsUploader(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Completes the work started in #39020 - utilizing symbols extraction functionality and uploads it to debugger's backend for tracked Go processes.

The debugger backend delivers symdb upload request through RC. When a service receives this request, the system-probe reads it's DWARF and start extracting symbols in hierarchy of Package -> Function -> Args/Locals.
The symbols are uploaded with an iterator to avoid excessive memory usage during the upload.  Currently, we cap the upload batches to packages accumulating to >= 10k functions.

### Motivation
Better experience when creating probes through DI UI. With symbols users are able to simply select which function they want to probe without Source code integration and without intimate knowledge of the way Go constructs functions fully qualified names. 