### PR TITLE
Remove moving files to system temp

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -76,7 +76,6 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 		return downloadInstallerOld(ctx, env, url, tmpDir)
 	}
 	return iexec.NewInstallerExec(env, installerBinPath), nil
-	//return newInstallerExecFromSystemTemp(env, installerBinPath)
 }
 
 // downloadInstallerOld downloads the installer package from the registry and returns the path to the executable.
@@ -113,7 +112,6 @@ func downloadInstallerOld(ctx context.Context, env *env.Env, url string, tmpDir 
 		return nil, fmt.Errorf("failed to get installer path: %w", err)
 	}
 
-	//return newInstallerExecFromSystemTemp(env, installPath)
 	return iexec.NewInstallerExec(env, installPath), nil
 }
 
@@ -186,39 +184,3 @@ func getInstallerOCI(_ context.Context, env *env.Env) (string, error) {
 	}
 	return oci.PackageURL(env, AgentPackage, agentVersion), nil
 }
-
-func moveInstallerToSystemTemp(installPath string) (string, error) {
-
-	// Check that there is a system temp directory to move the installer to
-	// Create one if there is none
-	systemTempPath, err := paths.CreateSystemTempDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to create system temp directory: %w", err)
-	}
-
-	tempInstallerPath, err := os.MkdirTemp(systemTempPath, "datadog-installer")
-	if err != nil {
-		return "", fmt.Errorf("failed to create system temp directory: %w", err)
-	}
-
-	tempInstallerPath = filepath.Join(tempInstallerPath, "datadog-installer.exe")
-
-	//err = os.Rename(installPath, tempInstallerPath)
-	err = paths.CopyFile(installPath, tempInstallerPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to move installer to system temp: %w", err)
-	}
-	return tempInstallerPath, nil
-}
-
-// newInstallerExecFromSystemTemp moves the installer to the system temp directory and returns a new InstallerExec.
-//
-// This executable will stay running after we return and on Windows we can't delete files that are in use,
-// so we move it to the system temporary directory so it gets cleaned up by the OS.
-// func newInstallerExecFromSystemTemp(env *env.Env, installPath string) (*iexec.InstallerExec, error) {
-// 	installPath, err := moveInstallerToSystemTemp(installPath)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to move installer to system temp: %w", err)
-// 	}
-// 	return iexec.NewInstallerExec(env, installPath), nil
-// }

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -75,7 +75,8 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 		// this is expected for versions earlier than 7.70
 		return downloadInstallerOld(ctx, env, url, tmpDir)
 	}
-	return newInstallerExecFromSystemTemp(env, installerBinPath)
+	return iexec.NewInstallerExec(env, installerBinPath), nil
+	//return newInstallerExecFromSystemTemp(env, installerBinPath)
 }
 
 // downloadInstallerOld downloads the installer package from the registry and returns the path to the executable.
@@ -112,7 +113,8 @@ func downloadInstallerOld(ctx context.Context, env *env.Env, url string, tmpDir 
 		return nil, fmt.Errorf("failed to get installer path: %w", err)
 	}
 
