### PR TITLE
Enable Test Singing For Windows Driver Testing

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -63,6 +63,9 @@
     - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
+    # set the environment variables for the windows test signing
+    - export WINDOWS_DDNPM_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)
+    - export WINDOWS_DDPROCMON_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)
   variables:
     SHOULD_RUN_IN_FLAKES_FINDER: "true"
     KUBERNETES_MEMORY_REQUEST: 12Gi

--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -14,6 +14,8 @@
   script:
     # LAST_STABLE_VERSION is used for upgrade test
     - export LAST_STABLE_VERSION=$(dda inv release.get-release-json-value "last_stable::7" --no-worktree)
+    - export WINDOWS_DDNPM_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)
+    - export WINDOWS_PROCMON_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_PROCMON_DRIVER" --no-worktree)
     - !reference [.new_e2e_template, script]
 
 .new-e2e_windows_msi:

--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -14,8 +14,6 @@
   script:
     # LAST_STABLE_VERSION is used for upgrade test
     - export LAST_STABLE_VERSION=$(dda inv release.get-release-json-value "last_stable::7" --no-worktree)
-    - export WINDOWS_DDNPM_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)
-    - export WINDOWS_DDPROCMON_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)
     - !reference [.new_e2e_template, script]
 
 .new-e2e_windows_msi:

--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -15,7 +15,7 @@
     # LAST_STABLE_VERSION is used for upgrade test
     - export LAST_STABLE_VERSION=$(dda inv release.get-release-json-value "last_stable::7" --no-worktree)
     - export WINDOWS_DDNPM_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDNPM_DRIVER" --no-worktree)
-    - export WINDOWS_PROCMON_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_PROCMON_DRIVER" --no-worktree)
+    - export WINDOWS_DDPROCMON_DRIVER=$(dda inv release.get-release-json-value "dependencies::WINDOWS_DDPROCMON_DRIVER" --no-worktree)
     - !reference [.new_e2e_template, script]
 
 .new-e2e_windows_msi:

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/pulumi/pulumi-libvirt/sdk v0.5.4 // indirect
 	github.com/pulumi/pulumi-random/sdk/v4 v4.16.8 // indirect
 	github.com/pulumi/pulumi-tls/sdk/v4 v4.11.1 // indirect
-	github.com/pulumiverse/pulumi-time/sdk v0.1.0 // indirect
+	github.com/pulumiverse/pulumi-time/sdk v0.1.0
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
@@ -186,8 +186,6 @@ func Run(ctx *pulumi.Context, env *environments.WindowsHost, params *Provisioner
 	}
 
 	if params.testsigningOptions != nil {
-		fmt.Println("Enabling test signing")
-		fmt.Println("testsigningOptions", params.testsigningOptions)
 		testsigning, err := testsigning.NewTestSigning(awsEnv.CommonEnvironment, host, params.testsigningOptions...)
 		if err != nil {
 			return err
@@ -298,10 +296,7 @@ func getProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	}
 
 	// check env and enable test signing if we have a test signed driver
-	fmt.Println("WINDOWS_DDNPM_DRIVER", sysos.Getenv("WINDOWS_DDNPM_DRIVER"))
-	fmt.Println("WINDOWS_DDPROCMON_DRIVER", sysos.Getenv("WINDOWS_DDPROCMON_DRIVER"))
 	if sysos.Getenv("WINDOWS_DDNPM_DRIVER") == "testsigned" || sysos.Getenv("WINDOWS_DDPROCMON_DRIVER") == "testsigned" {
-		fmt.Println("Enabling test signing :)")
 		params.testsigningOptions = append(params.testsigningOptions, testsigning.WithTestSigningEnabled())
 	}
 
@@ -309,7 +304,6 @@ func getProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	if err != nil {
 		panic(fmt.Errorf("unable to apply ProvisionerOption, err: %w", err))
 	}
-	fmt.Println("testsigningOptions", params.testsigningOptions)
 	return params
 }
 

