### PR TITLE
Upload code coverage after e2e test execution

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ stages:
 variables:
   # Special variable that allows us to set the pipeline to compute the code coverage of the e2e tests. It will impact several jobs so that
   # the agent is build with a special flag that allow computing code coverage of the binary when it is running.
-  E2E_COVERAGE_PIPELINE: false
+  E2E_COVERAGE_PIPELINE: true
   # Directory in which we execute the omnibus build.
   # For an unknown reason, it does not go well with
   # a ruby dependency if we build directly into $CI_PROJECT_DIR/.omnibus

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ stages:
 variables:
   # Special variable that allows us to set the pipeline to compute the code coverage of the e2e tests. It will impact several jobs so that
   # the agent is build with a special flag that allow computing code coverage of the binary when it is running.
-  E2E_COVERAGE_PIPELINE: true
+  E2E_COVERAGE_PIPELINE: false
   # Directory in which we execute the omnibus build.
   # For an unknown reason, it does not go well with
   # a ruby dependency if we build directly into $CI_PROJECT_DIR/.omnibus

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -85,7 +85,15 @@
   script:
     - dda inv -- -e new-e2e-tests.run $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
+    - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
+    - curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov
+    - mv codecov /usr/local/bin/codecov
+    - chmod +x /usr/local/bin/codecov
+    - |
+      if [ -d "$E2E_COVERAGE_OUT_DIR" ]; then
+        dda inv -- -e coverage.process-e2e-coverage-folders $E2E_COVERAGE_OUT_DIR
+      fi
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -87,9 +87,6 @@
   after_script:
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
-    - curl -Os https://uploader.codecov.io/v0.6.1/linux/codecov
-    - mv codecov /usr/local/bin/codecov
-    - chmod +x /usr/local/bin/codecov
     - |
       if [ -d "$E2E_COVERAGE_OUT_DIR" ]; then
         dda inv -- -e coverage.process-e2e-coverage-folders $E2E_COVERAGE_OUT_DIR

