### PR TITLE
[CWS] remove now unneeded `fmt.Printf` in `TestConnect*`

### DIFF
--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -89,7 +89,6 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Listener created on port 4243: %+v\n", listener)
 	defer listener.Close()
 
 	go listener.Accept()
@@ -101,7 +100,6 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Socket created with fd: %d\n", fd)
 	defer unix.Close(fd)
 
 	iour, err := iouring.New(1)
@@ -111,7 +109,6 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 		}
 		t.Skip("io_uring not supported")
 	}
-	fmt.Printf("io_uring initialized: %+v\n", iour)
 	defer iour.Close()
 
 	sa := unix.SockaddrInet4{
@@ -123,14 +120,12 @@ func TestConnectEventAFInetIOUring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("Prepared connect request: %+v\n", prepRequest)
 	ch := make(chan iouring.Result, 1)
 
 	test.WaitSignal(t, func() error {
 		if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
 			return err
 		}
-		fmt.Printf("Submitted connect request to io_uring: %+v\n", prepRequest)
 		var result iouring.Result
 		select {
 		case result = <-ch:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This test is stable now, we can remove the debug prints.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->