### PR TITLE
Allow rc_kubernetes_deploy job to fail

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -25,6 +25,7 @@ rc_kubernetes_deploy:
       optional: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
+  allow_failure: true
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
     SKIP_PLAN_CHECK: "true"

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -25,6 +25,7 @@ rc_kubernetes_deploy:
       optional: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64"]
+  # TODO: @agent-delivery to update this job when concuctor changes are properly verified
   allow_failure: true
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"


### PR DESCRIPTION
### What does this PR do?

This PR sets `allow_failure: true` on `rc_kubernetes_deploy` job.

### Motivation

The last job in the child pipeline created by rc_kubernetes_deploy is manual at the moment. We will clean that soon after enough verification, but for the time being we can allow this to fail.