### PR TITLE
fix(fleet): Get the agent install path from its own executable only for OCI

### DIFF
--- a/pkg/config/setup/config_nix.go
+++ b/pkg/config/setup/config_nix.go
@@ -9,7 +9,6 @@ package setup
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -60,12 +59,7 @@ const (
 // in time
 func osinit() {
 	// Agent binary
-	if installPathOverride, ok := os.LookupEnv("DD_TEST_INSTALL_PATH_OVERRIDE"); ok {
-		// Some tests use the InstallPath variable to fetch dependencies. These tests' executable.Folder()
-		// are relative to the test files, but dependencies are always put in the same place during the tests'
-		// executions. This environment variable allows us to override the install path during the tests.
-		InstallPath = installPathOverride
-	} else {
+	if InstallPath == "" {
 		_here, err := executable.Folder() // {InstallPath}/bin/agent OR {InstallPath}/embedded/bin
 		if err != nil {
 			panic(fmt.Sprintf("Failed to get executable path: %v", err))

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -246,6 +246,14 @@ def get_build_flags(
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
 
+    # setting the install path, allowing the agent to be installed in a custom location
+    if sys.platform.startswith('linux') and install_path:
+        if install_path.startswith('/opt/datadog-packages'):
+            # This is the OCI path -- we want to rely on os.Executable, so we left InstallPath empty.
+            ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath='' "
+        else:
+            ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath={install_path} "
+
     # setting the run path
     if sys.platform.startswith('linux') and run_path:
         ldflags += f"-X {REPO_PATH}/pkg/config/setup.defaultRunPath={run_path} "

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eEuo pipefail
 
-# The agent detects its install path by using os.Executable(), and then tries to fetch system-probe dependencies
-# like clang-bpf relatively. This doesn't work here as os.Executable() is actually the test file's, but
-# dependencies are expected to always be in the same directory.
-export DD_TEST_INSTALL_PATH_OVERRIDE="/opt/datadog-agent"
 docker_dir=/kmt-dockers
 
 # Add provisioning steps here !


### PR DESCRIPTION
### What does this PR do?
Iterates over https://github.com/DataDog/datadog-agent/pull/39595 to only get the install path from executable on the OCI build. This ensures that local builds, deb/rpm builds, or other agent flavors are not impacted.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->