### PR TITLE
Bump quality_gate_metrics_logs `cpu_usage` back to stops

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "CPU usage quality gate. This puts a bound on the total average collector millicore usage."
     bounds:
       series: avg(total_cpu_usage_millicores)
-      upper_bound: 3500
+      upper_bound: 4000
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This commit reverts the change to `cpu_usage` from #40014. We have seen in #40038 that Agent will still average spike in a way that is difficult to attribute. We believe on the SMP side that modifications to the `avg` calculation will make erroneous spikes much less likely. 
