### PR TITLE
[pkg/commonchecks] Make DCA only import required checks

### DIFF
--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// This combination of build tags ensures that this file is only included Agents that are not the Cluster Agent
+//go:build !(clusterchecks && kubeapiserver)
+
 // Package commonchecks contains shared checks for multiple agent components
 package commonchecks
 

--- a/pkg/commonchecks/corechecks_cluster.go
+++ b/pkg/commonchecks/corechecks_cluster.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// This combination of build tags ensures that this file is only included in the Cluster Agent
+//go:build clusterchecks && kubeapiserver
+
+// Package commonchecks contains the checks for the Cluster Agent
+package commonchecks
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/flare"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetesapiserver"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator"
+)
+
+// RegisterChecks registers the checks that can run in the Cluster Agent
+func RegisterChecks(store workloadmeta.Component, _ workloadfilter.Component, tagger tagger.Component, cfg config.Component,
+	_ telemetry.Component, _ rcclient.Component, _ flare.Component) {
+	corecheckLoader.RegisterCheck(kubernetesapiserver.CheckName, kubernetesapiserver.Factory(tagger))
+	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory(tagger))
+	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
+	corecheckLoader.RegisterCheck(orchestrator.CheckName, orchestrator.Factory(store, cfg, tagger))
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new file to register checks specific to the Cluster Agent.

The Cluster Agent can only run the 4 core Go cluster checks (helm, ksm, kubernetesapiserver, orchestrator). Previously, it was importing all checks because the check command loaded `pkg/commonchecks/corechecks.go`, which registers every check.

With this change, the Cluster Agent will only import the checks it needs. Other agents are unaffected.


### Describe how you validated your changes
CI