### PR TITLE
Fix queue index check for networkv2 code

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -398,13 +398,16 @@ func getEthtoolMetrics(driverName string, statsMap map[string]uint64) map[string
 				}
 			}
 			if queueIndex == -1 {
+				// The metric name contains the string "queue" but does not have a queue index
+				// In this case, this is not actually a queue metric and we should keep trying
 				continueCase = true
+			} else {
+				queueNum := parts[queueIndex+1]
+				parts = append(parts[:queueIndex], parts[queueIndex+2:]...)
+				queueTag = "queue:" + queueNum
+				newKey = strings.Join(parts, "_")
+				metricPrefix = ".queue."
 			}
-			queueNum := parts[queueIndex+1]
-			parts = append(parts[:queueIndex], parts[queueIndex+2:]...)
-			queueTag = "queue:" + queueNum
-			newKey = strings.Join(parts, "_")
-			metricPrefix = ".queue."
 		} else {
 			continueCase = true
 		}

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -106,6 +106,7 @@ func (f *MockEthtool) Stats(intf string) (map[string]uint64, error) {
 			"rx_packets[0]":      67890,
 			"cpu0_rx_xdp_tx":     123,
 			"tx_timeout":         456,
+			"tx_queue_dropped":   789, // Tests queue name parsing
 		}, nil
 	}
 


### PR DESCRIPTION
The network check code looks for metrics like queue_0_tx_len and will parse the queue index in order to set the tags correctly. However, sometimes there are also metrics that look like tx_queue_drops which contain the word "queue" but arent' actually queue-indexed metrics.

The old python checks would detect this case and stop trying to parse the queue number. The networkv2 go checks do not detect this case and would blow up instead. (https://github.com/DataDog/integrations-core/blob/master/network/datadog_checks/network/ethtool.py#L106-L107)

This change implements the check, avoiding a crash in the case described above.

### Describe how you validated your changes
I wrote a unit test which failed, then I changed the code so that it passed.

No e2e testing (I'm still figuring that env out) because this seems like the sort of code best validated through unit tests and there was a pre-existing unit test for this module.

### Possible Drawbacks / Trade-offs
My biggest concern about this change is that I'm classifying the metrics correctly. If the metric name fails to parse as a queue, it will fall through and probably hit the generic final clause which checks to see if this metric name is in the list of known metrics. I hope that's the right behavior.

I would not expect any performance changes in either CPU, Mem usage, or Disk usage as a result of this change.
