### PR TITLE
[CWS] fix `SetupOptionalDatadogConfigWithDir` by loading core config

### DIFF
--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -195,7 +195,7 @@ func load() (*types.Config, error) {
 
 // SetupOptionalDatadogConfigWithDir loads the datadog.yaml config file from a given config directory but will not fail on a missing file
 func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
-	cfg := pkgconfigsetup.GlobalSystemProbeConfigBuilder()
+	cfg := pkgconfigsetup.GlobalConfigBuilder()
 
 	cfg.AddConfigPath(configDir)
 	if configFile != "" {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes https://github.com/DataDog/datadog-agent/pull/39736/files?#diff-0daece1cfe8277578a50f7c867a3263c7b21fda3600c4a5f403c0bfc1b053df8L194 by making sure the core config is loaded, and not the system-probe one.

This code path is only used by CWS's functional tests (KMT), it's not used in the final agent (or system-probe).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->