### PR TITLE
fix(rc): declare existing config for WebSockets

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1270,6 +1270,8 @@ func remoteconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_list", defaultAllowedRCIntegrations)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.block_list", []string{})
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_log_config_scheduling", false)
+	// Websocket echo test
+	config.BindEnvAndSetDefault("remote_configuration.no_websocket_echo", false)
 }
 
 func autoconfig(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
@hush-hush pointed this out in slack 👍 

---

* fix(rc): declare existing config for WebSockets (853e59f7ed)
      
      This adds a config item used in [1] that was not declared, causing
      warning logs for users (not yet released).
      
      [1]: https://github.com/DataDog/datadog-agent/pull/38877