### PR TITLE
fix(check_for_changes): Use error code rather than stdout

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -94,9 +94,14 @@ jobs:
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
           if [ -n "${{ needs.find_release_branches.outputs.warning }}" ]; then
-            echo "CHANGES=$(dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
+            dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING"
           else
-            echo "CHANGES=$(dda inv -- -e release.check-for-changes -r "$MATRIX")" >> $GITHUB_OUTPUT
+            dda inv -- -e release.check-for-changes -r "$MATRIX"
+          fi
+          if [ $? -ne 0 ]; then
+            echo "CHANGES=true" >> $GITHUB_OUTPUT
+          else
+            echo "CHANGES=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Check if agent 6 is in qualification phase

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -628,7 +628,7 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False, st
 
         # tag_version only takes the highest version (Agent 7 currently), and creates
         # the tags for all supported versions
-        # TODO: make it possible to do Agent 6-only or Agent 7-only tags?
+        # TODO(team:agent-delivery): make it possible to do Agent 6-only or Agent 7-only tags?
         tag_version(ctx, version=str(new_version), force=False, start_qual=start_qual)
         tag_modules(ctx, version=str(new_version), force=False)
 
@@ -693,11 +693,10 @@ def set_release_json(ctx, key, value, release_branch=None, skip_checkout=False, 
         release_json = load_release_json()
         path = key.split('::')
         current_node = release_json
-        for key_idx in range(len(path)):
-            key = path[key_idx]
+        for idx, key in enumerate(path):
             if key not in current_node:
                 raise Exit(code=1, message=f"Couldn't find '{key}' in release.json")
-            if key_idx == len(path) - 1:
+            if idx == len(path) - 1:
                 current_node[key] = value
                 break
             else:
@@ -766,8 +765,7 @@ def create_and_update_release_branch(
             _main()
 
 
-# TODO: unfreeze is the former name of this task, kept for backward compatibility. Remove in a few weeks.
-@task(help={'upstream': "Remote repository name (default 'origin')"}, aliases=["unfreeze"])
+@task(help={'upstream': "Remote repository name (default 'origin')"})
 def create_release_branches(
     ctx, commit, base_directory="~/dd", major_version: int = 7, upstream="origin", check_state=True
 ):

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -535,8 +535,10 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "main")
-        print_mock.assert_called_with("false")
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "main")
+        self.assertEqual(e.exception.code, 0)
+        print_mock.assert_not_called()
 
     @patch('slack_sdk.WebClient', autospec=True)
     @patch('tasks.release.agent_context')
@@ -592,10 +594,11 @@ class TestCheckForChanges(unittest.TestCase):
                     'git push origin tag 7.55.0-rc.2': Result(""),
                 },
             )
-            release.check_for_changes(c, "main")
+            with self.assertRaises(SystemExit) as e:
+                release.check_for_changes(c, "main")
+            self.assertEqual(e.exception.code, 69)
             calls = [
                 call("omnibus-ruby has new commits since 7.55.0-rc.1", file=sys.stderr),
-                call("true"),
             ]
             print_mock.assert_has_calls(calls)
             client_mock.chat_postMessage.assert_called_once_with(
@@ -655,12 +658,13 @@ class TestCheckForChanges(unittest.TestCase):
                     'git push origin tag 7.55.0-rc.2': Result(""),
                 },
             )
-            release.check_for_changes(c, "main")
+            with self.assertRaises(SystemExit) as e:
+                release.check_for_changes(c, "main")
+            self.assertEqual(e.exception.code, 69)
             calls = [
                 call("omnibus-ruby has new commits since 7.55.0-rc.1", file=sys.stderr),
                 call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
                 call("datadog-agent has new commits since 7.55.0-devel", file=sys.stderr),
-                call("true"),
             ]
             print_mock.assert_has_calls(calls)
             client_mock.chat_postMessage.assert_called_once_with(
@@ -709,16 +713,17 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "main")
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "main")
+        self.assertEqual(e.exception.code, 69)
         calls = [
-            call("true"),
             call(
                 "omnibus-ruby has a new tag 7.55.0-rc.2 since last release candidate (was 7.55.0-rc.1)",
                 file=sys.stderr,
             ),
         ]
         print_mock.assert_has_calls(calls, any_order=True)
-        self.assertEqual(print_mock.call_count, 2)
+        self.assertEqual(print_mock.call_count, 1)
 
     @patch('slack_sdk.WebClient', autospec=True)
     @patch('tasks.release.agent_context')
@@ -774,10 +779,11 @@ class TestCheckForChanges(unittest.TestCase):
                     'git push origin tag 7.55.0-rc.2': Result(""),
                 },
             )
-            release.check_for_changes(c, "7.55.x")
+            with self.assertRaises(SystemExit) as e:
+                release.check_for_changes(c, "7.55.x")
+            self.assertEqual(e.exception.code, 69)
             calls = [
                 call("omnibus-ruby has new commits since 7.55.0-rc.1", file=sys.stderr),
-                call("true"),
             ]
             print_mock.assert_has_calls(calls)
             client_mock.chat_postMessage.assert_called_once_with(
@@ -813,8 +819,10 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "main", True)
-        print_mock.assert_called_with("false")
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "main", True)
+        self.assertEqual(e.exception.code, 0)
+        print_mock.assert_not_called()
 
     @patch('tasks.release.agent_context')
     @patch('builtins.print')
@@ -845,8 +853,10 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "main", True)
-        print_mock.assert_called_with("false")
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "main", True)
+        self.assertEqual(e.exception.code, 0)
+        print_mock.assert_not_called()
 
     @patch('tasks.release.agent_context')
     @patch('builtins.print')
@@ -877,13 +887,14 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "main", True)
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "main", True)
+        self.assertEqual(e.exception.code, 69)
         calls = [
             call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
-            call("true"),
         ]
         print_mock.assert_has_calls(calls)
-        self.assertEqual(print_mock.call_count, 2)
+        self.assertEqual(print_mock.call_count, 1)
 
     @patch('tasks.release.agent_context')
     @patch('builtins.print')
@@ -914,13 +925,14 @@ class TestCheckForChanges(unittest.TestCase):
                 ),
             },
         )
-        release.check_for_changes(c, "7.55.x", True)
+        with self.assertRaises(SystemExit) as e:
+            release.check_for_changes(c, "7.55.x", True)
+        self.assertEqual(e.exception.code, 69)
         calls = [
             call("integrations-core has new commits since 7.55.0-rc.1", file=sys.stderr),
-            call("true"),
         ]
         print_mock.assert_has_calls(calls)
-        self.assertEqual(print_mock.call_count, 2)
+        self.assertEqual(print_mock.call_count, 1)
 
 
 class TestUpdateModules(unittest.TestCase):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use an error_code in the `check-for-changes` method instead of stdout

### Motivation
In the Github workflow we are running a command which print to stdout, stored in env var and transferred to Github stack. 
```
echo "CHANGES=$(dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
```
Since the `dda` migration the stdout output causes [unexpected errors](https://github.com/DataDog/datadog-agent/actions/runs/17120882608/job/48561289796).
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'integrations-core has a new tag 7.70.0-rc.6 since last release candidate (was 7.70.0-rc.5)'
```
I decided to used an error code to have a more robust transfer of the env var to Github.
 

### Describe how you validated your changes
Updated the unit test.

I should try to run the command from my branch as well
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->