### PR TITLE
change error log to a require assertion

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -56,14 +56,10 @@ func (s *windowsTestSuite) SetupSuite() {
 	// Install chocolatey - https://chocolatey.org/install
 	// This may be due to choco rate limits - https://datadoghq.atlassian.net/browse/ADXT-950
 	stdout, err := s.Env().RemoteHost.Execute("Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex")
-	if err != nil {
-		s.T().Logf("Failed to install chocolatey: %s, err: %s", stdout, err)
-	}
+	require.NoErrorf(s.T(), err, "Failed to install chocolatey: %s, err: %s", stdout, err)
 	// Install diskspd for IO tests - https://learn.microsoft.com/en-us/azure/azure-local/manage/diskspd-overview
 	stdout, err = s.Env().RemoteHost.Execute("C:\\ProgramData\\chocolatey\\bin\\choco.exe install -y diskspd")
-	if err != nil {
-		s.T().Logf("Failed to install diskspd: %s, err: %s", stdout, err)
-	}
+	require.NoErrorf(s.T(), err, "Failed to install diskspd: %s, err: %s", stdout, err)
 }
 
 func (s *windowsTestSuite) TestAPIKeyRefresh() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- replaces a normal windows error log to a require assertion so we fail fast

### Motivation
- e2e test failing showed a `'diskspd.exe' process not found in payloads: ` which was misleading when the actualy error was 

```
windows_test.go:60: Failed to install chocolatey: , err: Forcing web requests to allow TLS v1.2 (Required for requests to Chocolatey.org)
        Getting latest version of the Chocolatey package for download.
        Not using proxy.
        Getting Chocolatey from https://community.chocolatey.org/api/v2/package/chocolatey/2.5.0.
        Downloading https://community.chocolatey.org/api/v2/package/chocolatey/2.5.0 to C:\Users\Administrator\AppData\Local\Temp\chocolatey\chocoInstall\chocolatey.zip
        Not using proxy.
        Request-File : Exception calling "DownloadFile" with "2" argument(s): "The operation has timed 
        out."
        At line:467 char:5
        +     Request-File -Url $ChocolateyDownloadUrl -File $file -ProxyConfig ...
        +     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            + CategoryInfo          : NotSpecified: (:) [Request-File], MethodInvocationException
            + FullyQualifiedErrorId : WebException,Request-File
         
        : Process exited with status 1
    host.go:149: 21-08-2025 18:54:59 - TestWindowsTestSuite - Executing command `$ErrorActionPreference='Stop'; $LASTEXITCODE=0; C:\ProgramData\chocolatey\bin\choco.exe install -y diskspd; if (-not $?) { exit $LASTEXITCODE }`
    windows_test.go:65: Failed to install diskspd: , err: C:\ProgramData\chocolatey\bin\choco.exe : The term 'C:\ProgramData\chocolatey\bin\choco.exe' is 
        not recognized as the name of a cmdlet, function, script file, or operable program. Check the 
        spelling of the name, or if a path was included, verify that the path is correct and try again.
        At line:1 char:49
        + ... op'; $LASTEXITCODE=0; C:\ProgramData\chocolatey\bin\choco.exe install ...
        +                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            + CategoryInfo          : ObjectNotFound: (C:\ProgramData\chocolatey\bin\choco.exe:String) [] 
           , ParentContainsErrorRecordException
            + FullyQualifiedErrorId : CommandNotFoundException
```

this requires you to scroll up a bit on the logs which is not ideal. Instead we want to fail fast if we get a timeout.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->