### PR TITLE
[AGNTLOG-272] Fix Agent Removing "Integration" Type From Docker Labels

### DIFF
--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -249,6 +249,7 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	}
 
 	if v, ok := cl.logReceiver.Get(); ok {
+		log.Debugf("Registering integration in loader: %s", c.ID())
 		v.RegisterIntegration(string(c.id), config)
 	}
 

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -253,7 +253,7 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType || cfg.Type == logsConfig.IntegrationType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType || config.Provider == names.ProcessLog) {
+			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType || cfg.Type == logsConfig.IntegrationType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType || config.Provider == names.ProcessLog || config.Provider == names.DataStreamsLiveMessages) {
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -253,7 +253,7 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType || config.Provider == names.ProcessLog) {
+			if (cfg.Type == logsConfig.FileType || cfg.Type == logsConfig.TCPType || cfg.Type == logsConfig.UDPType || cfg.Type == logsConfig.IntegrationType) && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType || config.Provider == names.ProcessLog) {
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier

--- a/pkg/logs/schedulers/ad/scheduler_test.go
+++ b/pkg/logs/schedulers/ad/scheduler_test.go
@@ -102,6 +102,30 @@ func TestScheduleUDPConfig(t *testing.T) {
 	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
+func TestScheduleIntegrationConfig(t *testing.T) {
+	scheduler, spy := setup()
+	configSource := integration.Config{
+		LogsConfig:    []byte(`[{"service":"foo","source":"bar", "type":"integration"}]`),
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
+		Provider:      names.Kubernetes,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ServiceID:     "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck:  false,
+	}
+
+	scheduler.Schedule([]integration.Config{configSource})
+
+	require.Equal(t, 1, len(spy.Events))
+	require.True(t, spy.Events[0].Add)
+	logSource := spy.Events[0].Source
+	assert.Equal(t, config.DockerType, logSource.Name)
+	assert.Equal(t, sourcesPkg.SourceType(""), logSource.GetSourceType())
+	assert.Equal(t, "foo", logSource.Config.Service)
+	assert.Equal(t, "bar", logSource.Config.Source)
+	assert.Equal(t, "integration", logSource.Config.Type)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
+}
+
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	scheduler, spy := setup()
 	configSource := integration.Config{

--- a/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
+++ b/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
@@ -8,5 +8,6 @@
 ---
 fixes:
   - |
-    Checks configured from Docker labels or k8s annotations are no
-    longer overridden in the scheduler.
+    Fix bug causing integrations configured via docker labels or K8s
+    annotations to be overwritten in the agent so logs from integrations
+    now work when configured using via docker labels or K8s annotations.

--- a/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
+++ b/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Checks configured from docker labels / k8s annotations are no
+    Checks configured from Docker labels or k8s annotations are no
     longer overridden in the scheduler.

--- a/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
+++ b/releasenotes/notes/fix-checks-from-labels-26b10d9d8952eefb.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Checks configured from docker labels / k8s annotations are no
+    longer overridden in the scheduler.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes it so the agent no longer removes "type: integration" from config providers. This was causing a bug where integrations configs configured via docker labels were being overridden, and therefore files were not being created for integration logs.

### Motivation

See above

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Verfied using the following setup
`docker-compose.yml`:
```yaml
services:
  datadog-agent:
    image: agent:latest
    container_name: datadog-agent
    environment:
      - DD_API_KEY=${DD_API_KEY}
      - DD_SITE=${DD_SITE}
      - DD_LOGS_ENABLED=true
      - DD_LOG_LEVEL=debug
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
      - /proc/:/host/proc/:ro
      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
      - ./custom_check.py:/etc/datadog-agent/checks.d/custom_check.py:ro
    depends_on:
      - data-generator

  data-generator:
    build:
      context: .
      dockerfile: Dockerfile.datagen
    container_name: my-data-generator
    ports:
      - "5005:5005"
    labels:
      com.datadoghq.ad.checks: >
        {
          "custom_check": {
            "instances": [
              {
                "metrics_url": "http://%%host%%:5005/metrics",
                "tags": ["env:dev", "app:data-generator"]
              }
            ],
            "logs": [
              {
                "type": "integration",
                "source": "python",
               "service": "data-generator-service"
              }
            ]
          }
        }
```
Where the agent image was built using `dda inv hacy-dev-image-build`.
`custom_check.py`
```pytyhon
from datadog_checks.base import AgentCheck
# import requests


class CustomCheck(AgentCheck):
    def check(self, instance):
        log = {"message": "hello world"}
        self.send_log(log)
```
`data_generator.py`:
```python
from flask import Flask, jsonify
import random
import time

app = Flask(__name__)

start_time = time.time()

@app.route('/metrics')
def get_metrics():
    """
    Exposes custom metrics in JSON format.
    """
    # Simulate some application metrics
    requests_processed = int((time.time() - start_time) * 10) + random.randint(1, 100)
    active_connections = random.randint(5, 20)
    error_rate = random.uniform(0.01, 0.05)
    
    # Simulate an application status
    statuses = ["OK", "DEGRADED", "ERROR"]
    current_status = random.choices(statuses, weights=[90, 8, 2], k=1)[0]

    data = {
        'requests_processed': requests_processed,
        'active_connections': active_connections,
        'error_rate': error_rate,
        'status': current_status,
        'uptime_seconds': time.time() - start_time
    }
    
    return jsonify(data)

if __name__ == '__main__':
    # Running on 0.0.0.0 makes it accessible from other containers
    app.run(host='0.0.0.0', port=5005)


```
`Dockerfile.datagen`:
```dockerfile
# Use a lightweight Python base image
FROM python:3.9-slim

# Set the working directory in the container
WORKDIR /app

# Install Flask
RUN pip install Flask

# Copy the Flask application into the container
COPY data_generator.py .

# Expose the port the app runs on
EXPOSE 5005

# Command to run the application
CMD ["python", "data_generator.py"]
```
There's also a new unit test covering this use case
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->