### PR TITLE
Collect logs in steps folder if DD_EMR_DRIVER_LOGS_ENABLED

### DIFF
--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -92,13 +92,13 @@ func SetupEmr(s *common.Setup) error {
 		s.Out.WriteString("Setting up Spark integration config on the Resource Manager\n")
 		setupResourceManager(s, clusterName)
 		if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
-			s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_LOGS_ENABLED=true\n")
+			s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_DRIVER_LOGS_ENABLED=true\n")
 			enableEmrLogs(s, false)
 		}
 	}
 	// Add logs config to both Resource Manager and Workers
 	if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
-		s.Out.WriteString("Enabling EMR logs collection on the driver only based on env variable DD_EMR_DRIVER_LOGS=true\n")
+		s.Out.WriteString("Enabling EMR logs collection on the driver only based on env variable DD_EMR_LOGS=true\n")
 		enableEmrLogs(s, true)
 	} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
 		s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -190,14 +190,14 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	return clusterName
 }
 
-func enableEmrLogs(s *common.Setup, driverOnly bool) {
+func enableEmrLogs(s *common.Setup, collectFromDriver bool) {
 	s.Config.DatadogYAML.LogsEnabled = true
 	loadLogProcessingRules(s)
 	s.Span.SetTag("host_tag_set.logs_enabled", "true")
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]
 	var emrLogs []config.IntegrationConfigLogs
-	if driverOnly {
+	if collectFromDriver {
 		s.Span.SetTag("host_tag_set.driver_logs_enabled", "true")
 		emrLogs = []config.IntegrationConfigLogs{
 			{

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -92,13 +92,13 @@ func SetupEmr(s *common.Setup) error {
 		s.Out.WriteString("Setting up Spark integration config on the Resource Manager\n")
 		setupResourceManager(s, clusterName)
 		if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
-			s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_DRIVER_LOGS_ENABLED=true\n")
+			s.Out.WriteString("Enabling EMR logs collection from driver based on env variable DD_EMR_DRIVER_LOGS_ENABLED=true\n")
 			enableEmrLogs(s, true)
 		}
 	}
 	// Add logs config to both Resource Manager and Workers
 	if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
-		s.Out.WriteString("Enabling EMR logs collection on the driver only based on env variable DD_EMR_LOGS=true\n")
+		s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_LOGS_ENABLED=true\n")
 		enableEmrLogs(s, false)
 	} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
 		s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")
@@ -193,7 +193,6 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 func enableEmrLogs(s *common.Setup, collectFromDriver bool) {
 	s.Config.DatadogYAML.LogsEnabled = true
 	loadLogProcessingRules(s)
-	s.Span.SetTag("host_tag_set.logs_enabled", "true")
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]
 	var emrLogs []config.IntegrationConfigLogs

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -24,6 +24,7 @@ const (
 	emrJavaTracerVersion = "1.51.1-1"
 	emrAgentVersion      = "7.68.2-1"
 	hadoopLogFolder      = "/var/log/hadoop-yarn/containers/"
+	hadoopDriverFolder   = "/mnt/var/log/hadoop/steps/"
 )
 
 var (
@@ -90,12 +91,16 @@ func SetupEmr(s *common.Setup) error {
 	if isMaster {
 		s.Out.WriteString("Setting up Spark integration config on the Resource Manager\n")
 		setupResourceManager(s, clusterName)
+		if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
+			s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_LOGS_ENABLED=true\n")
+			enableEmrLogs(s, false)
+		}
 	}
 	// Add logs config to both Resource Manager and Workers
 	if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
-		s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_LOGS_ENABLED=true\n")
-		enableEmrLogs(s)
-	} else {
+		s.Out.WriteString("Enabling EMR logs collection on the driver only based on env variable DD_EMR_DRIVER_LOGS=true\n")
+		enableEmrLogs(s, true)
+	} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
 		s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")
 	}
 	return nil
@@ -185,30 +190,53 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	return clusterName
 }
 
-func enableEmrLogs(s *common.Setup) {
+func enableEmrLogs(s *common.Setup, driverOnly bool) {
 	s.Config.DatadogYAML.LogsEnabled = true
 	loadLogProcessingRules(s)
 	s.Span.SetTag("host_tag_set.logs_enabled", "true")
-	// Add dd-agent user to yarn group so that it gets read permission to the hadoop-yarn logs folder
-	s.DdAgentAdditionalGroups = append(s.DdAgentAdditionalGroups, "yarn")
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]
-	emrLogs := []config.IntegrationConfigLogs{
-		{
-			Type:    "file",
-			Path:    hadoopLogFolder + "*/*/stdout",
-			Source:  "hadoop-yarn",
-			Service: "emr-logs",
-			LogProcessingRules: []config.LogProcessingRule{
-				{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
+	var emrLogs []config.IntegrationConfigLogs
+	if driverOnly {
+		s.Span.SetTag("host_tag_set.driver_logs_enabled", "true")
+		emrLogs = []config.IntegrationConfigLogs{
+			{
+				Type:    "file",
+				Path:    hadoopDriverFolder + "*/stdout",
+				Source:  "hadoop-yarn",
+				Service: "emr-logs",
+				LogProcessingRules: []config.LogProcessingRule{
+					{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
+				},
 			},
-		},
-		{
-			Type:    "file",
-			Path:    hadoopLogFolder + "*/*/stderr",
-			Source:  "hadoop-yarn",
-			Service: "emr-logs",
-		},
+			{
+				Type:    "file",
+				Path:    hadoopDriverFolder + "*/stderr",
+				Source:  "hadoop-yarn",
+				Service: "emr-logs",
+			},
+		}
+	} else {
+		s.Span.SetTag("host_tag_set.logs_enabled", "true")
+		// Add dd-agent user to yarn group so that it gets read permission to the hadoop-yarn logs folder
+		s.DdAgentAdditionalGroups = append(s.DdAgentAdditionalGroups, "yarn")
+		emrLogs = []config.IntegrationConfigLogs{
+			{
+				Type:    "file",
+				Path:    hadoopLogFolder + "*/*/stdout",
+				Source:  "hadoop-yarn",
+				Service: "emr-logs",
+				LogProcessingRules: []config.LogProcessingRule{
+					{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
+				},
+			},
+			{
+				Type:    "file",
+				Path:    hadoopLogFolder + "*/*/stderr",
+				Source:  "hadoop-yarn",
+				Service: "emr-logs",
+			},
+		}
 	}
 	sparkIntegration.Logs = emrLogs
 	s.Config.IntegrationConfigs["spark.d/conf.yaml"] = sparkIntegration

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -93,13 +93,13 @@ func SetupEmr(s *common.Setup) error {
 		setupResourceManager(s, clusterName)
 		if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
 			s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_DRIVER_LOGS_ENABLED=true\n")
-			enableEmrLogs(s, false)
+			enableEmrLogs(s, true)
 		}
 	}
 	// Add logs config to both Resource Manager and Workers
 	if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
 		s.Out.WriteString("Enabling EMR logs collection on the driver only based on env variable DD_EMR_LOGS=true\n")
-		enableEmrLogs(s, true)
+		enableEmrLogs(s, false)
 	} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
 		s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

Spark `--deploy-mode client` stdout logs don't end up in EMR executor nodes but are available on the driver in `/mnt/var/log/hadoop/steps/` so we give the option to setup logs collection on these folders rather than on the executors for workloads that are mostly client mode rather than cluster mode.

Note that we can't turn on collection for both folder, at the risk of collecting some logs twice.

New behavior:
- existing `DD_EMR_LOGS_ENABLED` keeps collecting logs only in the `/var/log/hadoop-yarn/containers/app_id>/<container_id>` folders
- new `DD_EMR_DRIVER_LOGS_ENABLED` introduces a new behavior where we only collect logs on the master node in `/mnt/var/log/hadoop/steps/`. These logs come from all nodes.

Benefit of the new collection: capturing stdout logs in spark client mode
Disadvantage is we loose correlation with spark's app_id for span to logs correlation.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Run an EMR cluster with DJM init script and set `DD_EMR_DRIVER_LOGS_ENABLED` and get status shows only the EMR steps log files are tailed:

```
 ============
  Integrations
  ============

  spark
  -----
    - Type: file
      Path: /mnt/var/log/hadoop/steps/*/stdout
      Service: emr-logs
      Source: hadoop-yarn
      Status: OK
        3 files tailed out of 3 files matching
      Inputs:
        /mnt/var/log/hadoop/steps/s-0980242TX191A2RZE8S/stdout
        /mnt/var/log/hadoop/steps/s-07419481852YHMLANXIR/stdout
        /mnt/var/log/hadoop/steps/s-03501683NGM7Y2LK09CW/stdout  
      Bytes Read: 0   
      Lines Combined: 0   
      MultiLine matches: 0   
      Pipeline Latency:
        Average Latency: 0s
        24h Average Latency: 0s
        Peak Latency: 0s
        24h Peak Latency: 0s
    - Type: file
      Path: /mnt/var/log/hadoop/steps/*/stderr
      Service: emr-logs
      Source: hadoop-yarn
      Status: OK
        3 files tailed out of 3 files matching
      Inputs:
        /mnt/var/log/hadoop/steps/s-0980242TX191A2RZE8S/stderr
        /mnt/var/log/hadoop/steps/s-07419481852YHMLANXIR/stderr
        /mnt/var/log/hadoop/steps/s-03501683NGM7Y2LK09CW/stderr  
      Bytes Read: 37504   
      Pipeline Latency:
        Average Latency: 333.093µs
        24h Average Latency: 333.093µs
        Peak Latency: 1.952271ms
        24h Peak Latency: 1.952271ms
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->