### PR TITLE
feat(fleet): Add aditional RUNPATH to OCI agent

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -163,6 +163,11 @@ build do
             # Most postgres binaries are removed in postgres' own software
             # recipe, but we need pg_config to build psycopq.
             delete "#{install_dir}/embedded/bin/pg_config"
+
+            # Edit rpath from a true path to relative path for each binary if install_dir contains /opt/datadog-packages
+            if install_dir.include?("/opt/datadog-packages")
+              command "inv omnibus.rpath-edit #{install_dir} /opt/datadog-packages/datadog-agent/stable:#{install_dir} --no-force-rpath", cwd: Dir.pwd
+            end
         end
 
         if osx_target?

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-ddot.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-ddot.service.tmpl
@@ -20,6 +20,9 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/otel-agent run --config {{.EtcDir}}/otel-config.yaml --core-config {{.EtcDir}}/datadog.yaml --pidfile {{.PIDDir}}/run/otel-agent.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-installer.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-installer.service.tmpl
@@ -21,6 +21,9 @@ PIDFile={{.InstallDir}}/run/installer.pid
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/installer run -p {{.InstallDir}}/run/installer.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-process.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-process.service.tmpl
@@ -18,6 +18,9 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/process-agent --cfgpath={{.EtcDir}}/datadog.yaml --sysprobe-config={{.EtcDir}}/system-probe.yaml --pid={{.InstallDir}}/run/process-agent.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-security.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-security.service.tmpl
@@ -21,6 +21,9 @@ PIDFile={{.InstallDir}}/run/security-agent.pid
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/security-agent start -c {{.EtcDir}}/datadog.yaml -c {{.EtcDir}}/security-agent.yaml --sysprobe-config {{.EtcDir}}/system-probe.yaml --pidfile {{.InstallDir}}/run/security-agent.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-sysprobe.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-sysprobe.service.tmpl
@@ -25,6 +25,9 @@ PIDFile={{.InstallDir}}/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/system-probe run --config={{.EtcDir}}/system-probe.yaml --pid={{.InstallDir}}/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent-trace.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent-trace.service.tmpl
@@ -18,6 +18,9 @@ User=dd-agent
 Restart=on-failure
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 ExecStart={{.InstallDir}}/embedded/bin/trace-agent --config {{.EtcDir}}/datadog.yaml --pidfile {{.InstallDir}}/run/trace-agent.pid
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/templates/datadog-agent.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/templates/datadog-agent.service.tmpl
@@ -19,6 +19,9 @@ PIDFile={{.InstallDir}}/run/agent.pid
 User=dd-agent
 EnvironmentFile=-{{.EtcDir}}/environment
 Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
+{{- if not .Stable}}
+Environment="LD_LIBRARY_PATH={{.InstallDir}}/embedded/lib"
+{{- end}}
 RuntimeDirectory=datadog
 StartLimitInterval=10
 StartLimitBurst=5

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -556,9 +556,14 @@ def _replace_dylib_id_paths_with_rpath(ctx, otool_output, install_path, file):
         ctx.run(f"install_name_tool -id {new_dylib_path} {file}")
 
 
-def _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, file):
+def _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, file, force_rpath=True):
+    rpath = ':'.join(f"{r}/embedded/lib" for r in new_rpath.split(':'))
     if platform == "linux":
-        ctx.run(f"patchelf --force-rpath --set-rpath \\$ORIGIN/{new_rpath}/embedded/lib {file}")
+        force_rpath_arg = ""
+        if force_rpath:
+            force_rpath_arg = "--force-rpath"
+
+        ctx.run(f"patchelf {force_rpath_arg} --set-rpath {rpath} {file}")
     else:
         # The macOS agent binary has 18 RPATH definition, replacing the first one should be enough
         # but just in case we're replacing them all.
@@ -566,7 +571,7 @@ def _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, fi
         number_of_rpaths = binary_rpath.count('\n') // 3
         for _ in range(number_of_rpaths):
             exit_code = ctx.run(
-                f"install_name_tool -rpath {install_path}/embedded/lib @loader_path/{new_rpath}/embedded/lib {file}",
+                f"install_name_tool -rpath {install_path}/embedded/lib {rpath} {file}",
                 warn=True,
                 hide=True,
             ).exited
@@ -575,7 +580,7 @@ def _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, fi
 
 
 @task
-def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux"):
+def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux", force_rpath=True):
     # Collect mime types for all files inside the Agent installation
     files = ctx.run(rf"find {install_path} -type f -exec file --mime-type \{{\}} \+", hide=True).stdout
     for line in files.splitlines():
@@ -610,5 +615,6 @@ def rpath_edit(ctx, install_path, target_rpath_dd_folder, platform="linux"):
 
         # if a binary has an rpath that use our installation path we are patching it
         if install_path in binary_rpath:
-            new_rpath = os.path.relpath(target_rpath_dd_folder, os.path.dirname(file))
-            _patch_binary_rpath(ctx, new_rpath, install_path, binary_rpath, platform, file)
+            _patch_binary_rpath(
+                ctx, target_rpath_dd_folder, install_path, binary_rpath, platform, file, force_rpath=force_rpath
+            )


### PR DESCRIPTION
### What does this PR do?
- Force the OCI agent to use `RUNPATH` instead of `RPATH`
- Adds a `RUNPATH` entry to `/opt/datadog-packages/datadog-agent/stable` to the OCI agent
- Adds an override `RUNPATH` entry through `LD_LIBRARY_PATH` to `/opt/datadog-packages/datadog-agent/experiment` in experimental OCI agent units
  - This doesn't work with `RPATH`, hence the change to `RUNPATH`

### Motivation
Allow installation of agent plugins through Fleet Automation requires being able to have experiments of the same version with different plugins. This means that the same agent version must live twice on disk on different paths.

This solution:
- Makes the agent use the experimental libraries if it's an experiment
- Makes the agent use the stable libraries if it's stable
- Falls back to the versioned install directory if none of these symlinks can be used, for backwards compatibility

### Describe how you validated your changes
Manual QA:
- Using objdump to check the `RUNPATH` / `RPATH` of different agent packages
- QA of upgrades to check all cases properly start with libraries

### Possible Drawbacks / Trade-offs
Only impacts the OCI agent

### Additional Notes
See https://man7.org/linux/man-pages/man8/ld.so.8.html for more context about library search order