### PR TITLE
[CONTINT-4735]: Add pod termination duration metric to kubelet check

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -49,6 +49,8 @@ type Provider struct {
 	config      *common.KubeletConfig
 	podUtils    *common.PodUtils
 	tagger      tagger.Component
+	// now timer func is used to mock time in tests
+	now func() time.Time
 }
 
 // NewProvider returns a new Provider
@@ -58,6 +60,7 @@ func NewProvider(filterStore workloadfilter.Component, config *common.KubeletCon
 		config:      config,
 		podUtils:    podUtils,
 		tagger:      tagger,
+		now:         time.Now,
 	}
 }
 
@@ -187,7 +190,7 @@ func (p *Provider) generatePodTerminationMetric(sender sender.Sender, pod *kubel
 		return
 	}
 
-	dur := time.Since(*pod.Metadata.DeletionTimestamp)
+	dur := p.now().Sub(*pod.Metadata.DeletionTimestamp)
 
 	// While DeletionTimestamp is in the future metric is not emitted.
 	if dur < 0 {

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -117,6 +117,9 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 			p.generateContainerSpecMetrics(sender, pod, &container, &cStatus, cID)
 			p.generateContainerStatusMetrics(sender, pod, &container, &cStatus, cID)
 		}
+
+		p.generatePodTerminationMetric(sender, pod)
+
 		runningAggregator.recordPod(p, pod)
 	}
 	runningAggregator.generateRunningAggregatorMetrics(sender)
@@ -175,6 +178,32 @@ func (p *Provider) generateContainerStatusMetrics(sender sender.Sender, pod *kub
 			sender.Gauge(common.KubeletMetricsPrefix+"containers."+key+".waiting", 1, "", waitTags)
 		}
 	}
+}
+
+func (p *Provider) generatePodTerminationMetric(sender sender.Sender, pod *kubelet.Pod) {
+	// This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client.
+	// If there is no DeletionTimestamp then POD is not in Termination and no metric is needed.
+	if pod.Metadata.DeletionTimestamp == nil {
+		return
+	}
+
+	dur := time.Since(*pod.Metadata.DeletionTimestamp)
+
+	// While DeletionTimestamp is in the future metric is not emitted.
+	if dur < 0 {
+		return
+	}
+
+	podID := pod.Metadata.UID
+	if podID == "" {
+		log.Debug("skipping pod with no uid for termination metric, duration: %f", dur.Seconds())
+		return
+	}
+	entityID := types.NewEntityID(types.KubernetesPodUID, podID)
+	tagList, _ := p.tagger.Tag(entityID, types.LowCardinality)
+	tagList = utils.ConcatenateTags(tagList, p.config.Tags)
+
+	sender.Gauge(common.KubeletMetricsPrefix+"pod.terminating.duration", float64(dur.Seconds()), "", tagList)
 }
 
 type runningAggregator struct {

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
@@ -149,12 +150,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 	mockConfig.SetWithoutSource("container_exclude", "name:agent-excluded")
 	mockFilterStore := workloadfilterfxmock.SetupMockFilter(suite.T())
 
-	suite.provider = &Provider{
-		config:      config,
-		filterStore: mockFilterStore,
-		podUtils:    common.NewPodUtils(fakeTagger),
-		tagger:      fakeTagger,
-	}
+	suite.provider = NewProvider(mockFilterStore, config, common.NewPodUtils(fakeTagger), fakeTagger)
 }
 
 func (suite *ProviderTestSuite) TearDownTest() {
@@ -308,4 +304,38 @@ func (suite *ProviderTestSuite) TestNoMetricNoKubeletData() {
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:prometheus-to-sd-exporter-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "pod_name:demo-app-success-c485bc67b-klj45-no-namespace"))
 	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"containers.running", append(config.Tags, "kube_container_name:fluentd-gcp-no-namespace", "kube_deployment:fluentd-gcp-v2.0.10"))
