### PR TITLE
[SINT-3921] Use new testing signing key locations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,7 @@ variables:
   # note the name is TEST_KEYS_URL, not TESTING_KEYS_URL;
   # this is because TESTING_KEYS_URL is a variable used by the install script,
   # and we don't want to modify its behavior inadvertently
-  TEST_KEYS_URL: apttesting.datad0g.com/test-keys-vault
+  TEST_KEYS_URL: apttesting.datad0g.com/test-keys
   INSTALLER_TESTING_S3_BUCKET: installtesting.datad0g.com
   WINDOWS_TESTING_S3_BUCKET: pipelines/A7/$CI_PIPELINE_ID
   WINDOWS_BUILDS_S3_BUCKET: $WIN_S3_BUCKET/builds
@@ -190,7 +190,7 @@ variables:
   # note the unusual ID for a GPG key:
   # it's the path of a Vault key to be used with gpg-vault
   # (https://github.com/DataDog/dd-source/tree/main/domains/seceng/sit/apps/artifact-security/vault-gpg-client/gpg-vault)
-  GPG_TEST_KEY_ID: crypto/k8s/keys/k8s_gitlab-runner_datadog-agent_testing-signing-key
+  GPG_TEST_KEY_ID: crypto/k8s/keys/k8s_gitlab-runner-datadog-agent_datadog-agent_testing_signing-key
   DOCKER_REGISTRY_URL: docker.io
   KITCHEN_INFRASTRUCTURE_FLAKES_RETRY: 2
   CLANG_LLVM_VER: 12.0.1

--- a/test/new-e2e/tests/agent-platform/ddot/ddot_install_test.go
+++ b/test/new-e2e/tests/agent-platform/ddot/ddot_install_test.go
@@ -187,7 +187,7 @@ func (is *ddotInstallSuite) ddotDebianTest(VMclient *common.TestClient) {
 		ExecuteWithoutError(t, VMclient, "sudo touch %s && sudo chmod a+r %s", aptUsrShareKeyring, aptUsrShareKeyring)
 		keys := []string{"DATADOG_APT_KEY_CURRENT.public", "DATADOG_APT_KEY_C0962C7D.public", "DATADOG_APT_KEY_F14F620E.public", "DATADOG_APT_KEY_382E94DE.public"}
 		for _, key := range keys {
-			ExecuteWithoutError(t, VMclient, "sudo curl --retry 5 -o \"/tmp/%s\" \"https://apttesting.datad0g.com/test-keys-vault/%s\"", key, key)
+			ExecuteWithoutError(t, VMclient, "sudo curl --retry 5 -o \"/tmp/%s\" \"https://apttesting.datad0g.com/test-keys/%s\"", key, key)
 			ExecuteWithoutError(t, VMclient, "sudo cat \"/tmp/%s\" | sudo gpg --import --batch --no-default-keyring --keyring \"%s\"", key, aptUsrShareKeyring)
 		}
 	})
@@ -242,10 +242,10 @@ func (is *ddotInstallSuite) ddotRhelTest(VMclient *common.TestClient) {
 		"enabled=1\n"+
 		"gpgcheck=1\n"+
 		"repo_gpgcheck=%s\n"+
-		"gpgkey=https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public\n"+
-		"\thttps://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public\n"+
-		"\thttps://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public\n"+
-		"\thttps://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public",
+		"gpgkey=https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public\n"+
+		"\thttps://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public\n"+
+		"\thttps://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public\n"+
+		"\thttps://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public",
 		yumrepo, repogpgcheck)
 	_, err = fileManager.WriteFile("/etc/yum.repos.d/datadog.repo", []byte(fileContent))
 	require.NoError(is.T(), err)
