### PR TITLE
[SQG] Disable flaky iot rpm gate

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -88,9 +88,9 @@ static_quality_gate_iot_agent_deb_armhf:
 static_quality_gate_iot_agent_rpm_amd64:
   max_on_disk_size: 54.55 MiB
   max_on_wire_size: 14.47 MiB
-static_quality_gate_iot_agent_rpm_arm64:
-  max_on_disk_size: 51.91 MiB
-  max_on_wire_size: 12.65 MiB
+#static_quality_gate_iot_agent_rpm_arm64:
+#  max_on_disk_size: 51.91 MiB
+#  max_on_wire_size: 12.65 MiB
 static_quality_gate_iot_agent_suse_amd64:
   max_on_disk_size: 54.55 MiB
   max_on_wire_size: 14.47 MiB


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
It disables `static_quality_gate_iot_agent_rpm_arm64` due to its flakiness. Even though Gitlab reports that the artifact's size is below the threshold the quality gate reports higher value every now and then. Retrigger of the SQG job doesn't help, the artifact has to be rebuilt to overcome the issue.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->