### PR TITLE
[SQG] Remove nightly postfix for dogstatsd image

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -179,10 +179,9 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                 }
             )
         except InfraError as e:
-            print("!" * 50)
-            print(f"Gate {gate.config.gate_name} flaked ! (InfraError)\n Restarting the job...")
-            traceback.print_exception(e)
-            print("!" * 50)
+            print(color_message(f"Gate {gate.config.gate_name} flaked ! (InfraError)\n Restarting the job...", "red"))
+            for line in traceback.format_exception(e):
+                print(color_message(line, "red"))
             ctx.run("datadog-ci tag --level job --tags static_quality_gates:\"restart\"")
             raise Exit(code=42) from e
         except Exception:

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -179,8 +179,10 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
                 }
             )
         except InfraError as e:
+            print("!" * 50)
             print(f"Gate {gate.config.gate_name} flaked ! (InfraError)\n Restarting the job...")
             traceback.print_exception(e)
+            print("!" * 50)
             ctx.run("datadog-ci tag --level job --tags static_quality_gates:\"restart\"")
             raise Exit(code=42) from e
         except Exception:

--- a/tasks/static_quality_gates/gates.py
+++ b/tasks/static_quality_gates/gates.py
@@ -388,7 +388,7 @@ class DockerArtifactMeasurer:
         image_suffix = ("-7" if flavor == "agent" else "") + jmx
 
         # Handle nightly builds
-        if os.environ.get("BUCKET_BRANCH") == "nightly":
+        if os.environ.get("BUCKET_BRANCH") == "nightly" and flavor != "dogstatsd":
             flavor += "-nightly"
 
         # Validate CI environment


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Nightly pipeline is a little bit inconsistent when it comes to docker image naming. For instance, there are `agent-nightly` and `cluster-agent-nightly`, but `dogstatsd` doesn't contain `nightly` bit. `_get_image_url` didn't reflect this.

### Motivation
Nightly pipeline is broken and should be fixed

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->