### PR TITLE
[CWS] remove types column in SECL operator documentation

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -32,30 +32,30 @@ open.file.path == "/etc/shadow" && process.file.path not in ["/usr/sbin/vipw"]
 ## Operators
 SECL operators are used to combine event attributes together into a full expression. The following operators are available:
 
-| SECL Operator         | Types            |  Definition                              | Agent Version |
-|-----------------------|------------------|------------------------------------------|---------------|
-| `==`                  | Process          | Equal                                    | 7.27          |
-| `!=`                  | File             | Not equal                                | 7.27          |
-| `>`                   | File             | Greater                                  | 7.27          |
-| `>=`                  | File             | Greater or equal                         | 7.27          |
-| `<`                   | File             | Lesser                                   | 7.27          |
-| `<=`                  | File             | Lesser or equal                          | 7.27          |
-| `!` or `not`          | File             | Not                                      | 7.27          |
-| `^`                   | File             | Binary not                               | 7.27          |
-| `in [elem1, ...]`     | File             | Element is contained in list             | 7.27          |
-| `not in [elem1, ...]` | File             | Element is not contained in list         | 7.27          |
-| `=~`                  | File             | String matching                          | 7.27          |
-| `!~`                  | File             | String not matching                      | 7.27          |
-| `&`                   | File             | Binary and                               | 7.27          |
-| `\|`                  | File             | Binary or                                | 7.27          |
-| `&&` or `and`         | File             | Logical and                              | 7.27          |
-| `\|\|` or `or`        | File             | Logical or                               | 7.27          |
-| `in CIDR`             | Network          | Element is in the IP range               | 7.37          |
-| `not in CIDR`         | Network          | Element is not in the IP range           | 7.37          |
-| `allin CIDR`          | Network          | All the elements are in the IP range     | 7.37          |
-| `in [CIDR1, ...]`     | Network          | Element is in the IP ranges              | 7.37          |
-| `not in [CIDR1, ...]` | Network          | Element is not in the IP ranges          | 7.37          |
-| `allin [CIDR1, ...]`  | Network          | All the elements are in the IP ranges    | 7.37          |
+| SECL Operator         |  Definition                              | Agent Version |
+|-----------------------|------------------------------------------|---------------|
+| `==`                  | Equal                                    | 7.27          |
+| `!=`                  | Not equal                                | 7.27          |
+| `>`                   | Greater                                  | 7.27          |
+| `>=`                  | Greater or equal                         | 7.27          |
+| `<`                   | Lesser                                   | 7.27          |
+| `<=`                  | Lesser or equal                          | 7.27          |
+| `!` or `not`          | Not                                      | 7.27          |
+| `^`                   | Binary not                               | 7.27          |
+| `in [elem1, ...]`     | Element is contained in list             | 7.27          |
+| `not in [elem1, ...]` | Element is not contained in list         | 7.27          |
+| `=~`                  | String matching                          | 7.27          |
+| `!~`                  | String not matching                      | 7.27          |
+| `&`                   | Binary and                               | 7.27          |
+| `\|`                  | Binary or                                | 7.27          |
+| `&&` or `and`         | Logical and                              | 7.27          |
+| `\|\|` or `or`        | Logical or                               | 7.27          |
+| `in CIDR`             | Element is in the IP range               | 7.37          |
+| `not in CIDR`         | Element is not in the IP range           | 7.37          |
+| `allin CIDR`          | All the elements are in the IP range     | 7.37          |
+| `in [CIDR1, ...]`     | Element is in the IP ranges              | 7.37          |
+| `not in [CIDR1, ...]` | Element is not in the IP ranges          | 7.37          |
+| `allin [CIDR1, ...]`  | All the elements are in the IP ranges    | 7.37          |
 
 ## Patterns and regular expressions
 Patterns or regular expressions can be used in SECL expressions. They can be used with the `in`, `not in`, `=~`, and `!~` operators.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the `Types` column in the SECL documentation for operators, as this column is confusing and is not actually describing the operator capabilities.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->