### PR TITLE
fix(fleet): Categorize installer download errors properly

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap.go
@@ -19,8 +19,7 @@ const (
 	// InstallerPackage is the name of the Datadog Installer OCI package
 	InstallerPackage = "datadog-installer"
 	// AgentPackage is the name of the Datadog Agent OCI package
-	AgentPackage     = "datadog-agent"
-	installerBinPath = "bin/installer/installer"
+	AgentPackage = "datadog-agent"
 )
 
 // Install self-installs the installer package from the given URL.

--- a/pkg/fleet/installer/bootstrap/bootstrap_nix.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_nix.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 )
@@ -33,7 +34,10 @@ func install(ctx context.Context, env *env.Env, url string, experiment bool) err
 	defer os.RemoveAll(tmpDir)
 	cmd, err := downloadInstaller(ctx, env, url, tmpDir)
 	if err != nil {
-		return err
+		return installerErrors.Wrap(
+			installerErrors.ErrDownloadFailed,
+			err,
+		)
 	}
 	if experiment {
 		return cmd.InstallExperiment(ctx, url)

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/msi"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
@@ -43,7 +44,10 @@ func install(ctx context.Context, env *env.Env, url string, experiment bool) err
 	defer os.RemoveAll(tmpDir)
 	cmd, err := downloadInstaller(ctx, env, url, tmpDir)
 	if err != nil {
-		return err
+		return installerErrors.Wrap(
+			installerErrors.ErrDownloadFailed,
+			err,
+		)
 	}
 	if experiment {
 		return cmd.InstallExperiment(ctx, url)


### PR DESCRIPTION
### What does this PR do?
When we install an agent experiment we first have to download the installer. It happens that this download fails (proxy issues for instance), but it's not categorized back up as a network error, making the whole error in the UI confusing. This PR fixes it by wrapping the error and making it a network error.

### Motivation
Clearer errors in the frontend

### Describe how you validated your changes
Manual QA in a VM done by blocking `install.datadoghq.com` only

### Possible Drawbacks / Trade-offs

### Additional Notes
