### PR TITLE
Fix incorrect replica value read in recommendations history

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -210,7 +210,7 @@ func (hr *horizontalController) computeScaleAction(
 		targetDesiredReplicas = stabilizationLimitedReplicas
 	}
 
-	// Scaling is allowed, applying Min/Max replicas constraints from Spec
+	// Applying Min/Max replicas constraints from Spec
 	if targetDesiredReplicas > maxReplicas {
 		targetDesiredReplicas = maxReplicas
 		limitReason = fmt.Sprintf("desired replica count limited to %d (originally %d) due to max replicas constraint", maxReplicas, originalTargetDesiredReplicas)
@@ -233,6 +233,7 @@ func (hr *horizontalController) computeScaleAction(
 		} else if scaleDirection == common.ScaleDown && autoscalerSpec.ApplyPolicy != nil {
 			rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleDownPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleDown, currentDesiredReplicas, targetDesiredReplicas)
 		}
+
 		// If rules had any effect, use values from rules
 		if rulesLimitReason != "" {
 			limitReason = rulesLimitReason

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -311,10 +311,12 @@ func (p *PodAutoscalerInternal) UpdateFromStatus(status *datadoghqcommon.Datadog
 
 			// TODO: Store the recommendations history as well, the last actions miss data
 			for _, recommendation := range status.Horizontal.LastActions {
-				p.horizontalLastRecommendations = addRecommendationToHistory(recommendation.Time.Time, p.horizontalRecommendationsRetention, p.horizontalLastRecommendations, HorizontalScalingValues{
-					Timestamp: recommendation.Time.Time,
-					Replicas:  recommendation.ToReplicas,
-				})
+				if recommendation.RecommendedReplicas != nil {
+					p.horizontalLastRecommendations = addRecommendationToHistory(recommendation.Time.Time, p.horizontalRecommendationsRetention, p.horizontalLastRecommendations, HorizontalScalingValues{
+						Timestamp: recommendation.Time.Time,
+						Replicas:  *recommendation.RecommendedReplicas,
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Small fixup on https://github.com/DataDog/datadog-agent/pull/39638.
We were not reading the correct value from status to feed the history.

### Motivation

Bugfix.

### Describe how you validated your changes

See https://github.com/DataDog/datadog-agent/pull/39638.
For this specific fix, you need to trigger a a leader switch (kill pods) and observe that history has the right number of replicas from running `agent autoscaler-list`.

### Possible Drawbacks / Trade-offs

### Additional Notes