### PR TITLE
Keep debugging info when DELVE is set for OTEL Agent

### DIFF
--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -3,7 +3,7 @@
     "configurations": [
         {
             "name": "Build Run Debug",
-            "preLaunchTask": "build agent",
+            "preLaunchTask": "build debug agent",
             "type": "go",
             "request": "launch",
             "mode": "exec",
@@ -26,6 +26,37 @@
                 "run",
                 "-c",
                 "${workspaceRoot}/bin/agent/dist/datadog.yaml"
+            ]
+        },
+        {
+            "name": "Build Run Debug Otel agent",
+            "preLaunchTask": "build debug otel-agent",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${workspaceRoot}/bin/otel-agent/otel-agent",
+            "env": {
+                "DD_OTELCOLLECTOR_ENABLED": "true"
+            },
+            "args": [
+                "run",
+                "--config", "${workspaceRoot}/cmd/otel-agent/dist/otel-config.yaml",
+                "--core-config" , "${workspaceRoot}/dev/dist/datadog.yaml",
+            ]
+        },
+        {
+            "name": "Run Debug Otel Agent",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "${workspaceRoot}/bin/otel-agent/otel-agent",
+            "env": {
+                "DD_OTELCOLLECTOR_ENABLED": "true"
+            },
+            "args": [
+                "run",
+                "--config", "${workspaceRoot}/cmd/otel-agent/dist/otel-config.yaml",
+                "--core-config" , "${workspaceRoot}/dev/dist/datadog.yaml",
             ]
         },
         {

--- a/.vscode/tasks.json.template
+++ b/.vscode/tasks.json.template
@@ -13,6 +13,39 @@
             "problemMatcher": []
         },
         {
+            "label": "build debug agent",
+            "command": "DELVE=1 dda inv -e agent.build",
+            "args": [],
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "build otel-agent",
+            "command": "dda inv -e otel-agent.build",            
+            "args": [],
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "build debug otel-agent",
+            "command": "DELVE=1 dda inv -e otel-agent.build",            
+            "args": [],
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },   
+        {
             "label": "clean",
             "command": "dda inv -e agent.clean",
             "args": [],

--- a/tasks/otel_agent.py
+++ b/tasks/otel_agent.py
@@ -53,6 +53,10 @@ def build(ctx, byoc=False):
     build_tags = get_default_build_tags(build="otel-agent")
     ldflags = get_version_ldflags(ctx, major_version='7')
     ldflags += f' -X github.com/DataDog/datadog-agent/cmd/otel-agent/command.BYOC={byoc}'
+    if os.environ.get("DELVE"):
+        gcflags = "all=-N -l"
+    else:
+        gcflags = ""
 
     go_build(
         ctx,
@@ -60,6 +64,7 @@ def build(ctx, byoc=False):
         mod="readonly",
         build_tags=build_tags,
         ldflags=ldflags,
+        gcflags=gcflags,
         bin_path=BIN_PATH,
         env=env,
     )


### PR DESCRIPTION
Update launch.json.template and task.json.template

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
 This PR keeps debug information with `DELVE=1` in order to have a better debug experience.
It also updates `launch.json.template` and `task.json.template`
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->