### PR TITLE
Fix python for awscli on macos

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -66,18 +66,13 @@
   - rm -f dda.tar.gz
   - export PATH="$DDA_DIR:$PATH"
   - dda self dep sync -f legacy-tasks
-  # Install awscli
-  - export AWSCLI_DIR="$TMPDIR/awscli-${CI_JOB_ID}"
+  # Add a shim to make aws work
   - |
-    echo 'Installing AWS CLI...'
-    AWSCLI_VERSION=1.29.45
-    awscli_d="$(mktemp -d)"
-    pushd "$awscli_d"
-    curl -fsSL "https://s3.amazonaws.com/aws-cli/awscli-bundle-$AWSCLI_VERSION.zip" --output bundle.zip
-    unzip bundle.zip
-    $(pyenv root)/versions/datadog-agent-python-3.12.6/bin/python awscli-bundle/install -i $AWSCLI_DIR/installation -b $AWSCLI_DIR/aws
-    popd
-    rm -rv "$awscli_d"
+    AWSCLI_DIR="$TMPDIR/awscli-${CI_JOB_ID}"
+    mkdir -p "$AWSCLI_DIR"
+    install -m 755 /dev/stdin $AWSCLI_DIR/aws <<'EOF'
+    $(pyenv root)/versions/datadog-agent-python-3.12.6/bin/python $(which aws)
+    EOF
   - export PATH="AWSCLI_DIR:$PATH"
 
 .vault_login:

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -66,6 +66,19 @@
   - rm -f dda.tar.gz
   - export PATH="$DDA_DIR:$PATH"
   - dda self dep sync -f legacy-tasks
+  # Install awscli
+  - export AWSCLI_DIR="$TMPDIR/awscli-${CI_JOB_ID}"
+  - |
+    echo 'Installing AWS CLI...'
+    AWSCLI_VERSION=1.29.45
+    awscli_d="$(mktemp -d)"
+    pushd "$awscli_d"
+    curl -fsSL "https://s3.amazonaws.com/aws-cli/awscli-bundle-$AWSCLI_VERSION.zip" --output bundle.zip
+    unzip bundle.zip
+    sudo /usr/local/bin/python"$PYTHON_VERSION" awscli-bundle/install -i $AWSCLI_DIR/installation -b $AWSCLI_DIR/aws
+    popd
+    rm -rv "$awscli_d"
+  - export PATH="AWSCLI_DIR:$PATH"
 
 .vault_login:
   # Point the CLI to our internal vault

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -75,7 +75,7 @@
     pushd "$awscli_d"
     curl -fsSL "https://s3.amazonaws.com/aws-cli/awscli-bundle-$AWSCLI_VERSION.zip" --output bundle.zip
     unzip bundle.zip
-    sudo /usr/local/bin/python"$PYTHON_VERSION" awscli-bundle/install -i $AWSCLI_DIR/installation -b $AWSCLI_DIR/aws
+    $(pyenv root)/versions/datadog-agent-python-3.12.6/bin/python awscli-bundle/install -i $AWSCLI_DIR/installation -b $AWSCLI_DIR/aws
     popd
     rm -rv "$awscli_d"
   - export PATH="AWSCLI_DIR:$PATH"


### PR DESCRIPTION
### What does this PR do?

It adds a shim to have aws be run with the python where it is installed.

### Motivation

#incident-41849

Originally trying to test something around https://github.com/DataDog/ci-platform-machine-images/pull/393, but that failed and I couldn't get it to work.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

This is not a permanent fix, and should be immediately followed up with a more sensible approach to managing python-based utilities.