@@ -295,21 +295,21 @@ func (is *ddotInstallSuite) ddotSuseTest(VMclient *common.TestClient) {
 		"enabled=1\n"+
 		"gpgcheck=1\n"+
 		"repo_gpgcheck=1\n"+
-		"gpgkey=https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public\n",
+		"gpgkey=https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public\n",
 		suseRepo)
 	_, err = fileManager.WriteFile("/etc/zypp/repos.d/datadog.repo", []byte(fileContent))
 	require.NoError(is.T(), err)
 
-	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public")
+	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public")
 	ExecuteWithoutError(nil, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_CURRENT.public")
-	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_B01082D3.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public")
+	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_B01082D3.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public")
 	ExecuteWithoutError(nil, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_B01082D3.public")
-	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public")
+	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public")
 	ExecuteWithoutError(nil, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public")
-	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public")
+	ExecuteWithoutError(nil, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public")
 	ExecuteWithoutError(nil, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public")
 
 	is.T().Run("install ddot", func(t *testing.T) {

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -94,7 +94,7 @@ func TestInstallScript(t *testing.T) {
 			suite := &installScriptSuite{cwsSupported: cwsSupported}
 			// will be set as TESTING_KEYS_URL in the install script
 			// the used in places like https://github.com/DataDog/agent-linux-install-script/blob/8f5c0b4f5b60847ee7989aa2c35052382f282d5d/install_script.sh.template#L1229
-			suite.testingKeysURL = "apttesting.datad0g.com/test-keys-vault"
+			suite.testingKeysURL = "apttesting.datad0g.com/test-keys"
 
 			e2e.Run(tt,
 				suite,

--- a/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
@@ -100,7 +100,7 @@ func TestPersistingIntegrations(t *testing.T) {
 			e2e.Run(tt,
 				// testingKeysURL will be set as TESTING_KEYS_URL in the install script
 				// then used in places like https://github.com/DataDog/agent-linux-install-script/blob/8f5c0b4f5b60847ee7989aa2c35052382f282d5d/install_script.sh.template#L1229
-				&persistingIntegrationsSuite{srcVersion: *srcAgentVersion, platform: *platform, testingKeysURL: "apttesting.datad0g.com/test-keys-vault"},
+				&persistingIntegrationsSuite{srcVersion: *srcAgentVersion, platform: *platform, testingKeysURL: "apttesting.datad0g.com/test-keys"},
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -195,7 +195,7 @@ func (is *stepByStepSuite) StepByStepDebianTest(VMclient *common.TestClient) {
 		ExecuteWithoutError(t, VMclient, "sudo touch %s && sudo chmod a+r %s", aptUsrShareKeyring, aptUsrShareKeyring)
 		keys := []string{"DATADOG_APT_KEY_CURRENT.public", "DATADOG_APT_KEY_C0962C7D.public", "DATADOG_APT_KEY_F14F620E.public", "DATADOG_APT_KEY_382E94DE.public"}
 		for _, key := range keys {
-			ExecuteWithoutError(t, VMclient, "sudo curl --retry 5 -o \"/tmp/%s\" \"https://apttesting.datad0g.com/test-keys-vault/%s\"", key, key)
+			ExecuteWithoutError(t, VMclient, "sudo curl --retry 5 -o \"/tmp/%s\" \"https://apttesting.datad0g.com/test-keys/%s\"", key, key)
 			ExecuteWithoutError(t, VMclient, "sudo cat \"/tmp/%s\" | sudo gpg --import --batch --no-default-keyring --keyring \"%s\"", key, aptUsrShareKeyring)
 		}
 	})
@@ -238,10 +238,10 @@ func (is *stepByStepSuite) StepByStepRhelTest(VMclient *common.TestClient) {
 		"enabled=1\n"+
 		"gpgcheck=1\n"+
 		"repo_gpgcheck=%s\n"+
-		"gpgkey=%s://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public\n"+
-		"\t%s://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public\n"+
-		"\t%s://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public\n"+
-		"\t%s://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public",
+		"gpgkey=%s://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public\n"+
+		"\t%s://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public\n"+
+		"\t%s://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public\n"+
+		"\t%s://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public",
 		yumrepo, repogpgcheck, protocol, protocol, protocol, protocol)
 	_, err = fileManager.WriteFile("/etc/yum.repos.d/datadog.repo", []byte(fileContent))
 	require.NoError(is.T(), err)
@@ -275,22 +275,22 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 		"enabled=1\n"+
 		"gpgcheck=1\n"+
 		"repo_gpgcheck=1\n"+
-		"gpgkey=https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public\n"+
-		"	    https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public\n",
+		"gpgkey=https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public\n"+
+		"	    https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public\n",
 		suseRepo)
 	_, err = fileManager.WriteFile("/etc/zypp/repos.d/datadog.repo", []byte(fileContent))
 	require.NoError(is.T(), err)
 
 	is.T().Run("install suse", func(t *testing.T) {
-		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_CURRENT.public")
+		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_CURRENT.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_CURRENT.public")
-		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_B01082D3.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_B01082D3.public")
+		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_B01082D3.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_B01082D3.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_B01082D3.public")
-		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_FD4BF915.public")
+		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_FD4BF915.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public")
-		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://apttesting.datad0g.com/test-keys-vault/DATADOG_RPM_KEY_E09422B3.public")
+		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://apttesting.datad0g.com/test-keys/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive --no-gpg-checks refresh datadog")
 		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive --no-refresh install %s", *flavorName)

--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -120,7 +120,7 @@ func (s *installScriptDefaultSuite) TestInstallParity() {
 	}
 	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(map[string]string{
 		"DD_API_KEY":               s.getAPIKey(),
-		"TESTING_KEYS_URL":         "apttesting.datad0g.com/test-keys-vault",
+		"TESTING_KEYS_URL":         "apttesting.datad0g.com/test-keys",
 		"TESTING_APT_URL":          fmt.Sprintf("s3.amazonaws.com/apttesting.datad0g.com/datadog-agent/pipeline-%s-a7", os.Getenv("E2E_PIPELINE_ID")),
 		"TESTING_APT_REPO_VERSION": fmt.Sprintf("stable-%s 7", s.arch),
 		"TESTING_YUM_URL":          "s3.amazonaws.com/yumtesting.datad0g.com",

--- a/test/new-e2e/tests/installer/unix/package_definitions.go
+++ b/test/new-e2e/tests/installer/unix/package_definitions.go
@@ -84,7 +84,7 @@ func installScriptPackageManagerEnv(env map[string]string, arch e2eos.Architectu
 	env["DD_API_KEY"] = apiKey
 	env["DD_SITE"] = "datadoghq.com"
 	// Install Script env variables
-	env["TESTING_KEYS_URL"] = "apttesting.datad0g.com/test-keys-vault"
+	env["TESTING_KEYS_URL"] = "apttesting.datad0g.com/test-keys"
 	env["TESTING_APT_URL"] = fmt.Sprintf("s3.amazonaws.com/apttesting.datad0g.com/datadog-agent/pipeline-%s-a7", os.Getenv("E2E_PIPELINE_ID"))
 	env["TESTING_APT_REPO_VERSION"] = fmt.Sprintf("stable-%s 7", arch)
 	env["TESTING_YUM_URL"] = "s3.amazonaws.com/yumtesting.datad0g.com"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR updates the locations for the testing keys. The new locations can be accessed by both the existing and future Gitlab CI runners of the `datadog-agent` project.
The public keys are now in `apttesting.datad0g.com/test-keys` (instead of `apttesting.datad0g.com/test-keys-vault`)
The private key is now in `crypto/k8s/keys/k8s_gitlab-runner-datadog-agent_datadog-agent_testing_signing-key` (instead of `crypto/k8s/keys/k8s_gitlab-runner_datadog-agent_testing-signing-key`).

This will require an equivalent `test-infra-definitions` change: https://github.com/DataDog/test-infra-definitions/pull/1665

### Motivation

Unblock Gitlab runner migration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran a full deploy pipeline to run all tests.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a