### PR TITLE
Remove runtime installation of shellcheck in CI

### DIFF
--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -17,7 +17,6 @@ lint_licenses:
 lint_shell:
   extends: .lint
   script:
-    - dda inv -- -e install-shellcheck
     - shellcheck --version
     #Excludes:
     #SC2028: echo may not expand escape sequences. Use printf.


### PR DESCRIPTION
### Motivation

The tool was added to the build images in https://github.com/DataDog/datadog-agent-buildimages/pull/954 and we started using a version of the images containing that change in https://github.com/DataDog/datadog-agent/pull/39896