### PR TITLE
move SBOM conversion code to own package

### DIFF
--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -24,6 +24,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/sbom/bomconvert"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/host"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/procfs"
 	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
@@ -238,7 +239,7 @@ func (p *processor) processHostScanResult(result sbom.ScanResult) {
 		Id:                 p.hostname,
 		InUse:              true,
 		GeneratedAt:        timestamppb.New(result.CreatedAt),
-		GenerationDuration: convertDuration(result.Duration),
+		GenerationDuration: bomconvert.ConvertDuration(result.Duration),
 	}
 
 	if result.Error != nil {
@@ -262,7 +263,7 @@ func (p *processor) processHostScanResult(result sbom.ScanResult) {
 				sbom.Status = model.SBOMStatus_FAILED
 			} else {
 				sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-					Cyclonedx: convertBOM(report),
+					Cyclonedx: bomconvert.ConvertBOM(report),
 				}
 			}
 
@@ -306,7 +307,7 @@ func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 		Type:               model.SBOMSourceType_CONTAINER_FILE_SYSTEM,
 		InUse:              true,
 		GeneratedAt:        timestamppb.New(result.CreatedAt),
-		GenerationDuration: convertDuration(result.Duration),
+		GenerationDuration: bomconvert.ConvertDuration(result.Duration),
 	}
 
 	if result.Error != nil {
@@ -333,7 +334,7 @@ func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 				sbom.Status = model.SBOMStatus_FAILED
 			} else {
 				sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-					Cyclonedx: convertBOM(report),
+					Cyclonedx: bomconvert.ConvertBOM(report),
 				}
 			}
 		}
@@ -453,9 +454,9 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 		default:
 			sbom.Status = model.SBOMStatus_SUCCESS
 			sbom.GeneratedAt = timestamppb.New(img.SBOM.GenerationTime)
-			sbom.GenerationDuration = convertDuration(img.SBOM.GenerationDuration)
+			sbom.GenerationDuration = bomconvert.ConvertDuration(img.SBOM.GenerationDuration)
 			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: convertBOM(img.SBOM.CycloneDXBOM),
+				Cyclonedx: bomconvert.ConvertBOM(img.SBOM.CycloneDXBOM),
 			}
 		}
 		p.queue <- sbom

--- a/pkg/sbom/bomconvert/convert.go
+++ b/pkg/sbom/bomconvert/convert.go
@@ -3,9 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || (windows && wmi)
-
-package sbom
+// Package bomconvert contains some cyclonedx conversion functions
+package bomconvert
 
 import (
 	"time"
@@ -124,7 +123,8 @@ func convertAttachedText(in *cyclonedx.AttachedText) *cyclonedx_v1_4.AttachedTex
 	}
 }
 
-func convertBOM(in *cyclonedx.BOM) *cyclonedx_v1_4.Bom {
+// ConvertBOM converts a CycloneDX BOM to a CycloneDX v1.4 BOM.
+func ConvertBOM(in *cyclonedx.BOM) *cyclonedx_v1_4.Bom {
 	if in == nil {
 		return nil
 	}
@@ -853,7 +853,8 @@ func convertTimestamp(in string) *timestamppb.Timestamp {
 	return timestamppb.New(ts)
 }
 
-func convertDuration(in time.Duration) *durationpb.Duration {
+// ConvertDuration converts a time.Duration to a protobuf Duration.
+func ConvertDuration(in time.Duration) *durationpb.Duration {
 	return durationpb.New(in)
 }
 

--- a/pkg/sbom/bomconvert/convert_test.go
+++ b/pkg/sbom/bomconvert/convert_test.go
@@ -3,9 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//go:build trivy || windows
-
-package sbom
+package bomconvert
 
 import (
 	"testing"
@@ -24,7 +22,7 @@ func FuzzConvertBOM(f *testing.F) {
 		f.Fuzz(&bom)
 		bom.SpecVersion = cyclonedx.SpecVersion1_6
 
-		pb := convertBOM(&bom)
+		pb := ConvertBOM(&bom)
 		_, err := proto.Marshal(pb)
 
 		assert.Nil(t, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Extracted from https://github.com/DataDog/datadog-agent/pull/39096

This PR extracts the SBOM conversion code (from trivy cyclonedx format to datadog's backend protobuf format) to an importable package. This will allow multiple code path to import and use it.

No functional change expected.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->