### PR TITLE
use write-host for native command stderr

### DIFF
--- a/releasenotes/notes/fix-install-script-error-visibility-5d3f0c608bb36790.yaml
+++ b/releasenotes/notes/fix-install-script-error-visibility-5d3f0c608bb36790.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``Install-Datadog.ps1`` now displays error messages when run in environments
+    without a proper console, such as PSRemoting or PowerShell ISE.

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -139,12 +139,14 @@ function Start-ProcessWithOutput {
    $stderr = Register-ObjectEvent -InputObject $process -EventName 'ErrorDataReceived' `
       -Action {
       if (![String]::IsNullOrEmpty($EventArgs.Data)) {
-         # Print stderr from process into host stderr
-         # Unfortunately that means this output cannot be captured from within PowerShell
-         # and it won't work within PowerShell ISE because it is not a console host.
-         [Console]::ForegroundColor = 'red'
-         [Console]::Error.WriteLine($EventArgs.Data)
-         [Console]::ResetColor()
+         # Different environments seem to show/hide different output streams
+         # PSRemoting and ISE won't see console
+         # PSRemoting sees Write-Error but neither console nor ISE do
+         # Write-Host seems pretty universal, though we lose the stdout/stderr distinction
+         # The only thing we're doing with the output right now is displaying to
+         # the user, so this seems okay. If we need the distinction later we can
+         # figure out how to output it.
+         Write-Host $EventArgs.Data -ForegroundColor 'red'
       }
    }
    [void]$process.Start()

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -3,7 +3,7 @@
    Downloads and installs Datadog on the machine.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Default')]
-$SCRIPT_VERSION = "1.1.0"
+$SCRIPT_VERSION = "1.1.1"
 $GENERAL_ERROR_CODE = 1
 
 # Set some defaults if not provided


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
`Install-Datadog.ps1` now displays error messages when run in environments without a proper console, such as PSRemoting or PowerShell ISE.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1682

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run the install script in PSRemoting or PowerShell ISE, and create an error in bootstrap. For example, don't provide an API key, or provide an unsupported version. Without patch, you won't see the error message, with patch you'll see the JSON formatted error message,

Example to run with PSRemoting on Hyper-V VM named `Windows Server 2022`
```PowerShell
Invoke-Command -VMName "Windows Server 2022" -Command {
    $env:DD_AGENT_MINOR_VERSION="60.0";
    (New-Object System.Net.WebClient).DownloadFile('https://install.datadoghq.com/Install-Datadog.ps1', 'C:\Windows\SystemTemp\Install-Datadog.ps1');
    C:\Windows\SystemTemp\Install-Datadog.ps1;
}
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->