### PR TITLE
Cleanup the unix socket the ethtool handler opens

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -269,6 +269,7 @@ func handleEthtoolStats(sender sender.Sender, interfaceIO net.IOCountersStat, co
 	}
 
 	ethtoolObjectPtr, err := ethtool.NewEthtool()
+	defer ethtoolObjectPtr.Close()
 	if err != nil {
 		log.Errorf("Failed to create ethtool object: %s", err)
 		return err

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -269,11 +269,11 @@ func handleEthtoolStats(sender sender.Sender, interfaceIO net.IOCountersStat, co
 	}
 
 	ethtoolObjectPtr, err := ethtool.NewEthtool()
-	defer ethtoolObjectPtr.Close()
 	if err != nil {
 		log.Errorf("Failed to create ethtool object: %s", err)
 		return err
 	}
+	defer ethtoolObjectPtr.Close()
 	ethtoolObject = *ethtoolObjectPtr
 
 	// Preparing the interface name and copy it into the request


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We need to [close](https://github.com/safchain/ethtool/blob/de57b3e27470f1f1ee76f73cbdc639b81f1dc1c1/ethtool.go#L1233-L1236) the ethtool handler which otherwise causes [a socket leak](https://github.com/safchain/ethtool/blob/de57b3e27470f1f1ee76f73cbdc639b81f1dc1c1/ethtool.go#L1253)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->