### PR TITLE
CONTINT-4744 expose init container metrics.

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -95,7 +95,7 @@ func (f *extendedPodFactory) MetricFamilyGenerators() []generator.FamilyGenerato
 			basemetrics.ALPHA,
 			"",
 			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				return f.customResourceOwnerGenerator(p, resourceRequests)
+				return f.customResourceOwnerGenerator(p, resourceRequests, Standard)
 			}),
 		),
 		*generator.NewFamilyGeneratorWithStability(
@@ -105,15 +105,97 @@ func (f *extendedPodFactory) MetricFamilyGenerators() []generator.FamilyGenerato
 			basemetrics.ALPHA,
 			"",
 			wrapPodFunc(func(p *v1.Pod) *metric.Family {
-				return f.customResourceOwnerGenerator(p, resourcelimits)
+				return f.customResourceOwnerGenerator(p, resourcelimits, Standard)
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_pod_init_container_resource_with_owner_tag_requests",
+			"The number of requested request resource by an init container, including pod owner information.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return f.customResourceOwnerGenerator(p, resourceRequests, Init)
+			}),
+		),
+		*generator.NewFamilyGeneratorWithStability(
+			"kube_pod_init_container_resource_with_owner_tag_limits",
+			"The number of requested limit resource by an init container, including pod owner information.",
+			metric.Gauge,
+			basemetrics.ALPHA,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return f.customResourceOwnerGenerator(p, resourcelimits, Init)
 			}),
 		),
 	}
 }
 
+// containerResourceOwnerGenerator builds a metric with for a single container (init or standard) and adds extra tags extracted
+// from the pod spec and the container spec.
+func containerResourceOwnerGenerator(c v1.Container, p *v1.Pod, resourceType string) []*metric.Metric {
+	var resources v1.ResourceList
+	switch resourceType {
+	case resourceRequests:
+		resources = c.Resources.Requests
+	case resourcelimits:
+		resources = c.Resources.Limits
+	default:
+		log.Warnf("unknown resource type requested for pod container resources: %s", resourceType)
+	}
+	var kind, name string
+
+	owners := p.GetOwnerReferences()
+	if len(owners) == 0 {
+		kind = "<none>"
+		name = "<none>"
+	}
+
+	for _, owner := range owners {
+		kind = owner.Kind
+		name = owner.Name
+		if owner.Controller != nil {
+			break
+		}
+	}
+
+	// because of the way we handle aggregation (based on labels), if we want to drop the job / replicaset tag in the
+	// final metric being pushed up, then we should do it here. Otherwise, each job or replicaset will not be combined
+	// properly
+	switch kind {
+	case kubernetes.JobKind:
+		if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
+			kind = kubernetes.CronJobKind
+			name = cronjob
+		}
+	case kubernetes.ReplicaSetKind:
+		if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
+			kind = kubernetes.DeploymentKind
+			name = deployment
+		}
+	}
+
+	ms := []*metric.Metric{}
+	for resourceName, val := range resources {
+		if resourceName == v1.ResourceCPU {
+			ms = append(ms, &metric.Metric{
+				LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore), kind, name},
+				Value:       float64(val.MilliValue()) / 1000,
+			})
+		} else if resourceName == v1.ResourceMemory {
+			ms = append(ms, &metric.Metric{
+				LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte), kind, name},
+				Value:       float64(val.Value()),
+			})
+		}
+	}
+
+	return ms
+}
+
 // customResourceOwnerGenerator is used to generate metrics related to resource requests or limits, tagged by the top-most
 // owner of the pod.
