### PR TITLE
Correct crash discovered by FuzzConvertBOM

### DIFF
--- a/pkg/sbom/bomconvert/convert.go
+++ b/pkg/sbom/bomconvert/convert.go
@@ -606,7 +606,7 @@ func convertMetadata(in *cyclonedx.Metadata) *cyclonedx_v1_4.Metadata {
 	}
 
 	var tools []*cyclonedx_v1_4.Tool
-	if in.Tools != nil {
+	if in.Tools != nil && in.Tools.Tools != nil {
 		tools = convertArray(in.Tools.Tools, convertTool)
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit resolves a fuzzydog discovered crash in the bomconvert code, see:

    fuzzydog crash get --input datadog-agent-pkg-sbom-bomconvert 3513bc8ae5e561b012df7800b477c2bfb8404b808169a38c68676b57ae5223e1

While we had a check for `in.Tools` as not nil `in.Tools.Tools` may be nil. I've re-run the failing fuzz test and have not discovered any further nil panics.

### Motivation

Resolve fuzz crash. 

### Describe how you validated your changes

Re-ran the fuzz test locally for 10 minutes, confirmed no failure in CI unit tests.

### Possible Drawbacks / Trade-offs

None known.