### PR TITLE
[SBOM] store SBOM compressed in the workloadmeta

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -319,7 +319,6 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 			Namespace: namespace,
 		},
 		MediaType: manifest.MediaType,
-		SBOM:      sbom,
 		SizeBytes: totalSizeBytes,
 	}
 	// Do not pull references for new image if agent is starting up,
@@ -365,8 +364,8 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 		}
 	}
 
-	if wlmImage.SBOM == nil {
-		wlmImage.SBOM = &workloadmeta.SBOM{
+	if sbom == nil {
+		sbom = &workloadmeta.SBOM{
 			Status: workloadmeta.Pending,
 		}
 	}
@@ -375,7 +374,7 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 	// not be able to inject them. For example, if we use the scanner from filesystem or
 	// if the `imgMeta` object does not contain all the metadata when it is sent.
 	// We add them here to make sure they are present.
-	wlmImage.SBOM = sbomutil.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
+	wlmImage.SBOM = sbomutil.UpdateSBOMRepoMetadata(sbom, wlmImage.RepoTags, wlmImage.RepoDigests)
 	return &wlmImage, nil
 }
 

--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -374,7 +374,14 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 	// not be able to inject them. For example, if we use the scanner from filesystem or
 	// if the `imgMeta` object does not contain all the metadata when it is sent.
 	// We add them here to make sure they are present.
-	wlmImage.SBOM = sbomutil.UpdateSBOMRepoMetadata(sbom, wlmImage.RepoTags, wlmImage.RepoDigests)
+	sbom = sbomutil.UpdateSBOMRepoMetadata(sbom, wlmImage.RepoTags, wlmImage.RepoDigests)
+
+	csbom, err := sbomutil.CompressSBOM(sbom)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compress SBOM for image %s: %v", wlmImage.ID, err)
+	}
+	wlmImage.SBOM = csbom
+
 	return &wlmImage, nil
 }
 

--- a/comp/core/workloadmeta/collectors/sbomutil/compress.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/compress.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package sbomutil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"google.golang.org/protobuf/proto"
+)
+
+// CompressSBOM converts a workloadmeta.SBOM into a workloadmeta.CompressedSBOM.
+func CompressSBOM(sbom *workloadmeta.SBOM) (*workloadmeta.CompressedSBOM, error) {
+	if sbom == nil {
+		return nil, nil
+	}
+
+	uncompressedBom, err := proto.Marshal(sbom.CycloneDXBOM)
+	if err != nil {
+		return nil, err
+	}
+
+	var compressedBom bytes.Buffer
+	writer := gzip.NewWriter(&compressedBom)
+	if _, err := writer.Write(uncompressedBom); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	return &workloadmeta.CompressedSBOM{
+		Bom:                compressedBom.Bytes(),
+		GenerationTime:     sbom.GenerationTime,
+		GenerationDuration: sbom.GenerationDuration,
+		Status:             sbom.Status,
+		Error:              sbom.Error,
+	}, nil
+}
+
+// UncompressSBOM converts a workloadmeta.CompressedSBOM into a workloadmeta.SBOM.
+func UncompressSBOM(csbom *workloadmeta.CompressedSBOM) (*workloadmeta.SBOM, error) {
+	if csbom == nil {
+		return nil, nil
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(csbom.Bom))
+	if err != nil {
+		return nil, err
+	}
+
+	uncompressedBom, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := reader.Close(); err != nil {
+		return nil, err
+	}
+
+	var cyclosbom cyclonedx_v1_4.Bom
+	if err := proto.Unmarshal(uncompressedBom, &cyclosbom); err != nil {
+		return nil, err
+	}
+
+	return &workloadmeta.SBOM{
+		CycloneDXBOM:       &cyclosbom,
+		GenerationTime:     csbom.GenerationTime,
+		GenerationDuration: csbom.GenerationDuration,
+		Status:             csbom.Status,
+		Error:              csbom.Error,
+	}, nil
+}