--- a/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
@@ -174,9 +174,9 @@ func Run(ctx *pulumi.Context, env *environments.WindowsHost, awsEnv aws.Environm
 		if err != nil {
 			return err
 		}
-		// Active Directory setup needs to happen after Windows Defender setup
-		params.activeDirectoryOptions = append(params.activeDirectoryOptions,
-			activedirectory.WithPulumiResourceOptions(
+		// TestSigning setup needs to happen after Windows Defender setup
+		params.testsigningOptions = append(params.testsigningOptions,
+			testsigning.WithPulumiResourceOptions(
 				pulumi.DependsOn(defender.Resources)))
 	}
 

--- a/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
@@ -153,12 +153,7 @@ func WithInstaller(opts ...installer.Option) ProvisionerOption {
 }
 
 // Run deploys a Windows environment given a pulumi.Context
-func Run(ctx *pulumi.Context, env *environments.WindowsHost, params *ProvisionerParams) error {
-	awsEnv, err := aws.NewEnvironment(ctx)
-	if err != nil {
-		return err
-	}
-
+func Run(ctx *pulumi.Context, env *environments.WindowsHost, awsEnv aws.Environment, params *ProvisionerParams) error {
 	env.Environment = &awsEnv
 
 	// Make sure to override any OS other than Windows
@@ -317,7 +312,12 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
 		params := GetProvisionerParams(opts...)
-		return Run(ctx, env, params)
+
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+		return Run(ctx, env, awsEnv, params)
 	}, nil)
 
 	return provisioner

--- a/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
@@ -298,7 +298,10 @@ func getProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	}
 
 	// check env and enable test signing if we have a test signed driver
+	fmt.Println("WINDOWS_DDNPM_DRIVER", sysos.Getenv("WINDOWS_DDNPM_DRIVER"))
+	fmt.Println("WINDOWS_DDPROCMON_DRIVER", sysos.Getenv("WINDOWS_DDPROCMON_DRIVER"))
 	if sysos.Getenv("WINDOWS_DDNPM_DRIVER") == "testsigned" || sysos.Getenv("WINDOWS_DDPROCMON_DRIVER") == "testsigned" {
+		fmt.Println("Enabling test signing :)")
 		params.testsigningOptions = append(params.testsigningOptions, testsigning.WithTestSigningEnabled())
 	}
 

--- a/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
+++ b/test/new-e2e/pkg/provisioners/aws/host/windows/host.go
@@ -282,7 +282,8 @@ func Run(ctx *pulumi.Context, env *environments.WindowsHost, params *Provisioner
 	return nil
 }
 
-func getProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
+// GetProvisionerParams return ProvisionerParams from options opts setup
+func GetProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	params := &ProvisionerParams{
 		name:               defaultVMName,
 		instanceOptions:    []ec2.VMOption{},
@@ -311,11 +312,11 @@ func getProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 // FakeIntake and Agent creation can be deactivated by using [WithoutFakeIntake] and [WithoutAgent] options.
 func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[environments.WindowsHost] {
 	// We need to build params here to be able to use params.name in the provisioner name
-	params := getProvisionerParams(opts...)
+	params := GetProvisionerParams(opts...)
 	provisioner := provisioners.NewTypedPulumiProvisioner(provisionerBaseID+params.name, func(ctx *pulumi.Context, env *environments.WindowsHost) error {
 		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
 		// and it's easy to forget about it, leading to hard to debug issues.
-		params := getProvisionerParams(opts...)
+		params := GetProvisionerParams(opts...)
 		return Run(ctx, env, params)
 	}, nil)
 

--- a/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
@@ -37,7 +37,7 @@ func TestEC2VMWKitSuite(t *testing.T) {
 
 	s := &ec2VMWKitSuite{}
 
-	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(provisioners.NewTypedPulumiProvisioner("hostHttpbinWindows", hostDockerHttpbinEnvProvisionerWindows(awsHostWindows.WithEC2InstanceOptions()), nil))}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(provisioners.NewTypedPulumiProvisioner("hostHttpbin", hostDockerHttpbinEnvProvisionerWindows(), nil))}
 
 	e2e.Run(t, s, e2eParams...)
 }

--- a/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
+++ b/test/new-e2e/tests/npm/ec2_1host_wkit_test.go
@@ -55,7 +55,7 @@ func hostDockerHttpbinEnvProvisionerWindows(opt ...awsHostWindows.ProvisionerOpt
 			opts = append(opts, opt...)
 		}
 		params := awsHostWindows.GetProvisionerParams(opts...)
-		awsHostWindows.Run(ctx, &env.WindowsHost, params)
+		awsHostWindows.Run(ctx, &env.WindowsHost, awsEnv, params)
 
 		vmName := "httpbinvm"
 

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 type vmSuite struct {
-	e2e.BaseSuite[environments.Host]
+	e2e.BaseSuite[environments.WindowsHost]
 
 	testspath string
 }

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	componentsos "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -36,7 +34,7 @@ var (
 )
 
 func TestVMSuite(t *testing.T) {
-	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake(awsHostWindows.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake())}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}

