### PR TITLE
Revert "[USM] Support http2 PRIORITY flag (#39366)"

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -13,10 +13,10 @@
 #define HTTP2_MAX_FRAMES_FOR_EOS_PARSER (HTTP2_MAX_FRAMES_FOR_EOS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_EOS_PARSER)
 
 // Represents the maximum number of frames we'll process in a single tail call in `handle_headers_frames` program.
-#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 15
+#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 16
 // Represents the maximum number of tail calls to process headers frames.
-// Currently we have up to 240 frames in a packet, thus 16 (15*16 = 240) tail calls is enough.
-#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 16
+// Currently we have up to 240 frames in a packet, thus 15 (15*16 = 240) tail calls is enough.
+#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 15
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER (HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER)
 // Maximum number of frames to be processed in a single tail call.
 #define HTTP2_MAX_FRAMES_ITERATIONS 240
@@ -69,12 +69,6 @@
 
 // The flag which will be sent in the data/header frame that indicates end of stream.
 #define HTTP2_END_OF_STREAM 0x1
-
-// The flag which will be sent in the PRIORITY field.
-#define HTTP2_PRIORITY_FLAG 0x20
-
-// 5-byte priority section at the start of a HEADERS frame when the PRIORITY flag is set.
-#define HTTP2_PRIORITY_BUFFER_LEN 5
 
 // Http2 max batch size.
 #define HTTP2_BATCH_SIZE (MAX_BATCH_SIZE(http2_event_t))

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -931,16 +931,6 @@ static __always_inline void headers_parser(pktbuf_t pkt, void *map_key, conn_tup
         current_stream->tags = tags;
         pktbuf_set_offset(pkt, current_frame.offset);
 
-        // If PRIORITY flag (0x20) set, skip 5-byte priority fields.
-        // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2
-        if (current_frame.frame.flags & HTTP2_PRIORITY_FLAG) {
-            pktbuf_advance(pkt, HTTP2_PRIORITY_BUFFER_LEN);
-            if (current_frame.frame.length > HTTP2_PRIORITY_BUFFER_LEN) {
-                current_frame.frame.length -= HTTP2_PRIORITY_BUFFER_LEN;
-            } else {
-                continue;
-            }
-        }
         interesting_headers = pktbuf_filter_relevant_headers(pkt, global_dynamic_counter, &http2_ctx->dynamic_index, headers_to_process, current_frame.frame.length, http2_tel);
         pktbuf_process_headers(pkt, &http2_ctx->dynamic_index, current_stream, headers_to_process, interesting_headers, http2_tel);
     }

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1319,36 +1319,6 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}: 1,
 			},
 		},
-		{
-			name: "headers frame with PRIORITY flag",
-			messageBuilder: func() [][]byte {
-				fr := newFramer()
-				hdrBlock, err := usmhttp2.NewHeadersFrameMessage(usmhttp2.HeadersFrameOptions{Headers: testHeaders()})
-				require.NoError(t, err, "could not create headers block")
-
-				// Write a HEADERS frame that carries a PRIORITY section (flag 0x20).
-				require.NoError(t, fr.framer.WriteHeaders(http2.HeadersFrameParam{
-					StreamID:      1,
-					BlockFragment: hdrBlock,
-					EndHeaders:    endHeaders,
-					Priority: http2.PriorityParam{
-						StreamDep: 0,
-						Exclusive: false,
-						Weight:    10, // non-zero weight triggers PRIORITY flag
-					},
-				}), "could not write priority headers")
-
-				fr.writeData(t, 1, endStream, emptyBody)
-
-				return [][]byte{fr.bytes()}
-			},
-			expectedEndpoints: map[usmhttp.Key]int{
-				{
-					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
-					Method: usmhttp.MethodPost,
-				}: 1,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This reverts commit af9061d16f861f4e6ec5167455e012a6a0ef24f7.

As part of the USM QA tests, we discovered a regression introduced in gRPC goTLS with this change.

### Motivation

Maintain gRPC accuracy.

### Describe how you validated your changes

USM load tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->