### PR TITLE
avoid causing deadlock in tagger subscription manager

### DIFF
--- a/comp/core/tagger/subscriber/subscription_manager.go
+++ b/comp/core/tagger/subscriber/subscription_manager.go
@@ -136,7 +136,7 @@ func (sm *subscriptionManager) Notify(events []types.EntityEvent) {
 			for _, subscriber := range subscribers {
 
 				if len(subscriber.ch) >= bufferSize {
-					log.Info("channel full, canceling subscription")
+					log.Errorf("subscriber with id %q has a channel full, canceling subscription", subscriber.id)
 					sm.unsubscribe(subscriber.id)
 					continue
 				}

--- a/comp/core/tagger/subscriber/subscription_manager.go
+++ b/comp/core/tagger/subscriber/subscription_manager.go
@@ -77,11 +77,9 @@ func (sm *subscriptionManager) Subscribe(id string, filter *types.Filter, events
 	return subscriber, nil
 }
 
-// Unsubscribe ends a subscription to entity events and closes its channel.
-func (sm *subscriptionManager) Unsubscribe(subscriptionID string) {
-	sm.Lock()
-	defer sm.Unlock()
-
+// unsubscribe ends a subscription to entity events and closes its channel.
+// This method is not thread-safe.
+func (sm *subscriptionManager) unsubscribe(subscriptionID string) {
 	sub, found := sm.subscribers[subscriptionID]
 	if !found {
 		log.Debugf("subscriber with %q is already unsubscribed", subscriptionID)
@@ -111,6 +109,13 @@ func (sm *subscriptionManager) Unsubscribe(subscriptionID string) {
 	sm.telemetryStore.Subscribers.Dec()
 }
 
+// Unsubscribe is a thread-safe implementation of unsubscribe
+func (sm *subscriptionManager) Unsubscribe(subscriptionID string) {
+	sm.Lock()
+	defer sm.Unlock()
+	sm.unsubscribe(subscriptionID)
+}
+
 // Notify sends a slice of EntityEvents to all registered subscribers at their
 // chosen cardinality.
 func (sm *subscriptionManager) Notify(events []types.EntityEvent) {
@@ -132,7 +137,7 @@ func (sm *subscriptionManager) Notify(events []types.EntityEvent) {
 
 				if len(subscriber.ch) >= bufferSize {
 					log.Info("channel full, canceling subscription")
-					sm.Unsubscribe(subscriber.id)
+					sm.unsubscribe(subscriber.id)
 					continue
 				}
 				subIDToEvents[subscriber.id] = append(subIDToEvents[subscriber.id], event)


### PR DESCRIPTION
### What does this PR do?

Removes the possibility of deadlock caused in the tagger subscription manager.

When the code enters in this error condition: https://github.com/DataDog/datadog-agent/blob/main/comp/core/tagger/subscriber/subscription_manager.go#L134 it deadlocks.
The reason is that the Notify() function takes the mutex and doesn’t unlock until it finishes, but in that if, it calls Unsubscribe which also tries to take the lock.

### Motivation



### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests and E2E tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->