### PR TITLE
[SBOM] extract common `convertScanResultToSBOM` code between collectors

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/crio/image_sbom_trivy.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/image_sbom_trivy.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
@@ -128,30 +127,7 @@ func (c *collector) processScanResult(result sbom.ScanResult) {
 		return
 	}
 
-	c.notifyStoreWithSBOMForImage(result.ImgMeta.ID, convertScanResultToSBOM(result))
-}
-
-// convertScanResultToSBOM converts an SBOM scan result to a workloadmeta SBOM.
-func convertScanResultToSBOM(result sbom.ScanResult) *workloadmeta.SBOM {
-	status := workloadmeta.Success
-	reportedError := ""
-	var report *cyclonedx_v1_4.Bom
-
-	if result.Error != nil {
-		log.Errorf("SBOM generation failed for image: %v", result.Error)
-		status = workloadmeta.Failed
-		reportedError = result.Error.Error()
-	} else {
-		report = result.Report.ToCycloneDX()
-	}
-
-	return &workloadmeta.SBOM{
-		CycloneDXBOM:       report,
-		GenerationTime:     result.CreatedAt,
-		GenerationDuration: result.Duration,
-		Status:             status,
-		Error:              reportedError,
-	}
+	c.notifyStoreWithSBOMForImage(result.ImgMeta.ID, result.ConvertScanResultToSBOM())
 }
 
 // notifyStoreWithSBOMForImage notifies the store about the SBOM for a given image.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The code converting a SBOM report into a workloadmeta SBOM is duplicated between containerd, docker, and crio collectors. This PR migrates all 3 collectors to use the same code instead.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->