### PR TITLE
feat(ssi): allow configuring volume storage limits

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation_extractor_test.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 )
 
 func TestAnnotationExtractor(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -420,12 +420,12 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			require.Equal(t, volumeName, tt.pod.Spec.Volumes[0].Name,
 				"expected datadog volume to be injected")
 
-			require.Equal(t, etcVolume(corev1.StorageMediumDefault).Name, tt.pod.Spec.Volumes[1].Name,
+			require.Equal(t, etcVolume(corev1.StorageMediumDefault, nil).Name, tt.pod.Spec.Volumes[1].Name,
 				"expected datadog-etc volume to be injected")
 
 			volumesMarkedAsSafeToEvict := strings.Split(tt.pod.Annotations[common.K8sAutoscalerSafeToEvictVolumesAnnotation], ",")
 			require.Contains(t, volumesMarkedAsSafeToEvict, volumeName, "expected volume %s to be marked as safe to evict", volumeName)
-			require.Contains(t, volumesMarkedAsSafeToEvict, etcVolume(corev1.StorageMediumDefault).Name, "expected volume %s to be marked as safe to evict", etcVolume(corev1.StorageMediumDefault).Name)
+			require.Contains(t, volumesMarkedAsSafeToEvict, etcVolume(corev1.StorageMediumDefault, nil).Name, "expected volume %s to be marked as safe to evict", etcVolume(corev1.StorageMediumDefault, nil).Name)
 
 			require.Equal(t, len(tt.libInfo.libs)+1, len(tt.pod.Spec.InitContainers),
 				"expected there to be one more than the number of libs to inject for init containers")
@@ -479,7 +479,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				SubPath:   "opt/datadog-packages/datadog-apm-inject",
 			}, mounts[0], "expected first container volume mount to be the injector")
 			require.Equal(t, corev1.VolumeMount{
-				Name:      etcVolume(corev1.StorageMediumDefault).Name,
+				Name:      etcVolume(corev1.StorageMediumDefault, nil).Name,
 				MountPath: "/etc/ld.so.preload",
 				SubPath:   "ld.so.preload",
 				ReadOnly:  true,
@@ -1739,7 +1739,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			mutator, err := NewNamespaceMutator(config, wmeta)
 			require.NoError(t, err)
 
-			c := tt.lang.libInfo("", tt.image).initContainers(config.version, config.libraryStorageMedium)[0]
+			c := tt.lang.libInfo("", tt.image).initContainers(config.version, config.libraryStorageMedium, config.libraryStorageLimit)[0]
 			requirements, injectionDecision := initContainerResourceRequirements(tt.pod, config.defaultResourceRequirements)
 			require.Equal(t, tt.wantSkipInjection, injectionDecision.skipInjection)
 			require.Equal(t, tt.resourceRequireAnnotation, injectionDecision.message)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
@@ -9,6 +9,7 @@ package autoinstrumentation
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type libRequirementOptions struct {
@@ -17,6 +18,7 @@ type libRequirementOptions struct {
 	podMutators           []podMutator
 	containerFilter       containerFilter
 	libraryStorageMedium  corev1.StorageMedium
+	libraryStorageLimit   *resource.Quantity
 }
 
 type libRequirement struct {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -198,6 +198,7 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 			initContainerMutators: initContainerMutators,
 			podMutators:           []podMutator{configInjector.podMutator(lib.lang)},
 			libraryStorageMedium:  m.config.libraryStorageMedium,
+			libraryStorageLimit:   m.config.libraryStorageLimit,
 		}).mutatePod(pod); err != nil {
 			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
 			lastError = err

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -797,6 +797,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")
 	config.BindEnv("admission_controller.auto_instrumentation.volume.empty_dir_storage_medium")
+	config.BindEnv("admission_controller.auto_instrumentation.volume.empty_dir_storage_limit")
 	config.BindEnv("admission_controller.auto_instrumentation.asm.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED")          // config for ASM which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.iast.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED")           // config for IAST which is implemented in the client libraries
 	config.BindEnv("admission_controller.auto_instrumentation.asm_sca.enabled", "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED")  // config for SCA

--- a/releasenotes-dca/notes/add-library-storage-limit-ffd31d620cca5814.yaml
+++ b/releasenotes-dca/notes/add-library-storage-limit-ffd31d620cca5814.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    A new configuration option has been added to control the library storage limit for the auto-instrumentation webhook.
+    This will allow customers to set a limit for their emptyDir size. To enable limits for the SDK emptyDir, set the
+    following configuration option for the Cluster Agent:
+
+    ```yaml
+    clusterAgent:
+      env:
+        - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_LIMIT"
+          value: "100Mi"
+    ```


### PR DESCRIPTION
**Note - this change is being merged to a feature branch that we don't expect to merge into main**
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit allows the user to configure a limit for their storage volume. This can be used in conjunction with the memory backed `emptyDir` or standalone to constrain the emptyDir size.

### Motivation
We have a customer who has disk constraints and they want to utilize memory instead. This limit allows them to control the size of memory for the dir.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I've been using injector-dev:
```bash
injector-dev apply -f storage-constraints.yaml --build
```

<details>
  <summary>storage-constraints.yaml</summary>

```yaml
operator:
  apps:
  - name: python
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      image:
        repository: registry.ddbuild.io/ci/injector-dev/python
        tag: 2cd78ded
      podLabels:
        language: python
        tags.datadoghq.com/env: local
      service:
        port: "8080"
  versions:
    operator: 1.17.0
    cluster_agent:
      build: {}
    agent: 7.69.1
    injector: 0.44.0
  config:
    apiVersion: datadoghq.com/v2alpha1
    kind: DatadogAgent
    metadata:
      name: datadog
    spec:
      override:
        clusterAgent:
          # image:
          #   name: "datadog/cluster-agent-dev:mark-spicer-inplat-772-add-library-storage-medium"
          env:
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
              value: "memory"
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_LIMIT"
              value: "100Mi"
      features:
        apm:
          instrumentation:
            enabled: true
            targets:
            - ddTraceVersions:
                python: default
              name: python
              podSelector:
                matchLabels:
                  language: python
```

</details>

### Possible Drawbacks / Trade-offs
Setting the limit does not appear to have an impact on how the application manages memory. It only limits how much space we have to copy libraries. If a library grows in size, this 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
```yaml
          env:
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
              value: "memory"
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_LIMIT"
              value: "100Mi"
```