-func (f *extendedPodFactory) customResourceOwnerGenerator(p *v1.Pod, resourceType string) *metric.Family {
+func (f *extendedPodFactory) customResourceOwnerGenerator(p *v1.Pod, resourceType string, contType ContainerType) *metric.Family {
 	// We want to omit pods that have succeeded, as those no longer count towards resource allocation
 	if p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
 		return &metric.Family{}
@@ -121,59 +203,23 @@ func (f *extendedPodFactory) customResourceOwnerGenerator(p *v1.Pod, resourceTyp
 
 	ms := []*metric.Metric{}
 
-	for _, c := range p.Spec.Containers {
-		var resources v1.ResourceList
-		switch resourceType {
-		case resourceRequests:
-			resources = c.Resources.Requests
-		case resourcelimits:
-			resources = c.Resources.Limits
-		default:
-			log.Warnf("unknown resource type requested for pod container resources: %s", resourceType)
-		}
-		var kind, name string
+	// gather the right resources (requests/limits) either for standard container or init containers
+	switch contType {
+	case Standard:
+		for _, c := range p.Spec.Containers {
+			containerMetrics := containerResourceOwnerGenerator(c, p, resourceType)
 
-		owners := p.GetOwnerReferences()
-		if len(owners) == 0 {
-			kind = "<none>"
-			name = "<none>"
+			ms = append(ms, containerMetrics...)
 		}
 
-		for _, owner := range owners {
-			kind = owner.Kind
-			name = owner.Name
-			if owner.Controller != nil {
-				break
-			}
-		}
+	case Init:
+		for _, c := range p.Spec.InitContainers {
+			// we only want the resource for init containers that are configured like a sidecar.
+			// these are identified by: pod.spec.Initcontainer.RestartPolicy == "always"
+			if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyAlways {
+				initContainerMetrics := containerResourceOwnerGenerator(c, p, resourceType)
 
-		// because of the way we handle aggregation (based on labels), if we want to drop the job / replicaset tag in the
-		// final metric being pushed up, then we should do it here. Otherwise, each job or replicaset will not be combined
-		// properly
-		switch kind {
-		case kubernetes.JobKind:
-			if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
-				kind = kubernetes.CronJobKind
-				name = cronjob
-			}
-		case kubernetes.ReplicaSetKind:
-			if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
-				kind = kubernetes.DeploymentKind
-				name = deployment
-			}
-		}
-
-		for resourceName, val := range resources {
-			if resourceName == v1.ResourceCPU {
-				ms = append(ms, &metric.Metric{
-					LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore), kind, name},
-					Value:       float64(val.MilliValue()) / 1000,
-				})
-			} else if resourceName == v1.ResourceMemory {
-				ms = append(ms, &metric.Metric{
-					LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte), kind, name},
-					Value:       float64(val.Value()),
-				})
+				ms = append(ms, initContainerMetrics...)
 			}
 		}
 	}

--- a/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/utils.go
@@ -31,6 +31,14 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/metric"
 )
 
