### PR TITLE
Add bugcheck data to Windows crash events

### DIFF
--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
@@ -18,10 +18,19 @@ typedef enum _readCrashDumpErrors {
     RCD_SET_OUTPUT_CALLBACKS_FAILED = 3,
     RCD_OPEN_DUMP_FILE_FAILED = 4,
     RCD_WAIT_FOR_EVENT_FAILED = 5,
-    RCD_EXECUTE_FAILED = 6
+    RCD_EXECUTE_FAILED = 6,
+    RCD_INVALID_ARG = 7
 } READ_CRASH_DUMP_ERROR;
 
-READ_CRASH_DUMP_ERROR readCrashDump(char *fname, void *ctx, long * extendedError);
+typedef struct _bugCheckInfo {
+    ULONG code;
+    ULONG64 arg1;
+    ULONG64 arg2;
+    ULONG64 arg3;
+    ULONG64 arg4;
+} BUGCHECK_INFO;
+
+READ_CRASH_DUMP_ERROR readCrashDump(char* fname, void* ctx, BUGCHECK_INFO* bugCheckInfo, long* extendedError);
 
 #ifdef __cplusplus
 } // close the extern "C"

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -16,7 +16,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testCrashReader(filename string, ctx *logCallbackContext, _ *uint32) error {
+func testCrashReader(filename string, ctx *logCallbackContext, crashCtx *crashContext, _ *uint32) error {
+	crashCtx.bugCheckCode = 0x7E
+	crashCtx.bugCheckArg1 = 0x1001
+	crashCtx.bugCheckArg2 = 0x1002
+	crashCtx.bugCheckArg3 = 0x1003
+	crashCtx.bugCheckArg4 = 0x1004
+
 	testbytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -29,7 +35,13 @@ func testCrashReader(filename string, ctx *logCallbackContext, _ *uint32) error 
 
 }
 
-func testCrashReaderWithLineSplits(filename string, ctx *logCallbackContext, _ *uint32) error {
+func testCrashReaderWithLineSplits(filename string, ctx *logCallbackContext, crashCtx *crashContext, _ *uint32) error {
+	crashCtx.bugCheckCode = 0x7E
+	crashCtx.bugCheckArg1 = 0x1001
+	crashCtx.bugCheckArg2 = 0x1002
+	crashCtx.bugCheckArg3 = 0x1003
+	crashCtx.bugCheckArg4 = 0x1004
+
 	testbytes, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -60,7 +72,11 @@ func TestCrashParser(t *testing.T) {
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")
 	assert.Equal(t, "ddapmcrash", before)
-	assert.Equal(t, "0000007E", wcs.BugCheck)
+	assert.Equal(t, "7E", wcs.BugCheck)
+	assert.Equal(t, "1001", wcs.BugCheckArg1)
+	assert.Equal(t, "1002", wcs.BugCheckArg2)
+	assert.Equal(t, "1003", wcs.BugCheckArg3)
+	assert.Equal(t, "1004", wcs.BugCheckArg4)
 
 }
 
@@ -80,6 +96,9 @@ func TestCrashParserWithLineSplits(t *testing.T) {
 	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
 	before, _, _ := strings.Cut(wcs.Offender, "+")
 	assert.Equal(t, "ddapmcrash", before)
-	assert.Equal(t, "0000007E", wcs.BugCheck)
-
+	assert.Equal(t, "7E", wcs.BugCheck)
+	assert.Equal(t, "1001", wcs.BugCheckArg1)
+	assert.Equal(t, "1002", wcs.BugCheckArg2)
+	assert.Equal(t, "1003", wcs.BugCheckArg3)
+	assert.Equal(t, "1004", wcs.BugCheckArg4)
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -48,11 +48,15 @@ const (
 // WinCrashStatus defines all of the information returned from the system
 // probe to the caller
 type WinCrashStatus struct {
-	StatusCode int    `json:"statuscode"`
-	ErrString  string `json:"errstring"`
-	FileName   string `json:"filename"`
-	Type       int    `json:"dumptype"`
-	DateString string `json:"datestring"`
-	Offender   string `json:"offender"`
-	BugCheck   string `json:"buckcheckcode"`
+	StatusCode   int    `json:"statuscode"`
+	ErrString    string `json:"errstring"`
+	FileName     string `json:"filename"`
+	Type         int    `json:"dumptype"`
+	DateString   string `json:"datestring"`
+	Offender     string `json:"offender"`
+	BugCheck     string `json:"buckcheckcode"`
+	BugCheckArg1 string `json:"bugcheckarg1"`
+	BugCheckArg2 string `json:"bugcheckarg2"`
+	BugCheckArg3 string `json:"bugcheckarg3"`
+	BugCheckArg4 string `json:"bugcheckarg4"`
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrash_testutil.go
@@ -7,7 +7,7 @@
 
 package probe
 
-type readCrashDumpType func(filename string, ctx *logCallbackContext, _ *uint32) error
+type readCrashDumpType func(filename string, ctx *logCallbackContext, crashCtx *crashContext, _ *uint32) error
 type parseCrashDumpType func(wcs *WinCrashStatus)
 
 // SetCachedSettings sets the settings used for tests without reading the Registry.

--- a/releasenotes/notes/windows_crash_bugcheck_data-96ddcd50ee4bfaa6.yaml
+++ b/releasenotes/notes/windows_crash_bugcheck_data-96ddcd50ee4bfaa6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Include bugcheck data if available as part of Windows crash reports.


### PR DESCRIPTION
### What does this PR do?
This PR fills the bugcheck code field, as well as provide bugcheck arguments, as part of the Windows crash detection events.  

### Motivation
The bugcheck code was originally filled but no longer reported after past updates.
The bugcheck code will help better understand customer crashes and provide better diagnostics data.
https://datadoghq.atlassian.net/browse/WINA-1705

### Describe how you validated your changes
Manual testing:
- Launch system probe in a test VM.
- Drop a known kernel memory dump file into C:\Windows\MEMORY.DMP.
- Copy NamedPipeCmd.exe to the test VM.
- With an elevated command prompt, run the following command twice:
-- `NamedPipeCmd.exe -method GET -path /windows_crash_detection/check`
-- Twice is required due to the asynchronous processing of crash detection.
- A JSON output should be provided by the command, which should include the bugcheck code from the kernel dump.

