### PR TITLE
fix(template): Fix key in application_monitoring.yaml.example

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4828,7 +4828,7 @@ api_key:
 ##   2. Environment variables
 ##   3. Local config file
 ##      (etc/datadog-agent/application_monitoring.yaml)
-# apm_configuration_rules:
+# apm_configuration_default:
 
   ## @param DD_APM_TRACING_ENABLED - boolean - optional - default: true
   ## Enable Datadog tracing.


### PR DESCRIPTION
### What does this PR do?
Fixes `application_monitoring.yaml.example` template, where the top key shouldn't be `apm_configuration_rules` but `apm_configuration_default`

### Motivation

### Describe how you validated your changes


### Possible Drawbacks / Trade-offs

### Additional Notes
