### PR TITLE
fix(fleet): Dynamically search the agent install path, fallback if not found

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -270,6 +270,11 @@ build do
     move 'bin/agent/dist/application_monitoring.yaml', "#{conf_dir}/application_monitoring.yaml.example"
   end
 
+  # Allows the agent to be installed in a custom location
+  if linux_target?
+    command "touch #{install_dir}/.install_root"
+  end
+
   # TODO: move this to omnibus-ruby::health-check.rb
   # check that linux binaries contains OpenSSL symbols when building to support FIPS
   if fips_mode? && linux_target?

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -246,6 +246,10 @@ def get_build_flags(
 
     rtloader_lib, rtloader_headers, rtloader_common_headers = get_rtloader_paths(embedded_path, rtloader_root)
 
+    # setting the install path, allowing the agent to be installed in a custom location
+    if sys.platform.startswith('linux') and install_path:
+        ldflags += f"-X {REPO_PATH}/pkg/config/setup.InstallPath={install_path} "
+
     # setting the run path
     if sys.platform.startswith('linux') and run_path:
         ldflags += f"-X {REPO_PATH}/pkg/config/setup.defaultRunPath={run_path} "

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eEuo pipefail
 
-# The agent detects its install path by using os.Executable(), and then tries to fetch system-probe dependencies
-# like clang-bpf relatively. This doesn't work here as os.Executable() is actually the test file's, but
-# dependencies are expected to always be in the same directory.
-export DD_TEST_INSTALL_PATH_OVERRIDE="/opt/datadog-agent"
 docker_dir=/kmt-dockers
 
 # Add provisioning steps here !


### PR DESCRIPTION
### What does this PR do?
This is a follow-up for https://github.com/DataDog/datadog-agent/pull/39595 that does the following:
1. Instead of hardcoding the relative path; we go up directory by directory from the binary in search of a .install_root file that indicates where to stop
2. If we can't find that .install_root file, we fallback to the hardcoded path

### Motivation
Fix dev setups & cluster agent

### Describe how you validated your changes
Manual QA, unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
