### PR TITLE
Add startup failure reason to remote-config status

### DIFF
--- a/comp/remote-config/rcstatus/rcstatusimpl/status.go
+++ b/comp/remote-config/rcstatus/rcstatusimpl/status.go
@@ -105,6 +105,13 @@ func (rc statusProvider) populateStatus(stats map[string]interface{}) {
 	}
 
 	stats["remoteConfiguration"] = status
+
+	if expvar.Get("remoteConfigStartup") != nil {
+		remoteConfigStartupJSON := expvar.Get("remoteConfigStartup").String()
+		startupMap := make(map[string]interface{})
+		json.Unmarshal([]byte(remoteConfigStartupJSON), &startupMap) //nolint:errcheck
+		stats["remoteConfigStartup"] = startupMap
+	}
 }
 
 func isRemoteConfigEnabled(conf config.Component) bool {

--- a/comp/remote-config/rcstatus/rcstatusimpl/status_templates/remoteconfiguration.tmpl
+++ b/comp/remote-config/rcstatus/rcstatusimpl/status_templates/remoteconfiguration.tmpl
@@ -1,5 +1,7 @@
 {{ with .remoteConfiguration }}
-{{ if not .disabledReason }}
+{{ if $.remoteConfigStartup.startupFailureReason }}
+Startup Failure Reason: {{ $.remoteConfigStartup.startupFailureReason }}
+{{ else if not .disabledReason }}
 Organization enabled: {{ if and .orgEnabled (eq .orgEnabled "true") }}True{{ else }}False{{ end }}
 API Key: {{ if and .apiKeyScoped (eq .apiKeyScoped "true") }}Authorized{{ else }}Not authorized, add the Remote Configuration Read permission to enable it for this agent.{{ end }}
 Last error: {{ if .lastError }}{{ .lastError }}{{ else }}None{{ end }}

--- a/comp/remote-config/rcstatus/rcstatusimpl/status_templates/remoteconfigurationHTML.tmpl
+++ b/comp/remote-config/rcstatus/rcstatusimpl/status_templates/remoteconfigurationHTML.tmpl
@@ -2,9 +2,13 @@
   <span class="stat_title">Remote Configuration</span>
   <span class="stat_data">
     {{ with .remoteConfiguration }}
-      API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
-      Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
-      Last error: {{ if .lastError }}{{ .lastError }}{{ else }}None{{ end }}
+      {{ if $.remoteConfigStartup.startupFailureReason }}
+        Startup Failure Reason: {{ $.remoteConfigStartup.startupFailureReason }}
+      {{ else }}
+        API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
+        Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
+        Last error: {{ if .lastError }}{{ .lastError }}{{ else }}None{{ end }}
+      {{ end }}
     {{ else }}
       Remote Configuration is disabled
     {{ end }}

--- a/pkg/config/remote/service/util.go
+++ b/pkg/config/remote/service/util.go
@@ -55,7 +55,7 @@ func recreate(path string, agentVersion string, apiKeyHash string, url string) (
 	if err == nil {
 		err := os.Remove(path)
 		if err != nil {
-			return nil, fmt.Errorf("could not remote existing rc db (%s): %v", path, err)
+			return nil, fmt.Errorf("could not remove existing rc db (%s): %v", path, err)
 		}
 	}
 	err = os.MkdirAll(filepath.Dir(path), 0700)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds to the Remote Configuration status the startup failure reason if the service fails to start up

### Motivation
If remote configuration fails during start up, the error is logged but currently the status message is not updated with the correct failure reason. This change provides transparency into why remote configuration failed to start up.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
To test the changes, I set the remote configuration service to look for a database file that it would not have permission to read and confirmed the status message matched. I also started the agent normally and confirmed the remote configuration status message was as expected.

#### Failed Status
```
====================
Remote Configuration
====================


Startup Failure Reason: could not remove existing rc db (/tmp/remote-config.db): remove /tmp/remote-config.db: permission denied
```

#### Successful Status
```
====================
Remote Configuration
====================


Organization enabled: True
API Key: Authorized
Last error: None
```

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Also includes a typo fix for a log message