### PR TITLE
logs: fix race condition with stream-logs

### DIFF
--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -372,7 +372,7 @@ func NewMessageFromLambda(content []byte, origin *Origin, status string, utcTime
 // if status is not set, StatusInfo will be returned.
 func (m *MessageMetadata) GetStatus() string {
 	if m.Status == "" {
-		m.Status = StatusInfo
+		return StatusInfo
 	}
 	return m.Status
 }


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

GetStatus() can be called from both the logFormatter's Format() and the Encode
(for example, jsonEncoder) at the same time.  But GetStatus() modifies the
MessageMetdata's status field. This is a race condition which sometimes
causes panics in the main agent process when running stream-logs:

```
 panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4b1e2e]

 goroutine 2645 [running]:
 fmt.(*buffer).writeString(...)
         fmt/print.go:108
 fmt.(*fmt).padString(0x44edf6?, {0x0, 0x4})
         fmt/format.go:113 +0xa5
 fmt.(*fmt).fmtS(0x10000000654?, {0x0?, 0x75a4a6638108?})
         fmt/format.go:362 +0x39
 fmt.(*pp).fmtString(0xc0023e4270?, {0x0?, 0xc001362bd0?}, 0x4ab77c?)
         fmt/print.go:497 +0xc5
 fmt.(*pp).printArg(0xc0023e4270, {0x349a8e0, 0xc0013153c0}, 0x73)
         fmt/print.go:741 +0x378
 fmt.(*pp).doPrintf(0xc0023e4270, {0x3f328f4, 0x80}, {0xc001362e20, 0x9, 0x9})
         fmt/print.go:1074 +0x37e
 fmt.Sprintf({0x3f328f4, 0x80}, {0xc001362e20, 0x9, 0x9})
         fmt/print.go:239 +0x53
 github.com/DataDog/datadog-agent/pkg/logs/diagnostic.(*logFormatter).Format(0xc001362f10?, 0xc003294f70, {0xc001b0c000?, 0x0?}, {0xc001678510, 0x88, 0x646e65735f74?})
         github.com/DataDog/datadog-agent/pkg/logs/diagnostic/format.go:35 +0x3a5
 github.com/DataDog/datadog-agent/pkg/logs/diagnostic.(*BufferedMessageReceiver).Filter.func1()
         github.com/DataDog/datadog-agent/pkg/logs/diagnostic/message_receiver.go:119 +0x186
 created by github.com/DataDog/datadog-agent/pkg/logs/diagnostic.(*BufferedMessageReceiver).Filter in goroutine 1085
         github.com/DataDog/datadog-agent/pkg/logs/diagnostic/message_receiver.go:113 +0xcb
```

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-179

### Describe how you validated your changes

Will be tested by CI.

The race condition itself is hard to reproduce on demand but I simulated it
with a test program and it leads to a very similar panic without the fix:

```
package main

import "fmt"

type MessageMetadata struct {
	Status string
}

func (m *MessageMetadata) GetStatus() string {
	if m.Status == "" {
		m.Status = "info"
	}
	return m.Status
}

func main() {
	done := make(chan bool)
	metadataChan := make(chan *MessageMetadata, 10)

	go func() {
		for metadata := range metadataChan {
			fmt.Println(metadata.GetStatus())
		}
	}()

	go func() {
		for i := 0; i < 1000000; i++ {
			metadata := &MessageMetadata{}
			metadataChan <- metadata
			fmt.Println(metadata.GetStatus())
		}
		done <- true
	}()

	<-done
}
```

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs


### Additional Notes

Not sure if some other code path was depending on the behavior of GetStatus
writing the "info" status to the struct.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