--- a/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
+++ b/test/new-e2e/tests/sysprobe-functional/sysprobe_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
+	awsHostWindows "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
@@ -36,7 +36,7 @@ var (
 )
 
 func TestVMSuite(t *testing.T) {
-	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(awshost.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
+	suiteParams := []e2e.SuiteOption{e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake(awsHostWindows.WithEC2InstanceOptions(ec2.WithOS(componentsos.WindowsDefault))))}
 	if *devMode {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}

--- a/test/new-e2e/tests/windows/common/powershell/command_builder.go
+++ b/test/new-e2e/tests/windows/common/powershell/command_builder.go
@@ -246,7 +246,7 @@ func (ps *powerShellCommandBuilder) EnableTestSigning() *powerShellCommandBuilde
 	ps.cmds = append(ps.cmds, `
 $result = bcdedit.exe | findstr "testsigning" | findstr "Yes"
 if ($result -eq $null) {
-	bcdedit.exe /set testsigning on /f
+	bcdedit.exe /set testsigning on
 	Restart-Computer -Force
 }
 else {

--- a/test/new-e2e/tests/windows/common/powershell/command_builder.go
+++ b/test/new-e2e/tests/windows/common/powershell/command_builder.go
@@ -240,3 +240,18 @@ func (ps *powerShellCommandBuilder) Execute(host *components.RemoteHost) (string
 func (ps *powerShellCommandBuilder) Compile() string {
 	return strings.Join(ps.cmds, ";")
 }
+
+// EnableTestSigning creates a command that enables TestSigning
+func (ps *powerShellCommandBuilder) EnableTestSigning() *powerShellCommandBuilder {
+	ps.cmds = append(ps.cmds, `
+$result = bcdedit.exe | findstr "testsigning" | findstr "Yes"
+if ($result -eq $null) {
+	bcdedit.exe /set testsigning on /f
+	Restart-Computer -Force
+}
+else {
+	Write-Host "TestSigning is already enabled"
+}
+`)
+	return ps
+}

--- a/test/new-e2e/tests/windows/components/testsigning/component.go
+++ b/test/new-e2e/tests/windows/components/testsigning/component.go
@@ -43,7 +43,7 @@ func NewTestSigning(e *config.CommonEnvironment, host *remote.Host, options ...O
 			Create: pulumi.String(powershell.PsHost().
 				EnableTestSigning().
 				Compile()),
-		})
+		}, params.ResourceOptions...)
 		if err != nil {
 			return nil, err
 		}
@@ -53,10 +53,11 @@ func NewTestSigning(e *config.CommonEnvironment, host *remote.Host, options ...O
 		if err != nil {
 			return nil, err
 		}
+		params.ResourceOptions = append(params.ResourceOptions, pulumi.DependsOn(manager.Resources), pulumi.Provider(timeProvider))
 
 		waitForRebootCmd, err := time.NewSleep(e.Ctx(), manager.namer.ResourceName("wait-for-host-to-reboot"), &time.SleepArgs{
 			CreateDuration: pulumi.String("60s"),
-		}, pulumi.Provider(timeProvider), pulumi.DependsOn(manager.Resources))
+		}, params.ResourceOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/test/new-e2e/tests/windows/components/testsigning/component.go
+++ b/test/new-e2e/tests/windows/components/testsigning/component.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package defender contains code to control the behavior of Windows defender in the E2E tests
+// Package testsigning contains code to control the behavior of Windows test signing in the E2E tests
 package testsigning
 
 import (
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/powershell"
 )
 
-// Manager contains the resources to manage Windows Defender
+// Manager contains the resources to manage Windows TestSigning
 type Manager struct {
 	namer namer.Namer
 	host  *remote.Host

--- a/test/new-e2e/tests/windows/components/testsigning/component.go
+++ b/test/new-e2e/tests/windows/components/testsigning/component.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package defender contains code to control the behavior of Windows defender in the E2E tests
+package testsigning
+
+import (
+	"github.com/DataDog/test-infra-definitions/common"
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumiverse/pulumi-time/sdk/go/time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/powershell"
+)
+
+// Manager contains the resources to manage Windows Defender
+type Manager struct {
+	namer namer.Namer
+	host  *remote.Host
+
+	Resources []pulumi.Resource
+}
+
+// NewTestSigning creates a new instance of the Windows TestSigning component
+func NewTestSigning(e *config.CommonEnvironment, host *remote.Host, options ...Option) (*Manager, error) {
+	params, err := common.ApplyOption(&Configuration{}, options)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := &Manager{
+		namer: e.CommonNamer().WithPrefix("windows-test-signing"),
+		host:  host,
+	}
+
+	if params.Enabled {
+		cmd, err := host.OS.Runner().Command(manager.namer.ResourceName("enable-test-signing"), &command.Args{
+			Create: pulumi.String(powershell.PsHost().
+				EnableTestSigning().
+				Compile()),
+		})
+		if err != nil {
+			return nil, err
+		}
+		manager.Resources = append(manager.Resources, cmd)
+
+		timeProvider, err := time.NewProvider(e.Ctx(), manager.namer.ResourceName("time-provider"), &time.ProviderArgs{}, pulumi.DeletedWith(host))
+		if err != nil {
+			return nil, err
+		}
+
+		waitForRebootCmd, err := time.NewSleep(e.Ctx(), manager.namer.ResourceName("wait-for-host-to-reboot"), &time.SleepArgs{
+			CreateDuration: pulumi.String("30s"),
+		}, pulumi.Provider(timeProvider), pulumi.DependsOn(manager.Resources))
+		if err != nil {
+			return nil, err
+		}
+		manager.Resources = append(manager.Resources, waitForRebootCmd)
+	}
+
+	return manager, nil
+}

--- a/test/new-e2e/tests/windows/components/testsigning/component.go
+++ b/test/new-e2e/tests/windows/components/testsigning/component.go
@@ -55,7 +55,7 @@ func NewTestSigning(e *config.CommonEnvironment, host *remote.Host, options ...O
 		}
 
 		waitForRebootCmd, err := time.NewSleep(e.Ctx(), manager.namer.ResourceName("wait-for-host-to-reboot"), &time.SleepArgs{
-			CreateDuration: pulumi.String("30s"),
+			CreateDuration: pulumi.String("60s"),
 		}, pulumi.Provider(timeProvider), pulumi.DependsOn(manager.Resources))
 		if err != nil {
 			return nil, err

--- a/test/new-e2e/tests/windows/components/testsigning/params.go
+++ b/test/new-e2e/tests/windows/components/testsigning/params.go
@@ -5,9 +5,21 @@
 
 package testsigning
 
+import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 // Configuration represents the Windows NewDefender configuration
 type Configuration struct {
-	Enabled bool
+	Enabled         bool
+	ResourceOptions []pulumi.ResourceOption
+}
+
+// WithPulumiResourceOptions sets some pulumi resource option, like which resource
+// to depend on.
+func WithPulumiResourceOptions(resources ...pulumi.ResourceOption) Option {
+	return func(p *Configuration) error {
+		p.ResourceOptions = resources
+		return nil
+	}
 }
 
 // Option is an optional function parameter type for Configuration options

--- a/test/new-e2e/tests/windows/components/testsigning/params.go
+++ b/test/new-e2e/tests/windows/components/testsigning/params.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testsigning
+
+// Configuration represents the Windows NewDefender configuration
+type Configuration struct {
+	Enabled bool
+}
+
+// Option is an optional function parameter type for Configuration options
+type Option = func(*Configuration) error
+
+// WithTestSigningEnabled configures the TestSigning component to enable Windows TestSigning
+func WithTestSigningEnabled() func(*Configuration) error {
+	return func(p *Configuration) error {
+		p.Enabled = true
+		return nil
+	}
+}
+
+// WithTestSigningDisabled configures the TestSigning component to disable Windows TestSigning
+func WithTestSigningDisabled() func(*Configuration) error {
+	return func(p *Configuration) error {
+		p.Enabled = false
+		return nil
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR checks `release.json`, if the windows drivers are test signed, it enables test-signing on all of the windows hosts. This allows us to kick off agent pipelines with test-signed windows drivers.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1731

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Adds new e2e functionality, see test pipeline here: [Test Fixed DDNPM](https://github.com/DataDog/datadog-agent/pull/39891)


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->