### PR TITLE
Enable GCE CCRID detection

### DIFF
--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -158,6 +158,7 @@ type cloudProviderCCRIDDetector func(context.Context) (string, error)
 var hostCCRIDDetectors = map[string]cloudProviderCCRIDDetector{
 	azure.CloudProviderName: azure.GetHostCCRID,
 	ec2.CloudProviderName:   ec2.GetHostCCRID,
+	gce.CloudProviderName:   gce.GetHostCCRID,
 }
 
 // GetHostCCRID returns the host CCRID from the first provider that works

--- a/pkg/util/cloudproviders/gce/gce.go
+++ b/pkg/util/cloudproviders/gce/gce.go
@@ -232,8 +232,8 @@ var ccridFetcher = cachedfetch.Fetcher{
 	},
 }
 
-// GetCCRID return the CCRID for the current instance
-func GetCCRID(ctx context.Context) (string, error) {
+// GetHostCCRID return the CCRID for the current instance
+func GetHostCCRID(ctx context.Context) (string, error) {
 	return ccridFetcher.FetchString(ctx)
 }
 

--- a/pkg/util/cloudproviders/gce/gce_test.go
+++ b/pkg/util/cloudproviders/gce/gce_test.go
@@ -266,12 +266,12 @@ func TestGetCCRID(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	_, err := GetCCRID(ctx)
+	_, err := GetHostCCRID(ctx)
 	require.Error(t, err)
 
 	errorOut = false
 
-	ccrid, err := GetCCRID(ctx)
+	ccrid, err := GetHostCCRID(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, ccrid, "//compute.googleapis.com/projects/gcp-test-project/zones/my-zone-for-test/instances/my-instance-name")
 }


### PR DESCRIPTION
### What does this PR do?

Enable GCE CCRID detection

### Describe how you validated your changes

Start a VM in GCE, install the agent and validate that both the V5 and inventoryhost metadata payload contains the correct CCRID. You can validate the CCRID in GCE Asset Inventory.