### PR TITLE
feat(ssi): allow configuring the library storage medium

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -420,12 +420,12 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			require.Equal(t, volumeName, tt.pod.Spec.Volumes[0].Name,
 				"expected datadog volume to be injected")
 
-			require.Equal(t, etcVolume.Name, tt.pod.Spec.Volumes[1].Name,
+			require.Equal(t, etcVolume(corev1.StorageMediumDefault).Name, tt.pod.Spec.Volumes[1].Name,
 				"expected datadog-etc volume to be injected")
 
 			volumesMarkedAsSafeToEvict := strings.Split(tt.pod.Annotations[common.K8sAutoscalerSafeToEvictVolumesAnnotation], ",")
 			require.Contains(t, volumesMarkedAsSafeToEvict, volumeName, "expected volume %s to be marked as safe to evict", volumeName)
-			require.Contains(t, volumesMarkedAsSafeToEvict, etcVolume.Name, "expected volume %s to be marked as safe to evict", etcVolume.Name)
+			require.Contains(t, volumesMarkedAsSafeToEvict, etcVolume(corev1.StorageMediumDefault).Name, "expected volume %s to be marked as safe to evict", etcVolume(corev1.StorageMediumDefault).Name)
 
 			require.Equal(t, len(tt.libInfo.libs)+1, len(tt.pod.Spec.InitContainers),
 				"expected there to be one more than the number of libs to inject for init containers")
@@ -479,7 +479,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				SubPath:   "opt/datadog-packages/datadog-apm-inject",
 			}, mounts[0], "expected first container volume mount to be the injector")
 			require.Equal(t, corev1.VolumeMount{
-				Name:      etcVolume.Name,
+				Name:      etcVolume(corev1.StorageMediumDefault).Name,
 				MountPath: "/etc/ld.so.preload",
 				SubPath:   "ld.so.preload",
 				ReadOnly:  true,
@@ -1739,7 +1739,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			mutator, err := NewNamespaceMutator(config, wmeta)
 			require.NoError(t, err)
 
-			c := tt.lang.libInfo("", tt.image).initContainers(config.version)[0]
+			c := tt.lang.libInfo("", tt.image).initContainers(config.version, config.libraryStorageMedium)[0]
 			requirements, injectionDecision := initContainerResourceRequirements(tt.pod, config.defaultResourceRequirements)
 			require.Equal(t, tt.wantSkipInjection, injectionDecision.skipInjection)
 			require.Equal(t, tt.resourceRequireAnnotation, injectionDecision.message)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -539,3 +539,50 @@ func TestGetPinnedLibraries(t *testing.T) {
 		})
 	}
 }
+
+func TestLibraryStorageMedium(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputString string
+		expected    corev1.StorageMedium
+		shouldErr   bool
+	}{
+		{
+			name:        "medium memory",
+			inputString: "memory",
+			expected:    corev1.StorageMediumMemory,
+			shouldErr:   false,
+		},
+		{
+			name:        "medium default",
+			inputString: "default",
+			expected:    corev1.StorageMediumDefault,
+			shouldErr:   false,
+		},
+		{
+			name:        "medium invalid",
+			inputString: "invalid",
+			shouldErr:   true,
+		},
+		{
+			name:        "medium empty",
+			inputString: "",
+			expected:    corev1.StorageMediumDefault,
+			shouldErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.volume.empty_dir_storage_medium", tt.inputString)
+			actual, err := NewConfig(mockConfig)
+			if tt.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual.libraryStorageMedium)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
@@ -16,6 +16,7 @@ type libRequirementOptions struct {
 	containerMutators     containerMutators
 	podMutators           []podMutator
 	containerFilter       containerFilter
+	libraryStorageMedium  corev1.StorageMedium
 }
 
 type libRequirement struct {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -197,6 +197,7 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 			containerMutators:     containerMutators,
 			initContainerMutators: initContainerMutators,
 			podMutators:           []podMutator{configInjector.podMutator(lib.lang)},
+			libraryStorageMedium:  m.config.libraryStorageMedium,
 		}).mutatePod(pod); err != nil {
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
 			lastError = err

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -796,6 +796,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")
+	config.BindEnv("admission_controller.auto_instrumentation.volume.empty_dir_storage_medium")
 	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")          // config for ASM which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")           // config for IAST which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.asm_sca.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED")  // config for SCA

