### PR TITLE
Remove outdated .setup_deb_signing_key reference in iot_agent_deb-armhf

### DIFF
--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -174,7 +174,6 @@ iot_agent_deb-armhf:
     STATIC_QUALITY_GATE_NAME: "static_quality_gate_iot_agent_deb_armhf"
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]
-    - !reference [.setup_deb_signing_key]
     # Use custom built dpkg for armhf packaging since we're on armv8/arm64
     - PATH="/opt/dpkg-armhf/bin:$PATH" dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --flavor iot
     - !reference [.create_signature_and_lint_linux_packages]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `.setup_deb_signing_key` reference in `iot_agent_deb-armhf`. It has been removed in #39759.

### Motivation

Fix CI.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->