### PR TITLE
[CWS-5005] Detect when exec is accessing a file through a symlink

### DIFF
--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -86,6 +86,7 @@ struct process_event_t {
     u64 envs_id;
     u32 args_truncated;
     u32 envs_truncated;
+    u32 is_through_symlink;
 };
 
 struct exit_event_t {

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -774,6 +774,8 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     // syscall context
     event->syscall_ctx.id = syscall->ctx_id;
 
+    // Through symlink
+    event->is_through_symlink = syscall->exec.is_through_symlink;
     // send the entry to maintain userspace cache
     send_event_ptr(ctx, EVENT_EXEC, event);
 
@@ -800,3 +802,12 @@ int hook_mprotect_fixup(ctx_t *ctx) {
 }
 
 #endif
+HOOK_ENTRY("security_inode_follow_link")
+int hook_security_inode_follow_link(ctx_t *ctx) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
+    if (!syscall) {
+        return 0;
+    }
+    syscall->exec.is_through_symlink = 1;    
+    return 0;
+}

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -143,6 +143,7 @@ struct syscall_cache_t {
             struct args_envs_parsing_context_t args_envs_ctx;
             struct span_context_t span_context;
             struct linux_binprm_t linux_binprm;
+            u32 is_through_symlink;
         } exec;
 
         struct {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -130,6 +130,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_do_coredump"),
 				hookFunc("hook_audit_set_loginuid"),
 				hookFunc("rethook_audit_set_loginuid"),
+				hookFunc("hook_security_inode_follow_link"),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_cgroup_procs_write"),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -172,6 +172,12 @@ func getExecProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_cgroup1_tasks_write",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_inode_follow_link",
+			},
+		},
 	}
 
 	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -790,7 +790,7 @@ func (p *EBPFResolver) SetProcessPath(fileEvent *model.FileEvent, pce *model.Pro
 // SetProcessSymlink resolves process file symlink path
 func (p *EBPFResolver) SetProcessSymlink(entry *model.ProcessCacheEntry) {
 	// TODO: busybox workaround only for now
-	if IsBusybox(entry.FileEvent.PathnameStr) {
+	if IsBusybox(entry.FileEvent.PathnameStr) || IsThroughSymLink(entry) {
 		arg0, _ := GetProcessArgv0(&entry.Process)
 		base := path.Base(arg0)
 

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -25,6 +25,10 @@ func IsBusybox(pathname string) bool {
 	return pathname == "/bin/busybox" || pathname == "/usr/bin/busybox"
 }
 
+func IsThroughSymLink(entry *model.ProcessCacheEntry) bool {
+	return entry.Process.IsThroughSymLink
+}
+
 func setPathname(fileEvent *model.FileEvent, pathnameStr string) {
 	baseName := path.Base(pathnameStr)
 	if fileEvent.FileFields.IsFileless() {

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -25,6 +25,7 @@ func IsBusybox(pathname string) bool {
 	return pathname == "/bin/busybox" || pathname == "/usr/bin/busybox"
 }
 
+// IsThroughSymLink returns true if the process is accessing a file through a symlink
 func IsThroughSymLink(entry *model.ProcessCacheEntry) bool {
 	return entry.Process.IsThroughSymLink
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -377,6 +377,8 @@ type Process struct {
 	// lineage
 	hasValidLineage *bool `field:"-"`
 	lineageError    error `field:"-"`
+
+	IsThroughSymLink bool `field:"-"` // Indicates whether the process is through a symlink
 }
 
 // SetAncestorFields force the process cache entry to be valid

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -243,7 +243,7 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Process) UnmarshalBinary(data []byte) (int, error) {
-	const size = 288 // size of struct exec_event_t starting from process_entry_t, inclusive
+	const size = 292 // size of struct exec_event_t starting from process_entry_t, inclusive
 	if len(data) < size {
 		return 0, ErrNotEnoughData
 	}
@@ -287,6 +287,8 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 	e.EnvsTruncated = binary.NativeEndian.Uint32(data[read+4:read+8]) == 1
 	read += 8
 
+	e.IsThroughSymLink = (binary.NativeEndian.Uint32(data[read:read+4]) > 0)
+	read += 4
 	return validateReadSize(size, read)
 }
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2487,7 +2487,7 @@ func TestSymLinkResolution(t *testing.T) {
 			cmd.Stderr = io.Discard
 			_ = cmd.Run()
 			return nil
-		}, func(ev *model.Event, rule *rules.Rule) {
+		}, func(_ *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "symlink_nc_exec")
 		})
 		assert.NoError(t, err)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2482,8 +2482,9 @@ func TestSymLinkResolution(t *testing.T) {
 			cmd.Stderr = io.Discard
 			_ = cmd.Run()
 			return nil
-		}, func(_ *model.Event, rule *rules.Rule) {
+		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "symlink_true_exec")
+			assert.True(t, event.Exec.IsThroughSymLink, "event.Process.IsThroughSymLink not matching")
 		})
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR allows us to detect when an exec is accessing a file through a symlink.
We added a hook that provides a flag. When the flag is set to 1, the event is manually edited to add common symlink paths in order to match the rule.
### Motivation
The following rule was not working on Ubuntu due to alternatives symlinks : 

`exec.file.name == "nc"
`
In fact 

```
type nc
nc is hashed (/usr/bin/nc)
```
```
ls -al /usr/bin/nc
lrwxrwxrwx 1 root root 20 janv. 10  2024 /usr/bin
```

### Describe how you validated your changes
We added a test that reproduce the example presented above.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->