### PR TITLE
[CWS] remove dig import from cws-instrumentation

### DIFF
--- a/cmd/cws-instrumentation/main_linux.go
+++ b/cmd/cws-instrumentation/main_linux.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/command"
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands"
-
-	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 )
 
 func main() {
 	rootCmd := command.MakeCommand(subcommands.CWSInjectorSubcommands())
-	os.Exit(runcmd.Run(rootCmd))
+
+	if err := rootCmd.Execute(); err != nil {
+		// the error has already been printed
+		os.Exit(1)
+	}
 }

--- a/cmd/cws-instrumentation/main_linux.go
+++ b/cmd/cws-instrumentation/main_linux.go
@@ -18,6 +18,6 @@ func main() {
 
 	if err := rootCmd.Execute(); err != nil {
 		// the error has already been printed
-		os.Exit(1)
+		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `cws-instrumentation` binary doesn't use fx, this means that we don't need the extra error display offered by `cmd/internal/runcmd` and cobra's default is good enough. This allows to remove the dig dependency from this binary.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->