### PR TITLE
[NDINT-365] Add Versa Client Options

### DIFF
--- a/pkg/collector/corechecks/network-devices/versa/client/client.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client.go
@@ -41,16 +41,17 @@ type Client struct {
 	directorAPIPort   int
 	analyticsEndpoint string
 	// TODO: replace with OAuth
-	token               string
-	tokenExpiry         time.Time
-	username            string
-	password            string
-	authenticationMutex *sync.Mutex
-	maxAttempts         int
-	maxPages            int
-	maxCount            string // Stored as string to be passed as an HTTP param
-	lookback            string
-	useStartPagination  bool // Use "start" instead of "offset" for pagination (necessary for some deployments)
+	token                  string
+	tokenExpiry            time.Time
+	username               string
+	password               string
+	authenticationMutex    *sync.Mutex
+	maxAttempts            int
+	maxPages               int
+	maxCount               string // Stored as string to be passed as an HTTP param
+	lookback               string
+	useStartPagination     bool // Use "start" instead of "offset" for pagination (necessary for some deployments)
+	useAlternateAppliances bool // Use GetAppliances instead of GetChildAppliancesDetail for appliance collection
 }
 
 // ClientOptions are the functional options for the Versa client
@@ -191,6 +192,13 @@ func WithLookback(lookback int) ClientOptions {
 func WithStartPagination(useStart bool) ClientOptions {
 	return func(c *Client) {
 		c.useStartPagination = useStart
+	}
+}
+
+// WithAlternateAppliances is a functional option to enable using GetAppliances instead of GetChildAppliancesDetail
+func WithAlternateAppliances(useAlternate bool) ClientOptions {
+	return func(c *Client) {
+		c.useAlternateAppliances = useAlternate
 	}
 }
 

--- a/pkg/collector/corechecks/network-devices/versa/client/client_test.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/client_test.go
@@ -829,3 +829,34 @@ func TestWithStartPaginationOption(t *testing.T) {
 	require.False(t, client.useStartPagination)
 	require.Equal(t, "offset", client.getOffsetParamName())
 }
+
+func TestWithAlternateAppliancesOption(t *testing.T) {
+	// Test with feature flag disabled (default)
+	client, err := NewClient("example.com", 9182, "analytics.example.com:8443", "user", "pass", false)
+	require.NoError(t, err)
+	require.False(t, client.useAlternateAppliances)
+
+	// Test with feature flag enabled
+	client, err = NewClient("example.com", 9182, "analytics.example.com:8443", "user", "pass", false, WithAlternateAppliances(true))
+	require.NoError(t, err)
+	require.True(t, client.useAlternateAppliances)
+
+	// Test with feature flag explicitly disabled
+	client, err = NewClient("example.com", 9182, "analytics.example.com:8443", "user", "pass", false, WithAlternateAppliances(false))
+	require.NoError(t, err)
+	require.False(t, client.useAlternateAppliances)
+}
+
+func TestUseAlternateAppliancesFlag(t *testing.T) {
+	t.Run("UseAlternateAppliances=false", func(t *testing.T) {
+		client, err := NewClient("example.com", 9182, "analytics.example.com:8443", "user", "pass", false, WithAlternateAppliances(false))
+		require.NoError(t, err)
+		require.False(t, client.useAlternateAppliances)
+	})
+
+	t.Run("UseAlternateAppliances=true", func(t *testing.T) {
+		client, err := NewClient("example.com", 9182, "analytics.example.com:8443", "user", "pass", false, WithAlternateAppliances(true))
+		require.NoError(t, err)
+		require.True(t, client.useAlternateAppliances)
+	})
+}

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -72,6 +72,7 @@ type checkCfg struct {
 	CollectQoSMetrics                     *bool    `yaml:"collect_qos_metrics"`
 	CollectDIAMetrics                     *bool    `yaml:"collect_dia_metrics"`
 	CollectSiteMetrics                    *bool    `yaml:"collect_site_metrics"`
+	UseStartPagination                    *bool    `yaml:"use_start_pagination"`
 }
 
 // VersaCheck contains the fields for the Versa check
@@ -390,6 +391,7 @@ func (v *VersaCheck) Configure(senderManager sender.SenderManager, integrationCo
 	instanceConfig.CollectQoSMetrics = boolPointer(false)
 	instanceConfig.CollectDIAMetrics = boolPointer(false)
 	instanceConfig.CollectSiteMetrics = boolPointer(false)
+	instanceConfig.UseStartPagination = boolPointer(false)
 
 	err = yaml.Unmarshal(rawInstance, &instanceConfig)
 	if err != nil {
@@ -446,6 +448,10 @@ func (v *VersaCheck) buildClientOptions() ([]client.ClientOptions, error) {
 
 	if v.config.LookbackTimeWindowMinutes > 0 {
 		clientOptions = append(clientOptions, client.WithLookback(v.config.LookbackTimeWindowMinutes))
+	}
+
+	if v.config.UseStartPagination != nil && *v.config.UseStartPagination {
+		clientOptions = append(clientOptions, client.WithStartPagination(true))
 	}
 
 	return clientOptions, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This adds two new config flags to the Versa integration:

- `use_start_pagination`

This changes the pagination behavior of Director endpoints to use `start` instead of `offset` for paginated API calls. This is necessary for some environments.

- `use_alternate_appliances_endpoint`

This changes the endpoint used for gathering appliance metadata and hardware metrics from the Versa API. This alternate endpoint is lighter weight, but it's missing data on controllers.

### Motivation
These changes are being made in response to early feedback on the integration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tested against our own Versa cluster

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->