--- a/tasks/coverage.py
+++ b/tasks/coverage.py
@@ -98,18 +98,6 @@ powershell.exe -executionpolicy Bypass -file {GO_COV_TEST_PATH}.ps1 %*"""
                     os.remove(f)
 
 
-@task
-def convert_coverage_folder_to_txt(
-    ctx: Context,
-    coverage_folder: str,
-    coverage_file: str,
-):
-    """
-    Convert the coverage folder to a txt file.
-    """
-    ctx.run(f"go tool covdata textfmt -i={coverage_folder} -o={coverage_file}")
-
-
 @task(iterable=['extra_tag'])
 def upload_to_codecov(
     ctx: Context,

--- a/tasks/libs/common/coverage.py
+++ b/tasks/libs/common/coverage.py
@@ -1,0 +1,18 @@
+import platform
+
+from invoke import Context
+
+from tasks.libs.common.utils import get_distro
+
+
+def upload_codecov(ctx: Context, coverage_file: str, extra_tag: list[str]):
+    distro_tag = get_distro()
+    tags = [distro_tag]
+    codecov_binary = "codecov" if platform.system() != "Windows" else "codecov.exe"
+
+    if extra_tag:
+        tags.extend(extra_tag)
+
+    # Build the flags string with all tags
+    flags_string = " ".join([f"-F {tag}" for tag in tags])
+    ctx.run(f"{codecov_binary} --git-service=github -f {coverage_file} {flags_string}", warn=True, timeout=2 * 60)

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -22,6 +22,7 @@ ENV_PASSHTROUGH = {
     'DD_CXX': 'Points at c++ compiler',
     'DD_CMAKE_TOOLCHAIN': 'Points at cmake toolchain',
     'DDA_NO_DYNAMIC_DEPS': 'Variable affecting dda behavior',
+    'E2E_COVERAGE_PIPELINE': 'Used to do a special build of the agent to generate coverage data',
     'DEPLOY_AGENT': 'Used to apply higher compression level for deployed artifacts',
     'FORCED_PACKAGE_COMPRESSION_LEVEL': 'Used as an override for the compression level of artifacts',
     'GEM_HOME': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',

--- a/tasks/unit_tests/libs/common/coverage_test.py
+++ b/tasks/unit_tests/libs/common/coverage_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the coverage module functions.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from invoke import Context
+
+from tasks.libs.common.coverage import upload_codecov
+
+
+class TestUploadCodecov(unittest.TestCase):
+    """Test cases for the upload_codecov function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_context = MagicMock(spec=Context)
+        self.mock_context.run = MagicMock()
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_basic_linux(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with basic parameters on Linux."""
+        # Setup mocks
+        mock_get_distro.return_value = "ubuntu"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function
+        upload_codecov(self.mock_context, "coverage.out", [])
+
+        # Verify the correct command was executed
+        self.mock_context.run.assert_called_once_with("codecov -f coverage.out -F ubuntu", warn=True, timeout=2 * 60)
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_windows(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov on Windows."""
+        # Setup mocks
+        mock_get_distro.return_value = "windows"
+        mock_platform_system.return_value = "Windows"
+
+        # Call the function
+        upload_codecov(self.mock_context, "coverage.out", [])
+
+        # Verify the correct command was executed with Windows binary
+        self.mock_context.run.assert_called_once_with(
+            "codecov.exe -f coverage.out -F windows", warn=True, timeout=2 * 60
+        )
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_extra_tags(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with extra tags."""
+        # Setup mocks
+        mock_get_distro.return_value = "centos"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with extra tags
+        extra_tags = ["tag1", "tag2", "tag3"]
+        upload_codecov(self.mock_context, "coverage.out", extra_tags)
+
+        # Verify the correct command was executed with extra tags
+        self.mock_context.run.assert_called_once_with(
+            "codecov -f coverage.out -F centos -F tag1 -F tag2 -F tag3", warn=True, timeout=2 * 60
+        )
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_empty_extra_tags(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with empty extra_tags list."""
+        # Setup mocks
+        mock_get_distro.return_value = "alpine"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with empty extra_tags
+        upload_codecov(self.mock_context, "coverage.out", [])
+
+        # Verify the correct command was executed with only the distro tag
+        self.mock_context.run.assert_called_once_with("codecov -f coverage.out -F alpine", warn=True, timeout=2 * 60)
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_single_extra_tag(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with a single extra tag."""
+        # Setup mocks
+        mock_get_distro.return_value = "debian"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with single extra tag
+        upload_codecov(self.mock_context, "coverage.out", ["test-tag"])
+
+        # Verify the correct command was executed
+        self.mock_context.run.assert_called_once_with(
+            "codecov -f coverage.out -F debian -F test-tag", warn=True, timeout=2 * 60
+        )
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_custom_coverage_file(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with a custom coverage file path."""
+        # Setup mocks
+        mock_get_distro.return_value = "rhel"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with custom coverage file
+        upload_codecov(self.mock_context, "/path/to/custom/coverage.out", ["custom-tag"])
+
+        # Verify the correct command was executed
+        self.mock_context.run.assert_called_once_with(
+            "codecov -f /path/to/custom/coverage.out -F rhel -F custom-tag", warn=True, timeout=2 * 60
+        )
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_special_characters_in_tags(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with special characters in tags."""
+        # Setup mocks
+        mock_get_distro.return_value = "fedora"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with tags containing special characters
+        extra_tags = ["test-tag", "tag_with_underscore", "tag-with-dash"]
+        upload_codecov(self.mock_context, "coverage.out", extra_tags)
+
+        # Verify the correct command was executed
+        self.mock_context.run.assert_called_once_with(
+            "codecov -f coverage.out -F fedora -F test-tag -F tag_with_underscore -F tag-with-dash",
+            warn=True,
+            timeout=2 * 60,
+        )
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_context_run_parameters(self, mock_platform_system, mock_get_distro):
+        """Test that context.run is called with correct parameters."""
+        # Setup mocks
+        mock_get_distro.return_value = "ubuntu"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function
+        upload_codecov(self.mock_context, "coverage.out", ["test-tag"])
+
+        # Verify context.run was called with correct parameters
+        call_args = self.mock_context.run.call_args
+        self.assertEqual(call_args[1]['warn'], True)
+        self.assertEqual(call_args[1]['timeout'], 2 * 60)
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_multiple_calls(self, mock_platform_system, mock_get_distro):
+        """Test multiple calls to upload_codecov."""
+        # Setup mocks
+        mock_get_distro.return_value = "centos"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function multiple times
+        upload_codecov(self.mock_context, "coverage1.out", ["tag1"])
+        upload_codecov(self.mock_context, "coverage2.out", ["tag2"])
+
+        # Verify both calls were made correctly
+        expected_calls = [
+            unittest.mock.call("codecov -f coverage1.out -F centos -F tag1", warn=True, timeout=2 * 60),
+            unittest.mock.call("codecov -f coverage2.out -F centos -F tag2", warn=True, timeout=2 * 60),
+        ]
+        self.mock_context.run.assert_has_calls(expected_calls)
+        self.assertEqual(self.mock_context.run.call_count, 2)
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_with_none_extra_tags(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with None extra_tags (should be treated as empty list)."""
+        # Setup mocks
+        mock_get_distro.return_value = "ubuntu"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with None extra_tags
+        upload_codecov(self.mock_context, "coverage.out", None)
+
+        # Verify the correct command was executed with only the distro tag
+        self.mock_context.run.assert_called_once_with("codecov -f coverage.out -F ubuntu", warn=True, timeout=2 * 60)
+
+    @patch('tasks.libs.common.coverage.get_distro')
+    @patch('tasks.libs.common.coverage.platform.system')
+    def test_upload_codecov_edge_case_empty_string_tags(self, mock_platform_system, mock_get_distro):
+        """Test upload_codecov with empty string tags."""
+        # Setup mocks
+        mock_get_distro.return_value = "ubuntu"
+        mock_platform_system.return_value = "Linux"
+
+        # Call the function with empty string tags
+        upload_codecov(self.mock_context, "coverage.out", ["", "valid-tag", ""])
+
+        # Verify the correct command was executed (empty strings should be included)
+        self.mock_context.run.assert_called_once_with(
+            "codecov -f coverage.out -F ubuntu -F  -F valid-tag -F ", warn=True, timeout=2 * 60
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/unit_tests/libs/common/coverage_test.py
+++ b/tasks/unit_tests/libs/common/coverage_test.py
@@ -196,7 +196,3 @@ class TestUploadCodecov(unittest.TestCase):
         self.mock_context.run.assert_called_once_with(
             "codecov -f coverage.out -F ubuntu -F  -F valid-tag -F ", warn=True, timeout=2 * 60
         )
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update the test suite so that code coverage is generated per test suite.
Add an after_script test to retrieve that coverage folder, convert it into `textfmt` that is compatible with Codecov.
Upload the coverage to Codecov so that it can be visualized.
The visualization can be done using the flags, for example for **new-e2e-agent-configuration**: https://app.codecov.io/gh/DataDog/datadog-agent/tree/kfairise%2Ftest-modifications

### Motivation

We now compute the coverage in order to use it to dynamically know which test should be executed, it costs nothing to upload it on codecov so we have a way to easily visualize what parts of the code are covered by e2e tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->