### PR TITLE
[Backport 7.69.x] Alleviate temporary file conflicts in JUnit uploads (#39544)

### DIFF
--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -35,7 +35,7 @@
       -e AWS_NETWORKING=true
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
-      -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME}.tgz"
+      -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME_SLUG}.tgz"
       -e PIP_INDEX_URL="${PIP_INDEX_URL}"
       -e TEST_OUTPUT_FILE="${TEST_OUTPUT_FILE}"
       -e EXTRA_OPTS="${FAST_TESTS_FLAG}"
@@ -62,6 +62,7 @@
 
 tests_windows-x64:
   extends: .tests_windows_base
+  #parallel: 10
   variables:
     ARCH: "x64"
 

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -123,6 +123,17 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
         )
         mock_check_call.assert_called()
         self.assertEqual(mock_check_call.call_count, 30)
+        tmp_dir_vars = ("TEMP", "TMP", "TMPDIR")
+        seen_tmp_dirs = set()
+        for _, kwargs in mock_check_call.call_args_list:
+            env = kwargs["env"]
+            for k in tmp_dir_vars:
+                self.assertIn(k, env)
+            last_tmp_dir = env[tmp_dir_vars[-1]]
+            self.assertDictEqual({k: env[k] for k in tmp_dir_vars}, {k: last_tmp_dir for k in tmp_dir_vars})
+            self.assertNotIn(last_tmp_dir, seen_tmp_dirs)
+            self.assertFalse(Path(last_tmp_dir).exists())
+            seen_tmp_dirs.add(last_tmp_dir)
 
     @patch.dict("os.environ", {"CI_PIPELINE_ID": "1664"})
     @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "beer"})
@@ -144,3 +155,5 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
         self.assertEqual(mock_check_call.call_count, 30)
         self.assertEqual(eg.exception.message, "15 junit uploads failed")
         self.assertEqual(len(eg.exception.exceptions), 15)
+        for _, kwargs in mock_check_call.call_args_list:
+            self.assertFalse(Path(kwargs["env"]["TMPDIR"]).exists())


### PR DESCRIPTION
This is to alleviate issues caused by a tool that likely reuses temporary paths across invocations by assigning each subprocess a dedicated temporary directory via `TEMP`, `TMP`, and `TMPDIR` environment variables.

Using `tempfile.TemporaryDirectory` ensures _sufficient entropy_ in the paths and automatic cleanup, avoiding collisions during concurrent JUnit uploads.

This change also renames the JUnit tarball using `CI_JOB_NAME_SLUG` in lieu of `CI_JOB_NAME`, ensuring compatibility with GitLab's `parallel` feature when experimenting with concurrent test job runs, in which case `CI_JOB_NAME` includes annoying spaces and, more importantly, filesystem-incompatible slashes, which result in invalid paths:
- `c:\mnt\junit-tests_windows-x64 3/10.tgz: No such file or directory` because `c:\mnt\junit-tests_windows-x64 3` is then expected to be an existing _directory_ where to find the `10.tgz` archive,
- `c:\mnt\junit-tests-windows-x64-3-10.tgz` works. (`-3-10` is of course absent when not leveraging `parallel`)

While this **does not address deeper concurrency issues** (shared access to `git` metadata), it isolates usage of temporaries and reduces the risk of interference between parallel executions leading to errors like:
```
Error: EPERM: operation not permitted, lstat '\\?\C:\Users\ContainerAdministrator\AppData\Local\Temp\pkg-UKhsg3\f6db2f7790c415a4726371e606fb3a9b4677c1226d9dfb63fd4798b687ee1579'
    at lstatSync (node:fs:1574:3)
    at rimrafSync (node:internal/fs/rimraf:180:13)
    at node:internal/fs/rimraf:253:9
    at Array.forEach (<anonymous>)
    at _rmdirSync (node:internal/fs/rimraf:250:7)
    at fixWinEPERMSync (node:internal/fs/rimraf:304:5)
    at rimrafSync (node:internal/fs/rimraf:200:14)
    at Object.rmSync (node:fs:1274:10)
    at removeTemporaryFolderAndContent (pkg/prelude/bootstrap.js:704:10)
    at process.<anonymous> (pkg/prelude/bootstrap.js:711:5) {
  errno: -4048,
  syscall: 'lstat',
  code: 'EPERM',
  path: '\\\\?\\C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\pkg-UKhsg3\\f6db2f7790c415a4726371e606fb3a9b4677c1226d9dfb63fd4798b687ee1579'
}
```