### PR TITLE
fix noisy logs

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cr.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/cr.go
@@ -96,7 +96,7 @@ func (c *CRCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.Coll
 	if err != nil {
 		return nil, collectors.NewListingError(err)
 	}
-	if len(list) > c.maximumCRDQuota {
+	if !c.metadata.IsGenericCollector && len(list) > c.maximumCRDQuota {
 		return nil, collectors.NewListingError(fmt.Errorf("crd collector %s/%s has reached to the limit %d, skipping it", c.metadata.Version, c.metadata.Name, c.maximumCRDQuota))
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR addresses noisy logs introduced in [#39018](https://github.com/DataDog/datadog-agent/pull/39018).

The endpointSlices collector is a [generic collector](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/generic.go#L43-L57), and it currently has no quota configured. As a result, it generates repetitive log messages like:
```
Collector discovery.k8s.io/v1/endpointslices failed to run: unable to list resources: crd collector discovery.k8s.io/v1/endpointslices has reached the limit 0, skipping it
```
This PR adds a check to detect generic collector and skip the quota check for it.