### PR TITLE
[BARX-908] fix image labels on windows agents and cluster-agent

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -58,14 +58,14 @@
     ["setup_agent_version", "windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-${VARIANT} --build-arg BASE_IMAGE_OS='windows nanoserver' --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
   retry: 2
 
 .docker_build_agent7_windows_servercore_common:
   extends:
     - .docker_build_agent7_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg BASE_IMAGE_OS='windows server core' --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
     SERVERCORE: "-servercore"
 
 .docker_build_fips_agent7_windows_common:
@@ -75,13 +75,13 @@
     ["windows_msi_and_bosh_zip_x64-a7-fips", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-fips-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}-fips"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-${VARIANT} --build-arg BASE_IMAGE_OS='windows nanoserver' --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}-fips"
 
 .docker_build_fips_agent7_windows_servercore_common:
   extends:
     - .docker_build_fips_agent7_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}-fips"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg BASE_IMAGE_OS='windows server core' --build-arg WITH_JMX=${WITH_JMX} --build-arg WITH_FIPS=true --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}-fips"
     SERVERCORE: "-servercore"
 
 include:

--- a/Dockerfiles/agent/windows/README.md
+++ b/Dockerfiles/agent/windows/README.md
@@ -35,13 +35,23 @@ From the `Dockerfiles\agent\` folder, run either of the following commands:
 a. To build the containerized Agent from a Nano Windows base image:
 ```
 # Build nano image
-docker build -t mycustomagent --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-1809 --build-arg WITH_JMX=false --build-arg VARIANT=1809 -f .\windows\amd64\Dockerfile .
+docker build -t mycustomagent \
+  --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-1809 \
+  --build-arg BASE_IMAGE_OS="windows nanoserver" \
+  --build-arg WITH_JMX=false \
+  --build-arg VARIANT=1809 \
+  -f .\windows\amd64\Dockerfile .
 ```
 
 a. To build the containerized Agent from a Core Windows base image:
 ```
 # Build core image