-	return newInstallerExecFromSystemTemp(env, installPath)
+	//return newInstallerExecFromSystemTemp(env, installPath)
+	return iexec.NewInstallerExec(env, installPath), nil
 }
 
 func getInstallerPath(ctx context.Context, tmpDir string) (string, error) {
@@ -201,7 +203,8 @@ func moveInstallerToSystemTemp(installPath string) (string, error) {
 
 	tempInstallerPath = filepath.Join(tempInstallerPath, "datadog-installer.exe")
 
-	err = os.Rename(installPath, tempInstallerPath)
+	//err = os.Rename(installPath, tempInstallerPath)
+	err = paths.CopyFile(installPath, tempInstallerPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to move installer to system temp: %w", err)
 	}
@@ -212,10 +215,10 @@ func moveInstallerToSystemTemp(installPath string) (string, error) {
 //
 // This executable will stay running after we return and on Windows we can't delete files that are in use,
 // so we move it to the system temporary directory so it gets cleaned up by the OS.
-func newInstallerExecFromSystemTemp(env *env.Env, installPath string) (*iexec.InstallerExec, error) {
-	installPath, err := moveInstallerToSystemTemp(installPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to move installer to system temp: %w", err)
-	}
-	return iexec.NewInstallerExec(env, installPath), nil
-}
+// func newInstallerExecFromSystemTemp(env *env.Env, installPath string) (*iexec.InstallerExec, error) {
+// 	installPath, err := moveInstallerToSystemTemp(installPath)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to move installer to system temp: %w", err)
+// 	}
+// 	return iexec.NewInstallerExec(env, installPath), nil
+// }

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 )
 
 func TestGetInstallPath(t *testing.T) {
@@ -41,68 +39,5 @@ func TestGetInstallPath(t *testing.T) {
 	// check the install path
 	if installPath != exePath {
 		t.Fatalf("Expected install path to be %s, got %s", exePath, installPath)
-	}
-}
-
-func TestGetInstallPathSystemTemp(t *testing.T) {
-	// create temp directory
-	tmpDir := t.TempDir()
-
-	// backup original CreateSystemTempDir() function and restore the original function once we're done
-	// Use a different function that creates a directory in the test's temp directory
-	var originalCreateSystemTempDir = paths.CreateSystemTempDir
-	defer func() {
-		paths.CreateSystemTempDir = originalCreateSystemTempDir
-	}()
-
-	paths.CreateSystemTempDir = func() (string, error) {
-		err := os.Mkdir(filepath.Join(tmpDir, "datadog-installer"), 0755)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(tmpDir, "datadog-installer"), nil
-	}
-
-	// add an exe to the temp directory
-	exePath := filepath.Join(tmpDir, "datadog-installer.exe")
-
-	// touch exe PATH
-	file, err := os.Create(exePath)
-	if err != nil {
-		t.Fatalf("Failed to create exe file: %v", err)
-	}
-	err = file.Close()
-	if err != nil {
-		t.Fatalf("Failed to close exe file: %v", err)
-	}
-
-	// get the install path
-	installPath, err := getInstallerPath(t.Context(), tmpDir)
-	if err != nil {
-		t.Fatalf("Failed to get install path: %v", err)
-	}
-
-	// check the install path
-	if installPath != exePath {
-		t.Fatalf("Expected install path to be %s, got %s", exePath, installPath)
-	}
-
-	// move the installer to the system temp directory
-	installPath, err = moveInstallerToSystemTemp(installPath)
-	if err != nil {
-		t.Fatalf("Failed to move installer to system temp: %v", err)
-	}
-
-	tempPaths, err := filepath.Glob(filepath.Join(tmpDir, "datadog-installer\\*\\datadog-installer.exe"))
-	if err != nil {
-		t.Fatalf("Failed to glob system temp path: %v", err)
-	}
-
-	if len(tempPaths) != 1 {
-		t.Fatalf("Expected 1 temp path, got %d", len(tempPaths))
-	}
-
-	if installPath != tempPaths[0] {
-		t.Fatalf("Expected install path to be %s, got %s", tempPaths[0], installPath)
 	}
 }

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -561,35 +561,3 @@ func resetPermissionsForTree(path string) error {
 	flags |= windows.UNPROTECTED_DACL_SECURITY_INFORMATION
 	return TreeResetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, flags, admins, admins, nil, nil, false)
 }
-
-// CreateSystemTempDir creates a directory in the system temp directory with the correct permissions
-// to run the installer.
-//
-// The directory is created with the following permissions:
-// - OWNER: Administrators
-// - GROUP: Administrators
-// - SYSTEM: Full Control (propagates to children)
-// - Administrators: Full Control (propagates to children)
-// - Everyone: 0x1200a9 List folder contents (propagates to container children only, so no access to file content)
-// - PROTECTED: does not inherit permissions from parent
-var CreateSystemTempDir = createSystemTempDir
-
-func createSystemTempDir() (string, error) {
-
-	sddl := "O:BAG:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;CI;0x1200a9;;;WD)"
-
-	// os.TempDir() uses GetTempPath, returning the first non-empty value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
-	//
-	// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w
-	tempDir := os.TempDir()
-	tempDir = filepath.Join(tempDir, "datadog-installer")
-
-	err := secureCreateDirectory(tempDir, sddl)
-	if err != nil {
-		// Failed to create directory or existing directory is not secure
-		log.Errorf("Failed to create system temp directory: %v", err)
-		return "", err
-	}
-
-	return tempDir, nil
-}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The `datadog-installer.exe` that is extracted during a fleet install is no longer moved to system temp. Instead it will be run from `Installer/tmp/bootstrap*/`

Reverts a portion of: https://github.com/DataDog/datadog-agent/pull/39565
Edits portions of: https://github.com/DataDog/datadog-agent/pull/39513 and https://github.com/DataDog/datadog-agent/pull/39671

### Motivation
Moving files to system temp can fail for situations where the Datadog Agent is installed in a drive other than `C:`. This can potentially cause fleet installations to fail.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Existing e2e tests will make sure that installations pass as expected. Added a test to ensure `tmp` directory is cleaned up as expected

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->