### PR TITLE
[Backport 7.69.x] Fix JUnit uploads blocked by undrained output streams (#39460)

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -2,15 +2,15 @@ import io
 import os
 import platform
 import re
-import sys
 import tarfile
 import tempfile
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from shutil import which
-from subprocess import PIPE, CalledProcessError, Popen
+from subprocess import check_call
 
 from invoke.exceptions import Exit
 
@@ -104,8 +104,7 @@ def junit_upload_from_tgz(junit_tgz, result_json, codeowners_path=".github/CODEO
         # Upload junit on a per-team basis (all folders except the one part of the original archive)
         team_folders = [item for item in working_dir.iterdir() if item.is_dir() and item not in xml_folders]
         with ThreadPoolExecutor() as executor:
-            for log in executor.map(upload_junitxmls, team_folders):
-                print(log)
+            _upload_junitxmls(team_folders, executor)
 
 
 def get_flaky_failures_and_marked_flaky_tests_from_test_output(result_json):
@@ -211,31 +210,38 @@ def split_junitxml(root_dir: Path, xml_path: Path, codeowners, flaky_failures, m
     return len(output_xmls)
 
 
-def upload_junitxmls(team_dir: Path):
+def _upload_junitxmls(team_dirs: list[Path], executor: ThreadPoolExecutor):
     """
-    Upload all per-team split JUnit XMLs from given directory.
+    Upload all per-team split JUnit XMLs from given directories.
     """
     datadog_ci_command = [get_datadog_ci_command(), "junit", "upload"]
+    futures = []
+    for team_dir in team_dirs:
+        for args, env in _generate_junitxmls(team_dir):
+            futures.append(executor.submit(check_call, args=datadog_ci_command + args, env=env))
+    exceptions = []
+    for future in futures:
+        try:
+            future.result()
+        except Exception as e:
+            exceptions.append(e)
+    if exceptions:
+        raise ExceptionGroup(f"{len(exceptions)} junit uploads failed", exceptions)
+
+
+def _generate_junitxmls(team_dir: Path) -> Iterator[tuple[list[str], dict[str, str]]]:
+    """
+    Generate all per-team split JUnit XMLs from given directory.
+    """
     additional_tags = read_additional_tags(team_dir.parent)
     process_env = _update_environ(team_dir.parent)
-    processes = []
-
     owner, flavor = team_dir.name.split("_")
     # Kitchen/e2e can generate additional tags
     xml_files = group_per_tags(team_dir, additional_tags)
     for flags, files in xml_files.items():
         args = set_tags(owner, flavor, flags, additional_tags, files[0])
         args.extend(files)
-        processes.append(Popen(datadog_ci_command + args, bufsize=-1, env=process_env, stdout=PIPE, stderr=PIPE))
-
-    for process in processes:
-        stdout, stderr = process.communicate()
-        print(stdout)
-        print(f" Uploaded {len(tuple(team_dir.iterdir()))} files for {team_dir.name}")
-        if stderr:
-            print(f"Failed uploading junit:\n{stderr.decode()}", file=sys.stderr)
-            raise CalledProcessError(process.returncode, datadog_ci_command)
-    return ""  # For ThreadPoolExecutor.map. Without this it prints None in the log output.
+        yield args, process_env
 
 
 def group_per_tags(team_dir: Path, additional_tags: list):


### PR DESCRIPTION
This change improves the upload of JUnit reports, especially in the `tests_windows-x64` job.

It addresses two inefficiencies in how subprocesses are managed:
1. Upload processes were launched with `stdout`/`stderr` pipes, requiring the parent process to actively drain them. If not drained promptly, the child process blocks, ignoring graceful termination signals. In practice, subprocesses were only drained one at a time per caller thread using `communicate`.
2. Multiple subprocesses were launched from the same thread in the thread pool, exceeding the intended parallelism and defeating controlled scheduling.

The fix lets subprocesses inherit `stdout`/`stderr` directly (no pipes) and ensures each upload process runs in its own thread pool task.

Problems:
```python
    for flags, files in xml_files.items():
        args = set_tags(owner, flavor, flags, additional_tags, files[0])
        args.extend(files)
        processes.append(Popen(datadog_ci_command + args, bufsize=-1, env=process_env, stdout=PIPE, stderr=PIPE))
        # 1.             ^ starts len(xml_files) processes in the background, disregarding ThreadPoolExecutor's max_workers

    for process in processes:
        stdout, stderr = process.communicate()
        # 2.                     ^ takes only 1 process in the foreground at a time, which means next background processes:
        #                          - keep executing until one of their output streams saturates
        #                          - are unlikely to react to graceful termination signals (let alone once blocked)
        print(stdout)
        # 3.  ^ buffered standard output is renderered as a bytestring at once
        #       - all lines are misleadingly prefixed with the same timestamp (down to the ms, despite 30+s between first and last ones)
        #       - rendered as bytes whereas the original output is UTF8-encoded (console shows `\n` instead of actual newlines)
        print(f" Uploaded {len(tuple(team_dir.iterdir()))} files for {team_dir.name}")
        if stderr:
            print(f"Failed uploading junit:\n{stderr.decode()}", file=sys.stderr)
            # 4.  ^ same as above for buffered standard error
            raise CalledProcessError(process.returncode, datadog_ci_command)
            # 5.  ^ assumes that an error message implies a nonzero exit code
            #       - transient errors may be logged, which should not prevent a programmatic recovery (successful retry)
            #       - if there's no error message, then an actual nonzero exit code will be lost
    return ""  # For ThreadPoolExecutor.map. Without this it prints None in the log output.
    # 6.   ^ workaround mandated by the approach
```

Note: the original `ThreadPoolExecutor` is preserved by the change, but we could later consider switching to `asyncio` (Python's answer to writing clean, efficient, and scalable code for concurrent I/O operations).