### PR TITLE
[SBOM] make sure we do not send running metric if container images are disabled

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -244,7 +244,9 @@ func (c *Check) Run() error {
 }
 
 func (c *Check) sendUsageMetrics() {
-	c.sender.Count("datadog.agent.sbom.container_images.running", 1.0, "", nil)
+	if c.cfg.GetBool("sbom.container_image.enabled") {
+		c.sender.Count("datadog.agent.sbom.container_images.running", 1.0, "", nil)
+	}
 
 	if c.cfg.GetBool("sbom.host.enabled") {
 		c.sender.Count("datadog.agent.sbom.hosts.running", 1.0, "", []string{"os:" + runtime.GOOS})


### PR DESCRIPTION
### What does this PR do?

Currently if:
- `sbom.enabled` is true
- `sbom.host.enabled` is true
- `sbom.container_image.enabled` is false
the agent will emit the `datadog.agent.sbom.container_images.running` metric, which is not what we want. This PR fixes this.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->