### PR TITLE
[OTAGENT-480] refactor host metadata pusher in serializer exporter

### DIFF
--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -175,12 +175,13 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/grpc v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.62.2 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.29.1 // indirect
 	github.com/aws/aws-sdk-go v1.55.7 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -107,6 +107,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/metrics v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.64.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
@@ -217,7 +217,7 @@ func (f *factory) createMetricsExporter(
 	statsv := set.BuildInfo.Command + set.BuildInfo.Version
 	ctx, cancel := context.WithCancel(ctx) // cancel() runs on shutdown
 	f.consumeStatsPayload(ctx, &wg, statsIn, statsv, fmt.Sprintf("datadogexporter-%s-%s", set.BuildInfo.Command, set.BuildInfo.Version), set.Logger)
-	sf := serializerexporter.NewFactoryForOTelAgent(f.s, &tagEnricher{}, f.h, statsIn, f.gatewayUsage, f.store)
+	sf := serializerexporter.NewFactoryForOTelAgent(f.s, &tagEnricher{}, f.h, statsIn, f.gatewayUsage, f.store, nil)
 	ex := &serializerexporter.ExporterConfig{
 		Metrics: serializerexporter.MetricsConfig{
 			Metrics: cfg.Metrics,

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -116,6 +116,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/metrics v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.61.0 // indirect
@@ -149,7 +151,6 @@ require (
 	github.com/DataDog/go-sqllexer v0.1.6 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
-	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.29.1 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.29.0 // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.29.1 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/apm_stats_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/apm_stats_test.go
@@ -86,7 +86,7 @@ func TestAPMStats_OTelAgent(t *testing.T) {
 	statsIn := make(chan []byte, 1000)
 	factory := NewFactoryForOTelAgent(&metricRecorder{}, &MockTagEnricher{}, func(context.Context) (string, error) {
 		return "", nil
-	}, statsIn, otel.NewDisabledGatewayUsage(), TelemetryStore{})
+	}, statsIn, otel.NewDisabledGatewayUsage(), TelemetryStore{}, nil)
 	testAPMStats(t, factory, statsIn)
 }
 

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -15,7 +15,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/otel"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata"
+
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics"

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util/otel"
-	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata"
 
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter_test.go
@@ -214,7 +214,7 @@ func Test_ConsumeMetrics_Tags(t *testing.T) {
 			ctx := context.Background()
 			f := NewFactoryForOTelAgent(rec, &MockTagEnricher{}, func(context.Context) (string, error) {
 				return "", nil
-			}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{})
+			}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{}, nil)
 			cfg := f.CreateDefaultConfig().(*ExporterConfig)
 			cfg.Metrics.Metrics.ExporterConfig.InstrumentationScopeMetadataAsTags = tt.instrumentationScopeMetadataAsTags
 			cfg.Metrics.Tags = strings.Join(tt.extraTags, ",")
@@ -331,7 +331,7 @@ func Test_ConsumeMetrics_MetricOrigins(t *testing.T) {
 			ctx := context.Background()
 			f := NewFactoryForOTelAgent(rec, &MockTagEnricher{}, func(context.Context) (string, error) {
 				return "", nil
-			}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{})
+			}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{}, nil)
 			cfg := f.CreateDefaultConfig().(*ExporterConfig)
 			exp, err := f.CreateMetrics(
 				ctx,
@@ -382,7 +382,7 @@ func testMetricPrefixWithFeatureGates(t *testing.T, disablePrefix bool, inName s
 	ctx := context.Background()
 	f := NewFactoryForOTelAgent(rec, &MockTagEnricher{}, func(context.Context) (string, error) {
 		return "", nil
-	}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{})
+	}, nil, otel.NewDisabledGatewayUsage(), TelemetryStore{}, nil)
 	cfg := f.CreateDefaultConfig().(*ExporterConfig)
 	exp, err := f.CreateMetrics(
 		ctx,
@@ -517,7 +517,7 @@ func TestUsageMetric_DDOT(t *testing.T) {
 	}
 	f := NewFactoryForOTelAgent(rec, &MockTagEnricher{}, func(context.Context) (string, error) {
 		return "agent-host", nil
-	}, nil, otel.NewDisabledGatewayUsage(), store)
+	}, nil, otel.NewDisabledGatewayUsage(), store, nil)
 	cfg := f.CreateDefaultConfig().(*ExporterConfig)
 	exp, err := f.CreateMetrics(
 		ctx,

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -158,9 +158,9 @@ require (
 require (
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.67.0
 	github.com/DataDog/datadog-agent/pkg/config/create v0.67.0
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.67.0
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.64.0
-	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.29.1
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.131.0
 	go.opentelemetry.io/collector/component/componenttest v0.131.0
@@ -214,6 +214,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/template v0.67.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
@@ -5,8 +5,6 @@ github.com/DataDog/agent-payload/v5 v5.0.162/go.mod h1:lxh9lb5xYrBXjblpIWYUi4deJ
 github.com/DataDog/datadog-agent/comp/core/secrets v0.67.0 h1:3VkM/GRDnT3Wnsmjtu2eikUgE0/Ml6gpz1pNKu4r2GQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.29.1 h1:La4jmC38Pv1CMlUhIMYl7uTZoH33FjplK+faeO7LK+c=
-github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.29.1/go.mod h1:7g86HsKmsUkON9d8LfiPZRZiS1+ucuvVB3SEwPuuF3c=
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.29.1 h1:NqX7omAjyRNL/enAnOWWzICfKgf3yog2eNCBQ5zDhdI=
 github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.29.1/go.mod h1:xQ8SuoIm/0lZcUeotR9caLqF5vFp76Dy1mNgn0yBWxs=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.29.1 h1:RoHver8/fv4qKZtmb11TJ/zcOMd0SqOKT8H9ZQIjjPA=

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/host_metadata_pusher.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/host_metadata_pusher.go
@@ -7,28 +7,25 @@ package serializerexporter
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/payload"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/payload"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
-type hostMetadataPusher struct {
-	forwarder defaultforwarder.Forwarder
+// HostMetadataPusher implements the inframetadata.Pusher interface
+type HostMetadataPusher struct {
+	s serializer.MetricSerializer
 }
 
-var _ inframetadata.Pusher = (*hostMetadataPusher)(nil)
+// NewPusher returns a new HostMetadataPusher
+func NewPusher(s serializer.MetricSerializer) *HostMetadataPusher {
+	return &HostMetadataPusher{s: s}
+}
 
-func (h *hostMetadataPusher) Push(_ context.Context, hm payload.HostMetadata) error {
-	marshaled, err := json.Marshal(hm)
-	if err != nil {
-		return fmt.Errorf("error marshaling metadata payload: %w", err)
-	}
+var _ inframetadata.Pusher = (*HostMetadataPusher)(nil)
 
-	bytesPayload := transaction.NewBytesPayloadsWithoutMetaData([]*[]byte{&marshaled})
-	return h.forwarder.SubmitHostMetadata(bytesPayload, http.Header{})
+// Push implements the Pusher.Push interface
+func (h *HostMetadataPusher) Push(_ context.Context, hm payload.HostMetadata) error {
+	return h.s.SendHostMetadata(&hm)
 }

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -109,7 +109,8 @@ func setupSerializer(config pkgconfigmodel.Config, cfg *ExporterConfig) {
 	config.Set("proxy.no_proxy", noProxy, pkgconfigmodel.SourceEnvVar)
 }
 
-func initSerializer(logger *zap.Logger, cfg *ExporterConfig, sourceProvider source.Provider) (*serializer.Serializer, *defaultforwarder.DefaultForwarder, error) {
+// InitSerializer initializes the serializer and forwarder for sending metrics. Should only be used in OSS Datadog exporter or in tests.
+func InitSerializer(logger *zap.Logger, cfg *ExporterConfig, sourceProvider source.Provider) (*serializer.Serializer, *defaultforwarder.DefaultForwarder, error) {
 	var f defaultforwarder.Component
 	var s *serializer.Serializer
 	app := fx.New(

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer_test.go
@@ -23,7 +23,7 @@ func TestInitSerializer(t *testing.T) {
 		return "test", nil
 	}
 	cfg := &ExporterConfig{}
-	s, fw, err := initSerializer(logger, cfg, sourceProvider)
+	s, fw, err := InitSerializer(logger, cfg, sourceProvider)
 	assert.Nil(t, err)
 	assert.IsType(t, &defaultforwarder.DefaultForwarder{}, fw)
 	assert.NotNil(t, fw)

--- a/go.mod
+++ b/go.mod
@@ -722,6 +722,8 @@ require (
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/impl v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/utils v0.0.0-00010101000000-000000000000 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/go-libddwaf/v3 v3.5.4 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.131.0 // indirect

--- a/pkg/opentelemetry-mapping-go/inframetadata/go.mod
+++ b/pkg/opentelemetry-mapping-go/inframetadata/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/pkg/serializer v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.37.0
 	go.opentelemetry.io/otel v1.37.0

--- a/pkg/opentelemetry-mapping-go/inframetadata/payload/payload.go
+++ b/pkg/opentelemetry-mapping-go/inframetadata/payload/payload.go
@@ -10,7 +10,11 @@
 package payload
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/gohai"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
 // HostMetadata includes metadata about the host tags,
@@ -90,3 +94,19 @@ func NewEmpty() HostMetadata {
 		Processes: &gohai.ProcessesPayload{},
 	}
 }
+
+// SplitPayload implements the JSONMarshaler.SplitPayload interface
+func (p *HostMetadata) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
+	// Metadata payloads are analyzed as a whole, so they cannot be split
+	return nil, fmt.Errorf("host Payload splitting is not implemented")
+}
+
+// MarshalJSON implements the JSONMarshaler.MarshalJSON interface
+func (p *HostMetadata) MarshalJSON() ([]byte, error) {
+	// use an alias to avoid infinite recursion while serializing
+	type PayloadAlias HostMetadata
+
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+var _ marshaler.JSONMarshaler = (*HostMetadata)(nil)


### PR DESCRIPTION
### What does this PR do?
Refactor and expose host metadata pusher in serializer exporter so that it can be reused in datadog exporter. This includes moving part of its dependency from opentelemetry-mapping-go repo to pkg/opentelemetry-mapping-go.

### Motivation
working towards https://github.com/DataDog/datadog-agent/pull/39893

### Describe how you validated your changes
no functional change yet, existing tests should cover