### PR TITLE
fakeintake expose option to command line

### DIFF
--- a/test/fakeintake/cmd/server/main.go
+++ b/test/fakeintake/cmd/server/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -20,6 +21,10 @@ import (
 func main() {
 	portPtr := flag.Int("port", 80, "fakeintake listening port, default to 80. Using -port=0 will use a random available port")
 	dddevForward := flag.Bool("dddev-forward", false, "Forward POST payloads to dddev, using the env variable DD_API_KEY as API key")
+	storeTypePtr := flag.String("store", "memory", "Store type, possible values: memory, sqlite")
+	retentionPeriodPtr := flag.Duration("retention-period", 15*time.Minute, "data retention period (use format: 1m, 10s, 1h), default: 15 minutes")
+	sqlLitePathPtr := flag.String("sqlite-path", "", "SQLite path to store data, can be overridden using env variable ")
+
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)
@@ -32,6 +37,27 @@ func main() {
 	if *dddevForward {
 		fiOptions = append(fiOptions, fakeintake.WithDDDevForward())
 	}
+
+	if retentionPeriodPtr != nil {
+		fiOptions = append(fiOptions, fakeintake.WithRetention(*retentionPeriodPtr))
+	}
+
+	if storeTypePtr != nil {
+		if *storeTypePtr != "memory" && *storeTypePtr != "sql" {
+			fmt.Println("wrong store type.\nPossible values are: memory, sql")
+			flag.Usage()
+
+			os.Exit(1)
+		}
+
+		fiOptions = append(fiOptions, fakeintake.WithStoreDriver(*storeTypePtr))
+
+		// if sql hqs been selected, check if the sqlite path has been overridden
+		if sqlLitePathPtr != nil && *storeTypePtr == "sql" {
+			fiOptions = append(fiOptions, fakeintake.WithSqlitePath(*sqlLitePathPtr))
+		}
+	}
+
 	log.Println("⌛️ Starting fake intake")
 	fi := fakeintake.NewServer(fiOptions...)
 	fi.Start()

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -80,6 +80,8 @@ type Server struct {
 	storeDriver string
 	store       serverstore.Store
 
+	sqliteDbPath string
+
 	responseOverridesMutex    sync.RWMutex
 	responseOverridesByMethod map[string]map[string]httpResponse
 }
@@ -108,7 +110,7 @@ func NewServer(options ...Option) *Server {
 		opt(fi)
 	}
 
-	fi.store = serverstore.NewStore(fi.storeDriver)
+	fi.store = serverstore.NewStore(fi.storeDriver, fi.sqliteDbPath)
 	registry := prometheus.NewRegistry()
 
 	storeMetrics := fi.store.GetInternalMetrics()
@@ -229,6 +231,13 @@ func WithDDDevForward() Option {
 			fi.apiKey = apiKey
 		}
 		fi.dddevForward = true
+	}
+}
+
+// WithSqlitePath sets the sqlite file path to store the received data.
+func WithSqlitePath(path string) Option {
+	return func(fi *Server) {
+		fi.sqliteDbPath = path
 	}
 }
 

--- a/test/fakeintake/server/serverstore/db_test.go
+++ b/test/fakeintake/server/serverstore/db_test.go
@@ -14,7 +14,7 @@ import (
 func TestSqlStore(t *testing.T) {
 	suite.Run(t, &StoreTestSuite{
 		StoreConstructor: func() Store {
-			return newSQLStore()
+			return newSQLStore("")
 		},
 	})
 }

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -41,10 +41,12 @@ type Store interface {
 }
 
 // NewStore returns a new store
-func NewStore(driver string) Store {
+func NewStore(driver, sqliteDbPath string) Store {
 	if driver == "sql" {
-		return newSQLStore()
+		log.Printf("💾 use SQLite store")
+		return newSQLStore(sqliteDbPath)
 	}
+	log.Printf("💾 use memory store")
 	return newInMemoryStore()
 }
 


### PR DESCRIPTION

### What does this PR do?

The fakeintake server can use some options to be configured, expose these options on the command line to run the fakeintake server.

Add option to select the data retention period.

Add option to choose between "memory" and "sql" store.

In case of "sql" store, add option to choose the path for the sqlite database.
This file path can only be set using env variable. Set the value using the env variable already provided. In order to preserve current usage, if the env variable is set too, the env variable will be used.


### Motivation

these changes will allow us to use the fake intake with some local disk storage while running end2end tests. 

these changes will allow us to increase/decrease the retention period of data to match the dd-agent period (like when sending host tags to the fake intake, this is done every 30 minutes)

### Describe how you validated your changes

- start the fake intake using the new options
  - change the store to `sql`
  - change the retention period (you'll see a log when data are cleared from store)
  - change the path for the sql driver

### Possible Drawbacks / Trade-offs

- none, it's very useful 🙃 

### Additional Notes
