### PR TITLE
workloadmeta: extract SBOM utilities into separate package

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -22,7 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/sbomutil"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -375,7 +375,7 @@ func (c *collector) createOrUpdateImageMetadata(ctx context.Context,
 	// not be able to inject them. For example, if we use the scanner from filesystem or
 	// if the `imgMeta` object does not contain all the metadata when it is sent.
 	// We add them here to make sure they are present.
-	wlmImage.SBOM = util.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
+	wlmImage.SBOM = sbomutil.UpdateSBOMRepoMetadata(wlmImage.SBOM, wlmImage.RepoTags, wlmImage.RepoDigests)
 	return &wlmImage, nil
 }
 

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/sbomutil"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -627,7 +628,7 @@ func (c *collector) getImageMetadata(ctx context.Context, imageID string, newSBO
 	// not be able to inject them. For example, if we use the scanner from filesystem or
 	// if the `imgMeta` object does not contain all the metadata when it is sent.
 	// We add them here to make sure they are present.
-	sbom = util.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
+	sbom = sbomutil.UpdateSBOMRepoMetadata(sbom, imgInspect.RepoTags, imgInspect.RepoDigests)
 
 	return &workloadmeta.ContainerImageMetadata{
 		EntityID: workloadmeta.EntityID{

--- a/comp/core/workloadmeta/collectors/sbomutil/doc.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package sbomutil contains SBOM utility functions for workload metadata collectors
+package sbomutil

--- a/comp/core/workloadmeta/collectors/sbomutil/image_util.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/image_util.go
@@ -5,7 +5,7 @@
 
 //go:build trivy
 
-package util
+package sbomutil
 
 import (
 	"slices"

--- a/comp/core/workloadmeta/collectors/sbomutil/image_util_stub.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/image_util_stub.go
@@ -5,7 +5,7 @@
 
 //go:build !trivy
 
-package util
+package sbomutil
 
 import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"

--- a/comp/core/workloadmeta/collectors/sbomutil/image_util_test.go
+++ b/comp/core/workloadmeta/collectors/sbomutil/image_util_test.go
@@ -5,7 +5,7 @@
 
 //go:build trivy
 
-package util
+package sbomutil
 
 import (
 	"reflect"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

As is always the case with util packages, the `github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util` contains a lot of different utilities some related SBOMs, some related to ECS making it difficult to add new functions without having it affect a lot of different agents.

To improve this, this PR extracts the SBOM related utilities into a new `sbomutil` package. 

This is driven by a need in https://github.com/DataDog/datadog-agent/pull/40043.

No functional change expected

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->