### PR TITLE
Wait for FIPS container agent to be deployed before starting fips E2E tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -1034,6 +1034,8 @@ generate-fips-e2e-pipeline:
     - qa_dogstatsd
     - qa_agent
     - qa_agent_full
+    - qa_agent_fips
+    - qa_agent_fips_jmx
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It adds `qa_agent_fips` to the set of jobs the generation of the child pipeline that runs E2E FIPS `needs` to avoid possible race conditions.

### Motivation

Failures in this [triggered pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/74329304), such as:

```
Error response from daemon: manifest for 669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:74328011-0bda2cb2-fips-jmx not found: manifest unknown: Requested image not found
```

```
Error response from daemon: manifest for 669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:74328011-0bda2cb2-fips not found: manifest unknown: Requested image not found
```

### Describe how you validated your changes

Probably not necessary, if gitlab doesn't complain when processing the pipeline's yaml this should be good. Testing whether this solves the issue is not too practical since it's a race condition between GitLab jobs / pipelines.

### Possible Drawbacks / Trade-offs

### Additional Notes

That `needs` list could use some refinement, perhaps leverage the existing `needs` templates.