### PR TITLE
[CWS-4782] Add eBPFLess support for setsockopt

### DIFF
--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -9,12 +9,17 @@
 package probe
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"golang.org/x/net/bpf"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/args"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
@@ -537,19 +542,51 @@ func (fh *EBPFLessFieldHandlers) ResolveAcceptHostnames(_ *model.Event, e *model
 }
 
 // ResolveSetSockOptFilterHash resolves the filter hash of a setsockopt event
-func (fh *EBPFLessFieldHandlers) ResolveSetSockOptFilterHash(_ *model.Event, _ *model.SetSockOptEvent) string {
-	// Not implemented in EBPFLess mode, as we don't have access to the BPF verifier
-	return ""
+func (fh *EBPFLessFieldHandlers) ResolveSetSockOptFilterHash(_ *model.Event, e *model.SetSockOptEvent) string {
+	if len(e.FilterHash) == 0 {
+		h := sha256.New()
+		h.Write(e.RawFilter)
+		bs := h.Sum(nil)
+		e.FilterHash = fmt.Sprintf("%x", bs)
+		return e.FilterHash
+	}
+	return e.FilterHash
 }
 
 // ResolveSetSockOptFilterInstructions resolves the filter instructions of a setsockopt event
-func (fh *EBPFLessFieldHandlers) ResolveSetSockOptFilterInstructions(_ *model.Event, _ *model.SetSockOptEvent) string {
-	// Not implemented in EBPFLess mode, as we don't have access to the BPF verifier
-	return ""
+func (fh *EBPFLessFieldHandlers) ResolveSetSockOptFilterInstructions(_ *model.Event, e *model.SetSockOptEvent) string {
+	if len(e.FilterInstructions) == 0 {
+		raw := parseFilter(e)
+
+		instructions, allDecoded := bpf.Disassemble(raw)
+		if !allDecoded {
+			seclog.Warnf("failed to decode setsockopt filter instructions: %s", e.FilterHash)
+			return ""
+		}
+
+		for i, inst := range instructions {
+			e.FilterInstructions += fmt.Sprintf("%03d: %s\n", i, inst)
+		}
+
+		return e.FilterInstructions
+	}
+	return e.FilterInstructions
 }
 
 // ResolveSetSockOptUsedImmediates resolves the immediates in the bpf filter of a setsockopt event
-func (fh *EBPFLessFieldHandlers) ResolveSetSockOptUsedImmediates(_ *model.Event, _ *model.SetSockOptEvent) []int {
-	// Not implemented in EBPFLess mode, as we don't have access to the BPF verifier
-	return nil
+func (fh *EBPFLessFieldHandlers) ResolveSetSockOptUsedImmediates(_ *model.Event, e *model.SetSockOptEvent) []int {
+	if e.UsedImmediates != nil {
+		return e.UsedImmediates
+	}
+	raw := parseFilter(e)
+	var kValues []int
+	for _, inst := range raw {
+		// Check if we load or branch on a magic value
+		if !slices.Contains(kValues, int(inst.K)) {
+			kValues = append(kValues, int(inst.K))
+		}
+
+	}
+	e.UsedImmediates = kValues
+	return e.UsedImmediates
 }

--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -50,7 +50,8 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "event.") &&
 				!strings.HasPrefix(field, "accept.") &&
 				!strings.HasPrefix(field, "bind.") &&
-				!strings.HasPrefix(field, "connect.") {
+				!strings.HasPrefix(field, "connect.") &&
+				!strings.HasPrefix(field, "setsockopt.") {
 				return rules.ErrEventTypeNotEnabled
 			}
 			return nil

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -333,6 +333,16 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.Bind.AddrFamily = syscallMsg.Bind.AddressFamily
 		event.Bind.Protocol = syscallMsg.Bind.Protocol
 		event.Bind.Retval = syscallMsg.Retval
+	case ebpfless.SyscallTypeSetsockopt:
+		event.Type = uint32(model.SetSockOptEventType)
+		event.SetSockOpt.SocketFamily = syscallMsg.Setsockopt.SocketFamily
+		event.SetSockOpt.SocketProtocol = syscallMsg.Setsockopt.SocketProtocol
+		event.SetSockOpt.SocketType = syscallMsg.Setsockopt.SocketType
+		event.SetSockOpt.Level = syscallMsg.Setsockopt.Level
+		event.SetSockOpt.OptName = syscallMsg.Setsockopt.OptName
+		event.SetSockOpt.RawFilter = syscallMsg.Setsockopt.Filter
+		event.SetSockOpt.FilterLen = syscallMsg.Setsockopt.FilterLen
+		event.SetSockOpt.SizeToRead = uint32(syscallMsg.Setsockopt.FilterLen)
 	}
 
 	// container context

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -97,6 +97,8 @@ const (
 	SyscallTypeConnect
 	// SyscallTypeBind bind
 	SyscallTypeBind
+	// SyscallTypeSetsockopt setsockopt type
+	SyscallTypeSetsockopt
 )
 
 // ContainerContext defines a container context
@@ -177,6 +179,7 @@ type PipeSyscallFakeMsg struct {
 type SocketSyscallFakeMsg struct {
 	AddressFamily uint16
 	Protocol      uint16
+	SocketType    uint16
 }
 
 // ChdirSyscallMsg defines a chdir message
@@ -335,6 +338,17 @@ type AcceptSyscallMsg struct {
 	SocketFd int32
 }
 
+// SetsockoptSyscallMsg defines a setsockopt message
+type SetsockoptSyscallMsg struct {
+	SocketFamily   uint16
+	SocketProtocol uint16
+	SocketType     uint16
+	Level          uint32
+	OptName        uint32
+	Filter         []byte
+	FilterLen      uint16
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type         SyscallType
@@ -369,6 +383,7 @@ type SyscallMsg struct {
 	Bind         *BindSyscallMsg         `json:",omitempty"`
 	Connect      *ConnectSyscallMsg      `json:",omitempty"`
 	Accept       *AcceptSyscallMsg       `json:",omitempty"`
+	Setsockopt   *SetsockoptSyscallMsg   `json:",omitempty"`
 
 	// internals
 	Dup    *DupSyscallFakeMsg    `json:",omitempty"`

--- a/pkg/security/ptracer/network_handlers.go
+++ b/pkg/security/ptracer/network_handlers.go
@@ -11,9 +11,10 @@ package ptracer
 import (
 	"encoding/binary"
 	"errors"
-	"golang.org/x/sys/unix"
 	"net"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 )
@@ -49,6 +50,12 @@ func registerNetworkHandlers(handlers map[int]syscallHandler) []string {
 			Func:       handleSocket,
 			ShouldSend: nil,
 			RetFunc:    handleSocketRet,
+		},
+		{
+			ID:         syscallID{ID: SetsockoptNr, Name: "setsockopt"},
+			Func:       handleSetsockopt,
+			ShouldSend: shouldSendSetsockopt,
+			RetFunc:    nil,
 		},
 	}
 
@@ -186,25 +193,18 @@ func handleConnect(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, r
 func handleSocket(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
 	socketMsg := &ebpfless.SocketSyscallFakeMsg{
 		AddressFamily: uint16(tracer.ReadArgInt32(regs, 0)),
+		SocketType:    uint16(tracer.ReadArgInt32(regs, 1)),
 	}
-
-	if socketMsg.AddressFamily != unix.AF_INET && socketMsg.AddressFamily != unix.AF_INET6 && socketMsg.AddressFamily != unix.AF_UNIX {
-		return nil
+	socketMsg.Protocol = uint16(tracer.ReadArgInt32(regs, 2))
+	if socketMsg.Protocol == 0 {
+		switch socketMsg.SocketType {
+		case unix.SOCK_STREAM:
+			socketMsg.Protocol = unix.IPPROTO_TCP
+		case unix.SOCK_DGRAM:
+			socketMsg.Protocol = unix.IPPROTO_UDP
+		default:
+		}
 	}
-
-	protocol := int16(tracer.ReadArgInt32(regs, 1))
-	// This argument can be masked, so just get what we need
-	protocol &= 0b1111
-
-	switch protocol {
-	case unix.SOCK_STREAM:
-		socketMsg.Protocol = unix.IPPROTO_TCP
-	case unix.SOCK_DGRAM:
-		socketMsg.Protocol = unix.IPPROTO_UDP
-	default:
-		return nil
-	}
-
 	msg.Socket = socketMsg
 	return nil
 }
@@ -256,6 +256,7 @@ func handleSocketRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg,
 		process.FdToSocket[ret] = SocketInfo{
 			AddressFamily: msg.Socket.AddressFamily,
 			Protocol:      msg.Socket.Protocol,
+			SocketType:    msg.Socket.SocketType,
 		}
 	}
 
@@ -273,4 +274,79 @@ func shouldSendAccept(msg *ebpfless.SyscallMsg) bool {
 
 func shouldSendBind(msg *ebpfless.SyscallMsg) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.EADDRINUSE) || msg.Retval == -int64(syscall.EFAULT)
+}
+
+func readRemote(pid int, addr uintptr, dst []byte) error {
+	local := []unix.Iovec{{Base: &dst[0], Len: uint64(len(dst))}}
+	remote := []unix.RemoteIovec{{Base: addr, Len: len(dst)}}
+	n, err := unix.ProcessVMReadv(pid, local, remote, 0)
+	if err != nil {
+		return err
+	}
+	if n != len(dst) {
+		return errors.New("short read from remote process")
+	}
+	return nil
+}
+
+func handleSetsockopt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := int32(tracer.ReadArgUint32(regs, 0))
+	socketInfo, ok := process.FdToSocket[fd]
+	if !ok {
+		return errors.New("unable to find socket")
+	}
+
+	level := tracer.ReadArgUint32(regs, 1)
+	optname := tracer.ReadArgUint32(regs, 2)
+
+	// Read the sock_fprog header from argument 3 (optval)
+	// Expected size on 64-bit: 16 bytes (2 bytes length, 6 bytes padding, 8 bytes pointer)
+	hdr, err := tracer.ReadArgData(process.Pid, regs, 3, 16)
+	if err != nil {
+		return err
+	}
+	fLen := binary.NativeEndian.Uint16(hdr[0:2])
+
+	// Pointer at offset 8..15 (due to padding)
+	ptrFilter := binary.NativeEndian.Uint64(hdr[8:16])
+
+	// Nothing to do if no filters
+	if fLen == 0 || ptrFilter == 0 {
+		msg.Type = ebpfless.SyscallTypeSetsockopt
+		msg.Setsockopt = &ebpfless.SetsockoptSyscallMsg{
+			Level:          level,
+			OptName:        optname,
+			Filter:         nil,
+			FilterLen:      0,
+			SocketFamily:   socketInfo.AddressFamily,
+			SocketProtocol: socketInfo.Protocol,
+			SocketType:     socketInfo.SocketType,
+		}
+		return nil
+	}
+
+	const insnSize = 8
+	total := int(fLen) * insnSize
+	raw := make([]byte, total)
+
+	// Read the sock_filter array from the target process's memory
+	if err := readRemote(process.Pid, uintptr(ptrFilter), raw); err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeSetsockopt
+	msg.Setsockopt = &ebpfless.SetsockoptSyscallMsg{
+		Level:          level,
+		OptName:        optname,
+		Filter:         raw,
+		FilterLen:      fLen,
+		SocketFamily:   socketInfo.AddressFamily,
+		SocketProtocol: socketInfo.Protocol,
+		SocketType:     socketInfo.SocketType,
+	}
+	return nil
+}
+
+func shouldSendSetsockopt(msg *ebpfless.SyscallMsg) bool {
+	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.EINVAL)
 }

--- a/pkg/security/ptracer/network_handlers.go
+++ b/pkg/security/ptracer/network_handlers.go
@@ -299,14 +299,11 @@ func handleSetsockopt(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg
 	var socketProtocol uint16
 	var socketType uint16
 
-	if !ok {
-		socketFamily = 0
-		socketProtocol = 0
-		socketType = 0
+	if ok {
+		socketFamily = socketInfo.AddressFamily
+		socketProtocol = socketInfo.Protocol
+		socketType = socketInfo.SocketType
 	}
-	socketFamily = socketInfo.AddressFamily
-	socketProtocol = socketInfo.Protocol
-	socketType = socketInfo.SocketType
 
 	if optname != unix.SO_ATTACH_FILTER {
 		// Send incomplete event because there is not filter

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -58,6 +58,7 @@ type SocketInfo struct {
 	AddressFamily uint16
 	Protocol      uint16
 	BoundToPort   uint16
+	SocketType    uint16
 }
 
 // Process represents a process context

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -81,6 +81,7 @@ const (
 	AcceptNr         = unix.SYS_ACCEPT            // AcceptNr defines the syscall ID for amd64
 	BindNr           = unix.SYS_BIND              // BindNr defines the syscall ID for amd64
 	SocketNr         = unix.SYS_SOCKET            // SocketNr defines the syscall ID for amd64
+	SetsockoptNr     = unix.SYS_SETSOCKOPT        // SetsockoptNr defines the syscall ID for amd64
 )
 
 // https://github.com/torvalds/linux/blob/v5.0/arch/x86/entry/entry_64.S#L126

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -63,6 +63,7 @@ const (
 	AcceptNr         = unix.SYS_ACCEPT            // AcceptNr defines the syscall ID for arm64
 	Accept4Nr        = unix.SYS_ACCEPT4           // Accept4Nr defines the syscall ID for arm64
 	SocketNr         = unix.SYS_SOCKET            // SocketNr defines the syscall ID for arm64
+	SetsockoptNr     = unix.SYS_SETSOCKOPT        // SetsockoptNr defines the syscall ID for arm64
 
 	OpenNr      = -1  // OpenNr not available on arm64
 	ForkNr      = -2  // ForkNr not available on arm64

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -111,7 +111,6 @@ func SkipIfNotAvailable(t *testing.T) {
 			"~TestConnectEventAFInetIOUring",
 			"TestAcceptEvent/accept-af-inet-any-tcp-success-sockaddrin-io-uring",
 			"TestOpenTree",
-			"TestSetSockOpt/setsockopt-TruncatedFilter",
 		}
 
 		if disableSeccomp {

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -79,6 +79,7 @@ func SkipIfNotAvailable(t *testing.T) {
 			"TestMountEvent",
 			"TestMount",
 			"TestMountPropagated",
+			"~TestSetSockOpt",
 		}
 
 		exclude := []string{
@@ -110,6 +111,7 @@ func SkipIfNotAvailable(t *testing.T) {
 			"~TestConnectEventAFInetIOUring",
 			"TestAcceptEvent/accept-af-inet-any-tcp-success-sockaddrin-io-uring",
 			"TestOpenTree",
+			"TestSetSockOpt/setsockopt-TruncatedFilter",
 		}
 
 		if disableSeccomp {

--- a/pkg/security/tests/setsockopt_test.go
+++ b/pkg/security/tests/setsockopt_test.go
@@ -277,6 +277,8 @@ func TestSetSockOpt(t *testing.T) {
 		})
 	})
 	t.Run("setsockopt-TruncatedFilter", func(t *testing.T) {
+		SkipIfNotAvailable(t)
+		// skipped for eBPFLess because there is no possible truncation
 		var fd int
 
 		defer func() {}()

--- a/pkg/security/tests/setsockopt_test.go
+++ b/pkg/security/tests/setsockopt_test.go
@@ -56,32 +56,12 @@ func TestSetSockOpt(t *testing.T) {
 			&& 12 in setsockopt.used_immediates`,
 		},
 		{
-			ID: "test_rule_setsockopt_truncated_filter",
-			Expression: `setsockopt.level == SOL_SOCKET 
-			&& setsockopt.optname == SO_ATTACH_FILTER 
-			&& setsockopt.socket_type == SOCK_DGRAM 
-			&& setsockopt.socket_protocol == IPPROTO_UDP 
-			&& setsockopt.socket_family == AF_INET 
-			&& setsockopt.is_filter_truncated == true
-			&& 12 in setsockopt.used_immediates`,
-		},
-		{
 			ID: "test_rule_setsockopt_reuseaddr",
 			Expression: `setsockopt.level == SOL_SOCKET
 			&& setsockopt.optname == SO_REUSEADDR
 			&& setsockopt.socket_type == SOCK_STREAM
 			&& setsockopt.socket_protocol == IPPROTO_TCP
 			&& setsockopt.socket_family == AF_INET`,
-		},
-		{
-			ID: "test_rule_setsockopt_truncated_filter_ebpfless",
-			Expression: `setsockopt.level == SOL_SOCKET 
-			&& setsockopt.optname == SO_ATTACH_FILTER 
-			&& setsockopt.socket_type == SOCK_DGRAM 
-			&& setsockopt.socket_protocol == IPPROTO_UDP 
-			&& setsockopt.socket_family == AF_INET
-			&& setsockopt.is_filter_truncated == false
-			&& 12 in setsockopt.used_immediates`,
 		},
 	}
 
@@ -286,6 +266,72 @@ func TestSetSockOpt(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_setsockopt_tcp")
 		})
 	})
+	t.Run("setsockopt-reuseaddr", func(t *testing.T) {
+		var fd int
+
+		test.WaitSignal(t, func() error {
+			var err error
+			fd, err = syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+			if err != nil {
+				return err
+			}
+			defer syscall.Close(fd)
+
+			reuseAddr := 1
+			_, _, errno := syscall.Syscall6(
+				syscall.SYS_SETSOCKOPT,
+				uintptr(fd),
+				uintptr(syscall.SOL_SOCKET),
+				uintptr(syscall.SO_REUSEADDR),
+				uintptr(unsafe.Pointer(&reuseAddr)),
+				uintptr(unsafe.Sizeof(reuseAddr)),
+				0,
+			)
+
+			if errno != 0 {
+				return fmt.Errorf("setsockopt failed: %v", errno)
+			}
+
+			return nil
+		}, func(_ *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_setsockopt_reuseaddr")
+		})
+	})
+
+}
+
+func TestSetSockOptTruncatedFilter(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID: "test_rule_setsockopt_truncated_filter",
+			Expression: `setsockopt.level == SOL_SOCKET 
+			&& setsockopt.optname == SO_ATTACH_FILTER 
+			&& setsockopt.socket_type == SOCK_DGRAM 
+			&& setsockopt.socket_protocol == IPPROTO_UDP 
+			&& setsockopt.socket_family == AF_INET 
+			&& setsockopt.is_filter_truncated == true
+			&& 12 in setsockopt.used_immediates`,
+		},
+		{
+			ID: "test_rule_setsockopt_truncated_filter_ebpfless",
+			Expression: `setsockopt.level == SOL_SOCKET 
+			&& setsockopt.optname == SO_ATTACH_FILTER 
+			&& setsockopt.socket_type == SOCK_DGRAM 
+			&& setsockopt.socket_protocol == IPPROTO_UDP 
+			&& setsockopt.socket_family == AF_INET
+			&& setsockopt.is_filter_truncated == false
+			&& 12 in setsockopt.used_immediates`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
 	t.Run("setsockopt-TruncatedFilter", func(t *testing.T) {
 		var fd int
 
@@ -1298,37 +1344,6 @@ func TestSetSockOpt(t *testing.T) {
 			} else {
 				assertTriggeredRule(t, rule, "test_rule_setsockopt_truncated_filter")
 			}
-		})
-	})
-	t.Run("setsockopt-reuseaddr", func(t *testing.T) {
-		var fd int
-
-		test.WaitSignal(t, func() error {
-			var err error
-			fd, err = syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
-			if err != nil {
-				return err
-			}
-			defer syscall.Close(fd)
-
-			reuseAddr := 1
-			_, _, errno := syscall.Syscall6(
-				syscall.SYS_SETSOCKOPT,
-				uintptr(fd),
-				uintptr(syscall.SOL_SOCKET),
-				uintptr(syscall.SO_REUSEADDR),
-				uintptr(unsafe.Pointer(&reuseAddr)),
-				uintptr(unsafe.Sizeof(reuseAddr)),
-				0,
-			)
-
-			if errno != 0 {
-				return fmt.Errorf("setsockopt failed: %v", errno)
-			}
-
-			return nil
-		}, func(_ *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_rule_setsockopt_reuseaddr")
 		})
 	})
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add eBPFLess support for setsockopt
### Describe how you validated your changes

### Motivation
Have setsockopt detection possible on Fargate.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->