--- a/comp/core/workloadmeta/collectors/sbomutil/compress_test.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/compress_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package sbomutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/cyclonedx_v1_4"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	trivycore "github.com/aquasecurity/trivy/pkg/sbom/core"
+	trivydx "github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompressUncompressSBOM(t *testing.T) {
+	sbom := &workloadmeta.SBOM{
+		CycloneDXBOM: &cyclonedx_v1_4.Bom{
+			Metadata: &cyclonedx_v1_4.Metadata{
+				Component: &cyclonedx_v1_4.Component{
+					Properties: []*cyclonedx_v1_4.Property{
+						{Name: trivydx.Namespace + trivycore.PropertyRepoDigest, Value: pointer.Ptr("digest1")},
+						{Name: trivydx.Namespace + trivycore.PropertyRepoTag, Value: pointer.Ptr("tag1")},
+					},
+				},
+			},
+		},
+		GenerationTime:     time.Now(),
+		GenerationDuration: 100 * time.Millisecond,
+		Status:             workloadmeta.Success,
+		Error:              "",
+	}
+
+	csbom, err := CompressSBOM(sbom)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	usbom, err := UncompressSBOM(csbom)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// use EqualExportedValues to compare protobuf values (internal state may be different)
+	assert.EqualExportedValues(t, sbom, usbom, "Uncompressed SBOM does not match original")
+}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1348,6 +1348,15 @@ type SBOM struct {
 	Error              string // needs to be stored as a string otherwise the merge() will favor the nil value
 }
 
+// CompressedSBOM represents a compressed version of the Software Bill Of Materials (SBOM) of a container
+type CompressedSBOM struct {
+	Bom                []byte
+	GenerationTime     time.Time
+	GenerationDuration time.Duration
+	Status             SBOMStatus
+	Error              string
+}
+
 // GetID implements Entity#GetID.
 func (i ContainerImageMetadata) GetID() EntityID {
 	return i.EntityID

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1327,7 +1327,7 @@ type ContainerImageMetadata struct {
 	Architecture string
 	Variant      string
 	Layers       []ContainerImageLayer
-	SBOM         *SBOM
+	SBOM         *CompressedSBOM
 }
 
 // ContainerImageLayer represents a layer of a container image

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmetafilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/util/workloadmeta"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/sbomutil"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -339,7 +340,7 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 		return
 	}
 
-	if img.SBOM.Status == workloadmeta.Success && img.SBOM.CycloneDXBOM == nil {
+	if img.SBOM.Status == workloadmeta.Success && len(img.SBOM.Bom) == 0 {
 		log.Debug("received a sbom with incorrect status")
 		return
 	}
@@ -369,6 +370,11 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 			inUse = true
 			break
 		}
+	}
+
+	cyclosbom, err := sbomutil.UncompressSBOM(img.SBOM)
+	if err != nil {
+		log.Errorf("Failed to uncompress SBOM for image %s: %v", img.ID, err)
 	}
 
 	for repo := range repos {
@@ -434,20 +440,20 @@ func (p *processor) processImageSBOM(img *workloadmeta.ContainerImageMetadata) {
 			InUse:       inUse,
 		}
 
-		switch img.SBOM.Status {
+		switch cyclosbom.Status {
 		case workloadmeta.Pending:
 			sbom.Status = model.SBOMStatus_PENDING
 		case workloadmeta.Failed:
 			sbom.Status = model.SBOMStatus_FAILED
 			sbom.Sbom = &model.SBOMEntity_Error{
-				Error: img.SBOM.Error,
+				Error: cyclosbom.Error,
 			}
 		default:
 			sbom.Status = model.SBOMStatus_SUCCESS
-			sbom.GeneratedAt = timestamppb.New(img.SBOM.GenerationTime)
-			sbom.GenerationDuration = bomconvert.ConvertDuration(img.SBOM.GenerationDuration)
+			sbom.GeneratedAt = timestamppb.New(cyclosbom.GenerationTime)
+			sbom.GenerationDuration = bomconvert.ConvertDuration(cyclosbom.GenerationDuration)
 			sbom.Sbom = &model.SBOMEntity_Cyclonedx{
-				Cyclonedx: img.SBOM.CycloneDXBOM,
+				Cyclonedx: cyclosbom.CycloneDXBOM,
 			}
 		}
 		p.queue <- sbom

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -29,6 +29,7 @@ import (
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/sbomutil"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
@@ -74,7 +75,7 @@ func TestProcessEvents(t *testing.T) {
 							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							CycloneDXBOM: &cyclonedx_v1_4.Bom{
 								SpecVersion: cyclonedx.SpecVersion1_4.String(),
 								Version:     pointer.Ptr(int32(42)),
@@ -93,7 +94,7 @@ func TestProcessEvents(t *testing.T) {
 							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,
 							Status:             workloadmeta.Success,
-						},
+						}),
 					},
 				},
 			},
