### PR TITLE
Fix Omnibus builds in developer environments

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -42,6 +42,7 @@ ENV_PASSHTROUGH = {
     'RUBY_VERSION': 'Used by Omnibus / Gemspec',
     'S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS': 'Use to determine whether Omnibus can write to the artifact cache',
     'S3_OMNIBUS_CACHE_BUCKET': 'Points at bucket used for Omnibus source artifacts',
+    'SSH_AUTH_SOCK': 'Developer environments configure Git to use SSH authentication',
     'rvm_path': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'rvm_bin_path': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',
     'rvm_prefix': 'rvm / Ruby stuff to make sure Omnibus itself runs correctly',

--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -117,6 +117,7 @@ def _get_environment_for_cache(env: dict[str, str]) -> dict:
         'RPM_SIGNING_PASSPHRASE',
         'S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS',
         'SIGN_WINDOWS_DD_WCS',
+        'SSH_AUTH_SOCK',
         'SYSTEMDRIVE',
         'SYSTEMROOT',
         'SSL_CERT_FILE',


### PR DESCRIPTION
### Motivation

Developer environments [rely on](https://github.com/DataDog/datadog-agent-buildimages/blob/9e7c1dc30c27cfecdafcc109305c31686d48d7b9/dev-envs/linux/git.sh#L9) the SSH agent to get Git credentials from the host.

This used to work out-of-the-box but recent changes to increase reproducibility made it so only a subset of explicit environment variables are allowed. I was in the process of documenting the developer environments when I found out this no longer worked. Here's an example:

```
❯ dda inv omnibus.build
...
Fetching https://github.com/DataDog/omnibus-ruby.git

Retrying `git clone --bare --no-hardlinks --quiet --no-tags --depth 1 --single-branch -- https://github.com/DataDog/omnibus-ruby.git /usr/local/rvm/gems/ruby-2.7.2/cache/bundler/git/omnibus-ruby-d1a996a4a5ed1b0979dd95dce3f73f172f30cafb` due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git clone --bare --no-hardlinks --quiet --no-tags --depth 1 --single-branch -- https://github.com/DataDog/omnibus-ruby.git /usr/local/rvm/gems/ruby-2.7.2/cache/bundler/git/omnibus-ruby-d1a996a4a5ed1b0979dd95dce3f73f172f30cafb` in directory /usr/local/rvm/gems/ruby-2.7.2/cache/bundler/git/omnibus-ruby-d1a996a4a5ed1b0979dd95dce3f73f172f30cafb has failed.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```