### PR TITLE
EKS duplicate log fix

### DIFF
--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -460,7 +460,8 @@ func (k *kubeletMessageForwarder) forward() {
 			// we check the timestamp to drop logs that have already been processed
 			logTime, _ := time.Parse(time.RFC3339Nano, output.ParsingExtra.Timestamp)
 			if logTime.Before(k.tailer.getLastSince()) {
-				log.Infof("Dropping message %s because its timestamp %s is before %s", string(output.GetContent()), output.ParsingExtra.Timestamp, k.tailer.getLastSince().String())
+				log.Debugf("Skipping log to avoid duplicates, %s has already been processed",
+					output.ParsingExtra.Timestamp)
 				continue
 			}
 

--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -456,7 +456,7 @@ func (k *kubeletMessageForwarder) forward() {
 	}()
 	for output := range k.tailer.decoder.OutputChan {
 		if len(output.GetContent()) > 0 {
-			// Because the kubelet API only does not support sub-second granularity we run the risk of logging duplicates
+			// Because the kubelet API does not support sub-second granularity we run the risk of logging duplicates
 			// we check the timestamp to drop logs that have already been processed
 			logTime, _ := time.Parse(time.RFC3339Nano, output.ParsingExtra.Timestamp)
 			if logTime.Before(k.tailer.getLastSince()) {

--- a/releasenotes/notes/duplicate_fargate_logging_bug-9a7da34353c5b4c3.yaml
+++ b/releasenotes/notes/duplicate_fargate_logging_bug-9a7da34353c5b4c3.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Remediate duplicated logs when using the native EKS Fargate logging
+    method.
+


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds a check to the kubelet API tailer to skip logs with a timestamp before `lastSince`. 

There is a [bug](https://github.com/kubernetes/kubernetes/issues/77856) in the kubelet API. Because the API does not respect sub-second granularity, it is possible to receive logs that are before the desired query time.

### Motivation
Fix a duplicate logging bug in the kubelet API tailer reported here: https://github.com/DataDog/datadog-agent/issues/39402

### Describe how you validated your changes
#### Reproduce the buggy behavior
In order to reproduce the bug, I created a container that logged once and then slept forever
```
- name: workload
   image: busybox:1.36
   command: ["/bin/sh", "-c"]
   args: ["echo 'Hello, Kubernetes! Logging once and staying alive...' && tail -f /dev/null"]
```
<img width="936" height="478" alt="Screenshot 2025-08-22 at 2 26 06 PM" src="https://github.com/user-attachments/assets/6a259e4f-d4ff-4bbb-8689-3988e3cb4713" />

This produced duplicate logs because the `lastSince +1 nanosecond` was being dropped by the kubelet API _and was therefore returning logs from before our requested timestamp._

#### Address the Bug
With the fix in place I deployed the same single log container and observed the fix
<img width="1013" height="224" alt="Screenshot 2025-08-22 at 2 42 03 PM" src="https://github.com/user-attachments/assets/c9ec23c2-64f0-40b3-9fcd-2a09c8d96e92" />


#### Vet Higher Log Throughput
I deployed a log generation application (flog) onto EKS Fargate at a rate of 10 logs/s in JSON Format. 

**NOTE:** Each log has a uniquely identifiable sequence number combined with a log number, for example: `1755872657701898600:88978`. 

#### Collect the Logs
After letting the application run for ~2 hours I downloaded the logs as a CSV with a column dedicated to the log sequence ID: 
<img width="648" height="64" alt="Screenshot 2025-08-22 at 1 20 10 PM" src="https://github.com/user-attachments/assets/a7a0e7ab-1a32-4485-9e27-327e275c0b60" />

#### Validate the Logs
I wrote a python script to process the CSV file and identify dropped or duplicate logs. 

```
======================================================================
Log Sequence Identifier.......1755872657701898600
Total log count...............88,990
Missing log count.............0
Missing log rate..............0.00%
Duplicate log count...........0
Duplicate log rate............0.00%

Missing logs: []
Duplicate logs: []
======================================================================
```

<details>
<summary>Script Validation</summary>
<br>

**I validated the script functions properly by manually deleting the 5000th log, and duplicating log 5001 and the resulting output proves that the script works properly to identify missing and duplicate logs**

```
======================================================================
Log Sequence Identifier.......1755872657701898600
Total log count...............88,990
Missing log count.............1
Missing log rate..............0.00%
Duplicate log count...........1
Duplicate log rate............0.00%

Missing logs: [
    "1755872657701898600:5000"
]
Duplicate logs: [
    "1755872657701898600:5001"
]
======================================================================
```
</details>

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->