### PR TITLE
(fleet) use slog for installer logs, tee them to telemetry

### DIFF
--- a/pkg/fleet/daemon/local_api_windows.go
+++ b/pkg/fleet/daemon/local_api_windows.go
@@ -24,7 +24,7 @@ const (
 // NewLocalAPI returns a new LocalAPI.
 func NewLocalAPI(daemon Daemon) (LocalAPI, error) {
 	// Prevent daemon from running in insecure directories
-	err := paths.IsInstallerDataDirSecure()
+	err := paths.IsInstallerDataDirSecure(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fleet/installer/bootstrap/bootstrap_nix.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_nix.go
@@ -57,7 +57,7 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 	}
 
 	installerBinPath := filepath.Join(tmpDir, "installer")
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -71,7 +71,7 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 
 	// Download just datadog-installer.exe from its own layer
 	installerBinPath := filepath.Join(tmpDir, "datadog-installer.exe")
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageInstallerLayerMediaType, installerBinPath) // Returns nil if the layer doesn't exist
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}
@@ -102,12 +102,12 @@ func downloadInstallerOld(ctx context.Context, env *env.Env, url string, tmpDir 
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	defer os.RemoveAll(layoutTmpDir)
-	err = downloadedPackage.WriteOCILayout(layoutTmpDir)
+	err = downloadedPackage.WriteOCILayout(ctx, layoutTmpDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write OCI layout: %w", err)
 	}
 
-	err = downloadedPackage.ExtractLayers(oci.DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(ctx, oci.DatadogPackageLayerMediaType, tmpDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime"
@@ -152,7 +153,9 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 	if _, set := os.LookupEnv("DD_SITE"); !set && config.Site != "" {
 		site = config.Site
 	}
-	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, site, "datadog-installer") // No sampling rules for commands
+	logger := telemetry.NewLogger(slog.Default().Handler())
+	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, logger, site, "datadog-installer") // No sampling rules for commands
+	slog.SetDefault(slog.New(logger))
 	return t
 }
 

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -154,7 +154,7 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 		site = config.Site
 	}
 	logger := telemetry.NewLogger(slog.Default().Handler())
-	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, logger, site, "datadog-installer") // No sampling rules for commands
+	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, site, "datadog-installer") // No sampling rules for commands
 	slog.SetDefault(slog.New(logger))
 	return t
 }

--- a/pkg/fleet/installer/fixtures/server.go
+++ b/pkg/fleet/installer/fixtures/server.go
@@ -7,6 +7,7 @@
 package fixtures
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -72,7 +73,7 @@ func extractLayoutsAndBuildRegistry(t *testing.T, layoutsDir string) *httptest.S
 		layoutDir := path.Join(layoutsDir, f.layoutPath)
 		file, err := fixturesFS.Open(f.layoutPath)
 		require.NoError(t, err)
-		err = tar.Extract(file, layoutDir, 1<<30)
+		err = tar.Extract(context.Background(), file, layoutDir, 1<<30)
 		require.NoError(t, err)
 
 		layout, err := layout.FromPath(layoutDir)

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 require (
 	cloud.google.com/go/compute/metadata v0.7.0
 	github.com/DataDog/datadog-agent/pkg/template v0.65.1
-	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel.0.20250129111638-01c8fb06949e
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.64.3
 	github.com/DataDog/datadog-agent/pkg/version v0.64.3
 	github.com/Microsoft/go-winio v0.6.2
@@ -27,6 +26,7 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel.0.20250129111638-01c8fb06949e // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.3 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
@@ -66,6 +66,6 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/log => ../../../pkg/util/log
 	github.com/DataDog/datadog-agent/pkg/util/scrubber => ../../../pkg/util/scrubber
 	github.com/DataDog/datadog-agent/pkg/version => ../../../pkg/version
+	github.com/DataDog/datadog-agent/pkg/util/winutil => ../../util/winutil
 )
 
-replace github.com/DataDog/datadog-agent/pkg/util/winutil => ../../util/winutil

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -579,7 +579,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.NoError(t, err)
 
 		// Verify the file was created with correct content
@@ -593,7 +593,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 	t.Run("remove_all", func(t *testing.T) {
 		tempDir := t.TempDir()
 
-		err := installer.writeConfig(tempDir, [][]byte{[]byte(`{"action_type": "remove_all"}`)})
+		err := installer.writeConfig(testCtx, tempDir, [][]byte{[]byte(`{"action_type": "remove_all"}`)})
 		assert.NoError(t, err)
 
 		// Verify the directory is empty
@@ -626,7 +626,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawRemoveAllConfig, err := json.Marshal(removeAllAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawWriteConfig, rawRemoveAllConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawWriteConfig, rawRemoveAllConfig})
 		assert.NoError(t, err)
 
 		// Verify the file is not present
@@ -653,7 +653,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.NoError(t, err)
 
 		// Verify the file was created in the subdirectory
@@ -688,7 +688,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.NoError(t, err)
 
 		// Verify the file was removed
@@ -729,7 +729,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawRemoveConfig, err := json.Marshal(removeAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawWriteConfig, rawRemoveConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawWriteConfig, rawRemoveConfig})
 		assert.NoError(t, err)
 
 		// Verify new file was created
@@ -760,7 +760,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "config file {/invalid/path.txt {\"test\":\"value\"}} is not allowed")
 	})
@@ -779,7 +779,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown config file action: invalid")
 	})
@@ -790,7 +790,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 
 		rawConfig := []byte(`{"action_type": "write", "files": [{"path": "/datadog.yaml", "conntteennttss": "nojson"}]}`)
 
-		err := installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err := installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "could not unmarshal config file contents: unexpected end of JSON input")
 	})
