### PR TITLE
quote and escape MSI property values

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -146,7 +146,7 @@ func getInstallerFromMSI(ctx context.Context, tmpDir string) (string, error) {
 	cmd, err := msi.Cmd(
 		msi.AdministrativeInstall(),
 		msi.WithMsi(msis[0]),
-		msi.WithAdditionalArgs([]string{fmt.Sprintf(`TARGETDIR="%s"`, strings.ReplaceAll(adminInstallDir, "/", `\`))}),
+		msi.WithProperties(map[string]string{"TARGETDIR": strings.ReplaceAll(adminInstallDir, "/", `\`)}),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create MSI command: %w", err)

--- a/pkg/fleet/installer/msi/msiexec.go
+++ b/pkg/fleet/installer/msi/msiexec.go
@@ -479,14 +479,23 @@ func Cmd(options ...MsiexecOption) (*Msiexec, error) {
 			_ = os.RemoveAll(tempDir)
 		})
 	}
+
+	// Add MSI properties to the command line
+	properties := map[string]string{}
 	if a.ddagentUserName != "" {
-		WithProperties(map[string]string{"DDAGENTUSER_NAME": a.ddagentUserName})(a)
+		properties["DDAGENTUSER_NAME"] = a.ddagentUserName
 	}
 	if a.ddagentUserPassword != "" {
-		WithProperties(map[string]string{"DDAGENTUSER_PASSWORD": a.ddagentUserPassword})(a)
+		properties["DDAGENTUSER_PASSWORD"] = a.ddagentUserPassword
 	}
 	if a.msiAction == "/i" {
-		WithProperties(map[string]string{"MSIFASTINSTALL": "7"})(a)
+		properties["MSIFASTINSTALL"] = "7"
+	}
+	if len(properties) > 0 {
+		err := WithProperties(properties)(a)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	cmd.logFile = a.logFile

--- a/pkg/fleet/installer/msi/msiexec.go
+++ b/pkg/fleet/installer/msi/msiexec.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -163,7 +164,28 @@ func WithLogFile(logFile string) MsiexecOption {
 	}
 }
 
-// WithAdditionalArgs specifies additional arguments for msiexec
+// WithProperties specifies additional MSI properties as Key=Value entries.
+// In the final command line, values are always quoted and any embedded quotes are escaped by doubling them.
+// Properties are appended in sorted key order to ensure deterministic command line construction.
+func WithProperties(props map[string]string) MsiexecOption {
+	return func(a *msiexecArgs) error {
+		if len(props) == 0 {
+			return nil
+		}
+		keys := make([]string, 0, len(props))
+		for k := range props {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			a.additionalArgs = append(a.additionalArgs, formatPropertyArg(k, props[k]))
+		}
+		return nil
+	}
+}
+
+// WithAdditionalArgs specifies raw additional arguments for msiexec, e.g. []string{"PROP=VALUE", "WIXUI_DONTVALIDATEPATH=1"}
+// These are appended as-is without additional quoting. Use WithProperties for MSI properties to ensure they are properly quoted.
 func WithAdditionalArgs(additionalArgs []string) MsiexecOption {
 	return func(a *msiexecArgs) error {
 		a.additionalArgs = append(a.additionalArgs, additionalArgs...)
@@ -190,10 +212,7 @@ func WithDdAgentUserPassword(ddagentUserPassword string) MsiexecOption {
 // HideControlPanelEntry passes a flag to msiexec so that the installed program
 // does not show in the Control Panel "Add/Remove Software"
 func HideControlPanelEntry() MsiexecOption {
-	return func(a *msiexecArgs) error {
-		a.additionalArgs = append(a.additionalArgs, "ARPSYSTEMCOMPONENT=1")
-		return nil
-	}
+	return WithProperties(map[string]string{"ARPSYSTEMCOMPONENT": "1"})
 }
 
 // withCmdRunner overrides how msiexec commands are executed.
@@ -461,13 +480,13 @@ func Cmd(options ...MsiexecOption) (*Msiexec, error) {
 		})
 	}
 	if a.ddagentUserName != "" {
-		a.additionalArgs = append(a.additionalArgs, fmt.Sprintf("DDAGENTUSER_NAME=%s", a.ddagentUserName))
+		WithProperties(map[string]string{"DDAGENTUSER_NAME": a.ddagentUserName})(a)
 	}
 	if a.ddagentUserPassword != "" {
-		a.additionalArgs = append(a.additionalArgs, fmt.Sprintf("DDAGENTUSER_PASSWORD=%s", a.ddagentUserPassword))
+		WithProperties(map[string]string{"DDAGENTUSER_PASSWORD": a.ddagentUserPassword})(a)
 	}
 	if a.msiAction == "/i" {
-		a.additionalArgs = append(a.additionalArgs, "MSIFASTINSTALL=7")
+		WithProperties(map[string]string{"MSIFASTINSTALL": "7"})(a)
 	}
 
 	cmd.logFile = a.logFile
@@ -510,4 +529,13 @@ func Cmd(options ...MsiexecOption) (*Msiexec, error) {
 	}
 
 	return cmd, nil
+}
+
+// formatPropertyArg returns an MSI property formatted as: Key="Value" with
+// any embedded quotes in Value doubled per MSI escaping requirements.
+func formatPropertyArg(key, value string) string {
+	// Escape embedded quotes by doubling them
+	// https://learn.microsoft.com/en-us/windows/win32/msi/command-line-options
+	escaped := strings.ReplaceAll(value, `"`, `""`)
+	return fmt.Sprintf(`%s="%s"`, key, escaped)
 }

--- a/pkg/fleet/installer/msi/msiexec_test.go
+++ b/pkg/fleet/installer/msi/msiexec_test.go
@@ -249,7 +249,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 	t.Run("install with args", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
 
-		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1=value1 ARG2=value2 DDAGENTUSER_NAME=ddagent DDAGENTUSER_PASSWORD=password MSIFASTINSTALL=7`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1=value1 ARG2="value2" DDAGENTUSER_NAME="ddagent" DDAGENTUSER_PASSWORD="password" MSIFASTINSTALL="7"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(
@@ -258,7 +258,10 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 			WithLogFile("test.log"),
 			WithDdAgentUserName("ddagent"),
 			WithDdAgentUserPassword("password"),
-			WithAdditionalArgs([]string{"ARG1=value1", "ARG2=value2"}),
+			// Expect WithAdditionalArgs to be verbatim
+			WithAdditionalArgs([]string{"ARG1=value1"}),
+			// Expect WithProperties to quote the values
+			WithProperties(map[string]string{"ARG2": "value2"}),
 			withCmdRunner(mockRunner),
 		)
 		require.NoError(t, err)
@@ -295,6 +298,51 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 			AdministrativeInstall(),
 			WithMsi("test.msi"),
 			WithLogFile("test.log"),
+			withCmdRunner(mockRunner),
+		)
+		require.NoError(t, err)
+
+		err = cmd.Run(t.Context())
+		assert.NoError(t, err)
+		mockRunner.AssertExpectations(t)
+	})
+
+	t.Run("install args with spaces", func(t *testing.T) {
+		mockRunner := &mockCmdRunner{}
+
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1="value 1" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password is long" MSIFASTINSTALL="7"`, msiexecPath)
+		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
+
+		cmd, err := Cmd(
+			Install(),
+			WithMsi("test.msi"),
+			WithLogFile("test.log"),
+			WithDdAgentUserName(`NT AUTHORITY\SYSTEM`),
+			WithDdAgentUserPassword("password is long"),
+			WithProperties(map[string]string{"ARG1": "value 1", "ARG2": "value2"}),
+			withCmdRunner(mockRunner),
+		)
+		require.NoError(t, err)
+
+		err = cmd.Run(t.Context())
+		assert.NoError(t, err)
+		mockRunner.AssertExpectations(t)
+	})
+
+	t.Run("install args with escaped quotes", func(t *testing.T) {
+		mockRunner := &mockCmdRunner{}
+
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1="value has ""quotes""" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password has ""quotes""" MSIFASTINSTALL="7"`, msiexecPath)
+		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
+
+		cmd, err := Cmd(
+			Install(),
+			WithMsi("test.msi"),
+			WithLogFile("test.log"),
+			WithDdAgentUserName(`NT AUTHORITY\SYSTEM`),
+			WithDdAgentUserPassword(`password has "quotes"`),
+			// Expect quotes to be double escaped
+			WithProperties(map[string]string{"ARG1": `value has "quotes"`, "ARG2": "value2"}),
 			withCmdRunner(mockRunner),
 		)
 		require.NoError(t, err)

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -361,8 +361,13 @@ func installAgentPackage(ctx context.Context, env *env.Env, target string, args 
 	// and we need to reinstall it with the same configuration
 	// and we wipe out our registry keys containing the configuration
 	// that the next install would have used
-	dataDir := fmt.Sprintf(`APPLICATIONDATADIRECTORY="%s"`, env.MsiParams.ApplicationDataDirectory)
-	projectLocation := fmt.Sprintf(`PROJECTLOCATION="%s"`, env.MsiParams.ProjectLocation)
+	props := map[string]string{
+		"FLEET_INSTALL":     "1",
+		"SKIP_INSTALL_INFO": "1",
+		// carry over directories directly
+		"APPLICATIONDATADIRECTORY": env.MsiParams.ApplicationDataDirectory,
+		"PROJECTLOCATION":          env.MsiParams.ProjectLocation,
+	}
 
 	opts := []msi.MsiexecOption{
 		msi.Install(),
@@ -375,11 +380,10 @@ func installAgentPackage(ctx context.Context, env *env.Env, target string, args 
 	if env.MsiParams.AgentUserPassword != "" {
 		opts = append(opts, msi.WithDdAgentUserPassword(env.MsiParams.AgentUserPassword))
 	}
-	additionalArgs := []string{"FLEET_INSTALL=1", "SKIP_INSTALL_INFO=1", dataDir, projectLocation}
-
+	opts = append(opts, msi.WithProperties(props))
 	// append input args last so they can take precedence
-	additionalArgs = append(additionalArgs, args...)
-	opts = append(opts, msi.WithAdditionalArgs(additionalArgs))
+	opts = append(opts, msi.WithAdditionalArgs(args))
+
 	cmd, err := msi.Cmd(opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create MSI command: %w", err)
@@ -408,7 +412,7 @@ func removeProductIfInstalled(ctx context.Context, product string) (err error) {
 			span.Finish(err)
 		}()
 		err := msi.RemoveProduct(ctx, product,
-			msi.WithAdditionalArgs([]string{"FLEET_INSTALL=1"}),
+			msi.WithProperties(map[string]string{"FLEET_INSTALL": "1"}),
 		)
 		if err != nil {
 			return err

--- a/releasenotes/notes/fix-remote-update-msi-property-quotes-089cdddf879937e3.yaml
+++ b/releasenotes/notes/fix-remote-update-msi-property-quotes-089cdddf879937e3.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Remote Updates on Windows now quotes and escapes MSI property values.
-    This fixes an issue that causes remote updates to fail when the Agent username
+    Remote updates on Windows now quotes and escapes MSI property values.
+    This fixes an issue that caused remote updates to fail when the Agent username
     contains whitespace, for example ``DDAGENTUSER_NAME=NT AUTHORITY\SYSTEM``.

--- a/releasenotes/notes/fix-remote-update-msi-property-quotes-089cdddf879937e3.yaml
+++ b/releasenotes/notes/fix-remote-update-msi-property-quotes-089cdddf879937e3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Remote Updates on Windows now quotes and escapes MSI property values.
+    This fixes an issue that causes remote updates to fail when the Agent username
+    contains whitespace, for example ``DDAGENTUSER_NAME=NT AUTHORITY\SYSTEM``.

--- a/test/new-e2e/tests/installer/windows/installer.go
+++ b/test/new-e2e/tests/installer/windows/installer.go
@@ -287,7 +287,7 @@ func (d *DatadogInstaller) Install(opts ...MsiOption) error {
 	}
 	msiArgList := params.msiArgs[:]
 	if params.agentUser != "" {
-		msiArgList = append(msiArgList, fmt.Sprintf("DDAGENTUSER_NAME=%s", params.agentUser))
+		msiArgList = append(msiArgList, fmt.Sprintf(`DDAGENTUSER_NAME="%s"`, params.agentUser))
 	}
 	msiArgs := ""
 	if msiArgList != nil {

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -534,6 +534,7 @@ func (s *testAgentUpgradeSuite) TestUpgradeWithLocalSystemUser() {
 	// Arrange
 	s.setAgentConfig()
 	agentUserInput := "LocalSystem"
+	agentDomainExpected := "NT AUTHORITY"
 	agentUserExpected := "SYSTEM"
 	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUserInput, "the custom user should be different from the default user")
 	s.installPreviousAgentVersion(
@@ -545,6 +546,7 @@ func (s *testAgentUpgradeSuite) TestUpgradeWithLocalSystemUser() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().
 		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedDomain", agentDomainExpected).
 		WithValueEqual("installedUser", agentUserExpected).
 		HasAService("datadogagent").
 		WithIdentity(identity)
@@ -560,6 +562,7 @@ func (s *testAgentUpgradeSuite) TestUpgradeWithLocalSystemUser() {
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().
 		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedDomain", agentDomainExpected).
 		WithValueEqual("installedUser", agentUserExpected).
 		HasAService("datadogagent").
 		WithIdentity(identity)

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -527,6 +527,42 @@ func (s *testAgentUpgradeSuite) TestUpgradeWithAgentUser() {
 		WithIdentity(identity)
 }
 
+// TestUpgradeWithLocalSystemUser tests that the agent user is preserved across remote upgrades.
+func (s *testAgentUpgradeSuite) TestUpgradeWithLocalSystemUser() {
+	// Arrange
+	s.setAgentConfig()
+	agentUserInput := "LocalSystem"
+	agentUserExpected := "SYSTEM"
+	s.Require().NotEqual(windowsagent.DefaultAgentUserName, agentUserInput, "the custom user should be different from the default user")
+	s.installPreviousAgentVersion(
+		installerwindows.WithOption(installerwindows.WithAgentUser(agentUserInput)),
+	)
+	// sanity check that the agent is running as the custom user
+	identity, err := windowscommon.GetIdentityForUser(s.Env().RemoteHost, agentUserInput)
+	s.Require().NoError(err)
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", agentUserExpected).
+		HasAService("datadogagent").
+		WithIdentity(identity)
+
+	// Act
+	s.MustStartExperimentCurrentVersion()
+	s.AssertSuccessfulAgentStartExperiment(s.CurrentAgentVersion().PackageVersion())
+	_, err = s.Installer().PromoteExperiment(consts.AgentPackage)
+	s.Require().NoError(err, "daemon should respond to request")
+	s.AssertSuccessfulAgentPromoteExperiment(s.CurrentAgentVersion().PackageVersion())
+
+	// Assert
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogAgentService().
+		HasRegistryKey(consts.RegistryKeyPath).
+		WithValueEqual("installedUser", agentUserExpected).
+		HasAService("datadogagent").
+		WithIdentity(identity)
+}
+
 func (s *testAgentUpgradeSuite) setWatchdogTimeout(timeout int) {
 	// Set HKEY_LOCAL_MACHINE\SOFTWARE\Datadog\Datadog Agent\WatchdogTimeout to timeout
 	err := windowscommon.SetRegistryDWORDValue(s.Env().RemoteHost, `HKLM:\SOFTWARE\Datadog\Datadog Agent`, "WatchdogTimeout", timeout)

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -528,6 +528,8 @@ func (s *testAgentUpgradeSuite) TestUpgradeWithAgentUser() {
 }
 
 // TestUpgradeWithLocalSystemUser tests that the agent user is preserved across remote upgrades.
+// Also serves as a regression test for WINA-1742, since it will upgrade with DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM"
+// which contains a space.
 func (s *testAgentUpgradeSuite) TestUpgradeWithLocalSystemUser() {
 	// Arrange
 	s.setAgentConfig()

--- a/test/new-e2e/tests/windows/common/user.go
+++ b/test/new-e2e/tests/windows/common/user.go
@@ -75,7 +75,12 @@ func MakeDownLevelLogonName(domain string, user string) string {
 
 // GetIdentityForUser returns the Identity for the given user.
 func GetIdentityForUser(host *components.RemoteHost, user string) (Identity, error) {
-	sid, err := GetSIDForUser(host, user)
+	var err error
+	sid, err := GetServiceAliasSID(user)
+	if err == nil {
+		return Identity{Name: user, SID: sid}, nil
+	}
+	sid, err = GetSIDForUser(host, user)
 	if err != nil {
 		return Identity{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix quoting of MSI property values during remote updates on Windows

Replaces usage of `WithAdditionalArgs`, which passes arguments through as-is, with a new helper `WithProperties` that ensures the property values are properly formatted. Some properties were being escaped (`PROJECTLOCATION`) and others were not (`DDAGENTUSER_NAME`). The `WithProperties` helper will help ensure consistency.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1742
Fix remote updates on systems where agent username contains whitespace, for example `NT AUTHORITY\SYSTEM`.



### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
add new unit tests and e2e test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
When remote updates fails it will hang, so we won't actually see an APM error span. The command line is ill formatted, so `msiexec.exe` pops a message box with help context. It does this even though we run it with the silent arg `/qn` in a non-graphical session... There does not appear to be a way to avoid this behavior with `msiexec.exe`. We could consider using the MSI API instead of running `msiexec.exe`.