--- a/releasenotes-dca/notes/add-library-storage-medium-config-option-1b8e03acf0b2ac3d.yaml
+++ b/releasenotes-dca/notes/add-library-storage-medium-config-option-1b8e03acf0b2ac3d.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    A new configuration option has been added to control the library storage medium for the auto-instrumentation webhook. This
+    will allow you to utilize a memory backed emptyDir for environments that are storage constrained. The default
+    behavior is to use a disk backed emptyDir for library storage. To enable memory backed emptyDir, set the following
+    configuration option for the cluster agent:
+    ```yaml
+    clusterAgent:
+      env:
+        - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
+          value: "memory"
+    ```


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This change allows customers to configure the storage medium for the  library storage `emptyDir`. The default will remain a file backed directory, and users can optionally use memory instead.

### Motivation
As part of Single Step Instrumentation in Kubernetes, we utilize init containers and an `emptyDir` to copy tracing libraries into place for the application to use. Historically, this has utilized disk space.

There is a customer who has a storage constrained environment that is looking to use Single Step Instrumentation. We want to allow them to use a memory backed `emptyDir` instead of a disk backed directory. This will allow them to consume memory instead of disk for their deployment.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The additional unit tests cover the feature from a configuration standpoint. Additionally, I've used `injector-dev` to run the following:

```bash
injector-dev apply -f storage-medium.yaml --build
```

<details>
  <summary>Test Scenario</summary>

```yaml
helm:
  apps:
    - name: java-app
      namespace: application
      values:
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
          - name: DD_APM_INSTRUMENTATION_DEBUG
            value: "true"
        image:
          repository: registry.ddbuild.io/ci/injector-dev/java
          tag: 95586dc4
        podLabels:
          language: "java"
          tags.datadoghq.com/env: local
        service:
          port: "8080"
    - name: java-app-with-resources
      namespace: application
      values:
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
          - name: DD_APM_INSTRUMENTATION_DEBUG
            value: "true"
        image:
          repository: registry.ddbuild.io/ci/injector-dev/java
          tag: 95586dc4
        podLabels:
          language: "java"
          tags.datadoghq.com/env: local
        service:
          port: "8080"
        resources:
          limits:
            memory: 500Mi
            cpu: 1
          requests:
            memory: 500Mi
            cpu: 1
    - name: java-app-constrained
      namespace: application
      values:
        env:
          - name: DD_TRACE_DEBUG
            value: "true"
          - name: DD_APM_INSTRUMENTATION_DEBUG
            value: "true"
        image:
          repository: registry.ddbuild.io/ci/injector-dev/java
          tag: 95586dc4
        podLabels:
          language: "java"
          tags.datadoghq.com/env: local
        service:
          port: "8080"
        resources:
          limits:
            memory: 100Mi
            cpu: 100m
          requests:
            memory: 100Mi
            cpu: 100m
  versions:
    agent: 7.69.1
    cluster_agent:
      version: 7.69.1
      build: {}
    injector:
      version: 0.44.0
  config:
    clusterAgent:
      env:
        - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
          value: "memory"
    datadog:
      apm:
        instrumentation:
          enabled: true
          targets:
            - name: java
              podSelector:
                matchLabels:
                  language: "java"
              ddTraceVersions:
                java: "1.52.1"
```

</details>

### Possible Drawbacks / Trade-offs
It's worth noting here and in our documentation that memory backed emptyDir will count against the memory limit of the pod. Some languages utilize the full limit of memory to configure heap sizes and will not account for the additional overhead of the tracing libraries. In these cases, 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
To enable the memory backed storage location, administrators should add the [Cluster Agent environment variable](https://docs.datadoghq.com/containers/cluster_agent/commands/?tab=datadogoperator#cluster-agent-environment-variables):

```yaml
- name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
   value: "memory" 
```
