### PR TITLE
[Backport 7.69.x] Extend JUnit upload isolation to `$HOME/.gitconfig` (#39524)

### DIFF
--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -123,7 +123,7 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
         )
         mock_check_call.assert_called()
         self.assertEqual(mock_check_call.call_count, 30)
-        tmp_dir_vars = ("TEMP", "TMP", "TMPDIR")
+        tmp_dir_vars = ("HOME", "TEMP", "TMP", "TMPDIR")
         seen_tmp_dirs = set()
         for _, kwargs in mock_check_call.call_args_list:
             env = kwargs["env"]


### PR DESCRIPTION
Found the reason why JUnit uploads sometimes fail on:
```
Internal Error: warning: unable to access 'C:/Users/ContainerAdministrator/.gitconfig': Permission denied
fatal: unknown error occurred while reading the configuration files
fatal: unknown error occurred while reading the configuration files
    at Object.action (C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:1274:25)
    at PluginStore.exec (C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:1309:29)
    at C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:1674:43
    at new Promise (<anonymous>)
    at GitExecutorChain.handleTaskData (C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:1672:16)
    at GitExecutorChain.<anonymous> (C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:1656:44)
    at Generator.next (<anonymous>)
    at fulfilled (C:\snapshot\datadog-ci\node_modules\simple-git\dist\cjs\index.js:55:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

It indeed turns out that the user's `.gitconfig` file (`C:\Users\ContainerAdministrator\.gitconfig`) is mutated a number of times during the concurrent JUnit upload process:
```ini
[user]
	name = Croissant Builder
	email = croissant@datadoghq.com
[safe]
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
	directory = C:\\buildroot\\datadog-agent
```
The said mutation happens here:
https://github.com/DataDog/datadog-ci/blob/5f5892d43fb46901ec1eababe620492c88679176/src/commands/git-metadata/git.ts#L24

I adjusted the upstream issue accordingly:
DataDog/datadog-ci#1793.

Until it's addressed, the present change simply consists in extending the earlier countermeasure (#39544) to the `HOME`
environment variable so that any `.gitconfig` mutation happens in the temporary directory specific to each JUnit upload execution.