### PR TITLE
Use CI_JOB_IMAGE as a part of Gitlab cache key

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -15,7 +15,7 @@
         - release.json
       # We still need to add the environment omnibus-related variables so that triggered pipelines
       # don't get undesired cache hits
-      prefix: omnibus-deps-$CI_JOB_NAME-$OMNIBUS_RUBY_VERSION
+      prefix: omnibus-deps-$CI_JOB_IMAGE-$CI_JOB_NAME-$OMNIBUS_RUBY_VERSION
     paths:
       - omnibus/vendor/bundle
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
After moving ARMHF builds to generic Linux images Gitlab cache seems to be broken, ARMHF builds are failing with the error:
```
failed to load the ffi-yajl c-extension, falling back to ffi interface
FATAL: to use the ffi extension instead of the compiled C extension, the ffi gem must be installed
       (it is optional, so you must include it in your bundle manually)
```

Most probably, it's related to cache poisoning as cache key calculated in `.gitlab/common/shared.yml` wasn't taking image version into account. 