### PR TITLE
[ACIX-973] Create `dda info owners jobs` local command

### DIFF
--- a/.dda/extend/commands/info/__init__.py
+++ b/.dda/extend/commands/info/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from dda.cli.base import dynamic_group
+
+# This command group is already defined in `dda` itself, so we do not need to redefine it here.
+# Redefining it here does not do anything, the help text and commands are taken from the original definition in `dda`.
+# However, if using an older version of `dda`, where the group does not exist, we need to define it, otherwise we will get an error.
+
+
+@dynamic_group(
+    short_help="Get information about the repo, CI and more",
+)
+def cmd() -> None:
+    pass

--- a/.dda/extend/commands/info/owners/__init__.py
+++ b/.dda/extend/commands/info/owners/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from dda.cli.base import dynamic_group
+
+
+@dynamic_group(
+    short_help="Find owners of repo content",
+)
+def cmd() -> None:
+    pass

--- a/.dda/extend/commands/info/owners/jobs/__init__.py
+++ b/.dda/extend/commands/info/owners/jobs/__init__.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+from dda.cli.base import dynamic_command, pass_app
+from dda.utils.fs import Path
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Find owners of GitLab CI jobs", features=["codeowners"])
+@click.argument(
+    "jobs",
+    required=True,
+    nargs=-1,
+)
+@click.option(
+    "--config",
+    "-c",
+    "config_filepath",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to JOBOWNERS file",
+    default=".gitlab/JOBOWNERS",
+)
+# TODO(@agent-devx): Make this respect any --non-interactive flag or other way to detect CI environment
+@click.option(
+    "--json",
+    is_flag=True,
+    help="Format the output as JSON",
+)
+@pass_app
+def cmd(app: Application, jobs: tuple[str, ...], *, config_filepath: Path, json: bool) -> None:
+    """
+    Gets the owners for the specified GitLab CI jobs.
+    """
+    import codeowners
+
+    with config_filepath.open(encoding="utf-8") as f:
+        owners = codeowners.CodeOwners(f.read())
+
+    res = {job: [owner[1] for owner in owners.of(job)] for job in jobs}
+
+    if json:
+        from json import dumps
+
+        app.output(dumps(res))
+    else:
+        display_res = {job: ", ".join(owners) for job, owners in res.items()}
+        app.display_table(display_res, stderr=False)

--- a/.dda/extend/commands/info/owners/jobs/__init__.py
+++ b/.dda/extend/commands/info/owners/jobs/__init__.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
     nargs=-1,
 )
 @click.option(
-    "--config",
-    "-c",
-    "config_filepath",
+    "--owners",
+    "-f",
+    "owners_filepath",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     help="Path to JOBOWNERS file",
     default=".gitlab/JOBOWNERS",
@@ -34,14 +34,13 @@ if TYPE_CHECKING:
     help="Format the output as JSON",
 )
 @pass_app
-def cmd(app: Application, jobs: tuple[str, ...], *, config_filepath: Path, json: bool) -> None:
+def cmd(app: Application, jobs: tuple[str, ...], *, owners_filepath: Path, json: bool) -> None:
     """
     Gets the owners for the specified GitLab CI jobs.
     """
     import codeowners
 
-    with config_filepath.open(encoding="utf-8") as f:
-        owners = codeowners.CodeOwners(f.read())
+    owners = codeowners.CodeOwners(owners_filepath.read_text(encoding="utf-8"))
 
     res = {job: [owner[1] for owner in owners.of(job)] for job in jobs}
 

--- a/tasks/owners.py
+++ b/tasks/owners.py
@@ -9,11 +9,12 @@ from tasks.libs.pipeline.notifications import GITHUB_SLACK_MAP
 
 @task
 def find_jobowners(_, job, owners_file=".gitlab/JOBOWNERS"):
-    print(", ".join(search_owners(job, owners_file)))
+    print("DEPRECTATED: Use `dda info owners jobs` command instead.")
 
 
 @task
 def find_codeowners(_, path, owners_file=".github/CODEOWNERS"):
+    # TODO(@agent-devx): Deprecate once `dda info owners code` is available and minimal `dda` version is bumped`
     print(", ".join(search_owners(path, owners_file)))
 
 

--- a/tasks/unit_tests/owners_lib_tests.py
+++ b/tasks/unit_tests/owners_lib_tests.py
@@ -5,18 +5,10 @@ from tasks.libs.owners.parsing import search_owners
 
 class TestSearchCodeOwners(unittest.TestCase):
     CODEOWNERS_FILE = './tasks/unit_tests/testdata/codeowners.txt'
-    JOBOWNERS_FILE = './tasks/unit_tests/testdata/jobowners.txt'
 
+    # TODO(@agent-devx): Remove these tests once `dda info owners code` is available
     def test_search_codeowners(self):
         self.assertListEqual(search_owners("no_owners/file", self.CODEOWNERS_FILE), [])
         self.assertListEqual(search_owners(".dotfile", self.CODEOWNERS_FILE), ["@DataDog/team-everything"])
         self.assertListEqual(search_owners("doc.md", self.CODEOWNERS_FILE), ["@DataDog/team-a", "@DataDog/team-doc"])
         self.assertListEqual(search_owners(".gitlab/security.yml", self.CODEOWNERS_FILE), ["@DataDog/team-b"])
-
-    def test_search_jobowners(self):
-        self.assertListEqual(search_owners("default_job", self.JOBOWNERS_FILE), ["@DataDog/team-everything"])
-        self.assertListEqual(search_owners("tests_team_a_42", self.JOBOWNERS_FILE), ["@DataDog/team-a"])
-        self.assertListEqual(search_owners("tests_team_b_1618", self.JOBOWNERS_FILE), ["@DataDog/team-b"])
-        self.assertListEqual(
-            search_owners("tests_letters_314", self.JOBOWNERS_FILE), ["@DataDog/team-a", "@DataDog/team-b"]
-        )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Create a new local `dda` command, called via `dda info owners jobs`, replicating the functionality of the `owners.find-jobowners` invoke task.

### Motivation

Improving devx + proof of concept for migration of invoke tasks to `dda` using local commands, and especially how they integrate within an already existing command group
See: DataDog/datadog-agent-dev#167

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Running the commands locally with a few examples.
Automated tests for `dda` local commands are harder to implement for the moment.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->