### PR TITLE
Mark TestKindSuite/*/agent_pods_are_ready_and_not_restarting as flaky

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -115,6 +116,7 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 	ctx := context.Background()
 
 	suite.Run("agent pods are ready and not restarting", func() {
+		flake.Mark(suite.T())
 		suite.EventuallyWithTf(func(c *assert.CollectT) {
 			linuxNodes, err := suite.Env().KubernetesCluster.Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{
 				LabelSelector: fields.AndSelectors(


### PR DESCRIPTION
### What does this PR do?

Marks `agent_pods_are_ready_and_not_restarting as flaky` tests under `TestKindSuite` as flaky.

### Motivation

Tests are flaking, exclusively on 7.69.x:

- https://app.datadoghq.com/s/yB5yjZ/jd2-pe6-5q2 (visualizes fail/pass ratio on 7.69.x)
- https://app.datadoghq.com/s/yB5yjZ/g98-z9u-sc3 (shows that only 7.69.x is affected)
- https://app.datadoghq.com/s/yB5yjZ/npu-et7-b3w (shows that both Test00 and TestZZ are failing, hence the marker placement).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->