### PR TITLE
[EBPF] gpu: use common timestamp for reporting metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -155,6 +155,8 @@ func (c *Check) Cancel() {
 
 // Run executes the check
 func (c *Check) Run() error {
+	currentExecutionTime := time.Now()
+
 	snd, err := c.GetSender()
 	if err != nil {
 		return fmt.Errorf("get metric sender: %w", err)
@@ -178,7 +180,7 @@ func (c *Check) Run() error {
 	// metrics with the tags of containers that are using them
 	gpuToContainersMap := c.getGPUToContainersMap()
 
-	if err := c.emitMetrics(snd, gpuToContainersMap); err != nil && logLimitCheck.ShouldLog() {
+	if err := c.emitMetrics(snd, gpuToContainersMap, currentExecutionTime); err != nil && logLimitCheck.ShouldLog() {
 		log.Warnf("error while sending gpu metrics: %s", err)
 	}
 
@@ -216,7 +218,7 @@ type deviceMetricsCollection struct {
 	totalCount       int                                      // total number of metrics across all collectors
 }
 
-func (c *Check) emitMetrics(snd sender.Sender, gpuToContainersMap map[string]*workloadmeta.Container) error {
+func (c *Check) emitMetrics(snd sender.Sender, gpuToContainersMap map[string]*workloadmeta.Container, currentExecutionTime time.Time) error {
 	err := c.ensureInitCollectors()
 	if err != nil {
 		return fmt.Errorf("failed to initialize NVML collectors: %w", err)
@@ -284,14 +286,20 @@ func (c *Check) emitMetrics(snd sender.Sender, gpuToContainersMap map[string]*wo
 			metricName := gpuMetricsNs + metric.Name
 			allTags := append(append(c.deviceTags[deviceUUID], containerTags...), metric.Tags...)
 
+			// Use the current execution time as the timestamp for the metrics, that way we can ensure that the metrics are aligned with the check interval.
+			// We need this to ensure weighted metrics are calibrated correctly.
 			switch metric.Type {
 			case ddmetrics.CountType:
-				snd.Count(metricName, metric.Value, "", allTags)
+				err = snd.CountWithTimestamp(metricName, metric.Value, "", allTags, float64(currentExecutionTime.UnixNano())/float64(time.Second))
 			case ddmetrics.GaugeType:
-				snd.Gauge(metricName, metric.Value, "", allTags)
+				err = snd.GaugeWithTimestamp(metricName, metric.Value, "", allTags, float64(currentExecutionTime.UnixNano())/float64(time.Second))
 			default:
 				multiErr = multierror.Append(multiErr, fmt.Errorf("unsupported metric type %s for metric %s", metric.Type, metricName))
 				continue
+			}
+
+			if err != nil {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("error sending metric %s: %w", metricName, err))
 			}
 		}
 	}

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -10,6 +10,7 @@ package gpu
 import (
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -89,7 +90,9 @@ func TestEmitNvmlMetrics(t *testing.T) {
 	}
 
 	// Process the metrics
-	err := check.emitMetrics(mockSender, gpuToContainersMap)
+	metricTime := time.Now()
+	metricTimestamp := float64(metricTime.UnixNano())
+	err := check.emitMetrics(mockSender, gpuToContainersMap, metricTime)
 	assert.NoError(t, err)
 
 	// Verify metrics for each device
@@ -114,13 +117,13 @@ func TestEmitNvmlMetrics(t *testing.T) {
 
 		// Verify metrics for this device
 		// metric1: only from device collector (priority 0)
-		mockSender.AssertCalled(t, "Gauge", "gpu.metric1", float64(metricValueBase+1), "", mock.MatchedBy(matchTagsFunc))
+		mockSender.AssertCalled(t, "GaugeWithTimestamp", "gpu.metric1", float64(metricValueBase+1), "", mock.MatchedBy(matchTagsFunc), metricTimestamp)
 
 		// metric2: priority 1 wins (from fields collector)
-		mockSender.AssertCalled(t, "Gauge", "gpu.metric2", float64(metricValueBase+2), "", mock.MatchedBy(matchTagsFunc))
+		mockSender.AssertCalled(t, "GaugeWithTimestamp", "gpu.metric2", float64(metricValueBase+2), "", mock.MatchedBy(matchTagsFunc), metricTimestamp)
 
 		// metric3: only from fields collector (priority 1)
-		mockSender.AssertCalled(t, "Gauge", "gpu.metric3", float64(metricValueBase+3), "", mock.MatchedBy(matchTagsFunc))
+		mockSender.AssertCalled(t, "GaugeWithTimestamp", "gpu.metric3", float64(metricValueBase+3), "", mock.MatchedBy(matchTagsFunc), metricTimestamp)
 	}
 }
 

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -91,7 +91,7 @@ func TestEmitNvmlMetrics(t *testing.T) {
 
 	// Process the metrics
 	metricTime := time.Now()
-	metricTimestamp := float64(metricTime.UnixNano())
+	metricTimestamp := float64(metricTime.UnixNano()) / float64(time.Second)
 	err := check.emitMetrics(mockSender, gpuToContainersMap, metricTime)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

This PR changes the GPU check to emit metrics with the timestamp of the time the check started to execute.

### Motivation

We have been seeing issues with a weighted metric not being calibrated correctly, and the issue seems to come from the GPU check not executing with a consistent timing. This will mitigate the issue, as the reporting time will be the same as the schedule time.

Related to https://datadoghq.atlassian.net/browse/EBPF-794

### Describe how you validated your changes

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Included tests, manually validated in ddev.

### Possible Drawbacks / Trade-offs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->