### PR TITLE
[AGENTCFG-377] Only add the secret-generic-connectory side binary to the non-fips agents

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -9,6 +9,8 @@ if linux_target?
 end
 if fips_mode?
   dependency 'openssl-fips-provider'
+else
+  dependency 'secret-generic-connector' unless heroku_target?
 end
 
 # Bundled cacerts file (is this a good idea?)
@@ -26,8 +28,6 @@ dependency 'libpcap' if linux_target? and !heroku_target? # system-probe depende
 
 # Include traps db file in snmp.d/traps_db/
 dependency 'snmp-traps'
-
-dependency 'secret-generic-connector' unless heroku_target?
 
 dependency 'datadog-agent-integrations-py3'
 

--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -77,13 +77,9 @@ build do
     # Extract the zip file
     copy "#{project_dir}/datadog-secret-backend.exe", "#{install_dir}/bin/secret-generic-connector.exe"
   else
-    if fips_mode?
-      next
-    else
-      # Extract the tar.gz file
-      target = "#{install_dir}/embedded/bin/secret-generic-connector"
-      copy "#{project_dir}/datadog-secret-backend", target
-      block { File.chmod(0500, target) }
-    end
+    # Extract the tar.gz file
+    target = "#{install_dir}/embedded/bin/secret-generic-connector"
+    copy "#{project_dir}/datadog-secret-backend", target
+    block { File.chmod(0500, target) }
   end
 end

--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -77,9 +77,13 @@ build do
     # Extract the zip file
     copy "#{project_dir}/datadog-secret-backend.exe", "#{install_dir}/bin/secret-generic-connector.exe"
   else
-    # Extract the tar.gz file
-    target = "#{install_dir}/embedded/bin/secret-generic-connector"
-    copy "#{project_dir}/datadog-secret-backend", target
-    block { File.chmod(0500, target) }
+    if fips_mode?
+      next
+    else
+      # Extract the tar.gz file
+      target = "#{install_dir}/embedded/bin/secret-generic-connector"
+      copy "#{project_dir}/datadog-secret-backend", target
+      block { File.chmod(0500, target) }
+    end
   end
 end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We discovered that the secret-generic-connectory binary (which is shipped along with the agent) isn't FIPS-encrypted, and so, for now, we will need to avoid shipping it with fips agents.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->