### PR TITLE
[CONS-7514] Upgrade `kube-state-metrics`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1024,7 +1024,7 @@ exclude go.opentelemetry.io/proto/otlp v1.1.0
 replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20250206221735-64e5a8c92d94
 
 // Remove once https://github.com/kubernetes/kube-state-metrics/pull/2553 is merged
-replace k8s.io/kube-state-metrics/v2 v2.13.1-0.20241025121156-110f03d7331f => github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20241119155242-07761b9fe9a0
+replace k8s.io/kube-state-metrics/v2 v2.13.1-0.20241025121156-110f03d7331f => github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20250808193648-ead8278ad9fb
 
 // Remove once https://github.com/Iceber/iouring-go/pull/31 or equivalent is merged,
 // among with the Connect, Bind and Accept requests

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/Intevation/gval v1.3.0 h1:+Ze5sft5MmGbZrHj06NVUbcxCb67l9RaPTLMNr37mjw
 github.com/Intevation/gval v1.3.0/go.mod h1:xmGyGpP5be12EL0P12h+dqiYG8qn2j3PJxIgkoOHO5o=
 github.com/Intevation/jsonpath v0.2.1 h1:rINNQJ0Pts5XTFEG+zamtdL7l9uuE1z0FBA+r55Sw+A=
 github.com/Intevation/jsonpath v0.2.1/go.mod h1:WnZ8weMmwAx/fAO3SutjYFU+v7DFreNYnibV7CiaYIw=
-github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20241119155242-07761b9fe9a0 h1:xrmnY+qafvx1mB2uKBDPBzL4VWea0nC7gTaELFHNjg0=
-github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20241119155242-07761b9fe9a0/go.mod h1:sGt/NFkZkA4hqb4cVd/xG2G17dzZ72TQXqSpHn8rF/U=
+github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20250808193648-ead8278ad9fb h1:pSjcYEPRbKevUMCm98BPtbGlnkJFyXercsC+mQGxEb0=
+github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20250808193648-ead8278ad9fb/go.mod h1:sGt/NFkZkA4hqb4cVd/xG2G17dzZ72TQXqSpHn8rF/U=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/releasenotes-dca/notes/cronjob-timezone-b38a4f6e4a92490c.yaml
+++ b/releasenotes-dca/notes/cronjob-timezone-b38a4f6e4a92490c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the ``cronjob.on_schedule_check``` service check of the ``kubernetes_state`` check for CronJobs that have a specific time zone.

--- a/releasenotes-dca/notes/cronjob-timezone-b38a4f6e4a92490c.yaml
+++ b/releasenotes-dca/notes/cronjob-timezone-b38a4f6e4a92490c.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix the ``cronjob.on_schedule_check``` service check of the ``kubernetes_state`` check for CronJobs that have a specific time zone.
+    Fix the ``cronjob.on_schedule_check`` service check of the ``kubernetes_state`` check for CronJobs that have a specific time zone.


### PR DESCRIPTION
### What does this PR do?

Backport kubernetes/kube-state-metrics#2376.

### Motivation

Fix timezone support for CronJobs in KSM check.

### Describe how you validated your changes

https://dddev.datadoghq.com/notebook/12874571/-cons-7514-cronjob-metric-does-not-adjust-to-timezone?range=172800000&view=view-mode&start=1754512233566&live=true

<img width="1284" height="1818" alt="image" src="https://github.com/user-attachments/assets/ecb3b422-b596-41fc-a3c2-0696d79c1a16" />

### Possible Drawbacks / Trade-offs

### Additional Notes
