### PR TITLE
Make vault read generalizable for omnibus tests

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -160,7 +160,7 @@ def get_dd_api_key(ctx):
     elif sys.platform == 'darwin':
         cmd = f'vault kv get -field=token kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     else:
-        cmd = f'vault kv get -field=token kv/k8s/gitlab-runner/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
+        cmd = f'vault kv get -field=token kv/k8s/{os.environ.get('POD_NAMESPACE', 'gitlab-runner')}/datadog-agent/{os.environ["AGENT_API_KEY_ORG2"]}'
     return ctx.run(cmd, hide=True).stdout.strip()
 
 

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -42,6 +42,7 @@ def _run_calls_to_string(mock_calls):
         'S3_OMNIBUS_GIT_CACHE_BUCKET': 'omnibus-cache',
         'API_KEY_ORG2': 'api-key',
         'AGENT_API_KEY_ORG2': 'agent-api-key',
+        'POD_NAMESPACE': os.environ.get('POD_NAMESPACE', 'gitlab-runner'),
     },
     clear=True,
 )


### PR DESCRIPTION
Its a redo of https://github.com/DataDog/datadog-agent/pull/39563 which is already approved. Quality check CI job on it kept failing and I am not sure why, so recreating PR with the same changes on latest main. 