### PR TITLE
Update windows images by default in go update workflow

### DIFF
--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -23,6 +23,11 @@ on:
         description: 'Whether to also bump the Go version in modules used by OpenTelemetry'
         required: true
         type: boolean
+      update_windows_images:
+        description: 'Whether to update the Windows images. They are always updated if the Go version was changed'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   open-go-update-pr:
@@ -96,9 +101,10 @@ jobs:
           CURRENT_BUILDIMAGE_TAG: ${{ steps.current_buildimage_tag.outputs.BUILDIMAGE_TAG }}
           IMAGES_ID: ${{ inputs.images_id }}
           TMP_PR_BODY_PATH: /tmp/pr_body
+          WINDOWS_FLAG: ${{ inputs.update_windows_images && '--windows' || '' }}
         run: |
           if [ "$CURRENT_GO_VERSION" = "$INPUT_GO_VERSION" ]; then
-            dda inv -- -e buildimages.update --tag "$IMAGES_ID" "$TEST_VERSION_FLAG"
+            dda inv -- -e buildimages.update --tag "$IMAGES_ID" "$TEST_VERSION_FLAG" $WINDOWS_FLAG
             echo "MESSAGE=Update buildimages ID to $IMAGES_ID" >> $GITHUB_OUTPUT
           else
             dda inv -- -e update-go --image-tag "$IMAGES_ID" "$TEST_VERSION_FLAG" $INCLUDE_OTEL_MODULES -v "$INPUT_GO_VERSION"

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -80,7 +80,7 @@ def update_go(
 
     if image_tag:
         try:
-            update_gitlab_config(".gitlab-ci.yml", image_tag, test=test)
+            update_gitlab_config(".gitlab-ci.yml", image_tag, test=test, windows=True)
         except RuntimeError as e:
             if warn:
                 print(color_message(f"WARNING: {str(e)}", "orange"))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the `go-update` workflow to update Windows buildimages by default.
Also add a `update_windows_images` on the buildimages update workflow.

### Motivation
The workflows didn't update Windows buildimages, which made Windows job fail, and required pushing another commit.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->