### PR TITLE
Add --development --no-development option to agent hacky_dev_image_build.

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -455,6 +455,7 @@ def hacky_dev_image_build(
     race=False,
     signed_pull=False,
     arch=None,
+    development=True,
 ):
     if arch is None:
         arch = CONTAINER_PLATFORM_MAPPING.get(platform.machine().lower())
@@ -486,13 +487,15 @@ def hacky_dev_image_build(
             f"docker run --platform linux/{arch} --rm '{base_image}' bash -c 'tar --create /opt/datadog-agent/embedded/{{bin,lib,include}}/*python*' | tar --directory '{extracted_python_dir}' --extract"
         )
 
-        os.environ["DELVE"] = "1"
+        if development:
+            os.environ["DELVE"] = "1"
         os.environ["LD_LIBRARY_PATH"] = (
             os.environ.get("LD_LIBRARY_PATH", "") + f":{extracted_python_dir}/opt/datadog-agent/embedded/lib"
         )
         build(
             ctx,
             race=race,
+            development=development,
             cmake_options=f'-DPython3_ROOT_DIR={extracted_python_dir}/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION',
         )
         ctx.run(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This exposes the development option that was already exposed by agent.build to agent.hacky-dev-image-build.  

```
dda inv agent.hacky-dev-image-build --help
Usage: inv[oke] [--core-opts] agent.hacky-dev-image-build [--options] [other tasks here ...]

Docstring:
  none

Options:
  -a, --race
  -b STRING, --base-image=STRING
  -c STRING, --arch=STRING
  -d, --[no-]development
  -i, --signed-pull
  -p, --process-agent
  -r, --trace-agent
  -s, --system-probe
  -t STRING, --target-image=STRING
  -u, --push
```

The default remains the same, development=True.  Specifying --no-development will create a hacky build that is built like a release build.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->