### PR TITLE
Bump secret-generic-connector to 1.1.1

### DIFF
--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -16,7 +16,7 @@
 require './lib/ostools.rb'
 
 name "secret-generic-connector"
-default_version "1.1.0"
+default_version "1.1.1"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -38,16 +38,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
   "linux" => {
-    "amd64" => "85a2ec8709981e450c95158fa89ecc26a80e19f8fd8f0b338c5d71e762e1cc09",
-    "arm64" => "d1ad920f90714a9a8ca8ce3161fd77afbf0cadb1e9aeea24d7cc771d59bef2e0"
+    "amd64" => "42499fc5bc2da362da00381cf5ea62afb67fd9f43dac1fdb9a84f1d72dce9af4",
+    "arm64" => "62e98bf8f631a1646cdffe8b808148512a6714a5a0c876063f2591cc090602f6"
   },
   "windows" => {
-    "amd64" => "ef35a5a4b4f8d03d43af16e7c1f1b33d1864c9a4fdb11ae839036db037df1bae",
-    "arm64" => "6e01289f696cbcda2e51bb2f51b28e804b95bffad9e5580a159c9e3c9394653d"
+    "amd64" => "68267d591c2bb65273903eee01b73d46a3a94714bdc4628c4deca6c779eb47d2",
+    "arm64" => "1e361a2d021465b67d4bacd43e39c7834602741f33fcb999194f4ece9152e746"
   },
   "darwin" => {
-    "amd64" => "775d0d00c66991b523a29047f67ccdcb1ff7f16891e5aaaae24693ad18f5e3d4",
-    "arm64" => "7712d5d748caf7931ed1c48dfb30311395c17163b7aca3d3d1a59450c1d006e8"
+    "amd64" => "bec7ed5bf38fc99e6bee8073d72bbc4e8eb407efece662c9689db1255024cefc",
+    "arm64" => "0edd1a3ac66b7cec2b46ee21360bc4f8842fc08a8c1ec5b7af01d04dd7b9f522"
   },
 }
 


### PR DESCRIPTION
### What does this PR do?

Bump secret-generic-connector to 1.1.1. This version is built with go version 1.24.6.

### Describe how you validated your changes

Running the CI is enough.