### PR TITLE
network v2: cleanup of ethtool handling

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -287,13 +287,13 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 	}
 
 	// Preparing the interface name and copy it into the request
-	ifaceBytes := []byte(interfaceIO.Name)
-	if len(ifaceBytes) > 15 {
-		ifaceBytes = ifaceBytes[:15]
+	iface := interfaceIO.Name
+	if len(iface) > 15 {
+		iface = iface[:15]
 	}
 
 	// Fetch driver information (ETHTOOL_GDRVINFO)
-	drvInfo, err := ethtoolObject.DriverInfo(string(ifaceBytes))
+	drvInfo, err := ethtoolObject.DriverInfo(iface)
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("driver info is not supported for interface: %s", interfaceIO.Name)
@@ -307,7 +307,7 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 	driverVersion := replacer.Replace(drvInfo.Version)
 
 	// Fetch ethtool stats values (ETHTOOL_GSTATS)
-	statsMap, err := ethtoolObject.Stats(string(ifaceBytes))
+	statsMap, err := ethtoolObject.Stats(iface)
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("ethtool stats are not supported for interface: %s", interfaceIO.Name)

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -112,6 +112,9 @@ func (f *MockEthtool) Stats(intf string) (map[string]uint64, error) {
 	return nil, unix.ENOTTY
 }
 
+func (f *MockEthtool) Close() {
+}
+
 type MockCommandRunner struct {
 	mock.Mock
 }
@@ -406,11 +409,12 @@ func TestNetworkCheck(t *testing.T) {
 	}
 
 	mockEthtool := new(MockEthtool)
-	mockEthtool.On("getDriverInfo", mock.Anything).Return(ethtool.DrvInfo{}, nil)
+	mockEthtool.On("DriverInfo", mock.Anything).Return(ethtool.DrvInfo{}, nil)
 	mockEthtool.On("Stats", mock.Anything).Return(map[string]int{}, nil)
 
-	getEthtoolDrvInfo = mockEthtool.DriverInfo
-	getEthtoolStats = mockEthtool.Stats
+	getNewEthtool = func() (ethtoolInterface, error) {
+		return mockEthtool, nil
+	}
 
 	ssAvailableFunction = func() bool { return false }
 
@@ -730,8 +734,9 @@ func TestFetchEthtoolStats(t *testing.T) {
 	mockEthtool.On("getDriverInfo", mock.Anything).Return(ethtool.DrvInfo{}, nil)
 	mockEthtool.On("Stats", mock.Anything).Return(map[string]int{}, nil)
 
-	getEthtoolDrvInfo = mockEthtool.DriverInfo
-	getEthtoolStats = mockEthtool.Stats
+	getNewEthtool = func() (ethtoolInterface, error) {
+		return mockEthtool, nil
+	}
 
 	net := &fakeNetworkStats{
 		counterStats: []net.IOCountersStat{
@@ -777,8 +782,9 @@ func TestFetchEthtoolStatsENOTTY(t *testing.T) {
 	mockEthtool.On("getDriverInfo", mock.Anything).Return(ethtool.DrvInfo{}, nil)
 	mockEthtool.On("Stats", mock.Anything).Return(map[string]int{}, nil)
 
-	getEthtoolDrvInfo = mockEthtool.DriverInfo
-	getEthtoolStats = mockEthtool.Stats
+	getNewEthtool = func() (ethtoolInterface, error) {
+		return mockEthtool, nil
+	}
 
 	net := &fakeNetworkStats{
 		counterStats: []net.IOCountersStat{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Related to https://github.com/DataDog/datadog-agent/pull/39679 that fixed an issue with closing the ethtool object and the related incident.

This PR cleans up the ethtool handling in the network v2 check around multiple dimensions:

#### ethtool lifetime:
in order to test this check, the function to get the driver info and stats are put into global variables ready to be overridden in tests. This is not great because it obfuscates the lifetime of the ethtool object (see the ptr/object/close dance that is on main currently). This PR refactors this to actually mock the fetching of the ethtool object itself. This allows the actual code to use the ethtool library directly, and the tests don't interact with ethtool at all and simply returns a mocked object directly

#### ethtool hoisting:
the ethtool object creation is hoisted up the loop, allowing to create a single ethtool object (which is a socket under the hood) once per check instead of once per interface

In addition to those points, the interface name extra copy is removed

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->