### PR TITLE
process_log: Do not use tracer service name

### DIFF
--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -254,10 +254,6 @@ func (p *processLogConfigProvider) processEventsInner(evBundle workloadmeta.Even
 
 // getServiceName returns the name of the service to be used in the log config.
 func getServiceName(service *workloadmeta.Service) string {
-	if len(service.TracerMetadata) > 0 {
-		return service.TracerMetadata[0].ServiceName
-	}
-
 	if service.DDService != "" {
 		return service.DDService
 	}

--- a/comp/core/autodiscovery/providers/process_log_test.go
+++ b/comp/core/autodiscovery/providers/process_log_test.go
@@ -886,7 +886,7 @@ func TestProcessLogProviderServiceName(t *testing.T) {
 					{ServiceName: "tracer-service"},
 				},
 			},
-			want: "tracer-service",
+			want: "bar",
 		},
 		{
 			name: "returns DDService if TracerMetadata is empty and DDService is set",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently, if a tracer is added to a service, the service name for
discovered process logs may change, even without linking logs and
traces.  This behaviour is different from how things work for discovered
container logs.  Change the process behaviour to match the container
behaviour:

Now, just adding a tracer will not change the service name.  If logs and
traces are linked, then the tracer's injected attributes will lead to
correct service names for the logs on the backend.  Also, if a
`DD_SERVICE` is manually set, then that name will be used in the logs
configuration.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-167

### Describe how you validated your changes

Unit tests modified.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
