### PR TITLE
[EBPF] gpu: add .process prefix to memory and core usage metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -9,6 +9,7 @@ package nvidia
 
 import (
 	"fmt"
+
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
@@ -144,13 +145,13 @@ func (c *ebpfCollector) Collect() ([]Metric, error) {
 		// Add per-process usage metrics
 		deviceMetrics = append(deviceMetrics,
 			Metric{
-				Name:  "core.usage",
+				Name:  "process.core.usage",
 				Value: metrics.UsedCores,
 				Type:  ddmetrics.GaugeType,
 				Tags:  pidTag,
 			},
 			Metric{
-				Name:  "memory.usage",
+				Name:  "process.memory.usage",
 				Value: float64(metrics.Memory.CurrentBytes),
 				Type:  ddmetrics.GaugeType,
 				Tags:  pidTag,
@@ -171,13 +172,13 @@ func (c *ebpfCollector) Collect() ([]Metric, error) {
 			// Emit zero metrics for inactive processes
 			deviceMetrics = append(deviceMetrics,
 				Metric{
-					Name:  "core.usage",
+					Name:  "process.core.usage",
 					Value: 0,
 					Type:  ddmetrics.GaugeType,
 					Tags:  pidTag,
 				},
 				Metric{
-					Name:  "memory.usage",
+					Name:  "process.memory.usage",
 					Value: 0,
 					Type:  ddmetrics.GaugeType,
 					Tags:  pidTag,

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -148,12 +148,12 @@ func testCollectWithSingleActiveProcess(t *testing.T) {
 	assert.Len(t, metrics, 4)
 
 	// Verify usage metrics
-	coreUsage := findMetric(metrics, "core.usage")
+	coreUsage := findMetric(metrics, "process.core.usage")
 	require.NotNil(t, coreUsage)
 	assert.Equal(t, float64(50), coreUsage.Value)
 	assert.Equal(t, []string{"pid:123"}, coreUsage.Tags)
 
-	memoryUsage := findMetric(metrics, "memory.usage")
+	memoryUsage := findMetric(metrics, "process.memory.usage")
 	require.NotNil(t, memoryUsage)
 	assert.Equal(t, float64(1024), memoryUsage.Value)
 	assert.Equal(t, []string{"pid:123"}, memoryUsage.Tags)
@@ -257,12 +257,12 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 	assert.Len(t, metrics, 4)
 
 	// Verify zero usage metrics for inactive process
-	coreUsage := findMetric(metrics, "core.usage")
+	coreUsage := findMetric(metrics, "process.core.usage")
 	require.NotNil(t, coreUsage)
 	assert.Equal(t, float64(0), coreUsage.Value)
 	assert.Equal(t, []string{"pid:123"}, coreUsage.Tags)
 
-	memoryUsage := findMetric(metrics, "memory.usage")
+	memoryUsage := findMetric(metrics, "process.memory.usage")
 	require.NotNil(t, memoryUsage)
 	assert.Equal(t, float64(0), memoryUsage.Value)
 	assert.Equal(t, []string{"pid:123"}, memoryUsage.Tags)
@@ -384,7 +384,7 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 	assert.Equal(t, expectedPidTags, memoryLimit.Tags)
 
 	// Verify usage metrics have individual PID tags
-	usageMetrics := findAllMetricsWithName(metrics, "core.usage")
+	usageMetrics := findAllMetricsWithName(metrics, "process.core.usage")
 	assert.Len(t, usageMetrics, 3)
 	for _, metric := range usageMetrics {
 		assert.Len(t, metric.Tags, 1)

--- a/pkg/collector/corechecks/gpu/nvidia/process.go
+++ b/pkg/collector/corechecks/gpu/nvidia/process.go
@@ -110,7 +110,7 @@ func (c *processCollector) collectComputeProcesses() ([]Metric, error) {
 			// Only emit memory.usage per process
 			processMetrics = append(processMetrics,
 				Metric{
-					Name:     "memory.usage",
+					Name:     "process.memory.usage",
 					Value:    float64(proc.UsedGpuMemory),
 					Type:     metrics.GaugeType,
 					Priority: High,

--- a/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
+++ b/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - gpu: `gpu.core.usage` and `gpu.memory.usage` metrics are renamed to `gpu.process.core/memory.usage`

--- a/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
+++ b/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 ---
 enhancements:
-  - "gpu: `gpu.core.usage` and `gpu.memory.usage` metrics are renamed to `gpu.process.core/memory.usage`"
+  - "gpu: Renamed `gpu.core.usage` and `gpu.memory.usage` to `gpu.process.core/memory.usage`"

--- a/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
+++ b/releasenotes/notes/gpu-process-prefix-e5082c144c202dd7.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 ---
 enhancements:
-  - gpu: `gpu.core.usage` and `gpu.memory.usage` metrics are renamed to `gpu.process.core/memory.usage`
+  - "gpu: `gpu.core.usage` and `gpu.memory.usage` metrics are renamed to `gpu.process.core/memory.usage`"

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -359,7 +359,7 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		// We are not including "gpu.memory", as that represents the "current
 		// memory usage" and that might be zero at the time it's checked
-		metricNames := []string{"gpu.core.usage"}
+		metricNames := []string{"gpu.process.core.usage"}
 
 		var usageMetricTags []string
 		for _, metricName := range metricNames {
@@ -367,7 +367,7 @@ func (v *gpuBaseSuite[Env]) TestVectorAddProgramDetected() {
 			assert.NoError(c, err)
 			assert.Greater(c, len(metrics), 0, "no '%s' with value higher than 0 yet", metricName)
 
-			if metricName == "gpu.core.usage" && len(metrics) > 0 {
+			if metricName == "gpu.process.core.usage" && len(metrics) > 0 {
 				usageMetricTags = metrics[0].Tags
 			}
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

This PR adds `gpu.process` prefix to the `gpu.core.usage` and `gpu.memory.usage` metrics, for consistency with newly added metrics.

### Motivation

Consistency with metric names.

### Describe how you validated your changes

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests updated

### Possible Drawbacks / Trade-offs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->