### PR TITLE
[EBPF]: gpu check: add bar1 memory metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -42,6 +42,7 @@ const (
 	field        CollectorName = "fields"
 	clock        CollectorName = "clocks"
 	device       CollectorName = "device"
+	memory       CollectorName = "memory"
 	remappedRows CollectorName = "remapped_rows"
 	samples      CollectorName = "samples"
 	process      CollectorName = "process"
@@ -82,6 +83,7 @@ var factory = map[CollectorName]subsystemBuilder{
 	device:       newDeviceCollector,
 	field:        newFieldsCollector,
 	gpm:          newGPMCollector,
+	memory:       newMemoryCollector,
 	nvlink:       newNVLinkCollector,
 	process:      newProcessCollector,
 	remappedRows: newRemappedRowsCollector,

--- a/pkg/collector/corechecks/gpu/nvidia/memory.go
+++ b/pkg/collector/corechecks/gpu/nvidia/memory.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+type memoryAPICall struct {
+	name     string
+	testFunc func(ddnvml.Device) error
+	callFunc func(*memoryCollector) ([]Metric, error)
+}
+
+var memoryAPICallFactory = []memoryAPICall{
+	{
+		name: "bar1_memory",
+		testFunc: func(d ddnvml.Device) error {
+			_, err := d.GetBAR1MemoryInfo()
+			return err
+		},
+		callFunc: (*memoryCollector).collectBAR1MemoryMetrics,
+	},
+}
+
+type memoryCollector struct {
+	device            ddnvml.Device
+	supportedAPICalls []memoryAPICall
+}
+
+func newMemoryCollector(device ddnvml.Device) (Collector, error) {
+	c := &memoryCollector{device: device}
+
+	c.removeUnsupportedMetrics()
+	if len(c.supportedAPICalls) == 0 {
+		return nil, errUnsupportedDevice
+	}
+
+	return c, nil
+}
+
+func (c *memoryCollector) removeUnsupportedMetrics() {
+	for _, apiCall := range memoryAPICallFactory {
+		err := apiCall.testFunc(c.device)
+		if err == nil || !ddnvml.IsUnsupported(err) {
+			c.supportedAPICalls = append(c.supportedAPICalls, apiCall)
+		}
+	}
+}
+
+func (c *memoryCollector) DeviceUUID() string {
+	return c.device.GetDeviceInfo().UUID
+}
+
+func (c *memoryCollector) Name() CollectorName {
+	return memory
+}
+
+func (c *memoryCollector) Collect() ([]Metric, error) {
+	var allMetrics []Metric
+	var multiErr error
+
+	for _, apiCall := range c.supportedAPICalls {
+		collectedMetrics, err := apiCall.callFunc(c)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("%s returned an error: %w", apiCall.name, err))
+			continue
+		}
+
+		allMetrics = append(allMetrics, collectedMetrics...)
+	}
+
+	return allMetrics, multiErr
+}
+
+// collectBAR1MemoryMetrics collects BAR1 memory metrics with a single API call
+func (c *memoryCollector) collectBAR1MemoryMetrics() ([]Metric, error) {
+	bar1Info, err := c.device.GetBAR1MemoryInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	return []Metric{
+		{
+			Name:  "memory.bar1.total",
+			Value: float64(bar1Info.Bar1Total),
+			Type:  metrics.GaugeType,
+		},
+		{
+			Name:  "memory.bar1.free",
+			Value: float64(bar1Info.Bar1Free),
+			Type:  metrics.GaugeType,
+		},
+		{
+			Name:  "memory.bar1.used",
+			Value: float64(bar1Info.Bar1Used),
+			Type:  metrics.GaugeType,
+		},
+	}, nil
+}

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -22,6 +22,8 @@ type SafeDevice interface {
 	GetArchitecture() (nvml.DeviceArchitecture, error)
 	// GetAttributes returns the attributes of the device
 	GetAttributes() (nvml.DeviceAttributes, error)
+	// GetBAR1MemoryInfo returns BAR1 memory information of the device
+	GetBAR1MemoryInfo() (nvml.BAR1Memory, error)
 	// GetClockInfo returns the current clock speed for the given clock type
 	GetClockInfo(clockType nvml.ClockType) (uint32, error)
 	// GetComputeRunningProcesses returns the list of compute processes running on the device
@@ -83,12 +85,12 @@ type SafeDevice interface {
 	GetUUID() (string, error)
 	// GetUtilizationRates returns the utilization rates for the device
 	GetUtilizationRates() (nvml.Utilization, error)
-	// IsMigDeviceHandle returns true if the device is a MIG device or false for a physical device
-	IsMigDeviceHandle() (bool, error)
 	// GpmQueryDeviceSupport returns true if the device supports GPM
 	GpmQueryDeviceSupport() (nvml.GpmSupport, error)
 	// GpmSampleGet gets a sample for GPM
 	GpmSampleGet(sample nvml.GpmSample) error
+	// IsMigDeviceHandle returns true if the device is a MIG device or false for a physical device
+	IsMigDeviceHandle() (bool, error)
 }
 
 // DeviceInfo holds common cached properties for a GPU device

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -33,6 +33,14 @@ func (d *safeDeviceImpl) GetAttributes() (nvml.DeviceAttributes, error) {
 	return attrs, NewNvmlAPIErrorOrNil("GetAttributes", ret)
 }
 
+func (d *safeDeviceImpl) GetBAR1MemoryInfo() (nvml.BAR1Memory, error) {
+	if err := d.lib.lookup(toNativeName("GetBAR1MemoryInfo")); err != nil {
+		return nvml.BAR1Memory{}, err
+	}
+	bar1Info, ret := d.nvmlDevice.GetBAR1MemoryInfo()
+	return bar1Info, NewNvmlAPIErrorOrNil("GetBAR1MemoryInfo", ret)
+}
+
 func (d *safeDeviceImpl) GetClockInfo(clockType nvml.ClockType) (uint32, error) {
 	if err := d.lib.lookup(toNativeName("GetClockInfo")); err != nil {
 		return 0, err
@@ -285,14 +293,6 @@ func (d *safeDeviceImpl) GetUtilizationRates() (nvml.Utilization, error) {
 	return utilization, NewNvmlAPIErrorOrNil("GetUtilizationRates", ret)
 }
 
-func (d *safeDeviceImpl) IsMigDeviceHandle() (bool, error) {
-	if err := d.lib.lookup(toNativeName("IsMigDeviceHandle")); err != nil {
-		return false, err
-	}
-	isMig, ret := d.nvmlDevice.IsMigDeviceHandle()
-	return isMig, NewNvmlAPIErrorOrNil("IsMigDeviceHandle", ret)
-}
-
 func (d *safeDeviceImpl) GpmQueryDeviceSupport() (nvml.GpmSupport, error) {
 	if err := d.lib.lookup("nvmlGpmQueryDeviceSupport"); err != nil {
 		return nvml.GpmSupport{}, err
@@ -307,4 +307,12 @@ func (d *safeDeviceImpl) GpmSampleGet(sample nvml.GpmSample) error {
 	}
 	ret := d.nvmlDevice.GpmSampleGet(sample)
 	return NewNvmlAPIErrorOrNil("GpmSampleGet", ret)
+}
+
+func (d *safeDeviceImpl) IsMigDeviceHandle() (bool, error) {
+	if err := d.lib.lookup(toNativeName("IsMigDeviceHandle")); err != nil {
+		return false, err
+	}
+	isMig, ret := d.nvmlDevice.IsMigDeviceHandle()
+	return isMig, NewNvmlAPIErrorOrNil("IsMigDeviceHandle", ret)
 }

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -50,6 +50,7 @@ func getNonCriticalAPIs() []string {
 		"nvmlGpmSampleGet",
 		toNativeName("GetArchitecture"),
 		toNativeName("GetAttributes"),
+		toNativeName("GetBAR1MemoryInfo"),
 		toNativeName("GetClockInfo"),
 		toNativeName("GetComputeRunningProcesses"),
 		toNativeName("GetCurrentClocksThrottleReasons"),


### PR DESCRIPTION
### What does this PR do?

creates a new memory collector to report bar1 memory metrics 
[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-692)

### Motivation

bar1 memory explanation - https://checkmk.com/integrations/nvidia_smi_memory_util 

### Describe how you validated your changes

manual tests

### Possible Drawbacks / Trade-offs

### Additional Notes
- in consequent PRs, more device level metrics will be added to the memory collector
- the check collectors will undergo refactor to consolidate common logic for metrics retrieval