### PR TITLE
[macos runners] Report runner ID to Datadog

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -4,11 +4,10 @@
 .macos_runner_maintenance:
   - DD_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DD_API_KEY
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
-  - uname -a
-  - hostname
-  - curl -s http://169.254.169.254/latest/meta-data/instance-id || true
-  - datadog-ci tag --level job --tags macos_runner:"$(hostname)"
-  - echo DATADOG CI OK
+  - |
+    RUNNER_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id || hostname)"
+    datadog-ci tag --level job --tags macos_runner:"$RUNNER_ID"
+    echo "Reported runner ID to Datadog: $RUNNER_ID"
   # Report current version to datadog if main / release branch
   - |
     if [ "$CI_COMMIT_BRANCH" = "main" ] || [[ "$CI_COMMIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.(x|[0-9]+)$ ]]; then

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -2,6 +2,8 @@
 # This is the scripts to be executed on the Gitlab macOS runners before every job.
 # We don't have virtualization now so we need to clean the environment and install the proper dependencies before every job.
 .macos_runner_maintenance:
+  - datadog-ci tag --level job --tags macos_runner:42
+  - echo DATADOG CI OK
   - DD_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DD_API_KEY
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
   # Report current version to datadog if main / release branch

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -4,7 +4,10 @@
 .macos_runner_maintenance:
   - DD_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DD_API_KEY
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
-  - datadog-ci tag --level job --tags macos_runner:42
+  - uname -a
+  - hostname
+  - curl -s http://169.254.169.254/latest/meta-data/instance-id || true
+  - datadog-ci tag --level job --tags macos_runner:"$(hostname)"
   - echo DATADOG CI OK
   # Report current version to datadog if main / release branch
   - |

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -2,10 +2,10 @@
 # This is the scripts to be executed on the Gitlab macOS runners before every job.
 # We don't have virtualization now so we need to clean the environment and install the proper dependencies before every job.
 .macos_runner_maintenance:
-  - datadog-ci tag --level job --tags macos_runner:42
-  - echo DATADOG CI OK
   - DD_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DD_API_KEY
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
+  - datadog-ci tag --level job --tags macos_runner:42
+  - echo DATADOG CI OK
   # Report current version to datadog if main / release branch
   - |
     if [ "$CI_COMMIT_BRANCH" = "main" ] || [[ "$CI_COMMIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.(x|[0-9]+)$ ]]; then

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -6,7 +6,8 @@
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
   # Report runner ID to Datadog, see this document for AWS meta data retrieval: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
   - |
-    RUNNER_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id || hostname)"
+    AWS_TOKEN="$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+    RUNNER_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $AWS_TOKEN" || hostname)"
     datadog-ci tag --level job --tags macos_runner:"$RUNNER_ID"
     echo "Reported runner ID to Datadog: $RUNNER_ID"
   # Report current version to datadog if main / release branch

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -4,6 +4,7 @@
 .macos_runner_maintenance:
   - DD_API_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_API_KEY_ORG2" token)" || exit $?; export DD_API_KEY
   - DD_APP_KEY="$("$CI_PROJECT_DIR"/tools/ci/fetch_secret.sh "$AGENT_APP_KEY_ORG2" token)" || exit $?; export DD_APP_KEY
+  # Report runner ID to Datadog, see this document for AWS meta data retrieval: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
   - |
     RUNNER_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id || hostname)"
     datadog-ci tag --level job --tags macos_runner:"$RUNNER_ID"

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -23,14 +23,13 @@
 
 .agent_dmg:
   stage: package_build
-  # needs: ["go_mod_tidy_check"]
-  needs: []
-  # rules:
-  #    - !reference [.on_macos_gui_change]
-  #    - !reference [.on_packaging_change]
-  #    - !reference [.on_main_or_release_branch]
-  #    - !reference [.on_all_builds]
-  #    - !reference [.manual]
+  needs: ["go_mod_tidy_check"]
+  rules:
+     - !reference [.on_macos_gui_change]
+     - !reference [.on_packaging_change]
+     - !reference [.on_main_or_release_branch]
+     - !reference [.on_all_builds]
+     - !reference [.manual]
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -23,13 +23,14 @@
 
 .agent_dmg:
   stage: package_build
-  needs: ["go_mod_tidy_check"]
-  rules:
-     - !reference [.on_macos_gui_change]
-     - !reference [.on_packaging_change]
-     - !reference [.on_main_or_release_branch]
-     - !reference [.on_all_builds]
-     - !reference [.manual]
+  # needs: ["go_mod_tidy_check"]
+  needs: []
+  # rules:
+  #    - !reference [.on_macos_gui_change]
+  #    - !reference [.on_packaging_change]
+  #    - !reference [.on_main_or_release_branch]
+  #    - !reference [.on_all_builds]
+  #    - !reference [.manual]
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This reports the macos runner ID to Datadog such that we can easily filter jobs by runner ID.

<img width="181" height="76" alt="image" src="https://github.com/user-attachments/assets/8b23478b-4e0b-46cb-b778-58752c52fbf6" />

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->