@@ -812,7 +812,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.NoError(t, err)
 
 		// Verify the file was created with cleaned path
@@ -849,7 +849,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawConfig, err := json.Marshal(configAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawConfig})
 		assert.NoError(t, err)
 
 		// Verify the file was created with complex structure
@@ -892,7 +892,7 @@ func TestWriteAndRemoveConfigFiles(t *testing.T) {
 		rawRemoveConfig, err := json.Marshal(removeAction)
 		assert.NoError(t, err)
 
-		err = installer.writeConfig(tempDir, [][]byte{rawWriteConfig, rawRemoveConfig})
+		err = installer.writeConfig(testCtx, tempDir, [][]byte{rawWriteConfig, rawRemoveConfig})
 		assert.NoError(t, err)
 
 		// Verify the file is not present
@@ -923,7 +923,7 @@ func TestTmpDirectoryCleanup(t *testing.T) {
 	err = os.Chtimes(newFile, newTime, newTime)
 	assert.NoError(t, err)
 
-	err = cleanupTmpDirectory(tempDir)
+	err = cleanupTmpDirectory(testCtx, tempDir)
 	assert.NoError(t, err)
 
 	assert.NoFileExists(t, oldFile, "old file should be deleted")

--- a/pkg/fleet/installer/installinfo/installinfo.go
+++ b/pkg/fleet/installer/installinfo/installinfo.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/google/uuid"
@@ -102,7 +102,7 @@ func writeInstallInfo(ctx context.Context, installInfoFile string, installSigFil
 func RemoveInstallInfo() {
 	for _, file := range []string{installInfoFile, installSigFile} {
 		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-			log.Warnf("Failed to remove %s: %v", file, err)
+			slog.WarnContext(context.TODO(), "Failed to remove file", "file", file, "error", err)
 		}
 	}
 }
@@ -151,7 +151,7 @@ func getDpkgVersion(ctx context.Context) (version string, err error) {
 	cmd := exec.CommandContext(cancelctx, "dpkg-query", "--showformat=${Version}", "--show", "dpkg")
 	output, err := cmd.Output()
 	if err != nil {
-		log.Warnf("Failed to get dpkg version: %s", err)
+		slog.WarnContext(context.TODO(), "Failed to get dpkg version", "error", err)
 		return "", err
 	}
 	splitVersion := strings.Split(strings.TrimSpace(string(output)), ".")

--- a/pkg/fleet/installer/installinfo/installinfo.go
+++ b/pkg/fleet/installer/installinfo/installinfo.go
@@ -17,9 +17,10 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"log/slog"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/google/uuid"
@@ -99,10 +100,10 @@ func writeInstallInfo(ctx context.Context, installInfoFile string, installSigFil
 }
 
 // RemoveInstallInfo removes both install info and signature files.
-func RemoveInstallInfo() {
+func RemoveInstallInfo(ctx context.Context) {
 	for _, file := range []string{installInfoFile, installSigFile} {
 		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-			slog.WarnContext(context.TODO(), "Failed to remove file", "file", file, "error", err)
+			slog.WarnContext(ctx, "Failed to remove file", "file", file, "error", err)
 		}
 	}
 }
@@ -151,7 +152,7 @@ func getDpkgVersion(ctx context.Context) (version string, err error) {
 	cmd := exec.CommandContext(cancelctx, "dpkg-query", "--showformat=${Version}", "--show", "dpkg")
 	output, err := cmd.Output()
 	if err != nil {
-		slog.WarnContext(context.TODO(), "Failed to get dpkg version", "error", err)
+		slog.WarnContext(ctx, "Failed to get dpkg version", "error", err)
 		return "", err
 	}
 	splitVersion := strings.Split(strings.TrimSpace(string(output)), ".")

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -68,7 +68,7 @@ func TestDownload(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }
@@ -84,7 +84,7 @@ func TestDownloadMirror(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }
@@ -99,7 +99,7 @@ func TestDownloadLayout(t *testing.T) {
 	assert.Equal(t, fixtures.FixtureSimpleV1.Version, downloadedPackage.Version)
 	assert.NotZero(t, downloadedPackage.Size)
 	tmpDir := t.TempDir()
-	err = downloadedPackage.ExtractLayers(DatadogPackageLayerMediaType, tmpDir)
+	err = downloadedPackage.ExtractLayers(context.Background(), DatadogPackageLayerMediaType, tmpDir)
 	assert.NoError(t, err)
 	fixtures.AssertEqualFS(t, s.PackageFS(fixtures.FixtureSimpleV1), os.DirFS(tmpDir))
 }

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -196,7 +196,7 @@ func TestGetRefAndKeychain(t *testing.T) {
 			RegistryAuthOverride:        tt.registryAuthOverride,
 			RegistryAuthOverrideByImage: tt.regAuthOverrideByImage,
 		}
-		actual := getRefAndKeychain(env, tt.url)
+		actual := getRefAndKeychain(context.Background(), env, tt.url)
 		assert.Equal(t, tt.expectedRef, actual.ref)
 		assert.Equal(t, tt.expectedKeychain, actual.keychain)
 	}
@@ -323,7 +323,7 @@ func TestGetRefAndKeychains(t *testing.T) {
 			if tt.isProd {
 				env.Site = "datadoghq.com"
 			}
-			actual := getRefAndKeychains(env, tt.url)
+			actual := getRefAndKeychains(context.Background(), env, tt.url)
 			assert.Len(t, actual, len(tt.expectedRefAndKeychains))
 			for i, a := range actual {
 				assert.Equal(t, tt.expectedRefAndKeychains[i].ref, a.ref)

--- a/pkg/fleet/installer/packages/apm_inject_linux.go
+++ b/pkg/fleet/installer/packages/apm_inject_linux.go
@@ -50,7 +50,7 @@ func postInstallAPMInjector(ctx HookContext) (err error) {
 	span, ctx := ctx.StartSpan("setup_injector")
 	defer func() { span.Finish(err) }()
 	installer := apminject.NewInstaller()
-	defer func() { installer.Finish(err) }()
+	defer func() { installer.Finish(ctx, err) }()
 	return installer.Setup(ctx)
 }
 
@@ -59,7 +59,7 @@ func preRemoveAPMInjector(ctx HookContext) (err error) {
 	span, ctx := ctx.StartSpan("remove_injector")
 	defer func() { span.Finish(err) }()
 	installer := apminject.NewInstaller()
-	defer func() { installer.Finish(err) }()
+	defer func() { installer.Finish(ctx, err) }()
 	return installer.Remove(ctx)
 }
 
@@ -69,7 +69,7 @@ func InstrumentAPMInjector(ctx context.Context, method string) (err error) {
 	defer func() { span.Finish(err) }()
 	installer := apminject.NewInstaller()
 	installer.Env.InstallScript.APMInstrumentationEnabled = method
-	defer func() { installer.Finish(err) }()
+	defer func() { installer.Finish(ctx, err) }()
 	return installer.Instrument(ctx)
 }
 
@@ -79,6 +79,6 @@ func UninstrumentAPMInjector(ctx context.Context, method string) (err error) {
 	defer func() { span.Finish(err) }()
 	installer := apminject.NewInstaller()
 	installer.Env.InstallScript.APMInstrumentationEnabled = method
-	defer func() { installer.Finish(err) }()
+	defer func() { installer.Finish(ctx, err) }()
 	return installer.Uninstrument(ctx)
 }

--- a/pkg/fleet/installer/packages/apm_library_dotnet_windows.go
+++ b/pkg/fleet/installer/packages/apm_library_dotnet_windows.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 var apmLibraryDotnetPackage = hooks{
@@ -120,7 +120,7 @@ func preRemoveAPMLibraryDotnet(ctx HookContext) (err error) {
 		// If the remove is being retried after a failed first attempt, the stable symlink may have been removed
 		// so we do not consider this an error
 		if errors.Is(err, fs.ErrNotExist) {
-			log.Warn("Stable symlink does not exist, assuming the package has already been partially removed and skipping UninstallProduct")
+			slog.WarnContext(ctx, "Stable symlink does not exist, assuming the package has already been partially removed and skipping UninstallProduct")
 			return nil
 		}
 		return err

--- a/pkg/fleet/installer/packages/apminject/apm_inject_test.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject_test.go
@@ -119,7 +119,7 @@ func TestShouldInstrumentHost(t *testing.T) {
 					APMInstrumentationEnabled: tt.envValue,
 				},
 			}
-			result := shouldInstrumentHost(execEnvs)
+			result := shouldInstrumentHost(context.Background(), execEnvs)
 			if result != tt.expected {
 				t.Errorf("shouldInstrumentHost() with envValue %s; got %t, want %t", tt.envValue, result, tt.expected)
 			}
@@ -147,7 +147,7 @@ func TestShouldInstrumentDocker(t *testing.T) {
 					APMInstrumentationEnabled: tt.envValue,
 				},
 			}
-			result := shouldInstrumentDocker(execEnvs)
+			result := shouldInstrumentDocker(context.Background(), execEnvs)
 			if result != tt.expected {
 				t.Errorf("shouldInstrumentDocker() with envValue %s; got %t, want %t", tt.envValue, result, tt.expected)
 			}

--- a/pkg/fleet/installer/packages/apminject/apm_sockets.go
+++ b/pkg/fleet/installer/packages/apminject/apm_sockets.go
@@ -94,7 +94,7 @@ func (a *InjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr err
 	if err = os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent: %w", envFilePath, err)
 	}
-	systemdRunning, err := systemd.IsRunning()
+	systemdRunning, err := systemd.IsRunning(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to check if systemd is running: %w", err)
 	}

--- a/pkg/fleet/installer/packages/apminject/apm_sockets_test.go
+++ b/pkg/fleet/installer/packages/apminject/apm_sockets_test.go
@@ -143,7 +143,7 @@ dogstatsd_socket: /banana/dsd.socket
 				os.WriteFile(agentConfigPath, []byte(tc.agentConfig), 0644)
 			}
 
-			apmSockPath, statsdSockPath, err := getSocketsPath()
+			apmSockPath, statsdSockPath, err := getSocketsPath(context.Background())
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedAPMSockPath, apmSockPath)
 			assert.Equal(t, tc.expectedStatsdSockPath, statsdSockPath)

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 const (
@@ -128,7 +128,7 @@ func setupAppArmor(ctx context.Context) (err error) {
 
 	if err = reloadAppArmor(ctx); err != nil {
 		if rollbackErr := os.Remove(appArmorInjectorProfilePath); rollbackErr != nil {
-			log.Warnf("failed to remove apparmor profile: %v", rollbackErr)
+			slog.WarnContext(ctx, "failed to remove apparmor profile", "error", rollbackErr)
 		}
 		return err
 	}

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -16,9 +16,10 @@ import (
 	"os/exec"
 	"strings"
 
+	"log/slog"
+
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"log/slog"
 )
 
 const (
@@ -162,7 +163,7 @@ func reloadAppArmor(ctx context.Context) error {
 	if !isAppArmorRunning() {
 		return nil
 	}
-	if running, err := systemd.IsRunning(); err != nil {
+	if running, err := systemd.IsRunning(ctx); err != nil {
 		return err
 	} else if running {
 		return tracedCommand(ctx, "systemctl", "reload", "apparmor")

--- a/pkg/fleet/installer/packages/apminject/file.go
+++ b/pkg/fleet/installer/packages/apminject/file.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 var rollbackNoop = func() error { return nil }
@@ -112,7 +112,7 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 	if ft.validateFinal != nil {
 		if err = ft.validateFinal(); err != nil {
 			if rollbackErr := rollback(); rollbackErr != nil {
-				log.Errorf("could not rollback file %s: %s", ft.path, rollbackErr)
+				slog.ErrorContext(ctx, "could not rollback file", "path", ft.path, "error", rollbackErr)
 			}
 			return nil, err
 		}

--- a/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_ddot_linux.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/packagemanager"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 var datadogAgentDDOTPackage = hooks{
@@ -70,13 +70,13 @@ var (
 // preInstallDatadogAgentDDOT performs pre-installation steps for DDOT
 func preInstallDatadogAgentDDOT(ctx HookContext) error {
 	if err := agentDDOTService.StopStable(ctx); err != nil {
-		log.Warnf("failed to stop stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to stop stable unit", "error", err)
 	}
 	if err := agentDDOTService.DisableStable(ctx); err != nil {
-		log.Warnf("failed to disable stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to disable stable unit", "error", err)
 	}
 	if err := agentDDOTService.RemoveStable(ctx); err != nil {
-		log.Warnf("failed to remove stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to remove stable unit", "error", err)
 	}
 	return packagemanager.RemovePackage(ctx, agentDDOTPackage)
 }
@@ -182,23 +182,23 @@ func postInstallDatadogAgentDDOTDEBRPM(ctx HookContext) (err error) {
 func preRemoveDatadogAgentDDOT(ctx HookContext) error {
 	err := agentDDOTService.StopExperiment(ctx)
 	if err != nil {
-		log.Warnf("failed to stop experiment unit: %s", err)
+		slog.WarnContext(ctx, "failed to stop experiment unit", "error", err)
 	}
 	err = agentDDOTService.RemoveExperiment(ctx)
 	if err != nil {
-		log.Warnf("failed to remove experiment unit: %s", err)
+		slog.WarnContext(ctx, "failed to remove experiment unit", "error", err)
 	}
 	err = agentDDOTService.StopStable(ctx)
 	if err != nil {
-		log.Warnf("failed to stop stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to stop stable unit", "error", err)
 	}
 	err = agentDDOTService.DisableStable(ctx)
 	if err != nil {
-		log.Warnf("failed to disable stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to disable stable unit", "error", err)
 	}
 	err = agentDDOTService.RemoveStable(ctx)
 	if err != nil {
-		log.Warnf("failed to remove stable unit: %s", err)
+		slog.WarnContext(ctx, "failed to remove stable unit", "error", err)
 	}
 
 	return nil

--- a/pkg/fleet/installer/packages/datadog_installer_linux.go
+++ b/pkg/fleet/installer/packages/datadog_installer_linux.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 var datadogInstallerPackage = hooks{
@@ -44,10 +44,10 @@ var (
 // preInstallDatadogInstaller prepares the installer
 func preInstallDatadogInstaller(ctx HookContext) error {
 	if err := systemd.StopUnit(ctx, installerUnit); err != nil {
-		log.Warnf("Failed to stop unit %s: %s", installerUnit, err)
+		slog.WarnContext(ctx, "Failed to stop unit %s: %s", installerUnit, err)
 	}
 	if err := systemd.DisableUnit(ctx, installerUnit); err != nil {
-		log.Warnf("Failed to disable %s: %s", installerUnit, err)
+		slog.WarnContext(ctx, "Failed to disable %s: %s", installerUnit, err)
 	}
 	return nil
 }
@@ -121,19 +121,19 @@ func preRemoveDatadogInstaller(ctx HookContext) error {
 			if ok && exitErr.ExitCode() == 5 {
 				continue
 			}
-			log.Warnf("Failed stop unit %s: %s", unit, err)
+			slog.WarnContext(ctx, "Failed stop unit %s: %s", unit, err)
 		}
 		if err := systemd.DisableUnit(ctx, unit); err != nil {
-			log.Warnf("Failed to disable %s: %s", unit, err)
+			slog.WarnContext(ctx, "Failed to disable %s: %s", unit, err)
 		}
 		if err := removeUnits(ctx, unit); err != nil {
-			log.Warnf("Failed to stop %s: %s", unit, err)
+			slog.WarnContext(ctx, "Failed to stop %s: %s", unit, err)
 		}
 	}
 
 	// Remove symlink
 	if err := os.Remove("/usr/bin/datadog-installer"); err != nil {
-		log.Warnf("Failed to remove /usr/bin/datadog-installer: %s", err)
+		slog.WarnContext(ctx, "Failed to remove /usr/bin/datadog-installer: %s", err)
 	}
 
 	// TODO: return error to caller?

--- a/pkg/fleet/installer/packages/service/systemd/systemd.go
+++ b/pkg/fleet/installer/packages/service/systemd/systemd.go
@@ -20,8 +20,9 @@ import (
 
 	"go.uber.org/multierr"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"log/slog"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 )
 
 const (
@@ -138,10 +139,10 @@ func Reload(ctx context.Context) (err error) {
 
 // IsRunning checks if systemd is running using the documented way
 // https://www.freedesktop.org/software/systemd/man/latest/sd_booted.html#Notes
-func IsRunning() (running bool, err error) {
+func IsRunning(ctx context.Context) (running bool, err error) {
 	_, err = os.Stat("/run/systemd/system")
 	if os.IsNotExist(err) {
-		slog.InfoContext(context.TODO(), "Installer: systemd is not running, skip unit setup")
+		slog.InfoContext(ctx, "Installer: systemd is not running, skip unit setup")
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/pkg/fleet/installer/packages/service/systemd/systemd.go
+++ b/pkg/fleet/installer/packages/service/systemd/systemd.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 const (
@@ -141,7 +141,7 @@ func Reload(ctx context.Context) (err error) {
 func IsRunning() (running bool, err error) {
 	_, err = os.Stat("/run/systemd/system")
 	if os.IsNotExist(err) {
-		log.Infof("Installer: systemd is not running, skip unit setup")
+		slog.InfoContext(context.TODO(), "Installer: systemd is not running, skip unit setup")
 		return false, nil
 	} else if err != nil {
 		return false, err

--- a/pkg/fleet/installer/packages/service/windows/impl.go
+++ b/pkg/fleet/installer/packages/service/windows/impl.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -18,7 +19,6 @@ import (
 	"golang.org/x/sys/windows/svc"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // WinServiceManager implements ServiceManager using the SystemAPI interface
@@ -56,13 +56,13 @@ func getTerminatePolicy() bool {
 		registry.ALL_ACCESS)
 	if err != nil {
 		// if the key isn't there, we might be running a standalone binary that wasn't installed through MSI
-		log.Debugf("Windows installation key root not found, using default")
+		slog.DebugContext(context.TODO(), "Windows installation key root not found, using default")
 		return defaultTerminatePolicy
 	}
 	defer k.Close()
 	val, _, err := k.GetIntegerValue("TerminatePolicy")
 	if err != nil {
-		log.Warnf("Windows installation key TerminatePolicy not found, using default")
+		slog.WarnContext(context.TODO(), "Windows installation key TerminatePolicy not found, using default")
 		return defaultTerminatePolicy
 	}
 	return val == 1
@@ -77,7 +77,7 @@ func (w *WinServiceManager) terminateServiceProcess(ctx context.Context, service
 
 	terminatePolicy := getTerminatePolicy()
 	if !terminatePolicy {
-		log.Debugf("TerminatePolicy is false, skipping termination of service %s", serviceName)
+		slog.DebugContext(context.TODO(), "TerminatePolicy is false, skipping termination of service", "serviceName", serviceName)
 		return fmt.Errorf("TerminatePolicy is false, skipping termination of service %s", serviceName)
 	}
 

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -12,11 +12,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"os/user"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // EnsureAgentUserAndGroup ensures that the user and group required by the agent are present on the system.
@@ -44,7 +44,7 @@ func ensureGroup(ctx context.Context, groupName string) (err error) {
 	}
 	var unknownGroupError *user.UnknownGroupError
 	if !errors.As(err, &unknownGroupError) {
-		log.Warnf("error looking up %s group: %v", groupName, err)
+		slog.WarnContext(ctx, "error looking up group", "groupName", groupName, "error", err)
 	}
 	err = exec.CommandContext(ctx, "groupadd", "--force", "--system", groupName).Run()
 	if err != nil {
@@ -64,7 +64,7 @@ func ensureUser(ctx context.Context, userName string, installPath string) (err e
 	}
 	var unknownUserError *user.UnknownUserError
 	if !errors.As(err, &unknownUserError) {
-		log.Warnf("error looking up %s user: %v", userName, err)
+		slog.WarnContext(ctx, "error looking up user", "userName", userName, "error", err)
 	}
 	err = exec.CommandContext(ctx, "useradd", "--system", "--shell", "/usr/sbin/nologin", "--home", installPath, "--no-create-home", "--no-user-group", "-g", "dd-agent", "dd-agent").Run()
 	if err != nil {

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -9,9 +9,11 @@
 package paths
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -23,7 +25,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -257,7 +258,7 @@ func secureCreateDirectory(path string, sddl string) error {
 // Unprivileged users (users without SeTakeOwnershipPrivilege/SeRestorePrivilege) cannot set the owner to Administrators.
 func IsInstallerDataDirSecure() error {
 	targetDir := DatadogInstallerData
-	log.Infof("Checking if installer data directory is secure: %s", targetDir)
+	slog.InfoContext(context.TODO(), "Checking if installer data directory is secure", "directory", targetDir)
 	return IsDirSecure(targetDir)
 }
 
@@ -484,13 +485,13 @@ func getProgramDataDirForProduct(product string) (path string, err error) {
 		registry.ALL_ACCESS)
 	if err != nil {
 		// if the key isn't there, we might be running a standalone binary that wasn't installed through MSI
-		log.Debugf("Windows installation key root (%s) not found, using default program data dir", keyname)
+		slog.DebugContext(context.TODO(), "Windows installation key root not found, using default program data dir", "keyname", keyname)
 		return filepath.Join(res, "Datadog"), nil
 	}
 	defer k.Close()
 	val, _, err := k.GetStringValue("ConfigRoot")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		slog.WarnContext(context.TODO(), "Windows installation key config not found, using default program data dir")
 		return filepath.Join(res, "Datadog"), nil
 	}
 	path = val
@@ -511,13 +512,13 @@ func getProgramFilesDirForProduct(product string) (path string, err error) {
 		registry.ALL_ACCESS)
 	if err != nil {
 		// if the key isn't there, we might be running a standalone binary that wasn't installed through MSI
-		log.Debugf("Windows installation key root (%s) not found, using default program data dir", keyname)
+		slog.DebugContext(context.TODO(), "Windows installation key root not found, using default program data dir", "keyname", keyname)
 		return filepath.Join(res, "Datadog", product), nil
 	}
 	defer k.Close()
 	val, _, err := k.GetStringValue("InstallPath")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		slog.WarnContext(context.TODO(), "Windows installation key config not found, using default program data dir")
 		return filepath.Join(res, "Datadog", product), nil
 	}
 	path = val

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -256,9 +256,9 @@ func secureCreateDirectory(path string, sddl string) error {
 //
 // CreateInstallerDataDir sets the owner to Administrators and is called during bootstrap.
 // Unprivileged users (users without SeTakeOwnershipPrivilege/SeRestorePrivilege) cannot set the owner to Administrators.
-func IsInstallerDataDirSecure() error {
+func IsInstallerDataDirSecure(ctx context.Context) error {
 	targetDir := DatadogInstallerData
-	slog.InfoContext(context.TODO(), "Checking if installer data directory is secure", "directory", targetDir)
+	slog.InfoContext(ctx, "Checking if installer data directory is secure", "directory", targetDir)
 	return IsDirSecure(targetDir)
 }
 
@@ -485,13 +485,13 @@ func getProgramDataDirForProduct(product string) (path string, err error) {
 		registry.ALL_ACCESS)
 	if err != nil {
 		// if the key isn't there, we might be running a standalone binary that wasn't installed through MSI
-		slog.DebugContext(context.TODO(), "Windows installation key root not found, using default program data dir", "keyname", keyname)
+		slog.Debug("Windows installation key root not found, using default program data dir", "keyname", keyname)
 		return filepath.Join(res, "Datadog"), nil
 	}
 	defer k.Close()
 	val, _, err := k.GetStringValue("ConfigRoot")
 	if err != nil {
-		slog.WarnContext(context.TODO(), "Windows installation key config not found, using default program data dir")
+		slog.Warn("Windows installation key config not found, using default program data dir")
 		return filepath.Join(res, "Datadog"), nil
 	}
 	path = val

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"log/slog"
 )
 
 const (
@@ -463,7 +463,7 @@ func (r *repositoryFiles) cleanup(ctx context.Context) error {
 		if pkgHook, hasHook := r.preRemoveHooks[pkgName]; hasHook {
 			canDelete, err := pkgHook(ctx, pkgRepositoryPath)
 			if err != nil {
-				log.Errorf("Pre-remove hook for package %s returned an error: %v", pkgRepositoryPath, err)
+				slog.ErrorContext(ctx, "Pre-remove hook for package returned an error", "package", pkgRepositoryPath, "error", err)
 			}
 			// if there is an error, the hook still decides if the package can be deleted
 			if !canDelete {
@@ -471,16 +471,16 @@ func (r *repositoryFiles) cleanup(ctx context.Context) error {
 			}
 		}
 
-		log.Debugf("Removing package %s", pkgRepositoryPath)
+		slog.DebugContext(ctx, "Removing package", "package", pkgRepositoryPath)
 		realPkgRepositoryPath, err := filepath.EvalSymlinks(pkgRepositoryPath)
 		if err != nil {
-			log.Errorf("could not evaluate symlinks for package %s: %v", pkgRepositoryPath, err)
+			slog.ErrorContext(ctx, "could not evaluate symlinks for package", "package", pkgRepositoryPath, "error", err)
 		}
 		if err := os.RemoveAll(realPkgRepositoryPath); err != nil {
-			log.Errorf("could not remove package %s directory, will retry: %v", realPkgRepositoryPath, err)
+			slog.ErrorContext(ctx, "could not remove package directory, will retry", "package", realPkgRepositoryPath, "error", err)
 		}
 		if err := os.RemoveAll(pkgRepositoryPath); err != nil {
-			log.Errorf("could not remove package %s directory, will retry: %v", pkgRepositoryPath, err)
+			slog.ErrorContext(ctx, "could not remove package directory, will retry", "package", pkgRepositoryPath, "error", err)
 		}
 	}
 

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -8,13 +8,13 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func (s *Setup) postInstallPackages() (err error) {
@@ -27,13 +27,13 @@ func (s *Setup) addAgentToAdditionalGroups() {
 	for _, group := range s.DdAgentAdditionalGroups {
 		// Add dd-agent user to additional group for permission reason, in particular to enable reading log files not world readable
 		if _, err := user.LookupGroup(group); err != nil {
-			log.Infof("Skipping group %s as it does not exist", group)
+			slog.InfoContext(context.TODO(), "Skipping group as it does not exist", "group", group)
 			continue
 		}
 		_, err := ExecuteCommandWithTimeout(s, "usermod", "-aG", group, "dd-agent")
 		if err != nil {
 			s.Out.WriteString("Failed to add dd-agent to group" + group + ": " + err.Error())
-			log.Warnf("failed to add dd-agent to group %s:  %v", group, err)
+			slog.WarnContext(context.TODO(), "failed to add dd-agent to group", "group", group, "error", err)
 		}
 	}
 }

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -18,22 +18,22 @@ import (
 )
 
 func (s *Setup) postInstallPackages() (err error) {
-	s.addAgentToAdditionalGroups()
+	s.addAgentToAdditionalGroups(s.Ctx)
 
 	return nil
 }
 
-func (s *Setup) addAgentToAdditionalGroups() {
+func (s *Setup) addAgentToAdditionalGroups(ctx context.Context) {
 	for _, group := range s.DdAgentAdditionalGroups {
 		// Add dd-agent user to additional group for permission reason, in particular to enable reading log files not world readable
 		if _, err := user.LookupGroup(group); err != nil {
-			slog.InfoContext(context.TODO(), "Skipping group as it does not exist", "group", group)
+			slog.InfoContext(ctx, "Skipping group as it does not exist", "group", group)
 			continue
 		}
 		_, err := ExecuteCommandWithTimeout(s, "usermod", "-aG", group, "dd-agent")
 		if err != nil {
 			s.Out.WriteString("Failed to add dd-agent to group" + group + ": " + err.Error())
-			slog.WarnContext(context.TODO(), "failed to add dd-agent to group", "group", group, "error", err)
+			slog.WarnContext(ctx, "failed to add dd-agent to group", "group", group, "error", err)
 		}
 	}
 }

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -7,8 +7,10 @@
 package djm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -16,7 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -274,7 +275,7 @@ func setupDatabricksDriver(s *common.Setup) {
 			},
 		}
 	} else {
-		log.Warn("DB_DRIVER_IP not set")
+		slog.WarnContext(context.TODO(), "DB_DRIVER_IP not set")
 	}
 	s.Config.IntegrationConfigs["spark.d/databricks.yaml"] = sparkIntegration
 }
@@ -343,7 +344,7 @@ func loadLogProcessingRules(s *common.Setup) {
 	if rawRules := os.Getenv("DD_LOGS_CONFIG_PROCESSING_RULES"); rawRules != "" {
 		processingRules, err := parseLogProcessingRules(rawRules)
 		if err != nil {
-			log.Warnf("Failed to parse log processing rules: %v", err)
+			slog.WarnContext(context.TODO(), "Failed to parse log processing rules", "error", err)
 			s.Out.WriteString(fmt.Sprintf("Invalid log processing rules: %v\n", err))
 		} else {
 			logsConfig := config.LogsConfig{ProcessingRules: processingRules}

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -7,7 +7,6 @@
 package djm
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -275,7 +274,7 @@ func setupDatabricksDriver(s *common.Setup) {
 			},
 		}
 	} else {
-		slog.WarnContext(context.TODO(), "DB_DRIVER_IP not set")
+		slog.WarnContext(s.Ctx, "DB_DRIVER_IP not set")
 	}
 	s.Config.IntegrationConfigs["spark.d/databricks.yaml"] = sparkIntegration
 }
@@ -344,7 +343,7 @@ func loadLogProcessingRules(s *common.Setup) {
 	if rawRules := os.Getenv("DD_LOGS_CONFIG_PROCESSING_RULES"); rawRules != "" {
 		processingRules, err := parseLogProcessingRules(rawRules)
 		if err != nil {
-			slog.WarnContext(context.TODO(), "Failed to parse log processing rules", "error", err)
+			slog.WarnContext(s.Ctx, "Failed to parse log processing rules", "error", err)
 			s.Out.WriteString(fmt.Sprintf("Invalid log processing rules: %v\n", err))
 		} else {
 			logsConfig := config.LogsConfig{ProcessingRules: processingRules}

--- a/pkg/fleet/installer/setup/djm/dataproc.go
+++ b/pkg/fleet/installer/setup/djm/dataproc.go
@@ -9,13 +9,13 @@ package djm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -94,7 +94,7 @@ func setupCommonDataprocHostTags(s *common.Setup, metadataClient *metadata.Clien
 
 	clusterName, err := metadataClient.InstanceAttributeValueWithContext(ctx, "dataproc-cluster-name")
 	if err != nil {
-		log.Warn("failed to get clusterName, using clusterID instead")
+		slog.WarnContext(ctx, "failed to get clusterName, using clusterID instead", "error", err)
 		return isMaster, clusterID, nil
 	}
 	setHostTag(s, "cluster_name", clusterName)

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -7,7 +7,6 @@
 package djm
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -147,7 +146,7 @@ func setupResourceManager(s *common.Setup, clusterName string) {
 	var yarnIntegration config.IntegrationConfig
 	hostname, err := os.Hostname()
 	if err != nil {
-		slog.InfoContext(context.TODO(), "Failed to get hostname, defaulting to localhost", "error", err)
+		slog.InfoContext(s.Ctx, "Failed to get hostname, defaulting to localhost", "error", err)
 		hostname = "localhost"
 	}
 	sparkIntegration.Instances = []any{
@@ -175,17 +174,17 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	defer func() { span.Finish(err) }()
 	emrResponseRaw, err := common.ExecuteCommandWithTimeout(s, "aws", "emr", "describe-cluster", "--cluster-id", jobFlowID)
 	if err != nil {
-		slog.WarnContext(context.TODO(), "error describing emr cluster, using cluster id as name", "error", err)
+		slog.WarnContext(s.Ctx, "error describing emr cluster, using cluster id as name", "error", err)
 		return jobFlowID
 	}
 	var response emrResponse
 	if err = json.Unmarshal(emrResponseRaw, &response); err != nil {
-		slog.WarnContext(context.TODO(), "error unmarshalling AWS EMR response, using cluster id as name", "error", err)
+		slog.WarnContext(s.Ctx, "error unmarshalling AWS EMR response, using cluster id as name", "error", err)
 		return jobFlowID
 	}
 	clusterName := response.Cluster.Name
 	if clusterName == "" {
-		slog.WarnContext(context.TODO(), "clusterName is empty, using cluster id as name")
+		slog.WarnContext(s.Ctx, "clusterName is empty, using cluster id as name")
 		return jobFlowID
 	}
 	return clusterName

--- a/pkg/fleet/installer/tar/tar.go
+++ b/pkg/fleet/installer/tar/tar.go
@@ -25,8 +25,8 @@ import (
 // This is purposeful as the archive is extracted only after its SHA256 hash has been validated
 // against its reference in the package catalog. This catalog is itself sent over Remote Config
 // which guarantees its integrity.
-func Extract(reader io.Reader, destinationPath string, maxSize int64) error {
-	slog.DebugContext(context.TODO(), "Extracting archive", "destination", destinationPath)
+func Extract(ctx context.Context, reader io.Reader, destinationPath string, maxSize int64) error {
+	slog.DebugContext(ctx, "Extracting archive", "destination", destinationPath)
 	tr := tar.NewReader(io.LimitReader(reader, maxSize))
 	for {
 		header, err := tr.Next()
@@ -67,11 +67,11 @@ func Extract(reader io.Reader, destinationPath string, maxSize int64) error {
 		case tar.TypeLink:
 			// we currently don't support hard links in the installer
 		default:
-			slog.WarnContext(context.TODO(), "Unsupported tar entry type", "type", header.Typeflag, "name", header.Name)
+			slog.WarnContext(ctx, "Unsupported tar entry type", "type", header.Typeflag, "name", header.Name)
 		}
 	}
 
-	slog.DebugContext(context.TODO(), "Successfully extracted archive", "destination", destinationPath)
+	slog.DebugContext(ctx, "Successfully extracted archive", "destination", destinationPath)
 	return nil
 }
 

--- a/pkg/fleet/installer/tar/tar.go
+++ b/pkg/fleet/installer/tar/tar.go
@@ -15,7 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"context"
+	"log/slog"
 )
 
 // Extract extracts a tar archive to the given destination path
@@ -25,7 +26,7 @@ import (
 // against its reference in the package catalog. This catalog is itself sent over Remote Config
 // which guarantees its integrity.
 func Extract(reader io.Reader, destinationPath string, maxSize int64) error {
-	log.Debugf("Extracting archive to %s", destinationPath)
+	slog.DebugContext(context.TODO(), "Extracting archive", "destination", destinationPath)
 	tr := tar.NewReader(io.LimitReader(reader, maxSize))
 	for {
 		header, err := tr.Next()
@@ -66,11 +67,11 @@ func Extract(reader io.Reader, destinationPath string, maxSize int64) error {
 		case tar.TypeLink:
 			// we currently don't support hard links in the installer
 		default:
-			log.Warnf("Unsupported tar entry type %d for %s", header.Typeflag, header.Name)
+			slog.WarnContext(context.TODO(), "Unsupported tar entry type", "type", header.Typeflag, "name", header.Name)
 		}
 	}
 
-	log.Debugf("Successfully extracted archive to %s", destinationPath)
+	slog.DebugContext(context.TODO(), "Successfully extracted archive", "destination", destinationPath)
 	return nil
 }
 

--- a/pkg/fleet/installer/telemetry/logger.go
+++ b/pkg/fleet/installer/telemetry/logger.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Logger is a logger that sends logs to the telemetry system.
+type Logger struct {
+	parent slog.Handler
+	logs   *logEntries
+}
+
+// NewLogger creates a new logger that sends logs to the telemetry system.
+func NewLogger(parent slog.Handler) *Logger {
+	return &Logger{
+		parent: parent,
+		logs:   &logEntries{},
+	}
+}
+
+type logEntries struct {
+	mu   sync.Mutex
+	logs []logEntry
+}
+
+type logEntry struct {
+	spanCtx *spanIDs
+	log     slog.Record
+}
+
+func (l *Logger) flush() []logEntry {
+	l.logs.mu.Lock()
+	defer l.logs.mu.Unlock()
+	logs := l.logs.logs
+	l.logs.logs = []logEntry{}
+	return logs
+}
+
+// Enabled checks if the logger is enabled for the given level.
+func (l *Logger) Enabled(ctx context.Context, level slog.Level) bool {
+	return l.parent.Enabled(context.Background(), slog.LevelError)
+}
+
+// Handle handles the log entry.
+func (l *Logger) Handle(ctx context.Context, record slog.Record) error {
+	var spanCtx *spanIDs
+	spanIDs, ok := getSpanIDsFromContext(ctx)
+	if ok {
+		spanCtx = &spanIDs
+	}
+	log := logEntry{
+		spanCtx: spanCtx,
+		log:     record.Clone(),
+	}
+	l.logs.mu.Lock()
+	l.logs.logs = append(l.logs.logs, log)
+	l.logs.mu.Unlock()
+	return l.parent.Handle(ctx, record)
+}
+
+// WithAttrs wraps the handler with the given attributes.
+func (l *Logger) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Logger{
+		parent: l.parent.WithAttrs(attrs),
+		logs:   l.logs,
+	}
+}
+
+// WithGroup wraps the handler with the given group.
+func (l *Logger) WithGroup(name string) slog.Handler {
+	return &Logger{
+		parent: l.parent.WithGroup(name),
+		logs:   l.logs,
+	}
+}

--- a/pkg/fleet/installer/telemetry/telemetry.go
+++ b/pkg/fleet/installer/telemetry/telemetry.go
@@ -36,7 +36,7 @@ type Telemetry struct {
 }
 
 // NewTelemetry creates a new telemetry instance
-func NewTelemetry(client *http.Client, apiKey string, logger *Logger, site string, service string) *Telemetry {
+func NewTelemetry(client *http.Client, apiKey string, site string, service string) *Telemetry {
 	t := newTelemetry(client, apiKey, site, service)
 	t.Start()
 	return t
@@ -86,7 +86,15 @@ func (t *Telemetry) Stop() {
 	<-t.flushed
 }
 
+// SetLogger sets the logger for the telemetry.
+func (t *Telemetry) SetLogger(logger *Logger) {
+	t.logger = logger
+}
+
 func (t *Telemetry) sendLogs() {
+	if t.logger == nil {
+		return
+	}
 	logs := t.logger.flush()
 	fmt.Println("sending logs", len(logs))
 }


### PR DESCRIPTION
### What does this PR do?

This PR:
1. Converts all logging usage in the installer CLI to slog.
2. Adds a telemetry wrapper that forwards the logs to telemetry

### Motivation

- More debugging info for the customer (those logs will be visible in their deployment screen in the future)
- Get some data for situations where the installer CLI gets stuck (today we don't get the trace since it never completes)
- Generally more telemetry information

Note: I used claude code to run the logging migration, be careful with the review ;)