### PR TITLE
set service to manual mode in driver verifier tests

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -259,6 +259,18 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.installer = NewDatadogInstaller(s.Env(), s.CurrentAgentVersion().MSIPackage().URL, outputDir)
 	s.installScriptImpl = NewDatadogInstallScript(s.Env())
 
+	host := s.Env().RemoteHost
+	// Clear agent logs
+	s.T().Logf("Clearing agent logs")
+	logsFolder, err := host.GetLogsFolder()
+	s.Require().NoError(err, "should get logs folder")
+	entries, err := host.ReadDir(logsFolder)
+	if s.Assert().NoError(err, "should read log folder") {
+		for _, entry := range entries {
+			err = host.Remove(filepath.Join(logsFolder, entry.Name()))
+			s.Assert().NoError(err, "should remove %s", entry.Name())
+		}
+	}
 	// clear the event logs before each test
 	for _, logName := range []string{"System", "Application"} {
 		s.T().Logf("Clearing %s event log", logName)

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -259,18 +259,6 @@ func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.installer = NewDatadogInstaller(s.Env(), s.CurrentAgentVersion().MSIPackage().URL, outputDir)
 	s.installScriptImpl = NewDatadogInstallScript(s.Env())
 
-	host := s.Env().RemoteHost
-	// Clear agent logs
-	s.T().Logf("Clearing agent logs")
-	logsFolder, err := host.GetLogsFolder()
-	s.Require().NoError(err, "should get logs folder")
-	entries, err := host.ReadDir(logsFolder)
-	if s.Assert().NoError(err, "should read log folder") {
-		for _, entry := range entries {
-			err = host.Remove(filepath.Join(logsFolder, entry.Name()))
-			s.Assert().NoError(err, "should remove %s", entry.Name())
-		}
-	}
 	// clear the event logs before each test
 	for _, logName := range []string{"System", "Application"} {
 		s.T().Logf("Clearing %s event log", logName)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
disable service auto-start during startstop-tests that enable the driver verifier.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1714

tests flaking with error
```
Error:      	Received unexpected error:
        	            	sftp: "Bad message" (SSH_FX_BAD_MESSAGE)
        	Test:       	TestDriverVerifierOnServiceBehaviorAgentCommand/TestAgentStartsAllServices
        	Messages:   	should remove agent.log
```

I think this is due to the log files being in use. The test normally stops the services before this, but when the driver verifier is enabled the host is rebooted which creates a race between the stopservice call and the OS auto starting the services.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
call `host.Remove("/ProgramData/Datadog/logs/agent.log")` while the Agent is running and observe the `SSH_FX_BAD_MESSAGE` error
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->