+}
+
+func (suite *ProviderTestSuite) TestNoPodMetricsIfDurationIsNegative() {
+	// termination time: 2018-02-14T14:57:17Z
+	err := suite.dummyKubelet.loadPodList("../../testdata/pods_termination.json")
+	require.Nil(suite.T(), err)
+	config := suite.provider.config
+
+	suite.provider.now = func() time.Time {
+		t, _ := time.Parse(time.RFC3339, "2018-02-14T10:57:17Z")
+		return t
+	}
+
+	err = suite.provider.Provide(suite.kubeUtil, suite.mockSender)
+	require.Nil(suite.T(), err)
+	// ensure that metrics are not emitted when there are no kubelet tags
+	suite.mockSender.AssertMetricNotTaggedWith(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.terminating.duration", config.Tags)
+}
+
+func (suite *ProviderTestSuite) TestPodMetricsIfDurationIsPositive() {
+	// termination time: 2018-02-14T14:57:17Z
+	err := suite.dummyKubelet.loadPodList("../../testdata/pods_termination.json")
+	require.Nil(suite.T(), err)
+	config := suite.provider.config
+
+	suite.provider.now = func() time.Time {
+		t, _ := time.Parse(time.RFC3339, "2018-02-15T14:57:17Z")
+		return t
+	}
+
+	err = suite.provider.Provide(suite.kubeUtil, suite.mockSender)
+	require.Nil(suite.T(), err)
+	// ensure that metrics are not emitted when there are no kubelet tags
+	suite.mockSender.AssertMetric(suite.T(), "Gauge", common.KubeletMetricsPrefix+"pod.terminating.duration", 86400, "", config.Tags)
 }

--- a/pkg/collector/corechecks/containers/kubelet/testdata/pods_termination.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/pods_termination.json
@@ -1,0 +1,332 @@
+{
+  "items": [
+    {
+      "status": {
+        "qosClass": "Burstable",
+        "containerStatuses": [
+          {
+            "restartCount": 0,
+            "name": "fluentd-gcp",
+            "image": "asia.gcr.io/google-containers/fluentd-gcp:2.0.10",
+            "imageID": "docker-pullable://asia.gcr.io/google-containers/fluentd-gcp@sha256:a81a2c0137aee9f8a3e870898773976df9b63b27809bed2a4b9297531fb3c3c9",
+            "state": {
+              "running": {
+                "startedAt": "2018-02-13T16:10:45Z"
+              }
+            },
+            "ready": true,
+            "lastState": {},
+            "containerID": "docker://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561"
+          },
+          {
+            "restartCount": 0,
+            "name": "prometheus-to-sd-exporter",
+            "image": "asia.gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+            "imageID": "docker-pullable://asia.gcr.io/google-containers/prometheus-to-sd@sha256:5831390762c790b0375c202579fd41dd5f40c71950f7538adbe14b0c16f35d56",
+            "state": {
+              "running": {
+                "startedAt": "2018-02-13T16:10:46Z"
+              }
+            },
+            "ready": true,
+            "lastState": {},
+            "containerID": "docker://580cb469826a10317fd63cc780441920f49913ae63918d4c7b19a72347645b05"
+          }
+        ],
+        "initContainerStatuses": [
+          {
+            "name": "init",
+            "state": {
+              "terminated": {
+                "exitCode": 0,
+                "startedAt": "2024-02-27T19:30:39Z",
+                "finishedAt": "2024-02-27T19:30:49Z",
+                "reason": "Completed",
+                "containerID": "docker://1d1f139dc1c9d49010512744df34740abcfaadf9930d3afd85afbf5fccfadbd6"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "docker.io/library/alpine:latest",
+            "imageID": "docker.io/library/alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b",
+            "containerID": "docker://1d1f139dc1c9d49010512744df34740abcfaadf9930d3afd85afbf5fccfadbd6",
+            "started": false
+          }
+        ],
+        "podIP": "10.8.2.4",
+        "startTime": "2018-02-13T14:57:17Z",
+        "hostIP": "10.132.0.4",
+        "phase": "Running",
+        "conditions": [
+          {
+            "status": "True",
+            "lastProbeTime": null,
+            "type": "Initialized",
+            "lastTransitionTime": "2018-02-13T14:57:17Z"
+          },
+          {
+            "status": "True",
+            "lastProbeTime": null,
+            "type": "Ready",
+            "lastTransitionTime": "2018-02-13T16:10:47Z"
+          },
+          {
+            "status": "True",
+            "lastProbeTime": null,
+            "type": "PodScheduled",
+            "lastTransitionTime": "2018-02-13T14:57:27Z"
+          }
+        ]
+      },
+      "spec": {
+        "dnsPolicy": "Default",
+        "securityContext": {},
+        "serviceAccountName": "fluentd-gcp",
+        "schedulerName": "default-scheduler",
+        "serviceAccount": "fluentd-gcp",
+        "nodeSelector": {
+          "beta.kubernetes.io/fluentd-ds-ready": "true"
+        },
+        "terminationGracePeriodSeconds": 30,
+        "restartPolicy": "Always",
+        "volumes": [
+          {
+            "hostPath": {
+              "path": "/var/log",
+              "type": ""
+            },
+            "name": "varlog"
+          },
+          {
+            "hostPath": {
+              "path": "/var/lib/docker/containers",
+              "type": ""
+            },
+            "name": "varlibdockercontainers"
+          },
+          {
+            "hostPath": {
+              "path": "/usr/lib64",
+              "type": ""
+            },
+            "name": "libsystemddir"
+          },
+          {
+            "configMap": {
+              "name": "fluentd-gcp-config-v1.2.3",
+              "defaultMode": 420
+            },
+            "name": "config-volume"
+          },
+          {
+            "secret": {
+              "defaultMode": 420,
+              "secretName": "fluentd-gcp-token-vcd8d"
+            },
+            "name": "fluentd-gcp-token-vcd8d"
+          }
+        ],
+        "tolerations": [
+          {
+            "effect": "NoSchedule",
+            "key": "node.alpha.kubernetes.io/ismaster"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/not-ready"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "key": "node.kubernetes.io/unreachable"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoSchedule",
+            "key": "node.kubernetes.io/disk-pressure"
+          },
+          {
+            "operator": "Exists",
+            "effect": "NoSchedule",
+            "key": "node.kubernetes.io/memory-pressure"
+          }
+        ],
+        "containers": [
+          {
+            "livenessProbe": {
+              "timeoutSeconds": 1,
+              "exec": {
+                "command": [
+                  "/bin/sh",
+                  "-c",
+                  "LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-buffers ]; then\n  exit 1;\nfi; LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r \"s/Modify: (.*)/\\1/\"`; LAST_MODIFIED_TIMESTAMP=`date -d \"$LAST_MODIFIED_DATE\" +%s`; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ]; then\n  rm -rf /var/log/fluentd-buffers;\n  exit 1;\nfi; if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then\n  exit 1;\nfi;\n"
+                ]
+              },
+              "initialDelaySeconds": 600,
+              "periodSeconds": 60,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "name": "fluentd-gcp",
+            "image": "gcr.io/google-containers/fluentd-gcp:2.0.10",
+            "volumeMounts": [
+              {
+                "mountPath": "/var/log",
+                "name": "varlog"
+              },
+              {
+                "readOnly": true,
+                "mountPath": "/var/lib/docker/containers",
+                "name": "varlibdockercontainers"
+              },
+              {
+                "readOnly": true,
+                "mountPath": "/host/lib",
+                "name": "libsystemddir"
+              },
+              {
+                "mountPath": "/etc/fluent/config.d",
+                "name": "config-volume"
+              },
+              {
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "fluentd-gcp-token-vcd8d"
+              }
+            ],
+            "terminationMessagePolicy": "File",
+            "env": [
+              {
+                "name": "FLUENTD_ARGS",
+                "value": "--no-supervisor -q"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent",
+            "resources": {
+              "requests": {
+                "cpu": "100m",
+                "memory": "200Mi"
+              },
+              "limits": {
+                "memory": "300Mi"
+              }
+            }
+          },
+          {
+            "terminationMessagePath": "/dev/termination-log",
+            "name": "prometheus-to-sd-exporter",
+            "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.2",
+            "volumeMounts": [
+              {
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "fluentd-gcp-token-vcd8d"
+              }
+            ],
+            "terminationMessagePolicy": "File",
+            "command": [
+              "/monitor",
+              "--stackdriver-prefix=container.googleapis.com/internal/addons",
+              "--api-override=https://monitoring.googleapis.com/",
+              "--source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count",
+              "--pod-id=$(POD_NAME)",
+              "--namespace-id=$(POD_NAMESPACE)"
+            ],
+            "env": [
+              {
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name",
+                    "apiVersion": "v1"
+                  }
+                },
+                "name": "POD_NAME"
+              },
+              {
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace",
+                    "apiVersion": "v1"
+                  }
+                },
+                "name": "POD_NAMESPACE"
+              }
+            ],
+            "imagePullPolicy": "IfNotPresent",
+            "resources": {}
+          }
+        ],
+        "initContainers": [
+          {
+            "terminationMessagePath": "/dev/termination-log",
+            "name": "init",
+            "image": "alpine:latest",
+            "terminationMessagePolicy": "File",
+            "command": [
+              "/bin/sh",
+              "-c",
+              "sleep 10s"
+            ],
+            "imagePullPolicy": "IfNotPresent",
+            "resources": {
+              "requests": {
+                "cpu": "50m",
+                "memory": "100Mi"
+              },
+              "limits": {
+                "memory": "150Mi"
+              }
+            }
+          }
+        ],
+        "nodeName": "gke-haissam-default-pool-be5066f1-wnvn"
+      },
+      "metadata": {
+        "name": "fluentd-gcp-v2.0.10-9q9t4",
+        "labels": {
+          "k8s-app": "fluentd-gcp",
+          "version": "v2.0.10",
+          "pod-template-generation": "1",
+          "kubernetes.io/cluster-service": "true",
+          "controller-revision-hash": "1108666223"
+        },
+        "namespace": "kube-system",
+        "ownerReferences": [
+          {
+            "kind": "DaemonSet",
+            "name": "fluentd-gcp-v2.0.10",
+            "apiVersion": "extensions/v1beta1",
+            "controller": true,
+            "blockOwnerDeletion": true,
+            "uid": "77585C76-10CC-4A58-BB7F-5839C8FC1587"
+          }
+        ],
+        "resourceVersion": "30704838",
+        "generateName": "fluentd-gcp-v2.0.10-",
+        "creationTimestamp": "2018-02-13T14:57:17Z",
+        "deletionTimestamp": "2018-02-14T14:57:17Z",
+        "annotations": {
+          "scheduler.alpha.kubernetes.io/critical-pod": "",
+          "kubernetes.io/config.source": "api",
+          "kubernetes.io/config.seen": "2018-02-13T16:10:19.509264637Z"
+        },
+        "selfLink": "/api/v1/namespaces/kube-system/pods/fluentd-gcp-v2.0.10-9q9t4",
+        "uid": "2C3A06E9-5E74-4A58-BB7F-5839C8FC1587"
+      }
+    }
+  ],
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {}
+}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -36,6 +36,7 @@ type PodMetadata struct {
 	Labels            map[string]string `json:"labels,omitempty"`
 	Owners            []PodOwner        `json:"ownerReferences,omitempty"`
 	CreationTimestamp time.Time         `json:"creationTimestamp,omitempty"`
+	DeletionTimestamp *time.Time        `json:"deletionTimestamp,omitempty"`
 }
 
 // PodOwner contains fields for unmarshalling a Pod.Metadata.Owners

--- a/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
+++ b/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
@@ -9,5 +9,4 @@
 enhancements:
   - |
     Add the new metric `kubernetes.pod.terminating.duration` to kubelet check to track pods
-    that are stuck in the termination phase. The metric will be emitted after resource `deletionTimestamp`
-    is in the past relative to now.
+    that are stuck in the termination phase. If `deletionTimestamp` is set to a time in the future,`kubernetes.pod.terminating.duration` is only emitted when the current time reaches the time set in `deletionTimestamp`.

--- a/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
+++ b/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Add new metric `kubernetes.pod.terminating.duration` to kubelet check to track PODs
-    that are stuck in Termination phase. Metric will be emitted once resource `deletionTimestamp`
+    Add the new metric `kubernetes.pod.terminating.duration` to kubelet check to track pods
+    that are stuck in the termination phase. The metric will be emitted after resource `deletionTimestamp`
     is in the past relative to now.

--- a/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
+++ b/releasenotes/notes/add-pod-termination-duration-metric-8827f349dd3cc15b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add new metric `kubernetes.pod.terminating.duration` to kubelet check to track PODs
+    that are stuck in Termination phase. Metric will be emitted once resource `deletionTimestamp`
+    is in the past relative to now.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add `kubernetes.pod.terminating.duration` metric to highlight the PODs that stuck beyond `deletionTimestamp` in Termination phase.
Metric is only emitted if `deletionTimestamp` is present and before Now().

### Motivation
Required in order to monitor POD that hang in Termination stage for a long time

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

1. Create Kind cluster: `kind create cluster --config config.yaml -n kind-4735`
config.yaml:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
  - role: worker
  - role: worker
```
2. Build agent change in dev container: `inv agent.hacky-dev-image-build`
3. Load the image to the cluster: `kind load docker-image testload:latest -n kind-4735`
4. Deploy agent using helm: `helm install ddtest datadog/datadog -f agent-values.yaml`
5. Make a test deployment with POD spec containing a finilizer:
```yaml
spec:
  template:
    metadata:
      finalizers:
        - example.com/my-finalizer
```
6. Delete successfully deployed testload POD and expect metric to appear after grace peroid
![Screenshot 2025-08-12 at 16 27 17](https://github.com/user-attachments/assets/26471608-d197-4962-818d-2dbaf9259cf4)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->