### PR TITLE
process_log: Allow ignoring agent processes

### DIFF
--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -161,17 +161,17 @@ func (p *processLogConfigProvider) isFileReadable(logPath string) bool {
 	return true
 }
 
-func isAgentProcess(process *workloadmeta.Process) bool {
-	// Check if the process name matches any of the known agent process names,
-	// since we may not be able to make assumptions about the executable paths.
-	agentProcessNames := []string{
-		"agent",
-		"process-agent",
-		"trace-agent",
-		"security-agent",
-		"system-probe",
-	}
+var agentProcessNames = []string{
+	"agent",
+	"process-agent",
+	"trace-agent",
+	"security-agent",
+	"system-probe",
+}
 
+func isAgentProcess(process *workloadmeta.Process) bool {
+	// Check if the process name matches any of the known agent process names;
+	// we may not be able to make assumptions about the executable paths.
 	for _, agentName := range agentProcessNames {
 		if process.Name == agentName {
 			return true

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1752,6 +1752,9 @@ func logsagent(config pkgconfigmodel.Setup) {
 
 	// If true, then the registry file will be written atomically. This behavior is not supported on ECS Fargate.
 	config.BindEnvAndSetDefault("logs_config.atomic_registry_write", !pkgconfigenv.IsECSFargate())
+
+	// If true, exclude agent processes from process log collection
+	config.BindEnvAndSetDefault("logs_config.process_exclude_agent", false)
 }
 
 func vector(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add an option to ignore collecting logs from the agent
processes.  This option could eventually be replaced by a more elaborate
CEL-based filter.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-180

### Describe how you validated your changes

Tests added.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
