### PR TITLE
retry scan file

### DIFF
--- a/.gitlab/scan/windows.yml
+++ b/.gitlab/scan/windows.yml
@@ -67,12 +67,27 @@
         echo "Go to https://www.virustotal.com/gui/file/$SHA256 for more details"
       }
 
-      # tee result so we can see output in case of errors
-      ./vt --apikey "$VT_API_KEY" scan file "$MSI_FILE" | tee result.txt
-      # Expected output
-      # filename analysis_id
-      ANALYSIS_ID=$(head -n1 result.txt | awk '{print $2}')
-      echo "Submitted file for analysis, analysis id: $ANALYSIS_ID"
+      # Scan file and verify output contains the expected filename; retry if not (max 5 minutes)
+      SECONDS=0
+      while true; do
+        ./vt --apikey "$VT_API_KEY" scan file "$MSI_FILE" | tee result.txt
+        # at the moment, vt does not exit with a non-zero code on errors, so
+        # we try to sanity check the output to detect errors.
+        # Expected output:
+        # filename analysis_id
+        if grep -Fq "$MSI_FILE" result.txt; then
+          ANALYSIS_ID=$(head -n1 result.txt | awk '{print $2}')
+          echo "Submitted file for analysis, analysis id: $ANALYSIS_ID"
+          break
+        else
+          if [ "$SECONDS" -ge 300 ]; then
+            echo "Timed out submitting file for scan after 5 minutes"
+            exit 1
+          fi
+          echo "Scan output did not contain expected filename; retrying..."
+          sleep 30
+        fi
+      done
 
       # Poll for analysis results
       while true; do
@@ -92,7 +107,7 @@
               else
                   echo "ALL GOOD"
                   print_report
-              exit 0
+                  exit 0
               fi
           fi
       done


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
retry `vt scan file` operation for up to 5 minutes

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1708
the operation occasionally fails/flakes, see card for example error messages.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
make sure scan task still works

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`vt` is not exiting with a non-zero exit code on error, making failures difficult to detect.