### PR TITLE
sender: add comment specifying unit of timestamp

### DIFF
--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -313,6 +313,7 @@ func (s *checkSender) Distribution(metric string, value float64, hostname string
 // GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.
 // Gauge time series measure a simple value over time.
 // Unlike Gauge(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.
+// The timestamp is in seconds since epoch (accepts fractional seconds)
 func (s *checkSender) GaugeWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error {
 	if timestamp <= 0 {
 		return fmt.Errorf("invalid timestamp")
@@ -324,6 +325,7 @@ func (s *checkSender) GaugeWithTimestamp(metric string, value float64, hostname 
 // CountWithTimestamp reports a new count value to the intake with the given timestamp.
 // Count time series measure how many times something happened in some time period.
 // Unlike Count(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.
+// The timestamp is in seconds since epoch (accepts fractional seconds)
 func (s *checkSender) CountWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error {
 	if timestamp <= 0 {
 		return fmt.Errorf("invalid timestamp")

--- a/pkg/aggregator/sender/sender.go
+++ b/pkg/aggregator/sender/sender.go
@@ -32,10 +32,12 @@ type Sender interface {
 	// GaugeWithTimestamp reports a new gauge value to the intake with the given timestamp.
 	// Gauge time series measure a simple value over time.
 	// Unlike Gauge(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.
+	// The timestamp is in seconds since epoch (accepts fractional seconds)
 	GaugeWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error
 	// CountWithTimestamp reports a new count value to the intake with the given timestamp.
 	// Count time series measure how many times something happened in some time period.
 	// Unlike Count(), each submitted value will be passed to the intake as is, without aggregation. Each time series can have only one value per timestamp.
+	// The timestamp is in seconds since epoch (accepts fractional seconds)
 	CountWithTimestamp(metric string, value float64, hostname string, tags []string, timestamp float64) error
 	Event(e event.Event)
 	EventPlatformEvent(rawEvent []byte, eventType string)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -102,7 +102,7 @@ type MetricSample struct {
 	Tags            []string
 	Host            string
 	SampleRate      float64
-	Timestamp       float64
+	Timestamp       float64 // Seconds since epoch (accepts fractional seconds)
 	FlushFirstValue bool
 	OriginInfo      taggertypes.OriginInfo
 	ListenerID      string


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a comment to specify the unit expected in the timestamp variable in the `sender.{Count,Gauge}WithTimestamp` functions.

### Motivation

Avoid confusion when using these functions.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

No code change to test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->