### PR TITLE
Fix dda version selection in devcontainer test

### DIFF
--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -3,6 +3,11 @@ name: test devcontainer
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .github/workflows/test-devcontainer.yml
 
 permissions: {}
 

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Install dda
       uses: ./.github/actions/install-dda
       with:
-        version: "0.13.0"
         features: legacy-tasks
 
     - name: Build image

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         git clone https://github.com/DataDog/datadog-agent-buildimages.git
         cd datadog-agent-buildimages
-        dda run build devcontainer --tag legacy-devenv
+        dda run build devcontainer legacy-devenv
 
     - name: Create Dev Container config
       run: dda inv -- devcontainer.setup --image legacy-devenv


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/datadog-agent/pull/39361 changed the behavior of the action such that the version refers to an actual tag rather than a raw version number which broke this. We can just remove the hardcoded version now that the default version is pinned.