+// ContainerType is an enum to define metric name for container type which can be either init = 'initcontainer' or  standard = 'container'
+type ContainerType string
+
+const (
+	Init     ContainerType = "initcontainer" // Init initcontainer metric name
+	Standard ContainerType = "container"     // Standard standard container name
+)
+
 const networkBandwidthResourceName = "kubernetes.io/network-bandwidth"
 
 var (

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -428,5 +428,19 @@ func defaultMetricAggregators() map[string]metricAggregator {
 			[]string{"namespace", "container", "owner_name", "owner_kind"},
 			[]string{"cpu", "memory", "gpu", "mig"},
 		),
+		"kube_pod_init_container_resource_with_owner_tag_requests": newResourceValuesAggregator(
+			"initcontainer",
+			"requested.total",
+			"kube_pod_init_container_resource_with_owner_tag_requests",
+			[]string{"namespace", "container", "owner_name", "owner_kind"},
+			[]string{"cpu", "memory"},
+		),
+		"kube_pod_init_container_resource_with_owner_tag_limits": newResourceValuesAggregator(
+			"initcontainer",
+			"limit.total",
+			"kube_pod_init_container_resource_with_owner_tag_limits",
+			[]string{"namespace", "container", "owner_name", "owner_kind"},
+			[]string{"cpu", "memory", "gpu", "mig"},
+		),
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -43,6 +43,8 @@ func defaultMetricNamesMapper() map[string]string {
 		"kube_pod_container_status_waiting":                                                        "container.waiting",
 		"kube_pod_init_container_status_waiting":                                                   "initcontainer.waiting",
 		"kube_pod_init_container_status_restarts_total":                                            "initcontainer.restarts",
+		"kube_pod_init_container_status_ready":                                                     "initcontainer.ready",
+		"kube_pod_init_container_status_running":                                                   "initcontainer.running",
 		"kube_persistentvolumeclaim_status_phase":                                                  "persistentvolumeclaim.status",
 		"kube_persistentvolumeclaim_access_mode":                                                   "persistentvolumeclaim.access_mode",
 		"kube_persistentvolumeclaim_resource_requests_storage_bytes":                               "persistentvolumeclaim.request_storage",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	crs "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -93,35 +94,39 @@ func resourceDDName(resource string, allowedResources map[string]struct{}) (ddna
 // For reference see METRIC_TRANSFORMERS in KSM check V1
 func defaultMetricTransformers() map[string]metricTransformerFunc {
 	return map[string]metricTransformerFunc{
-		"kube_pod_created":                              podCreationTransformer,
-		"kube_pod_start_time":                           podStartTimeTransformer,
-		"kube_pod_status_phase":                         podPhaseTransformer,
-		"kube_pod_container_status_waiting_reason":      containerWaitingReasonTransformer,
-		"kube_pod_container_status_terminated_reason":   containerTerminatedReasonTransformer,
-		"kube_pod_container_extended_resource_requests": containerResourceRequestsTransformer,
-		"kube_pod_container_resource_requests":          containerResourceRequestsTransformer,
-		"kube_pod_container_resource_limits":            containerResourceLimitsTransformer,
-		"kube_pod_container_extended_resource_limits":   containerResourceLimitsTransformer,
-		"kube_cronjob_next_schedule_time":               cronJobNextScheduleTransformer,
-		"kube_cronjob_status_last_schedule_time":        cronJobLastScheduleTransformer,
-		"kube_cronjob_status_last_successful_time":      cronJobLastSuccessfulTransformer,
-		"kube_job_complete":                             jobCompleteTransformer,
-		"kube_job_duration":                             jobDurationTransformer,
-		"kube_job_failed":                               jobFailedTransformer,
-		"kube_job_status_failed":                        jobStatusFailedTransformer,
-		"kube_job_status_succeeded":                     jobStatusSucceededTransformer,
-		"kube_node_status_condition":                    nodeConditionTransformer,
-		"kube_node_spec_unschedulable":                  nodeUnschedulableTransformer,
-		"kube_node_status_allocatable":                  nodeAllocatableTransformer,
-		"kube_node_status_extended_allocatable":         nodeAllocatableTransformer,
-		"kube_node_status_capacity":                     nodeCapacityTransformer,
-		"kube_node_status_extended_capacity":            nodeCapacityTransformer,
-		"kube_node_created":                             nodeCreationTransformer,
-		"kube_resourcequota":                            resourcequotaTransformer,
-		"kube_limitrange":                               limitrangeTransformer,
-		"kube_persistentvolume_status_phase":            pvPhaseTransformer,
-		"kube_service_spec_type":                        serviceTypeTransformer,
-		"kube_ingress_tls":                              removeSecretTransformer,
+		"kube_pod_created":                                podCreationTransformer,
+		"kube_pod_start_time":                             podStartTimeTransformer,
+		"kube_pod_status_phase":                           podPhaseTransformer,
+		"kube_pod_container_status_waiting_reason":        containerWaitingReasonTransformer,
+		"kube_pod_container_status_terminated_reason":     containerTerminatedReasonTransformer,
+		"kube_pod_container_extended_resource_requests":   containerResourceRequestsTransformer,
+		"kube_pod_container_resource_requests":            containerResourceRequestsTransformer,
+		"kube_pod_container_resource_limits":              containerResourceLimitsTransformer,
+		"kube_pod_container_extended_resource_limits":     containerResourceLimitsTransformer,
+		"kube_pod_init_container_status_waiting_reason":   initcontainerWaitingReasonTransformer,
+		"kube_pod_initcontainer_status_terminated_reason": initcontainerTerminatedReasonTransformer,
+		"kube_pod_init_container_resource_limits":         initContainerResourceLimitsTransformer,
+		"kube_pod_init_container_resource_requests":       initContainerResourceRequestsTransformer,
+		"kube_cronjob_next_schedule_time":                 cronJobNextScheduleTransformer,
+		"kube_cronjob_status_last_schedule_time":          cronJobLastScheduleTransformer,
+		"kube_cronjob_status_last_successful_time":        cronJobLastSuccessfulTransformer,
+		"kube_job_complete":                               jobCompleteTransformer,
+		"kube_job_duration":                               jobDurationTransformer,
+		"kube_job_failed":                                 jobFailedTransformer,
+		"kube_job_status_failed":                          jobStatusFailedTransformer,
+		"kube_job_status_succeeded":                       jobStatusSucceededTransformer,
+		"kube_node_status_condition":                      nodeConditionTransformer,
+		"kube_node_spec_unschedulable":                    nodeUnschedulableTransformer,
+		"kube_node_status_allocatable":                    nodeAllocatableTransformer,
+		"kube_node_status_extended_allocatable":           nodeAllocatableTransformer,
+		"kube_node_status_capacity":                       nodeCapacityTransformer,
+		"kube_node_status_extended_capacity":              nodeCapacityTransformer,
+		"kube_node_created":                               nodeCreationTransformer,
+		"kube_resourcequota":                              resourcequotaTransformer,
+		"kube_limitrange":                                 limitrangeTransformer,
+		"kube_persistentvolume_status_phase":              pvPhaseTransformer,
+		"kube_service_spec_type":                          serviceTypeTransformer,
+		"kube_ingress_tls":                                removeSecretTransformer,
 	}
 }
 
@@ -258,12 +263,20 @@ var allowedWaitingReasons = map[string]struct{}{
 	"createcontainerconfigerror": {},
 }
 
-// containerWaitingReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_waiting_reason
 func containerWaitingReasonTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerWaitingReasonTransformer(s, metric, hostname, tags, crs.Standard)
+}
+
+func initcontainerWaitingReasonTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerWaitingReasonTransformer(s, metric, hostname, tags, crs.Init)
+}
+
+// containerWaitingReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_waiting_reason
+func submitContainerWaitingReasonTransformer(s sender.Sender, metric ksmstore.DDMetric, hostname string, tags []string, contType crs.ContainerType) {
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedWaitingReasons[strings.ToLower(reason)]; allowed {
-			s.Gauge(ksmMetricPrefix+"container.status_report.count.waiting", metric.Val, hostname, tags)
+			s.Gauge(ksmMetricPrefix+string(contType)+".status_report.count.waiting", metric.Val, hostname, tags)
 		}
 	}
 }
