### PR TITLE
[workloadmeta/kubelet] Stop relying on the pod watcher

### DIFF
--- a/comp/core/autodiscovery/listeners/common.go
+++ b/comp/core/autodiscovery/listeners/common.go
@@ -14,12 +14,15 @@ import (
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
+	tolerateUnreadyAnnotation = "ad.datadoghq.com/tolerate-unready"
+
 	// Keys of standard tags
 	tagKeyEnv     = "env"
 	tagKeyVersion = "version"
@@ -86,4 +89,10 @@ func getPrometheusIncludeAnnotations() types.PrometheusAnnotations {
 		maps.Copy(annotations, check.AD.GetIncludeAnnotations())
 	}
 	return annotations
+}
+
+// shouldSkipPodReadiness checks if a pod should skip readiness checks based on its annotations
+func shouldSkipPodReadiness(pod *workloadmeta.KubernetesPod) bool {
+	tolerate, ok := pod.Annotations[tolerateUnreadyAnnotation]
+	return ok && tolerate == "true"
 }

--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -129,7 +129,7 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 
 	if pod != nil {
 		svc.hosts = map[string]string{"pod": pod.IP}
-		svc.ready = pod.Ready
+		svc.ready = pod.Ready || shouldSkipPodReadiness(pod)
 
 		svc.metricsExcluded = l.filterStore.IsContainerExcluded(
 			workloadmetafilter.CreateContainer(container, workloadmetafilter.CreatePod(pod)),

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -162,7 +162,7 @@ func (l *KubeletListener) createContainerService(
 	svc := &service{
 		entity:   container,
 		tagsHash: l.tagger.GetEntityHash(types.NewEntityID(types.ContainerID, container.ID), types.ChecksConfigCardinality),
-		ready:    pod.Ready,
+		ready:    pod.Ready || shouldSkipPodReadiness(pod),
 		ports:    ports,
 		extraConfig: map[string]string{
 			"pod_name":  pod.Name,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1874,6 +1874,11 @@ func kubernetes(config pkgconfigmodel.Setup) {
 		defaultPodresourcesSocket = `\\.\pipe\kubelet-pod-resources`
 	}
 	config.BindEnvAndSetDefault("kubernetes_kubelet_podresources_socket", defaultPodresourcesSocket)
+
+	// Temporary option. When enabled, workloadmeta uses the Kubelet pod watcher
+	// to fetch pod information (old behavior). Useful as a fallback if the new
+	// behavior causes issues. This option will be removed.
+	config.BindEnvAndSetDefault("kubelet_use_pod_watcher", false)
 }
 
 func podman(config pkgconfigmodel.Setup) {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -403,6 +403,16 @@ func IsPodReady(pod *Pod) bool {
 		return false
 	}
 
+	// In the previous implementation that used the pod watcher, the
+	// tolerate-unready annotation logic was handled here. The new
+	// implementation moves this logic into the autodiscovery parts that need
+	// it.
+	if pkgconfigsetup.Datadog().GetBool("kubelet_use_pod_watcher") {
+		if tolerate, ok := pod.Metadata.Annotations[unreadyAnnotation]; ok && tolerate == "true" {
+			return true
+		}
+	}
+
 	for _, status := range pod.Status.Conditions {
 		if status.Type == "Ready" && status.Status == "True" {
 			return true

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -403,9 +403,6 @@ func IsPodReady(pod *Pod) bool {
 		return false
 	}
 
-	if tolerate, ok := pod.Metadata.Annotations[unreadyAnnotation]; ok && tolerate == "true" {
-		return true
-	}
 	for _, status := range pod.Status.Conditions {
 		if status.Type == "Ready" && status.Status == "True" {
 			return true

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -113,7 +113,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), changes, 2)
 	assert.Equal(suite.T(), "nginx", changes[0].Spec.Containers[0].Name)
-	require.True(suite.T(), IsPodReady(changes[0]))
+	require.False(suite.T(), IsPodReady(changes[0]))
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {


### PR DESCRIPTION
### What does this PR do?

This PR changes the kubelet workloadmeta collector to query the Kubelet directly instead of using the PodWatcher.

The first commit moves the tolerate-unready annotation to the AD code. Similar to what was done in this PR that needed to be reverted: https://github.com/DataDog/datadog-agent/pull/36253

  The PodWatcher has caused several issues in the past. For example, subtle bugs like missing tags under specific conditions. Some of the reasons are:
  - Custom update logic: It uses its own logic to detect when containers or pods have changed, which differs from workloadmeta's approach (`reflect.DeepEqual`).
  - Custom "ready" logic: It overrides the pod's ready field with its own logic.
  - Automatic deletion of containers: It deletes containers of pods that went unready (by its own definition) after 25 seconds, even when the Kubelet still returns them.

With the changes in this PR, instead of relying on the PodWatcher, the kubelet workloadmeta collector now:
- Queries the Kubelet directly.
- Uses workloadmeta's standard logic to detect updates.
- Reports exactly what the Kubelet returns without custom modifications.

Any custom logic that was in the PodWatcher should be moved to the specific components that need it, not applied globally in workloadmeta where it affects all subscribers. As an example, this PR moves the "tolerate-unready" annotation logic from the PodWatcher to the autodiscovery component where it belongs.

To reduce risk, this PR adds a new configuration option to fallback to the old behavior. Set `kubelet_use_pod_watcher: true` to use the pod watcher.

Workloadmeta was the only user of the PodWatcher. The other one was the KSM check, but it was already migrated in a previous PR: https://github.com/DataDog/datadog-agent/pull/39657

### Describe how you validated your changes

Unit tests for the new code plus existing e2e tests.
Also, manually verified that some of the components that could be impacted still work as expected: autodiscovery, logs, etc.