### PR TITLE
[CWS-4987] Add the ability to replace a policy

### DIFF
--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -370,9 +370,10 @@ type HookPointArg struct {
 
 // PolicyDef represents a policy file definition
 type PolicyDef struct {
-	Version string             `yaml:"version,omitempty" json:"version"`
-	Macros  []*MacroDefinition `yaml:"macros,omitempty" json:"macros,omitempty"`
-	Rules   []*RuleDefinition  `yaml:"rules" json:"rules"`
+	Version         string             `yaml:"version,omitempty" json:"version"`
+	ReplacePolicyID string             `yaml:"replace_policy_id,omitempty" json:"replace_policy_id,omitempty"`
+	Macros          []*MacroDefinition `yaml:"macros,omitempty" json:"macros,omitempty"`
+	Rules           []*RuleDefinition  `yaml:"rules" json:"rules"`
 }
 
 // HumanReadableDuration represents a duration that can unmarshalled from YAML from a human readable format (like `10m`)

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -186,6 +186,8 @@ type PolicyInfo struct {
 	Type PolicyType
 	// Version is the version of the policy, this field is copied from the policy definition
 	Version string
+	// ReplacePolicyID is the ID that this policy should replace
+	ReplacePolicyID string
 	// IsInternal is true if the policy is internal
 	IsInternal bool
 }
@@ -347,6 +349,7 @@ RULES:
 func LoadPolicyFromDefinition(info *PolicyInfo, def *PolicyDef, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
 	if def != nil && def.Version != "" {
 		info.Version = def.Version
+		info.ReplacePolicyID = def.ReplacePolicyID
 	}
 
 	p := &Policy{

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -7,6 +7,7 @@
 package rules
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -80,7 +81,27 @@ func (p *PolicyLoader) LoadPolicies(opts PolicyLoaderOpts) ([]*Policy, *multierr
 		allPolicies = append([]*Policy{defaultPolicy}, allPolicies...)
 	}
 
+	// Remove policies that should be replaced
+	allPolicies = removeReplacedPolicies(allPolicies)
+
 	return allPolicies, errs
+}
+
+func removeReplacedPolicies(policies []*Policy) []*Policy {
+
+	policyIDsToRemove := make([]string, 0)
+
+	for _, policy := range policies {
+		if policy.Info.Source == PolicyProviderTypeRC && policy.Info.Type == CustomPolicyType && policy.Def.ReplacePolicyID != "" {
+			policyIDsToRemove = append(policyIDsToRemove, policy.Def.ReplacePolicyID)
+		}
+	}
+
+	policies = slices.DeleteFunc(policies, func(p *Policy) bool {
+		return p.Info.Source == PolicyProviderTypeRC && p.Info.Type == DefaultPolicyType && slices.Contains(policyIDsToRemove, p.Info.Name)
+	})
+
+	return policies
 }
 
 // NewPolicyReady returns chan to listen new policy ready event

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -428,6 +428,9 @@
     "version": {
       "type": "string"
     },
+    "replace_policy_id": {
+      "type": "string"
+    },
     "macros": {
       "items": {
         "$ref": "#/$defs/MacroDefinition"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds the possibility to replace a policy. The replacing policy has a field `replace_policy_id` in the policy definition. The resulting loaded ruleset should not include the replace policy.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->