### PR TITLE
fix(generate ci): Prevent failure on config parsing

### DIFF
--- a/tasks/fips.py
+++ b/tasks/fips.py
@@ -40,6 +40,7 @@ def generate_fips_e2e_pipeline(ctx, generate_config=False):
     for job, job_details in config.items():
         if (
             'variables' in job_details
+            and isinstance(job_details, dict)
             and 'ON_NIGHTLY_FIPS' in job_details['variables']
             and job_details['variables']['ON_NIGHTLY_FIPS'] == "true"
             and not job.startswith(".")
@@ -103,6 +104,7 @@ def e2e_running_in_fips_mode_on_nightly(ctx):
             continue
         if (
             'variables' in job_details
+            and isinstance(job_details, dict)
             and 'ON_NIGHTLY_FIPS' in job_details['variables']
             and job_details['variables']['ON_NIGHTLY_FIPS'] == "true"
         ):

--- a/tasks/libs/pipeline/generation.py
+++ b/tasks/libs/pipeline/generation.py
@@ -13,7 +13,7 @@ def update_child_job_variables(kept_jobs):
     # Create n jobs with the same configuration
     for job in kept_jobs:
         new_job = copy.deepcopy(kept_jobs[job])
-        if 'variables' in new_job:
+        if 'variables' in new_job and isinstance(new_job, dict):
             # Variables that reference the parent pipeline should be updated
             for key, value in new_job['variables'].items():
                 new_value = value

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -36,7 +36,7 @@ def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info",
         if host_distribution:
             overrides.append(f"--override=host_distribution:{host_distribution}")
 
-        omnibus = f"bundle exec {"omnibus.bat" if sys.platform == "win32" else "omnibus"}"
+        omnibus = f"bundle exec {'omnibus.bat' if sys.platform == 'win32' else 'omnibus'}"
         cmd = "{omnibus} {task} {project_name} --log-level={log_level} {overrides}"
         args = {
             "omnibus": omnibus,

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -237,6 +237,7 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
     for job, job_details in config.items():
         if (
             'variables' in job_details
+            and isinstance(job_details, dict)
             and 'SHOULD_RUN_IN_FLAKES_FINDER' in job_details['variables']
             and job_details['variables']['SHOULD_RUN_IN_FLAKES_FINDER'] == "true"
             and not job.startswith(".")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Add a new condition on the parsing of the ci configuration
- Fix a warning raised by `mypy` on f-string usage

### Motivation
In #39773, there is a new part of the gitlab configuration, `.static_quality_gate_package`, which contains `variable` but is a string. This new part is causing a failure in the [parsing condition](https://github.com/DataDog/datadog-agent/blob/main/tasks/testwasher.py#L239-L240) that was used in the generation of [testwasher](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1091225533) and [fips](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1091225815) pipelines.
So I added a new condition to prevent this failure.

### Describe how you validated your changes
Executed locally the following commands:
```
dda inv -- -e gitlab.compute-gitlab-ci-config --before-file artifacts/before.gitlab-ci.yml --after-file artifacts/after.gitlab-ci.yml --diff-file artifacts/diff.gitlab-ci.yml
dda inv -- -e testwasher.generate-flake-finder-pipeline
dda inv -- -e fips.generate-fips-e2e-pipeline
```
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
The condition is still fragile. I suggest we don't have big scripts like in `.static_quality_gate_package` to reduce the possibility of configuration parsing errors

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->