### PR TITLE
Add support for discovery section in autodiscovery config files

### DIFF
--- a/comp/core/autodiscovery/discovery/discovery.go
+++ b/comp/core/autodiscovery/discovery/discovery.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package discovery provides discovery information storage and lookup for autodiscovery.
+package discovery
+
+import (
+	"sync"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Info contains the discovery information parsed from configuration files
+type Info struct {
+	LogSource string `yaml:"log_source,omitempty"`
+}
+
+// Registry stores discovery information indexed by AD identifiers
+type Registry struct {
+	mu           sync.RWMutex
+	discoveryMap map[string]Info
+}
+
+var registry *Registry
+var registryOnce sync.Once
+
+// GetRegistry returns the singleton discovery registry
+func GetRegistry() *Registry {
+	registryOnce.Do(func() {
+		registry = &Registry{
+			discoveryMap: make(map[string]Info),
+		}
+	})
+	return registry
+}
+
+// RegisterConfig registers discovery information from a configuration
+func (r *Registry) RegisterConfig(config integration.Config) {
+	if config.DiscoveryConfig == nil {
+		return
+	}
+
+	var discoveryInfo Info
+	if err := yaml.Unmarshal(config.DiscoveryConfig, &discoveryInfo); err != nil {
+		log.Warnf("Failed to parse discovery config for %s: %v", config.Name, err)
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, identifier := range config.ADIdentifiers {
+		if identifier != "" {
+			r.discoveryMap[identifier] = discoveryInfo
+			log.Debugf("Registered discovery info for identifier '%s': log_source=%s", identifier, discoveryInfo.LogSource)
+		}
+	}
+}
+
+// GetLogSource returns the configured log source for the given AD identifier
+func (r *Registry) GetLogSource(identifier string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	info, exists := r.discoveryMap[identifier]
+	if !exists || info.LogSource == "" {
+		return "", false
+	}
+	return info.LogSource, true
+}
+
+// Reset clears all registered discovery information
+func (r *Registry) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.discoveryMap = make(map[string]Info)
+}

--- a/comp/core/autodiscovery/discovery/discovery_test.go
+++ b/comp/core/autodiscovery/discovery/discovery_test.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistry_RegisterConfig(t *testing.T) {
+	registry := &Registry{
+		discoveryMap: make(map[string]Info),
+	}
+
+	tests := []struct {
+		name   string
+		config integration.Config
+		want   map[string]Info
+	}{
+		{
+			name: "register config with discovery info",
+			config: integration.Config{
+				Name:            "postgres",
+				ADIdentifiers:   []string{"postgres", "postgresql"},
+				DiscoveryConfig: []byte(`{"log_source": "postgresql"}`),
+			},
+			want: map[string]Info{
+				"postgres":   {LogSource: "postgresql"},
+				"postgresql": {LogSource: "postgresql"},
+			},
+		},
+		{
+			name: "register config with YAML discovery info",
+			config: integration.Config{
+				Name:            "redis",
+				ADIdentifiers:   []string{"redis"},
+				DiscoveryConfig: []byte(`log_source: redis-server`),
+			},
+			want: map[string]Info{
+				"redis": {LogSource: "redis-server"},
+			},
+		},
+		{
+			name: "register config without discovery info",
+			config: integration.Config{
+				Name:          "nginx",
+				ADIdentifiers: []string{"nginx"},
+			},
+			want: map[string]Info{},
+		},
+		{
+			name: "register config with empty discovery info",
+			config: integration.Config{
+				Name:            "mysql",
+				ADIdentifiers:   []string{"mysql"},
+				DiscoveryConfig: []byte(`{}`),
+			},
+			want: map[string]Info{
+				"mysql": {LogSource: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry.Reset()
+			registry.RegisterConfig(tt.config)
+			assert.Equal(t, tt.want, registry.discoveryMap)
+		})
+	}
+}
+
+func TestRegistry_GetLogSource(t *testing.T) {
+	registry := &Registry{
+		discoveryMap: map[string]Info{
+			"postgres": {LogSource: "postgresql"},
+			"redis":    {LogSource: "redis-server"},
+			"empty":    {LogSource: ""},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		identifier string
+		want       string
+		wantExists bool
+	}{
+		{
+			name:       "get existing log source",
+			identifier: "postgres",
+			want:       "postgresql",
+			wantExists: true,
+		},
+		{
+			name:       "get another existing log source",
+			identifier: "redis",
+			want:       "redis-server",
+			wantExists: true,
+		},
+		{
+			name:       "get non-existent identifier",
+			identifier: "nginx",
+			want:       "",
+			wantExists: false,
+		},
+		{
+			name:       "get identifier with empty log source",
+			identifier: "empty",
+			want:       "",
+			wantExists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, exists := registry.GetLogSource(tt.identifier)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantExists, exists)
+		})
+	}
+}
+
+func TestRegistry_Reset(t *testing.T) {
+	registry := &Registry{
+		discoveryMap: map[string]Info{
+			"postgres": {LogSource: "postgresql"},
+			"redis":    {LogSource: "redis-server"},
+		},
+	}
+
+	registry.Reset()
+	assert.Empty(t, registry.discoveryMap)
+}
+
+func TestGetRegistry_Singleton(t *testing.T) {
+	reg1 := GetRegistry()
+	reg2 := GetRegistry()
+	assert.Same(t, reg1, reg2, "GetRegistry should return the same instance")
+}

--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	// LogsConfig is the logs config in YAML or JSON (logs-agent only)
 	LogsConfig Data `json:"logs"` // (include in digest: true)
 
+	// DiscoveryConfig contains discovery information for autodiscovery
+	DiscoveryConfig Data `json:"discovery"` // (include in digest: false)
+
 	// ADIdentifiers is the list of AutoDiscovery identifiers for this
 	// integration.  If either ADIdentifiers or AdvancedADIdentifiers are
 	// present, then this config is a template and will be resolved when a
@@ -145,6 +148,11 @@ type KubeNamespacedName struct {
 	Namespace string `yaml:"namespace"`
 }
 
+// DiscoveryConfig contains discovery information for autodiscovery
+type DiscoveryConfig struct {
+	LogSource string `yaml:"log_source,omitempty"`
+}
+
 // IsEmpty returns true if the KubeNamespacedName is empty
 func (k KubeNamespacedName) IsEmpty() bool {
 	return k.Name == "" && k.Namespace == ""
@@ -165,6 +173,7 @@ func (c *Config) String() string {
 	var initConfig interface{}
 	var instances []interface{}
 	var logsConfig interface{}
+	var discoveryConfig interface{}
 
 	rawConfig["check_name"] = c.Name
 
@@ -180,6 +189,9 @@ func (c *Config) String() string {
 
 	yaml.Unmarshal(c.LogsConfig, &logsConfig) //nolint:errcheck
 	rawConfig["logs_config"] = logsConfig
+
+	yaml.Unmarshal(c.DiscoveryConfig, &discoveryConfig) //nolint:errcheck
+	rawConfig["discovery"] = discoveryConfig
 
 	buffer, err := yaml.Marshal(&rawConfig)
 	if err != nil {
@@ -464,6 +476,7 @@ func (c *Config) Dump(multiline bool) string {
 	fmt.Fprintf(&b, ws("InitConfig: %s,"), dataField(c.InitConfig))
 	fmt.Fprintf(&b, ws("MetricConfig: %s,"), dataField(c.MetricConfig))
 	fmt.Fprintf(&b, ws("LogsConfig: %s,"), dataField(c.LogsConfig))
+	fmt.Fprintf(&b, ws("DiscoveryConfig: %s,"), dataField(c.DiscoveryConfig))
 	fmt.Fprintf(&b, ws("ADIdentifiers: %#v,"), c.ADIdentifiers)
 	fmt.Fprintf(&b, ws("AdvancedADIdentifiers: %#v,"), c.AdvancedADIdentifiers)
 	fmt.Fprintf(&b, ws("Provider: %#v,"), c.Provider)

--- a/comp/core/autodiscovery/integration/config_test.go
+++ b/comp/core/autodiscovery/integration/config_test.go
@@ -84,6 +84,7 @@ func TestString(t *testing.T) {
 	config.Instances = []Data{Data("justFoo")}
 
 	expected := `check_name: foo
+discovery: null
 init_config:
   fooBarBaz: test
 instances:

--- a/comp/core/autodiscovery/providers/config_reader_test.go
+++ b/comp/core/autodiscovery/providers/config_reader_test.go
@@ -110,6 +110,21 @@ func TestGetIntegrationConfig(t *testing.T) {
 	config, err = GetIntegrationConfigFromFile("foo", "tests/ad_with_service_id.yaml")
 	assert.Nil(t, err)
 	assert.Empty(t, config.ServiceID)
+
+	// discovery configuration with instances
+	config, err = GetIntegrationConfigFromFile("foo", "tests/discovery.yaml")
+	require.Nil(t, err)
+	assert.Equal(t, config.ADIdentifiers, []string{"postgres"})
+	assert.NotNil(t, config.DiscoveryConfig)
+	assert.Contains(t, string(config.DiscoveryConfig), "postgresql")
+
+	// discovery-only configuration (no instances, init_config)
+	config, err = GetIntegrationConfigFromFile("foo", "tests/discovery_only.yaml")
+	require.Nil(t, err)
+	assert.Equal(t, config.ADIdentifiers, []string{"postgres"})
+	assert.NotNil(t, config.DiscoveryConfig)
+	assert.Contains(t, string(config.DiscoveryConfig), "postgresql")
+	assert.Empty(t, config.Instances)
 }
 
 func TestReadConfigFiles(t *testing.T) {
@@ -118,7 +133,7 @@ func TestReadConfigFiles(t *testing.T) {
 
 	configs, errors, err := ReadConfigFiles(GetAll)
 	require.Nil(t, err)
-	require.Equal(t, 20, len(configs))
+	require.Equal(t, 22, len(configs))
 	require.Equal(t, 4, len(errors))
 
 	for _, c := range configs {
@@ -129,7 +144,7 @@ func TestReadConfigFiles(t *testing.T) {
 
 	configs, _, err = ReadConfigFiles(WithoutAdvancedAD)
 	require.Nil(t, err)
-	require.Equal(t, 18, len(configs))
+	require.Equal(t, 20, len(configs))
 
 	expectedConfig1 := integration.Config{
 		Name: "advanced_ad",

--- a/comp/core/autodiscovery/providers/file.go
+++ b/comp/core/autodiscovery/providers/file.go
@@ -8,6 +8,7 @@ package providers
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/discovery"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
@@ -34,6 +35,12 @@ func (c *FileConfigProvider) Collect(_ context.Context) ([]integration.Config, e
 	configs, errors, err := ReadConfigFiles(WithoutAdvancedAD)
 	if err != nil {
 		return nil, err
+	}
+
+	// Register discovery information from configs
+	discoveryRegistry := discovery.GetRegistry()
+	for _, config := range configs {
+		discoveryRegistry.RegisterConfig(config)
 	}
 
 	c.Errors = errors

--- a/comp/core/autodiscovery/providers/file_test.go
+++ b/comp/core/autodiscovery/providers/file_test.go
@@ -78,11 +78,17 @@ func TestCollect(t *testing.T) {
 	// logs files collected in root directory
 	assert.Equal(t, 1, len(get("logs-agent_only")))
 
+	// discovery configs collected (discovery.yaml and discovery_only.yaml)
+	discoveryConfigs := get("discovery")
+	discoveryOnlyConfigs := get("discovery_only")
+	assert.Equal(t, 1, len(discoveryConfigs))
+	assert.Equal(t, 1, len(discoveryOnlyConfigs))
+
 	// ignored autoconf file not collected
 	assert.Equal(t, 0, len(get("ignored")))
 
 	// total number of configurations found
-	assert.Equal(t, 17, len(configs))
+	assert.Equal(t, 19, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml & ad_deprecated.yaml & null_instances.yml)
 	assert.Equal(t, 4, len(provider.Errors))

--- a/comp/core/autodiscovery/providers/tests/discovery.yaml
+++ b/comp/core/autodiscovery/providers/tests/discovery.yaml
@@ -1,0 +1,6 @@
+ad_identifiers:
+  - postgres
+discovery:
+  log_source: postgresql
+init_config: {}
+instances: []

--- a/comp/core/autodiscovery/providers/tests/discovery_only.yaml
+++ b/comp/core/autodiscovery/providers/tests/discovery_only.yaml
@@ -1,0 +1,4 @@
+ad_identifiers:
+  - postgres
+discovery:
+  log_source: postgresql


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This feature allows customization of default log sources for autodiscovered containers
through a new 'discovery' section in auto_conf.yaml files. This enables mapping
short image names to correct source names (e.g., postgres -> postgresql).

Key changes:
- Add DiscoveryConfig field to integration.Config struct
- Update config parsing to support discovery section in YAML files
- Create discovery.Registry to store and lookup discovery information
- Modify container log source assignment to use discovery configs before falling back to short names
- Support discovery-only config files (no instances/init_config required)
- Maintain existing priority: user config > discovery config > short image name

Example usage:
```yaml
ad_identifiers:
  - postgres
discovery:
  log_source: postgresql
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