-docker build -t mycustomagent --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-1809 --build-arg WITH_JMX=false --build-arg VARIANT=1809 -f .\windows\amd64\Dockerfile .
+docker build -t mycustomagent \
+  --build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-1809 \
+  --build-arg BASE_IMAGE_OS="windows server core" \
+  --build-arg WITH_JMX=false \
+  --build-arg VARIANT=1809 \
+  -f .\windows\amd64\Dockerfile .
 ```
 
 If you need JMX, change `WITH_JMX` to `true`.

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,7 +1,8 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 FROM ${BASE_IMAGE}
 ARG BASE_IMAGE
-LABEL baseimage.os "windows server core"
+ARG BASE_IMAGE_OS="windows server core"
+LABEL baseimage.os "${BASE_IMAGE_OS}"
 LABEL baseimage.name "${BASE_IMAGE}"
 LABEL org.opencontainers.image.base.name "${BASE_IMAGE}"
 LABEL org.opencontainers.image.title="Datadog Agent"

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -16,6 +16,9 @@ LABEL baseimage.os "ubuntu ${BASE_IMAGE_UBUNTU_NAME}"
 LABEL baseimage.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
 LABEL org.opencontainers.image.base.name "ubuntu:${BASE_IMAGE_UBUNTU_VERSION}"
 LABEL org.opencontainers.image.title "Datadog Cluster Agent"
+LABEL org.opencontainers.image.authors="Datadog <package@datadoghq.com>"
+LABEL org.opencontainers.image.source="https://github.com/DataDog/datadog-agent"
+LABEL org.opencontainers.image.vendor="Datadog, Inc."
 
 ARG CIBUILD
 # NOTE about APT mirrorlists:


### PR DESCRIPTION
### What does this PR do?
- Windows Agent images:
  - Parametrize `baseimage.os` via new `BASE_IMAGE_OS` build arg in `Dockerfiles/agent/windows/amd64/Dockerfile` to correctly label nanoserver vs server core.
  - Update `Dockerfiles/agent/windows/README.md` examples to pass `BASE_IMAGE_OS`.
  - Update GitLab pipelines (`.gitlab/container_build/docker_windows.yml`) to pass `BASE_IMAGE_OS` for nanoserver and server core (including FIPS/JMX variants).

- Cluster Agent images:
  - Add missing standard OCI labels in `Dockerfiles/cluster-agent/Dockerfile`: `org.opencontainers.image.authors`, `org.opencontainers.image.source`, `org.opencontainers.image.vendor`.
  - Continue using Dockerfile defaults for `BASE_IMAGE_UBUNTU_VERSION`/`BASE_IMAGE_UBUNTU_NAME` (consistent with Agent).

### Motivation
Fixes BARX-908:
- Windows nanoserver images were labeled with `baseimage.os: windows server core`.
- Cluster Agent images had incomplete `baseimage.*` values and were missing some OCI labels.

### Describe how you validated your changes
Pre-change inspection confirmed issues:
- Windows nanoserver (`datadog/agent:7-rc-ltsc2022`): `baseimage.os` incorrectly “windows server core”.
- Cluster Agent (`datadog/cluster-agent:latest`): `baseimage.os` “ubuntu ” and `baseimage.name` “ubuntu:”.

Post-change validation plan (after CI builds):
- Windows images:
  - For nanoserver: `baseimage.os` should be “windows nanoserver”.
  - For server core: `baseimage.os` should be “windows server core”.
  - Command:
    ```bash
    docker inspect <built-tag> | jq '.[0].Config.Labels'
    ```
  <details>
  <summary>windows labels</summary>

  ```
  {
    "baseimage.name": "mcr.microsoft.com/powershell:windowsservercore-1809",
    "baseimage.os": "windows server core",
    "maintainer": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.authors": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.base.name": "mcr.microsoft.com/powershell:windowsservercore-1809",
    "org.opencontainers.image.created": "2025-08-12T19:57:15Z",
    "org.opencontainers.image.revision": "0940bac445f0975cef5d5ffb7e86bbfb4c8f6d59",
    "org.opencontainers.image.source": "https://github.com/DataDog/datadog-agent",
    "org.opencontainers.image.title": "Datadog Agent",
    "org.opencontainers.image.vendor": "Datadog, Inc.",
    "org.opencontainers.image.version": "7.71.0-devel+git.65.0940bac.pipeline.73473472"
  }
  ```
  ```
  {
    "baseimage.name": "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022",
    "baseimage.os": "windows nanoserver",
    "maintainer": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.authors": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.base.name": "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022",
    "org.opencontainers.image.created": "2025-08-12T19:55:44Z",
    "org.opencontainers.image.revision": "0940bac445f0975cef5d5ffb7e86bbfb4c8f6d59",
    "org.opencontainers.image.source": "https://github.com/DataDog/datadog-agent",
    "org.opencontainers.image.title": "Datadog Agent",
    "org.opencontainers.image.vendor": "Datadog, Inc.",
    "org.opencontainers.image.version": "7.71.0-devel+git.65.0940bac.pipeline.73473472"
  }
  ```
  </details>

- Cluster Agent:
  - `baseimage.os` includes Ubuntu codename (e.g., “ubuntu noble”).
  - `baseimage.name` includes Ubuntu version (e.g., “ubuntu:24.04”).
  - OCI labels include: `org.opencontainers.image.version`, `org.opencontainers.image.revision`, `org.opencontainers.image.source`, `org.opencontainers.image.authors`, `org.opencontainers.image.vendor`.
  - Commands:
    ```bash
    docker inspect <built-tag> | jq '.[0].Config.Labels'
    docker buildx imagetools inspect <multi-arch-tag>
    ```
  <details>
  <summary>cluster-agent labels</summary>
  
  ```
  {
    "baseimage.name": "ubuntu:24.04",
    "baseimage.os": "ubuntu noble",
    "maintainer": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.authors": "Datadog <package@datadoghq.com>",
    "org.opencontainers.image.base.name": "ubuntu:24.04",
    "org.opencontainers.image.created": "2025-08-12 19:26:50+00:00",
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.revision": "0940bac445f0975cef5d5ffb7e86bbfb4c8f6d59",
    "org.opencontainers.image.source": "https://github.com/DataDog/datadog-agent",
    "org.opencontainers.image.title": "Datadog Cluster Agent",
    "org.opencontainers.image.vendor": "Datadog, Inc.",
    "org.opencontainers.image.version": "7.71.0-devel+git.65.0940bac.pipeline.73473472",
    "target": "none"
  }
  ```
  </details>

### Possible Drawbacks / Trade-offs
- Windows builds now rely on `BASE_IMAGE_OS`; downstream/custom build paths must pass this arg (pipelines updated here).
- Cluster Agent still relies on Dockerfile defaults for base image labels; if external consumers override `BASE_IMAGE_UBUNTU_*`, they must ensure correctness.

### Additional Notes
- No CI validation rules added here (handled in a separate repo per BARX-908).
- Scope is limited to Dockerfiles and CI build args; no runtime code changes.
