### PR TITLE
[AGENTRUN-633] Refactor `pkg/util/log` to avoid nil pointer dereference

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -385,7 +385,7 @@ func logFormatWithError(logLevel LogLevel, lpointer *loggerPointer, logFunc func
 	if isInnerNil {
 		if !fallbackStderr {
 			addLogToBuffer(func() {
-				logFormatWithError(logLevel, lpointer, logFunc, format, fallbackStderr, params...)
+				_ = logFormatWithError(logLevel, lpointer, logFunc, format, fallbackStderr, params...)
 			})
 		}
 	} else if l.shouldLog(logLevel) {
@@ -446,7 +446,7 @@ func logContextWithError(logLevel LogLevel, lpointer *loggerPointer, logFunc fun
 	l := lpointer.Load()
 	if l == nil {
 		addLogToBuffer(func() {
-			logContextWithError(logLevel, lpointer, logFunc, message, fallbackStderr, depth, context...)
+			_ = logContextWithError(logLevel, lpointer, logFunc, message, fallbackStderr, depth, context...)
 		})
 		err := formatErrorc(message, context...)
 		if fallbackStderr {
@@ -462,7 +462,7 @@ func logContextWithError(logLevel LogLevel, lpointer *loggerPointer, logFunc fun
 	if isInnerNil {
 		if !fallbackStderr {
 			addLogToBuffer(func() {
-				logContextWithError(logLevel, lpointer, logFunc, message, fallbackStderr, depth, context...)
+				_ = logContextWithError(logLevel, lpointer, logFunc, message, fallbackStderr, depth, context...)
 			})
 		}
 	} else if l.shouldLog(logLevel) {

--- a/pkg/util/log/wrapper_test.go
+++ b/pkg/util/log/wrapper_test.go
@@ -20,6 +20,11 @@ func TestNewWrapper(t *testing.T) {
 }
 
 func TestWrapperMethods(t *testing.T) {
+	// reset buffer state
+	logsBuffer = []func(){}
+	logger.Store(nil)
+	jmxLogger.Store(nil)
+
 	// create buffer to capture logs from the wrapper
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR refactor the logger helpers in order to remove existing nil pointer dereferences when using different logger than the default one (`logger` global variable).

### Motivation
Prevent SEGFAULT.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->