### PR TITLE
[Backport 7.70.x] fix(installer): Skip ensureUserInGroup is user is already in group

### DIFF
--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os/exec"
 	"os/user"
+	"slices"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -65,6 +66,24 @@ func ensureUser(ctx context.Context, userName string, installPath string) error 
 }
 
 func ensureUserInGroup(ctx context.Context, userName string, groupName string) error {
+	// Check if user is already in group and abort if it is -- this allows us
+	// to skip where the user / group are set in LDAP / AD
+	group, err := user.LookupGroup(groupName)
+	if err != nil {
+		return fmt.Errorf("error looking up %s group: %w", groupName, err)
+	}
+	user, err := user.Lookup(userName)
+	if err != nil {
+		return fmt.Errorf("error looking up %s user: %w", userName, err)
+	}
+	userGroups, err := user.GroupIds()
+	if err != nil {
+		return fmt.Errorf("error getting groups for user %s: %w", userName, err)
+	}
+	if slices.Contains(userGroups, group.Gid) {
+		// User is already in the group, nothing to do
+		return nil
+	}
 	err := exec.CommandContext(ctx, "usermod", "-g", groupName, userName).Run()
 	if err != nil {
 		return fmt.Errorf("error adding %s user to %s group: %w", userName, groupName, err)

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -84,7 +84,7 @@ func ensureUserInGroup(ctx context.Context, userName string, groupName string) e
 		// User is already in the group, nothing to do
 		return nil
 	}
-	err := exec.CommandContext(ctx, "usermod", "-g", groupName, userName).Run()
+	err = exec.CommandContext(ctx, "usermod", "-g", groupName, userName).Run()
 	if err != nil {
 		return fmt.Errorf("error adding %s user to %s group: %w", userName, groupName, err)
 	}


### PR DESCRIPTION
Backport [582290a](https://github.com/DataDog/datadog-agent/pull/39991/commits/582290adc14a9434eda8413546a2dcaaa134c1a0) from #39991.

___

### What does this PR do?
Skip `ensureUserInGroup` is user is already in group. Avoid failing on usermod if the users are managed by LDAP.

### Motivation

### Describe how you validated your changes
Manually tested on a VM with LDAP+PAM 

### Possible Drawbacks / Trade-offs

### Additional Notes
