### PR TITLE
Surface not captured reason for reference cycle

### DIFF
--- a/pkg/dyninst/decode/notCapturedReason.go
+++ b/pkg/dyninst/decode/notCapturedReason.go
@@ -18,6 +18,7 @@ var (
 	notCapturedReasonPruned         jsontext.Token = jsontext.String("pruned")
 	notCapturedReasonUnavailable    jsontext.Token = jsontext.String("unavailable")
 	notCapturedReasonUnimplemented  jsontext.Token = jsontext.String("unimplemented")
+	notCapturedReasonCycle          jsontext.Token = jsontext.String("circular reference")
 	// notCapturedReasonFieldCount     jsontext.Token = jsontext.String("fieldCount")
 
 	truncated jsontext.Token = jsontext.String("truncated")

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -797,6 +797,12 @@ func encodePointer(
 		); err != nil {
 			return fmt.Errorf("could not encode referenced value: %w", err)
 		}
+	} else {
+		// If we're already encoding this value, we've hit a cycle and want to write a not captured reason
+		return writeTokens(enc,
+			notCapturedReason,
+			notCapturedReasonCycle,
+		)
 	}
 	return nil
 }

--- a/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
+++ b/pkg/dyninst/testdata/decoded/sample/testPointerLoop.json
@@ -60,7 +60,8 @@
                   },
                   "b": {
                     "type": "*main.node",
-                    "address": "[addr]"
+                    "address": "[addr]",
+                    "notCapturedReason": "circular reference"
                   }
                 }
               }


### PR DESCRIPTION
### What does this PR do?

In the case of circularly referenced types, we prevent decoding cycles. However this previously wasn't exactly clear to users, and now this PR uses the not captured reason as a mechanism for doing so.

### Motivation

Clearer feedback for the user.

### Describe how you validated your changes

Integration tests have a case for circular types.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->