### PR TITLE
dyninst/symdb: teach CLI to upload symbols

### DIFF
--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -11,14 +11,17 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
+	"net/url"
 	"os"
 	"runtime/trace"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/symdbutil"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -30,6 +33,18 @@ var (
 		"Only output symbols for \"1st party\" code (i.e. code from modules belonging "+
 			"to the same GitHub org as the main one).")
 
+	upload     = flag.Bool("upload", false, "If specified, the SymDB data will be uploaded through a trace-agent.")
+	uploadSite = flag.String("upload-site", "", "The site to which SymDB data will be uploaded. "+
+		"If neither -upload-site or -upload-url are specified, datad0g.com is used as the site.")
+	uploadURL = flag.String("upload-url",
+		"https://debugger-intake.datad0g.com/api/v2/debugger",
+		"If specified, the SymDB data will be uploaded to this URL. "+
+			"Either -upload-site or -upload-url must be set when -upload is specified.")
+	uploadService = flag.String("service", "", "The service name to use when uploading SymDB data.")
+	uploadEnv     = flag.String("env", "", "The environment name to use when uploading SymDB data.")
+	uploadVersion = flag.String("version", "", "The version to use when uploading SymDB data.")
+	uploadAPIKey  = flag.String("api-key", "", "The API key used to authenticate uploads.")
+
 	pprofPort = flag.Int("pprof-port", 8081, "Port for pprof server.")
 	traceFile = flag.String("trace", "", "Path to the file to save an execution trace to.")
 )
@@ -38,9 +53,11 @@ func main() {
 	flag.Parse()
 	if *binaryPath == "" {
 		fmt.Print(`Usage: symdbcli --binary-path <path-to-binary> [--only-1stparty] [--silent]
+or
+symdbcli --binary-path <path-to-binary> [--only-1stparty] --upload --service <service> --env <env> --version <version> --api-key <api-key> [--upload-site <site>]
 
-The symbols from the specified binary will be extracted and printed to stdout
-(unless --silent is specified).
+The symbols from the specified binary will be extracted and either printed to stdout
+(unless --silent is specified) or uploaded to the backend.
 `)
 		os.Exit(1)
 	}
@@ -64,10 +81,41 @@ The symbols from the specified binary will be extracted and printed to stdout
 	}
 }
 
-func run(binaryPath string) error {
+func run(binaryPath string) (retErr error) {
 	log.Infof("Analyzing binary: %s", binaryPath)
 	start := time.Now()
 	scope := symdb.ExtractScopeAllSymbols
+
+	var uploadURLParsed *url.URL
+	if *upload {
+		// Upload implies silent mode.
+		*silent = true
+
+		if *uploadURL != "" && *uploadSite != "" {
+			return fmt.Errorf("only one of -upload-url or -upload-side must be specified")
+		}
+		if *uploadSite == "" {
+			*uploadSite = "datad0g.com"
+		}
+		if *uploadURL == "" {
+			*uploadURL = fmt.Sprintf("https://debugger-intake.%s/api/v2/debugger", *uploadSite)
+		}
+
+		if *uploadAPIKey == "" {
+			return fmt.Errorf("-api-key must be specified when -upload is used")
+		}
+		var err error
+
+		uploadURLParsed, err = url.Parse(*uploadURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse upload URL %s: %w", *uploadURL, err)
+		}
+
+		if *uploadService == "" || *uploadEnv == "" || *uploadVersion == "" {
+			return fmt.Errorf("when --upload is specified, --service, --env and --version must also be specified")
+		}
+	}
+
 	if *onlyFirstParty {
 		log.Infof("Extracting only 1st party symbols")
 		scope = symdb.ExtractScopeModulesFromSameOrg
@@ -95,11 +143,39 @@ func run(binaryPath string) error {
 		Scope:                   scope,
 		IncludeInlinedFunctions: !*stream,
 	}
+
+	var up *uploader.SymDBUploader
+	if *upload {
+		up = uploader.NewSymDBUploader(
+			*uploadService, *uploadEnv, *uploadVersion,
+			fmt.Sprintf("manual-upload-%d", rand.Intn(1000)),
+			uploader.WithURL(uploadURLParsed),
+			uploader.WithHeader("DD-EVP-ORIGIN", "symdb-cli"),
+			uploader.WithHeader("DD-EVP-ORIGIN-VERSION", "0.1"),
+			uploader.WithHeader("DD-API-KEY", *uploadAPIKey),
+		)
+		defer func() {
+			log.Infof("Waiting for upload to complete.")
+			if err := up.Stop(); err != nil {
+				if retErr == nil {
+					retErr = err
+				}
+			}
+		}()
+	}
+
 	if !*stream {
 		var err error
 		symbols, err = symdb.ExtractSymbols(binaryPath, opt)
 		if err != nil {
 			return err
+		}
+		if up != nil {
+			for _, pkg := range symbols.Packages {
+				if err := up.Enqueue(pkg); err != nil {
+					log.Errorf("Failed to enqueue package %s for upload: %v", pkg.Name, err)
+				}
+			}
 		}
 	} else {
 		it, err := symdb.PackagesIterator(binaryPath, opt)
@@ -110,6 +186,13 @@ func run(binaryPath string) error {
 			if err != nil {
 				return err
 			}
+
+			if up != nil {
+				if err := up.Enqueue(pkg); err != nil {
+					log.Errorf("Failed to enqueue package %s for upload: %v", pkg.Name, err)
+				}
+			}
+
 			symbols.Packages = append(symbols.Packages, pkg)
 		}
 	}

--- a/pkg/dyninst/uploader/config.go
+++ b/pkg/dyninst/uploader/config.go
@@ -25,6 +25,8 @@ type config struct {
 	batcherConfig
 	client *http.Client
 	url    *url.URL
+	// Key-value pairs to be added to all upload HTTP requests as headers.
+	headers [][2]string
 }
 
 type batcherConfig struct {
@@ -39,6 +41,8 @@ type batcherConfig struct {
 func defaultConfig() config {
 	return config{
 		client: http.DefaultClient,
+		url:    nil,
+
 		batcherConfig: batcherConfig{
 			maxBatchItems:     defaultMaxBatchItems,
 			maxBatchSizeBytes: defaultMaxBatchSizeBytes,
@@ -82,5 +86,13 @@ func WithMaxBatchSizeBytes(maxSizeBytes int) Option {
 func WithMaxBufferDuration(d time.Duration) Option {
 	return func(c *config) {
 		c.batcherConfig.maxBufferDuration = d
+	}
+}
+
+// WithHeader adds a header key-value pair to all upload HTTP requests. The
+// option can be used repeatedly to add multiple headers.
+func WithHeader(key, val string) Option {
+	return func(c *config) {
+		c.headers = append(c.headers, [2]string{key, val})
 	}
 }

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -113,8 +113,8 @@ func (u *DiagnosticsUploader) Enqueue(diag *DiagnosticMessage) error {
 }
 
 // Stop gracefully stops the uploader.
-func (u *DiagnosticsUploader) Stop() {
-	u.stop()
+func (u *DiagnosticsUploader) Stop() error {
+	return u.stop()
 }
 
 // Stats returns the uploader's metrics.

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -101,6 +101,9 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 		}
 		headers[key] = value
 	}
+	for _, keyVal := range u.cfg.headers {
+		addHeader(keyVal[0], keyVal[1])
+	}
 	var logsURL, name string
 	if metadata.Tags == "" {
 		logsURL = u.cfg.url.String()


### PR DESCRIPTION
This should be useful for manual testing, but also for dogfooding where we don't have a new-enough agent or dd-trace-go.

