### PR TITLE
[EBPF-793] kmt: wait-for-setup-job supports multiple setup jobs

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -2279,7 +2279,7 @@ def wait_for_setup_job(ctx: Context, pipeline_id: int, arch: str | Arch, compone
         has_finished = True
         for setup_job in matching_jobs:
             setup_job.refresh()
-            info(f"[+] Status for job {setup_job.name}: {setup_job.status}")
+            info(f"[+] Status for job {setup_job.name} ({setup_job.id}): {setup_job.status}")
             if not setup_job.status.has_finished():
                 has_finished = False
 
@@ -2288,7 +2288,7 @@ def wait_for_setup_job(ctx: Context, pipeline_id: int, arch: str | Arch, compone
     loop_status(_check_status, timeout_sec=timeout_sec)
 
     for setup_job in matching_jobs:
-        info(f"[+] Setup job {setup_job.name} finished with status {setup_job.status}")
+        info(f"[+] Setup job {setup_job.name} ({setup_job.id}) finished with status {setup_job.status}")
 
 
 # by default the PyYaml dumper does not indent lists correctly using to problem when


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

Changes `kmt.wait-for-setup-job` command to support multiple setup jobs in the pipeline.

### Motivation

If the setup job has been retried, the command will fail and will cause the instances to not be cleaned up, making any further retries impossible.

### Describe how you validated your changes

CI passing.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->