@@ -242,7 +243,7 @@ func TestProcessEvents(t *testing.T) {
 							// Notice that there's a repo tag for gcr.io, but no repo digest.
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							CycloneDXBOM: &cyclonedx_v1_4.Bom{
 								SpecVersion: cyclonedx.SpecVersion1_4.String(),
 								Version:     pointer.Ptr(int32(42)),
@@ -261,7 +262,7 @@ func TestProcessEvents(t *testing.T) {
 							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,
 							Status:             workloadmeta.Success,
-						},
+						}),
 					},
 				},
 			},
@@ -321,7 +322,7 @@ func TestProcessEvents(t *testing.T) {
 						RepoTags: []string{
 							"my-image:latest",
 						},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							CycloneDXBOM: &cyclonedx_v1_4.Bom{
 								SpecVersion: cyclonedx.SpecVersion1_4.String(),
 								Version:     pointer.Ptr(int32(42)),
@@ -340,7 +341,7 @@ func TestProcessEvents(t *testing.T) {
 							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,
 							Status:             workloadmeta.Success,
-						},
+						}),
 					},
 				},
 			},
@@ -393,7 +394,7 @@ func TestProcessEvents(t *testing.T) {
 						},
 						RepoTags:    []string{"datadog/agent:7-rc"},
 						RepoDigests: []string{"datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409"},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							CycloneDXBOM: &cyclonedx_v1_4.Bom{
 								SpecVersion: cyclonedx.SpecVersion1_4.String(),
 								Version:     pointer.Ptr(int32(42)),
@@ -401,7 +402,7 @@ func TestProcessEvents(t *testing.T) {
 							GenerationTime:     sbomGenerationTime,
 							GenerationDuration: 10 * time.Second,
 							Status:             workloadmeta.Success,
-						},
+						}),
 					},
 				},
 				{
@@ -498,9 +499,9 @@ func TestProcessEvents(t *testing.T) {
 							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							Status: workloadmeta.Pending,
-						},
+						}),
 					},
 				},
 			},
@@ -590,10 +591,10 @@ func TestProcessEvents(t *testing.T) {
 							"gcr.io/datadoghq/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 							"public.ecr.aws/datadog/agent@sha256:052f1fdf4f9a7117d36a1838ab60782829947683007c34b69d4991576375c409",
 						},
-						SBOM: &workloadmeta.SBOM{
+						SBOM: mustCompressSBOM(t, &workloadmeta.SBOM{
 							Status: workloadmeta.Failed,
 							Error:  "error",
-						},
+						}),
 					},
 				},
 			},
@@ -751,4 +752,13 @@ func TestProcessEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustCompressSBOM(t *testing.T, sbom *workloadmeta.SBOM) *workloadmeta.CompressedSBOM {
+	t.Helper()
+
+	csbom, err := sbomutil.CompressSBOM(sbom)
+	assert.Nil(t, err)
+
+	return csbom
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently we store full SBOMs for all container image metadata in the workloadmeta store. This is used both by the flare provider (that creates a `sbom.json` file in the flare) and also by the periodic refresh that will send the SBOM for all images periodically.

Now SBOMs can be big (a few megabytes), and we expect them to get bigger when we enable more scanners (like the apps and libraries scanners). This is especially impactful on nodes with a lot of images thanks to binpacking (internally we call this nodeless), and can result in agent OOM kills.

To improve this state, this PR converts the workloadmeta store to store SBOMs in a proto-encoded + compressed format. SBOMs are decompressed on demand when they are needed (which should be pretty rare).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->