### PR TITLE
incident-41849: disable `TestDiff` inv unit test

### DIFF
--- a/tasks/unit_tests/diff_tests.py
+++ b/tasks/unit_tests/diff_tests.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 from tasks.libs.common.diff import diff
 
 
+# TODO(incident-41849): re-enable this test once macOS runners are back up
+@unittest.SkipTest
 class TestDiff(unittest.TestCase):
     @patch('os.stat')
     @patch('os.path.islink')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This test is currently causing some issues with the `binary` import
```
  File "/Users/ec2-user/builds/S5mXwxTmW/0/DataDog/datadog-agent/tasks/libs/common/diff.py", line 5, in diff
    from binary import convert_units
ModuleNotFoundError: No module named 'binary'
```
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1074701616

Let's skip it while we understand the issue with runners.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->