### PR TITLE
[SBOM] switch fs walker to use `os.Root`

### DIFF
--- a/pkg/util/trivy/walker/walker.go
+++ b/pkg/util/trivy/walker/walker.go
@@ -52,18 +52,23 @@ func cleanSkipPaths(root string, skipPaths []string) []string {
 }
 
 // Walk walks the filesystem rooted at root, calling fn for each unfiltered file.
-func (w *FSWalker) Walk(ctx context.Context, root string, opt walker.Option, fn walker.WalkFunc) error {
+func (w *FSWalker) Walk(ctx context.Context, rootPath string, opt walker.Option, fn walker.WalkFunc) error {
 	opt.SkipDirs = append(opt.SkipDirs, defaultSkipDirs...)
 
-	opt.SkipDirs = cleanSkipPaths(root, opt.SkipDirs)
-	opt.SkipFiles = cleanSkipPaths(root, opt.SkipFiles)
-	opt.OnlyDirs = cleanSkipPaths(root, opt.OnlyDirs)
+	opt.SkipDirs = cleanSkipPaths(rootPath, opt.SkipDirs)
+	opt.SkipFiles = cleanSkipPaths(rootPath, opt.SkipFiles)
+	opt.OnlyDirs = cleanSkipPaths(rootPath, opt.OnlyDirs)
+
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return xerrors.Errorf("failed to open root %s: %w", rootPath, err)
+	}
 
 	walkDirFunc := w.walkDirFunc(ctx, root, fn, opt)
 	walkDirFunc = w.onError(walkDirFunc, opt)
 
 	// Walk the filesystem
-	if err := fs.WalkDir(os.DirFS(root), ".", walkDirFunc); err != nil {
+	if err := fs.WalkDir(root.FS(), ".", walkDirFunc); err != nil {
 		return xerrors.Errorf("walk dir error: %w", err)
 	}
 
@@ -72,7 +77,7 @@ func (w *FSWalker) Walk(ctx context.Context, root string, opt walker.Option, fn 
 
 // walkDirFunc is the type of the function called by [WalkDir] to visit
 // each file or directory.
-func (w *FSWalker) walkDirFunc(ctx context.Context, root string, fn walker.WalkFunc, opt walker.Option) fs.WalkDirFunc {
+func (w *FSWalker) walkDirFunc(ctx context.Context, root *os.Root, fn walker.WalkFunc, opt walker.Option) fs.WalkDirFunc {
 	return func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if errors.Is(err, fs.ErrPermission) || errors.Is(err, os.ErrNotExist) {
@@ -106,8 +111,7 @@ func (w *FSWalker) walkDirFunc(ctx context.Context, root string, fn walker.WalkF
 			return xerrors.Errorf("file info error: %w", err)
 		}
 
-		rootedPath := filepath.Join(root, filePath)
-		if err = fn(ctx, filePath, info, fileOpener(rootedPath)); err != nil {
+		if err = fn(ctx, filePath, info, fileOpener(root, filePath)); err != nil {
 			return xerrors.Errorf("failed to analyze file: %w", err)
 		}
 
@@ -140,8 +144,8 @@ func (w *FSWalker) onError(wrapped fs.WalkDirFunc, opt walker.Option) fs.WalkDir
 }
 
 // fileOpener returns a function opening a file.
-func fileOpener(filePath string) func() (xio.ReadSeekCloserAt, error) {
+func fileOpener(root *os.Root, filePath string) func() (xio.ReadSeekCloserAt, error) {
 	return func() (xio.ReadSeekCloserAt, error) {
-		return os.Open(filePath)
+		return root.Open(filePath)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes sure all file accesses in the SBOM fs walker are done through `os.Root` instead of regular `filepath.Join` allowing prevention of file access outside of the root (see https://go.dev/blog/osroot for more info).

The behavior should stay unchanged (thus current tests should be enough).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->