### PR TITLE
fix(fleet): Fix dependencies between jobs

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -620,7 +620,7 @@ new-e2e-installer:
     - deploy_suse_rpm_testing_x64-a7
     - deploy_installer_oci
     - deploy_agent_oci
-    - installer-install-scripts
+    - qa_installer_script_linux
   variables:
     TARGETS: ./tests/installer/unix
     TEAM: fleet


### PR DESCRIPTION
### What does this PR do?
Fixes a mishap of https://github.com/DataDog/datadog-agent/pull/39180, as the job dependency cycle is actually:
1. installer-install-scripts
2. qa_installer_script_linux
3. new-e2e-installer

### Motivation
No cascading failures

### Describe how you validated your changes
Pipeline running

### Possible Drawbacks / Trade-offs

### Additional Notes
