### PR TITLE
[incident-41849] Minimal repair for failing macOS jobs (w/o `venv`)

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -35,8 +35,19 @@
     echo "Temporary folder created, TMPDIR=$TMPDIR -> $NEWTMPDIR"
 
 .install_python_dependencies:
-  # Create custom temporary folder to isolate jobs from each other
-  # We have to symlink it to /tmp/gitlabci to avoid some path length issues (sockets should be <= 104 characters on MacOS)
+  - |
+    echo "Setting PYENV_VERSION for aws v1..."
+    [ -n "$PYENV_VERSION" ] && { echo >&2 "❌ Unexpected PYENV_VERSION=$PYENV_VERSION"; exit 1; }
+    export PATH="$(pyenv root)/bin:$PATH"
+    eval "$(pyenv init -)"
+    candidates=($(pyenv versions --bare | grep '^datadog-agent-python'))
+    case "${#candidates[@]}" in
+    1) export PYENV_VERSION="${candidates[0]}"; echo "PYENV_VERSION=$PYENV_VERSION";;
+    0) echo >&2 "❌ No datadog-agent-python* environment found"; exit 1;;
+    *) echo >&2 "❌ Multiple datadog-agent-python* environments found: ${candidates[@]}"; exit 1;;
+    esac
+    which aws
+    cat "$(which aws)"
   - |
     if [ -z "$TMPDIR" ]; then
       echo "TMPDIR must be set" >& 2


### PR DESCRIPTION
### What does this PR do? / Motivation
This is a follow-up of #39719 consisting in restoring the `pyenv` setup for `aws` (still a Python dependency as of v1), but without the mediation of `virtualenv`.

### Motivation
```
/bin/bash: /usr/local/bin/aws: /Users/ec2-user/.venv/bin/python3: bad interpreter: No such file or directory
Encountered a bad command exit code!
Command: 'aws s3 cp s3://dd-ci-artefacts-build-stable/datadog-agent/73380754/agent-version.cache .'
```
See [#incident-41849](https://dd.enterprise.slack.com/archives/C099N2KTA2X) for more details.