@@ -274,29 +287,47 @@ var allowedTerminatedReasons = map[string]struct{}{
 	"error":              {},
 }
 
-// containerTerminatedReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_terminated_reason
 func containerTerminatedReasonTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerTerminatedReasonTransformer(s, metric, hostname, tags, crs.Standard)
+}
+
+func initcontainerTerminatedReasonTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerTerminatedReasonTransformer(s, metric, hostname, tags, crs.Init)
+}
+
+// submitContainerTerminatedReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_terminated_reason
+func submitContainerTerminatedReasonTransformer(s sender.Sender, metric ksmstore.DDMetric, hostname string, tags []string, contType crs.ContainerType) {
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {
-			s.Gauge(ksmMetricPrefix+"container.status_report.count.terminated", metric.Val, hostname, tags)
+			s.Gauge(ksmMetricPrefix+string(contType)+".status_report.count.terminated", metric.Val, hostname, tags)
 		}
 	}
 }
 
 // containerResourceRequestsTransformer transforms the generic ksm resource request metrics into resource-specific metrics
 func containerResourceRequestsTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	submitContainerResourceMetric(s, name, metric, hostname, tags, "requested")
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "requested", crs.Standard)
 }
 
 // containerResourceLimitsTransformer transforms the generic ksm resource limit metrics into resource-specific metrics
 func containerResourceLimitsTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	submitContainerResourceMetric(s, name, metric, hostname, tags, "limit")
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "limit", crs.Standard)
+}
+
+// initContainerResourceRequestsTransformer transforms the generic ksm resource request metrics into resource-specific metrics
+func initContainerResourceRequestsTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "requested", crs.Init)
+}
+
+// initContainerResourceLimitsTransformer transforms the generic ksm resource limit metrics into resource-specific metrics
+func initContainerResourceLimitsTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	submitContainerResourceMetric(s, name, metric, hostname, tags, "limit", crs.Init)
 }
 
 // submitContainerResourceMetric can be called by container resource metric transformers to submit resource-specific metrics
 // metricSuffix can be either requested or limit
