### PR TITLE
[AGENTRUN-642] remove global jmx logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,9 +65,6 @@ issues:
       linters: [staticcheck]
     # Treat this list as a TODO for fixing issues with pkgconfigusage custom linter
     # DO NOT ADD NEW ENTRIES
-    - path: comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
-      linters:
-        - pkgconfigusage
     - path: comp/aggregator/demultiplexer/demultiplexerimpl/test_agent_demultiplexer.go
       linters:
         - pkgconfigusage

--- a/comp/agent/jmxlogger/component.go
+++ b/comp/agent/jmxlogger/component.go
@@ -12,4 +12,5 @@ package jmxlogger
 type Component interface {
 	JMXInfo(v ...interface{})
 	JMXError(v ...interface{}) error
+	Flush()
 }

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
@@ -38,6 +38,7 @@ type jmxLoggerInterface interface {
 	Info(v ...interface{})
 	Error(v ...interface{}) error
 	Flush()
+	Close()
 }
 
 type logger struct {
@@ -87,6 +88,7 @@ func newJMXLogger(deps dependencies) (jmxlogger.Component, error) {
 	deps.Lc.Append(fx.Hook{
 		OnStop: func(_ context.Context) error {
 			jmxLogger.Flush()
+			jmxLogger.close()
 			return nil
 		},
 	})
@@ -104,4 +106,9 @@ func (j logger) JMXError(v ...interface{}) error {
 
 func (j logger) Flush() {
 	j.inner.Flush()
+}
+
+// close is use in to ensure we release any resource associated with the JMXLogger
+func (j logger) close() {
+	j.inner.Close()
 }

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger.go
@@ -86,7 +86,7 @@ func newJMXLogger(deps dependencies) (jmxlogger.Component, error) {
 
 	deps.Lc.Append(fx.Hook{
 		OnStop: func(_ context.Context) error {
-			jmxLogger.inner.Flush()
+			jmxLogger.Flush()
 			return nil
 		},
 	})
@@ -100,4 +100,8 @@ func (j logger) JMXInfo(v ...interface{}) {
 
 func (j logger) JMXError(v ...interface{}) error {
 	return j.inner.Error(v...)
+}
+
+func (j logger) Flush() {
+	j.inner.Flush()
 }

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package jmxloggerimpl implements the logger for JMX.
+package jmxloggerimpl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func TestJMXLog(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "jmx_test.log")
+	_, err := os.Create(filePath)
+	assert.NoError(t, err)
+
+	deps := fxutil.Test[dependencies](t, fx.Options(
+		config.MockModule(),
+		fx.Supply(NewCliParams(filePath)),
+	))
+
+	jmxLogger, err := newJMXLogger(deps)
+
+	assert.NoError(t, err)
+
+	jmxLogger.JMXError("jmx error message")
+	jmxLogger.JMXInfo("jmx info message")
+
+	jmxLogger.Flush()
+
+	bytes, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+
+	assert.Subset(t, strings.Split(string(bytes), "\n"), []string{
+		"jmx error message",
+		"jmx info message",
+	})
+}

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
@@ -22,8 +22,9 @@ import (
 func TestJMXLog(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "jmx_test.log")
-	_, err := os.Create(filePath)
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	assert.NoError(t, err)
+	defer f.Close()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		config.MockModule(),

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
@@ -24,7 +24,6 @@ func TestJMXLog(t *testing.T) {
 	filePath := filepath.Join(dir, "jmx_test.log")
 	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	assert.NoError(t, err)
-	defer f.Close()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		config.MockModule(),
@@ -39,6 +38,7 @@ func TestJMXLog(t *testing.T) {
 	jmxLogger.JMXInfo("jmx info message")
 
 	jmxLogger.Flush()
+	f.Close()
 
 	bytes, err := os.ReadFile(filePath)
 	assert.NoError(t, err)

--- a/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
+++ b/comp/agent/jmxlogger/jmxloggerimpl/jmxlogger_test.go
@@ -24,6 +24,7 @@ func TestJMXLog(t *testing.T) {
 	filePath := filepath.Join(dir, "jmx_test.log")
 	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	assert.NoError(t, err)
+	defer f.Close()
 
 	deps := fxutil.Test[dependencies](t, fx.Options(
 		config.MockModule(),
@@ -38,7 +39,9 @@ func TestJMXLog(t *testing.T) {
 	jmxLogger.JMXInfo("jmx info message")
 
 	jmxLogger.Flush()
-	f.Close()
+
+	jmxLoggerInternal := jmxLogger.(logger)
+	jmxLoggerInternal.close()
 
 	bytes, err := os.ReadFile(filePath)
 	assert.NoError(t, err)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -33,8 +33,7 @@ type loggerPointer struct {
 
 var (
 	// Logger is the main DatadogLogger
-	logger    loggerPointer
-	jmxLogger loggerPointer
+	logger loggerPointer
 
 	// This buffer holds log lines sent to the logger before its
 	// initialization. Even if initializing the logger is one of the first
@@ -232,8 +231,8 @@ func (sw *loggerPointer) replaceInnerLogger(li LoggerInterface) LoggerInterface 
 // Flush flushes the underlying inner log
 func Flush() {
 	logger.flush()
-	jmxLogger.flush()
 }
+
 func (sw *loggerPointer) flush() {
 	l := sw.Load()
 	if l == nil {
@@ -915,23 +914,4 @@ func CriticalStackDepth(depth int, v ...interface{}) error {
 	return logWithError(CriticalLvl, func() { _ = CriticalStackDepth(depth, v...) }, func(s string) error {
 		return logger.criticalStackDepth(s, depth)
 	}, true, v...)
-}
-
-/*
-*	JMX Logger Section
- */
-
-// JMXError Logs for JMX check
-func JMXError(v ...interface{}) error {
-	return logWithError(ErrorLvl, func() { _ = JMXError(v...) }, jmxLogger.error, true, v...)
-}
-
-// JMXInfo Logs
-func JMXInfo(v ...interface{}) {
-	log(InfoLvl, func() { JMXInfo(v...) }, jmxLogger.info, v...)
-}
-
-// SetupJMXLogger setup JMXfetch specific logger
-func SetupJMXLogger(i LoggerInterface, level string) {
-	jmxLogger.Store(setupCommonLogger(i, level))
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -824,27 +824,3 @@ func TestTraceNilLogger(t *testing.T) {
 	// should not write to the logs buffer
 	assert.Equal(t, 0, len(logsBuffer))
 }
-
-func TestJMXLoggerSetup(t *testing.T) {
-	SetupJMXLogger(Default(), DebugStr)
-	assert.NotNil(t, jmxLogger.Load())
-}
-
-func TestJMXLog(t *testing.T) {
-	var b bytes.Buffer
-	w := bufio.NewWriter(&b)
-
-	l, _ := LoggerFromWriterWithMinLevelAndFormat(w, DebugLvl, "[%LEVEL] %FuncShort: %Msg\n")
-	SetupLogger(l, DebugStr)
-	SetupJMXLogger(l, DebugStr)
-
-	JMXError("jmx error message")
-	JMXInfo("jmx info message")
-
-	w.Flush()
-
-	assert.Subset(t, strings.Split(b.String(), "\n"), []string{
-		"[ERROR] TestJMXLog: jmx error message",
-		"[INFO] TestJMXLog: jmx info message",
-	})
-}

--- a/pkg/util/log/setup/log.go
+++ b/pkg/util/log/setup/log.go
@@ -112,28 +112,23 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 	return nil
 }
 
-// SetupJMXLogger sets up a logger with JMX logger name and log level
+// BuildJMXLogger sets up a logger with JMX logger name and log level
 // if a non empty logFile is provided, it will also log to the file
 // a non empty syslogURI will enable syslog, and format them following RFC 5424 if specified
 // you can also specify to log to the console and in JSON format
-func SetupJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) error {
+func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (seelog.LoggerInterface, error) {
 	// The JMX logger always logs at level "info", because JMXFetch does its
 	// own level filtering on and provides all messages to seelog at the info
 	// or error levels, via log.JMXInfo and log.JMXError.
 	seelogLogLevel, err := log.ValidateLogLevel("info")
 	if err != nil {
-		return err
+		return nil, err
 	}
 	jmxSeelogConfig, err = buildLoggerConfig(JMXLoggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	jmxLoggerInterface, err := GenerateLoggerInterface(jmxSeelogConfig)
-	if err != nil {
-		return err
-	}
-	log.SetupJMXLogger(jmxLoggerInterface, seelogLogLevel)
-	return nil
+	return GenerateLoggerInterface(jmxSeelogConfig)
 }
 
 // SetupDogstatsdLogger sets up a logger with dogstatsd logger name and log level


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

After fixing a SEGFAULT because of a nil pointer https://github.com/DataDog/datadog-agent/pull/39847, we decided to make the jmxLogger not use a global pointer. That way we no longer have to worry about the SEGFAULT problem before. 

### Motivation

Refactor, cleanup and remove use of global variables

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->