### PR TITLE
[OTAGENT-480] allow host metadata config in DDOT

### DIFF
--- a/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-enhanced-result.yaml
+++ b/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-enhanced-result.yaml
@@ -7,7 +7,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []

--- a/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-provided-result.yaml
+++ b/comp/otelcol/ddflareextension/impl/testdata/simple-dd/config-provided-result.yaml
@@ -7,7 +7,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
@@ -127,7 +127,6 @@ func CreateDefaultConfig() component.Config {
 	ddcfg := datadogconfig.CreateDefaultConfig().(*datadogconfig.Config)
 	ddcfg.Traces.TracesConfig.ComputeTopLevelBySpanKind = true
 	ddcfg.Logs.Endpoint = "https://agent-http-intake.logs.datadoghq.com"
-	ddcfg.HostMetadata.Enabled = false
 	return ddcfg
 }
 
@@ -147,9 +146,6 @@ func logWarnings(cfg *datadogconfig.Config, logger *zap.Logger) {
 	cfg.LogWarnings(logger)
 	if cfg.Hostname != "" {
 		logger.Warn(fmt.Sprintf("hostname \"%s\" is ignored in the embedded collector", cfg.Hostname))
-	}
-	if cfg.HostMetadata.Enabled {
-		logger.Warn("host_metadata should not be enabled and is ignored in the embedded collector")
 	}
 	if cfg.OnlyMetadata {
 		logger.Warn("only_metadata should not be enabled and is ignored in the embedded collector")

--- a/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/minimal-full-config.yml
@@ -21,7 +21,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []

--- a/test/new-e2e/tests/otel/otel-agent/testdata/minimal-provided-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/minimal-provided-config.yml
@@ -21,7 +21,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []

--- a/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-full-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-full-config.yml
@@ -7,7 +7,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []

--- a/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-provided-config.yml
+++ b/test/new-e2e/tests/otel/otel-agent/testdata/no-dd-exporter-provided-config.yml
@@ -7,7 +7,7 @@ exporters:
       site: datadoghq.com
     headers: {}
     host_metadata:
-      enabled: false
+      enabled: true
       hostname_source: config_or_system
       reporter_period: 30m0s
       tags: []


### PR DESCRIPTION
### What does this PR do?
Remove the hard-coded check on host metadata config in otel-agent so that it can be set from now on. The config has no effect until https://github.com/DataDog/datadog-agent/pull/39893.

### Motivation
working towards https://github.com/DataDog/datadog-agent/pull/39893

### Describe how you validated your changes
modified tests 