-func submitContainerResourceMetric(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, metricSuffix string) {
+func submitContainerResourceMetric(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, metricSuffix string, contType crs.ContainerType) {
 	resource, found := metric.Labels["resource"]
 	if !found {
 		log.Debugf("Couldn't find 'resource' label, ignoring resource metric '%s'", name)
@@ -305,7 +336,7 @@ func submitContainerResourceMetric(s sender.Sender, name string, metric ksmstore
 
 	if ddname, extraTags, allowed := resourceDDName(resource, containerAllowedResources); allowed {
 		tags = append(tags, extraTags...)
-		s.Gauge(ksmMetricPrefix+"container."+ddname+"_"+metricSuffix, metric.Val, hostname, tags)
+		s.Gauge(ksmMetricPrefix+string(contType)+"."+ddname+"_"+metricSuffix, metric.Val, hostname, tags)
 		return
 	}
 	log.Tracef("Ignoring container resource metric '%s': resource '%s' is not supported", name, resource)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -1840,6 +1840,73 @@ func Test_validateJob(t *testing.T) {
 	}
 }
 
+func Test_initContainerResourceRequestsTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_pod_init_container_resource_requests",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.initcontainer.memory_requested",
+				val:      50000000,
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_pod_init_container_resource_requests",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.initcontainer.cpu_requested",
+				val:      2,
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			currentTime := time.Now()
+			initContainerResourceRequestsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+
+}
+
 func Test_containerResourceRequestsTransformer(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1931,6 +1998,72 @@ func Test_containerResourceRequestsTransformer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			currentTime := time.Now()
 			containerResourceRequestsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
+			if tt.expected != nil {
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertNumberOfCalls(t, "Gauge", 1)
+			} else {
+				s.AssertNotCalled(t, "Gauge")
+			}
+		})
+	}
+}
+
+func Test_initContainerResourceLimitsTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     args
+		expected *metricsExpected
+	}{
+		{
+			name: "memory",
+			args: args{
+				name: "kube_pod_init_container_resource_limits",
+				metric: ksmstore.DDMetric{
+					Val: 50000000,
+					Labels: map[string]string{
+						"resource": "memory",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.initcontainer.memory_limit",
+				val:      50000000,
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+		},
+		{
+			name: "cpu",
+			args: args{
+				name: "kube_pod_init_container_resource_limits",
+				metric: ksmstore.DDMetric{
+					Val: 2,
+					Labels: map[string]string{
+						"resource": "cpu",
+						"unit":     "core",
+					},
+				},
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.initcontainer.cpu_limit",
+				val:      2,
+				tags:     []string{"cluster_name:rick-sanchez"},
+				hostname: "garage",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+		t.Run(tt.name, func(t *testing.T) {
+			currentTime := time.Now()
+			initContainerResourceLimitsTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)

--- a/releasenotes/notes/ksm_init_container_metrics-55cbdd2d620e86dc.yaml
+++ b/releasenotes/notes/ksm_init_container_metrics-55cbdd2d620e86dc.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    gather and expose kubernetes state metrics for init containers.
+    gather and expose init containers resources requests and limits
+    when container is set with `restartPolicy=Always`.


### PR DESCRIPTION
### What does this PR do?

Expose the bellow init container metrics:

- `kube_pod_init_container_status_read`
  - 1 to 1 direct mapping
  - no changes are made from the source metric
- `kube_pod_init_container_status_running`
  - 1 to 1 direct mapping
  - no changes are made from the source metric
- `kube_pod_init_container_status_restarts_total`
  - was already defined and already exposed, nothing to do here
- `kube_pod_init_container_resource_limits`
  - this is generated from a custom resource generator, in order to expose a unified value.
  - this is transformed to expose a metric per allowed resource ('memory','cpu')
- `kube_pod_init_container_resource_requests`
  - this is generated from a custom resource generator, in order to expose a unified value.
  - this is transformed to expose a metric per allowed resource ('memory','cpu')
- `kube_pod_init_container_status_waiting_reason`
  - this is transformed in order to expose a single counter for all waiting reasons.
- `kube_pod_init_container_status_terminated_reason`
  - this is transformed in order to expose a single counter for all termination reasons.

it has been discussed that refactoring the current code to handle init+standard containers is at first glance the simplest way to add init container metrics.

To achieve this a new enum-like type has been added, 2 constants have been created: `Init=initcontainer` and `Standard=container`.

The function `containerResourceOwnerGenerator` contains the common code for standard containers and init containers

The calling function `customResourceOwnerGenerator` will take the decision of taking Resource* metrics for init containers *only* if they are actually sidecars.
We won't collect Resource* metrics for short lived init containers as they will always die before the standard containers start.


### Motivation

### Describe how you validated your changes

ran the agent, check each metrics in the metrics explorer
added basic unit tests.

### Possible Drawbacks / Trade-offs

closes: CONTINT-4744 
