### PR TITLE
[CWS] fix SECL error types

### DIFF
--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -49,15 +49,6 @@ var (
 	ErrPolicyIsEmpty = errors.New("the policy is empty")
 )
 
-// ErrFieldTypeUnknown is returned when a field has an unknown type
-type ErrFieldTypeUnknown struct {
-	Field string
-}
-
-func (e *ErrFieldTypeUnknown) Error() string {
-	return fmt.Sprintf("field type unknown for `%s`", e.Field)
-}
-
 // ErrValueTypeUnknown is returned when the value of a field has an unknown type
 type ErrValueTypeUnknown struct {
 	Field string
@@ -149,7 +140,7 @@ func (e ErrRuleLoad) Type() RuleLoadErrType {
 	}
 
 	switch e.Err.(type) {
-	case *ErrFieldTypeUnknown, *ErrValueTypeUnknown, *ErrRuleSyntax, *ErrFieldNotAvailable:
+	case *ErrValueTypeUnknown, *ErrRuleSyntax, *ErrFieldNotAvailable:
 		return SyntaxErrType
 	}
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -65,8 +65,12 @@ type ErrPolicyLoad struct {
 	Err     error
 }
 
-func (e ErrPolicyLoad) Error() string {
+func (e *ErrPolicyLoad) Error() string {
 	return fmt.Sprintf("error loading policy `%s` from source `%s`: %s", e.Name, e.Source, e.Err)
+}
+
+func (e *ErrPolicyLoad) Unwrap() error {
+	return e.Err
 }
 
 // ErrMacroLoad is on macro definition error

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -169,11 +169,11 @@ type ErrScopeField struct {
 	Err        error
 }
 
-func (e ErrScopeField) Error() string {
+func (e *ErrScopeField) Error() string {
 	return fmt.Sprintf("scope_field `%s` error: %s", e.Expression, e.Err)
 }
 
-func (e ErrScopeField) Unwrap() error {
+func (e *ErrScopeField) Unwrap() error {
 	return e.Err
 }
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -155,11 +155,11 @@ type ErrActionFilter struct {
 	Err        error
 }
 
-func (e ErrActionFilter) Error() string {
+func (e *ErrActionFilter) Error() string {
 	return fmt.Sprintf("filter `%s` error: %s", e.Expression, e.Err)
 }
 
-func (e ErrActionFilter) Unwrap() error {
+func (e *ErrActionFilter) Unwrap() error {
 	return e.Err
 }
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -93,11 +93,11 @@ type ErrRuleLoad struct {
 	Err  error
 }
 
-func (e ErrRuleLoad) Error() string {
+func (e *ErrRuleLoad) Error() string {
 	return fmt.Sprintf("rule `%s` error: %s", e.Rule.Def.ID, e.Err)
 }
 
-func (e ErrRuleLoad) Unwrap() error {
+func (e *ErrRuleLoad) Unwrap() error {
 	return e.Err
 }
 
@@ -118,7 +118,7 @@ const (
 )
 
 // Type return the type of the error
-func (e ErrRuleLoad) Type() RuleLoadErrType {
+func (e *ErrRuleLoad) Type() RuleLoadErrType {
 	switch e.Err {
 	case ErrRuleAgentVersion:
 		return AgentVersionErrType

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -9,7 +9,6 @@ package rules
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -48,15 +47,6 @@ var (
 	// ErrPolicyIsEmpty is returned when a policy has no rules or macros
 	ErrPolicyIsEmpty = errors.New("the policy is empty")
 )
-
-// ErrNoApprover is returned when no approver was found for a set of rules
-type ErrNoApprover struct {
-	Fields []string
-}
-
-func (e ErrNoApprover) Error() string {
-	return fmt.Sprintf("no approver for fields `%s`", strings.Join(e.Fields, ", "))
-}
 
 // ErrNoEventTypeBucket is returned when no bucket could be found for an event type
 type ErrNoEventTypeBucket struct {

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -49,15 +49,6 @@ var (
 	ErrPolicyIsEmpty = errors.New("the policy is empty")
 )
 
-// ErrValueTypeUnknown is returned when the value of a field has an unknown type
-type ErrValueTypeUnknown struct {
-	Field string
-}
-
-func (e *ErrValueTypeUnknown) Error() string {
-	return fmt.Sprintf("value type unknown for `%s`", e.Field)
-}
-
 // ErrNoApprover is returned when no approver was found for a set of rules
 type ErrNoApprover struct {
 	Fields []string
@@ -140,7 +131,7 @@ func (e ErrRuleLoad) Type() RuleLoadErrType {
 	}
 
 	switch e.Err.(type) {
-	case *ErrValueTypeUnknown, *ErrRuleSyntax, *ErrFieldNotAvailable:
+	case *ErrRuleSyntax, *ErrFieldNotAvailable:
 		return SyntaxErrType
 	}
 

--- a/pkg/security/secl/rules/errors.go
+++ b/pkg/security/secl/rules/errors.go
@@ -79,8 +79,12 @@ type ErrMacroLoad struct {
 	Err   error
 }
 
-func (e ErrMacroLoad) Error() string {
+func (e *ErrMacroLoad) Error() string {
 	return fmt.Sprintf("macro `%s` definition error: %s", e.Macro.Def.ID, e.Err)
+}
+
+func (e *ErrMacroLoad) Unwrap() error {
+	return e.Err
 }
 
 // ErrRuleLoad is on rule definition error

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -2088,7 +2088,7 @@ func TestLoadPolicy(t *testing.T) {
 			},
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
-				return assert.EqualError(t, err, ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`EOF`)}.Error())
+				return assert.Error(t, err, &ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`EOF`)})
 			},
 		},
 		{
@@ -2104,7 +2104,7 @@ func TestLoadPolicy(t *testing.T) {
 			},
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
-				return assert.EqualError(t, err, ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`EOF`)}.Error())
+				return assert.Error(t, err, &ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`EOF`)})
 			},
 		},
 		{
@@ -2144,7 +2144,7 @@ broken
 			},
 			want: nil,
 			wantErr: func(t assert.TestingT, err error, _ ...interface{}) bool {
-				return assert.ErrorContains(t, err, ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`yaml: unmarshal error`)}.Error())
+				return assert.ErrorContains(t, err, (&ErrPolicyLoad{Name: "myLocal.policy", Source: PolicyProviderTypeRC, Err: fmt.Errorf(`yaml: unmarshal error`)}).Error())
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

The error types from the secl library are currently not great for `errors.As` and `errors.Is` usage because they are sometimes used as pointers, sometimes used as the struct directly and the `Error()` method is sometimes defined on the struct receiver and sometimes on the pointer receiver.

This PR cleans this up by ensuring all usage of all structs are always using the same way (in most case pointers).
This PR also adds a few missing `.Unwrap()` methods, and removed a few unused structs.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->