### PR TITLE
Cross-org telemetry for DogStatsD metrics type mixture

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -208,12 +208,9 @@ var defaultProfiles = `
       metrics:
         - name: dogstatsd.udp_packets_bytes
         - name: dogstatsd.uds_packets_bytes
-        - name: dogstatsd.metric_type_gauge_count
-        - name: dogstatsd.metric_type_counter_count
-        - name: dogstatsd.metric_type_distribution_count
-        - name: dogstatsd.metric_type_histogram_count
-        - name: dogstatsd.metric_type_set_count
-        - name: dogstatsd.metric_type_timing_count
+        - name: dogstatsd.metric_type_count
+          aggregate_tags:
+            - metric_type
         - name: aggregator.dogstatsd_contexts_by_mtype
           aggregate_tags:
             - shard

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -208,6 +208,16 @@ var defaultProfiles = `
       metrics:
         - name: dogstatsd.udp_packets_bytes
         - name: dogstatsd.uds_packets_bytes
+        - name: dogstatsd.metric_type_gauge_count
+        - name: dogstatsd.metric_type_counter_count
+        - name: dogstatsd.metric_type_distribution_count
+        - name: dogstatsd.metric_type_histogram_count
+        - name: dogstatsd.metric_type_set_count
+        - name: dogstatsd.metric_type_timing_count
+        - name: aggregator.dogstatsd_contexts_by_mtype
+          aggregate_tags:
+            - shard
+            - metric_type
         - name: logs.bytes_missed
         - name: logs.bytes_sent
         - name: logs.decoded

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -213,7 +213,6 @@ var defaultProfiles = `
             - metric_type
         - name: aggregator.dogstatsd_contexts_by_mtype
           aggregate_tags:
-            - shard
             - metric_type
         - name: logs.bytes_missed
         - name: logs.bytes_sent

--- a/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
+++ b/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    DogStatsD emits a new metric `metric_type_count` that tracks gauge, counters etc totals. Exposed via COATs as well as contexts_by_mtype.
+    DogStatsD emits a new metric ``metric_type_count`` that tracks gauge, counters etc totals.

--- a/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
+++ b/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    DogStatsD emits a new metric ``metric_type_count`` that tracks gauge, counters etc totals.
+    DogStatsD emits a new metric, ``metric_type_count``, that tracks total gauges, counters, etc.

--- a/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
+++ b/releasenotes/notes/Add-DogStatsD-metrics-to-count-metric-types.-4d74421bcd2222e6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    DogStatsD emits a new metric `metric_type_count` that tracks gauge, counters etc totals. Exposed via COATs as well as contexts_by_mtype.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit introduces COATs metrics for the metrics type mix we get in DogStatsD traffic. We understand that dogstatsd performance is heavily dictated by the metrics mixture an instance of dogstatsd receives. The goal of this change is to record this measure to improve fidelity of performance experiments.

I've introduced a new metric in the server `metric_type_count` that is an absolute counters, distinct from our existing `context_by_mtype` metric in that if a gauge is sent for the same context 1,000 times context_by_mtype will be 1 whereas metric_type_count will be 1,000. Metric types are distinguished by the `metric_type` tag. 

I have, with the same reasoning, exposed the `context_by_mtype` metric via COATs. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Confirmed collected by the Regression Detector, see [this panel](https://app.datadoghq.com/dashboard/ykh-ua8-vcu/SMP-Regression-Detector-Metrics?fromUser=false&refresh_mode=paused&tpl_var_experiment%5B0%5D=quality_gate_metrics_logs&tpl_var_run-id%5B0%5D=14f1df1d-98c0-4a21-a6ab-78c65515dbac&view=spans&from_ts=1755552364000&to_ts=1755552964000&live=false&tile_focus=3140684982653796). 

### Additional Notes

This also serves as a correctness check on our Regression Detector experiments: if the metrics mix recorded by DogStatsD is distinct from the experiment configuration, that's a problem. This will make it much, much more feasible to model workloads in Regression Detector experiments. 

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->