### PR TITLE
fix(serverless-init): set serverless log hostname to empty string

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -164,6 +164,17 @@ tests_serverless-init:
     - !reference [.retrieve_linux_go_deps]
     - go test -tags "serverless otlp test" ./cmd/serverless-init/.
 
+tests_serverless-init-logs:
+  extends: .linux_x64
+  stage: source_test
+  needs: ["go_deps"]
+  rules:
+    - !reference [.except_disable_unit_tests]
+    - !reference [.except_mergequeue]
+    - when: on_success
+  script:
+    - !reference [.retrieve_linux_go_deps]
+    - go test -tags "serverless otlp test" ./cmd/serverless-init/.
 
 # Check consistency of go.mod file with project imports
 go_mod_tidy_check:

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -55,8 +56,8 @@ func CreateConfig(origin string) *Config {
 }
 
 // SetupLogAgent creates the log agent and sets the base tags
-func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component, compression logscompression.Component, origin string) logsAgent.ServerlessLogsAgent {
-	logsAgent, _ := serverlessLogs.SetupLogAgent(conf.Channel, sourceName, conf.source, tagger, compression)
+func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component, origin string) logsAgent.ServerlessLogsAgent {
+	logsAgent, _ := serverlessLogs.SetupLogAgent(conf.Channel, sourceName, conf.source, tagger, compression, hostname)
 
 	tagsArray := serverlessTag.MapToArray(tags)
 

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -56,7 +56,7 @@ func CreateConfig(origin string) *Config {
 }
 
 // SetupLogAgent creates the log agent and sets the base tags
-func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component, origin string) logsAgent.ServerlessLogsAgent {
+func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component, compression logscompression.Component, hostname hostnameinterface.Component, origin string) logsAgent.ServerlessLogsAgent {
 	logsAgent, _ := serverlessLogs.SetupLogAgent(conf.Channel, sourceName, conf.source, tagger, compression, hostname)
 
 	tagsArray := serverlessTag.MapToArray(tags)

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -24,8 +24,8 @@ import (
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	healthprobeDef "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobeFx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
-	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	logdef "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
@@ -105,7 +105,7 @@ func main() {
 }
 
 // removing these unused dependencies will cause silent crash due to fx framework
-func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Component, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) error {
+func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Component, tagger tagger.Component, compression logscompression.Component, hostname hostnameinterface.Component) error {
 	cloudService, logConfig, traceAgent, metricAgent, logsAgent := setup(modeConf, tagger, compression, hostname)
 
 	err := modeConf.Runner(logConfig)
@@ -119,7 +119,7 @@ func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Compon
 	return err
 }
 
-func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) (cloudservice.CloudService, *serverlessInitLog.Config, trace.ServerlessTraceAgent, *metrics.ServerlessMetricAgent, logsAgent.ServerlessLogsAgent) {
+func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Component, hostname hostnameinterface.Component) (cloudservice.CloudService, *serverlessInitLog.Config, trace.ServerlessTraceAgent, *metrics.ServerlessMetricAgent, logsAgent.ServerlessLogsAgent) {
 	tracelog.SetLogger(corelogger{})
 
 	// load proxy settings

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/mode"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
 
@@ -32,6 +33,7 @@ func TestTagsSetup(t *testing.T) {
 
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	fakeCompression := compressionmock.NewMockCompressor()
+	fakeHostname, _ := hostnameinterface.NewMock(hostnameinterface.MockHostname(""))
 
 	configmock.New(t)
 
@@ -44,7 +46,7 @@ func TestTagsSetup(t *testing.T) {
 
 	allTags := append(ddTags, ddExtraTags...)
 
-	_, _, traceAgent, metricAgent, _ := setup(mode.Conf{}, fakeTagger, fakeCompression)
+	_, _, traceAgent, metricAgent, _ := setup(mode.Conf{}, fakeTagger, fakeCompression, fakeHostname)
 	defer traceAgent.Stop()
 	defer metricAgent.Stop()
 	assert.Subset(t, metricAgent.GetExtraTags(), allTags)

--- a/cmd/serverless-init/mode/mode.go
+++ b/cmd/serverless-init/mode/mode.go
@@ -33,6 +33,7 @@ func DetectMode() Conf {
 	envToSet := map[string]string{
 		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "false",
 		"DD_REMOTE_CONFIGURATION_ENABLED":      "false",
+		"DD_HOSTNAME":                          "none",
 		"DD_APM_ENABLED":                       "true",
 		"DD_TRACE_ENABLED":                     "true",
 	}

--- a/cmd/serverless-init/mode/mode.go
+++ b/cmd/serverless-init/mode/mode.go
@@ -33,7 +33,6 @@ func DetectMode() Conf {
 	envToSet := map[string]string{
 		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": "false",
 		"DD_REMOTE_CONFIGURATION_ENABLED":      "false",
-		"DD_HOSTNAME":                          "none",
 		"DD_APM_ENABLED":                       "true",
 		"DD_TRACE_ENABLED":                     "true",
 	}

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggernoop "github.com/DataDog/datadog-agent/comp/core/tagger/fx-noop"
 	logConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -81,6 +83,7 @@ func main() {
 		runAgent,
 		taggernoop.Module(),
 		logscompressionfx.Module(),
+		hostnameimpl.Module(),
 	)
 
 	if err != nil {
@@ -89,7 +92,7 @@ func main() {
 	}
 }
 
-func runAgent(tagger tagger.Component, compression logscompression.Component) {
+func runAgent(tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) {
 
 	startTime := time.Now()
 
@@ -129,7 +132,7 @@ func runAgent(tagger tagger.Component, compression logscompression.Component) {
 
 	go startTraceAgent(&wg, lambdaSpanChan, coldStartSpanId, serverlessDaemon, tagger, rcService)
 	go startOtlpAgent(&wg, metricAgent, serverlessDaemon, tagger)
-	go startTelemetryCollection(&wg, serverlessID, logChannel, serverlessDaemon, tagger, compression)
+	go startTelemetryCollection(&wg, serverlessID, logChannel, serverlessDaemon, tagger, compression, hostname)
 
 	// start appsec
 	appsecProxyProcessor := startAppSec(serverlessDaemon)
@@ -302,7 +305,7 @@ func startAppSec(serverlessDaemon *daemon.Daemon) *httpsec.ProxyLifecycleProcess
 	return appsecProxyProcessor
 }
 
-func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, logChannel chan *logConfig.ChannelMessage, serverlessDaemon *daemon.Daemon, tagger tagger.Component, compression logscompression.Component) {
+func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, logChannel chan *logConfig.ChannelMessage, serverlessDaemon *daemon.Daemon, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) {
 	defer wg.Done()
 	if os.Getenv(daemon.LocalTestEnvVar) == "true" || os.Getenv(daemon.LocalTestEnvVar) == "1" {
 		log.Debug("Running in local test mode. Telemetry collection HTTP route won't be enabled")
@@ -326,7 +329,7 @@ func startTelemetryCollection(wg *sync.WaitGroup, serverlessID registration.ID, 
 	if logRegistrationError != nil {
 		log.Error("Can't subscribe to logs:", logRegistrationError)
 	} else {
-		logsAgent, err := serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda", tagger, compression)
+		logsAgent, err := serverlessLogs.SetupLogAgent(logChannel, "AWS Logs", "lambda", tagger, compression, hostname)
 		if err != nil {
 			log.Errorf("Error setting up the logs agent: %s", err)
 		}

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -40,7 +40,7 @@ func (a *logAgent) SetupPipeline(
 	_ integrations.Component,
 	fingerprintConfig types.FingerprintConfig,
 ) {
-	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(streamlogs.Formatter{}, nil)
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(streamlogs.Formatter{}, a.hostname)
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender

--- a/comp/logs/agent/agentimpl/agent_serverless_init_test.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init_test.go
@@ -17,11 +17,12 @@ import (
 )
 
 func TestBuildServerlessEndpoints(t *testing.T) {
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "function")
 	config := config.NewMock(t)
 
-	endpoints, err := buildEndpoints()
+	endpoints, err := buildEndpoints(config)
 	assert.Nil(t, err)
-	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "http-intake.logs.datadoghq.com.", endpoints.Main.Host)
 	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
-	assert.True(t, endpoints.Main.BatchWait > config.BatchWait*time.Second)
+	assert.Equal(t, endpoints.BatchWait, 365*24*time.Hour)
 }

--- a/comp/logs/agent/agentimpl/agent_serverless_init_test.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init_test.go
@@ -8,12 +8,16 @@
 package agentimpl
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	compressionmock "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 )
 
 func TestBuildServerlessEndpoints(t *testing.T) {
@@ -25,4 +29,35 @@ func TestBuildServerlessEndpoints(t *testing.T) {
 	assert.Equal(t, "http-intake.logs.datadoghq.com.", endpoints.Main.Host)
 	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
 	assert.Equal(t, endpoints.BatchWait, 365*24*time.Hour)
+}
+
+func TestServerlessLogsAgent(t *testing.T) {
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	fakeCompression := compressionmock.NewMockCompressor()
+	hostnameService := hostnameimpl.NewHostnameService()
+	config := config.NewMock(t)
+
+	serverlessLogsAgent := NewServerlessLogsAgent(fakeTagger, fakeCompression, hostnameService)
+	logsAgent, ok := serverlessLogsAgent.(*logAgent)
+	assert.True(t, ok, "Expected NewServerlessLogsAgent to return *logAgent type")
+
+	// Build endpoints first, setupAgent() calls SetupPipeline which references logsAgent.endpoints
+	endpoints, err := buildEndpoints(config)
+	assert.NoError(t, err, "buildEndpoints should not fail")
+	logsAgent.endpoints = endpoints
+
+	err = logsAgent.setupAgent()
+	assert.NoError(t, err, "setupAgent should not return an error")
+
+	// Assert that setupAgent() correctly initialized the pipeline components
+	assert.NotNil(t, logsAgent.diagnosticMessageReceiver, "diagnosticMessageReceiver should not be nil")
+	assert.NotNil(t, logsAgent.pipelineProvider, "pipelineProvider should be set")
+	assert.NotNil(t, logsAgent.launchers, "launchers should be set")
+	assert.NotNil(t, logsAgent.destinationsCtx, "destinationsCtx should be set")
+	assert.NotNil(t, logsAgent.schedulers, "schedulers should be set")
+
+	// Assert that the hostname component returns an empty string
+	hostname, err := logsAgent.hostname.Get(context.TODO())
+	assert.NoError(t, err, "Getting hostname should not error")
+	assert.Equal(t, "", hostname, "hostname should be an empty string")
 }

--- a/comp/logs/agent/agentimpl/serverless.go
+++ b/comp/logs/agent/agentimpl/serverless.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log/impl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -23,7 +24,7 @@ import (
 )
 
 // NewServerlessLogsAgent creates a new instance of the logs agent for serverless
-func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression.Component) agent.ServerlessLogsAgent {
+func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) agent.ServerlessLogsAgent {
 
 	logsAgent := &logAgent{
 		log:     logComponent.NewTemporaryLoggerWithoutInit(),
@@ -37,6 +38,7 @@ func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression
 		flarecontroller: flareController.NewFlareController(),
 		tagger:          tagger,
 		compression:     compression,
+		hostname:        hostname,
 	}
 	return logsAgent
 }

--- a/comp/logs/agent/agentimpl/serverless.go
+++ b/comp/logs/agent/agentimpl/serverless.go
@@ -10,7 +10,7 @@ import (
 
 	"go.uber.org/atomic"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log/impl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
@@ -24,7 +24,7 @@ import (
 )
 
 // NewServerlessLogsAgent creates a new instance of the logs agent for serverless
-func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) agent.ServerlessLogsAgent {
+func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression.Component, hostname hostnameinterface.Component) agent.ServerlessLogsAgent {
 
 	logsAgent := &logAgent{
 		log:     logComponent.NewTemporaryLoggerWithoutInit(),

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -6,7 +6,7 @@
 package logs
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
@@ -21,7 +21,7 @@ import (
 var logsScheduler *channel.Scheduler
 
 // SetupLogAgent sets up the logs agent to handle messages on the given channel.
-func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) (logsAgent.ServerlessLogsAgent, error) {
+func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string, tagger tagger.Component, compression logscompression.Component, hostname hostnameinterface.Component) (logsAgent.ServerlessLogsAgent, error) {
 	agent := agentimpl.NewServerlessLogsAgent(tagger, compression, hostname)
 	err := agent.Start()
 	if err != nil {

--- a/pkg/serverless/logs/scheduler.go
+++ b/pkg/serverless/logs/scheduler.go
@@ -6,6 +6,7 @@
 package logs
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
@@ -20,8 +21,8 @@ import (
 var logsScheduler *channel.Scheduler
 
 // SetupLogAgent sets up the logs agent to handle messages on the given channel.
-func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string, tagger tagger.Component, compression logscompression.Component) (logsAgent.ServerlessLogsAgent, error) {
-	agent := agentimpl.NewServerlessLogsAgent(tagger, compression)
+func SetupLogAgent(logChannel chan *config.ChannelMessage, sourceName string, source string, tagger tagger.Component, compression logscompression.Component, hostname hostname.Component) (logsAgent.ServerlessLogsAgent, error) {
+	agent := agentimpl.NewServerlessLogsAgent(tagger, compression, hostname)
 	err := agent.Start()
 	if err != nil {
 		log.Error("Could not start an instance of the Logs Agent:", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Passes the `hostnameinterface` component to the Serverless Logs Agent so the hostname on logs is set to an empty string.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-7460

Currently the hostname is being set to `unknown`. In Datadog Orgs where a host with the name `unknown` already exists and has tags on it, logs with a matching hostname will inherit these tags, potentially resulting in scenarios where a log has multiple tags with the same key but different values.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added a serverless-init log test to validate that the hostname component has an empty string set for a build of serverless-init.

Also deployed manually to Google Cloud Run and Azure Container Apps using both the sidecar and in process approach to validate the logs have hostname set as an empty string.

### Possible Drawbacks / Trade-offs

### Additional Notes

A regression was introduced in `v1.2.1` of the serverless-init image that caused the hostname to be set to `unknown`. It's unclear what specific change caused the regression as no Github tags were created for these older versions.

There is already a provider hostname configuration for Serverless. By passing the `hostnameinterface` component to the Serverless Logs Agent we can set the empty string hostname on the provider.
https://github.com/DataDog/datadog-agent/blob/cc85b5170958191c3385c517cc9d9763654fdb12/pkg/util/hostname/providers_serverless.go#L19

Ultimately the hostname is passed to the logs processor where it is read and inserted into the log message. This is where the hostname was set to `unknown` prior to this change.
https://github.com/DataDog/datadog-agent/blob/35ec44794e8b6f90d8fb5c5c208b086f62dadaa0/pkg/logs/processor/processor.go#L199-L219

Since the signature of `SetupLogAgent` is updated to include the hostname component `cmd/serverless` needs to be updated as well. However Lambda Functions have special handling in the logs processor which means this change will not affect the hostname on Lambda Function logs.
https://github.com/DataDog/datadog-agent/blob/42a25bbcf8055ea5c9be056f5bf539754d147df7/cmd/serverless-init/log/log.go#L59