### PR TITLE
[CWS] Fix cgroup cache consistency and add cgroupfs fallbacks

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -91,7 +91,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_image_tags", 20)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", GetDefaultSecurityProfilesDir())
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", true)
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 20)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dns_match_max_depth", 3)
 

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -91,7 +91,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_image_tags", 20)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", GetDefaultSecurityProfilesDir())
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", true)
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 20)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dns_match_max_depth", 3)
 

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -27,7 +27,7 @@ type CacheEntry struct {
 }
 
 // NewCacheEntry returns a new instance of a CacheEntry
-func NewCacheEntry(containerID containerutils.ContainerID, cgroupContext *model.CGroupContext, pids ...uint32) (*CacheEntry, error) {
+func NewCacheEntry(containerID containerutils.ContainerID, cgroupContext *model.CGroupContext, pids ...uint32) *CacheEntry {
 	newCGroup := CacheEntry{
 		Deleted: atomic.NewBool(false),
 		ContainerContext: model.ContainerContext{
@@ -43,7 +43,7 @@ func NewCacheEntry(containerID containerutils.ContainerID, cgroupContext *model.
 	for _, pid := range pids {
 		newCGroup.PIDs[pid] = true
 	}
-	return &newCGroup, nil
+	return &newCGroup
 }
 
 // GetPIDs returns the list of pids for the current workload

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -11,6 +11,7 @@ package cgroup
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -21,7 +22,6 @@ import (
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -45,8 +45,8 @@ const (
 type ResolverInterface interface {
 	Start(context.Context)
 	AddPID(*model.ProcessCacheEntry)
-	GetWorkload(containerutils.ContainerID) (*cgroupModel.CacheEntry, bool)
 	DelPID(uint32)
+	GetWorkload(containerutils.ContainerID) (*cgroupModel.CacheEntry, bool)
 	Len() int
 	RegisterListener(Event, utils.Listener[*cgroupModel.CacheEntry]) error
 }
@@ -55,6 +55,7 @@ type ResolverInterface interface {
 type Resolver struct {
 	*utils.Notifier[Event, *cgroupModel.CacheEntry]
 	sync.Mutex
+	cgroupFS           *utils.CGroupFS
 	statsdClient       statsd.ClientInterface
 	cgroups            *simplelru.LRU[model.PathKey, *model.CGroupContext]
 	hostWorkloads      *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
@@ -66,6 +67,7 @@ func NewResolver(statsdClient statsd.ClientInterface) (*Resolver, error) {
 	cr := &Resolver{
 		Notifier:     utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
 		statsdClient: statsdClient,
+		cgroupFS:     utils.DefaultCGroupFS(),
 	}
 
 	cleanup := func(value *cgroupModel.CacheEntry) {
@@ -106,32 +108,82 @@ func NewResolver(statsdClient statsd.ClientInterface) (*Resolver, error) {
 func (cr *Resolver) Start(_ context.Context) {
 }
 
-// AddPID associates a container id and a pid which is expected to be the pid 1
-func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
-	cr.Lock()
-	defer cr.Unlock()
-
-	if process.ContainerID != "" {
-		entry, exists := cr.containerWorkloads.Get(process.ContainerID)
-		if exists {
-			entry.AddPID(process.Pid)
-			return
-		}
+func (cr *Resolver) removeCgroup(cgroup *cgroupModel.CacheEntry) {
+	cr.cgroups.Remove(cgroup.CGroupFile)
+	cr.hostWorkloads.Remove(cgroup.CGroupID)
+	if cgroup.ContainerID != "" {
+		cr.containerWorkloads.Remove(cgroup.ContainerID)
 	}
+}
 
-	entry, exists := cr.hostWorkloads.Get(process.CGroup.CGroupID)
-	if exists {
-		entry.AddPID(process.Pid)
-		return
-	}
-
-	var err error
-	// create new entry now
-	newCGroup, err := cgroupModel.NewCacheEntry(process.ContainerID, &process.CGroup, process.Pid)
+// cgroup already locked
+func (cr *Resolver) syncOrDeleteCgroup(cgroup *cgroupModel.CacheEntry, deletedPid uint32) {
+	// check if the cgroup still contains pids
+	pids, err := cr.cgroupFS.GetCgroupPids(string(cgroup.CGroupContext.CGroupID))
 	if err != nil {
-		seclog.Errorf("couldn't create new cgroup_resolver cache entry: %v", err)
+		cr.removeCgroup(cgroup)
 		return
 	}
+
+	// if there is no pid left, or the only one being the one we want to delete,
+	// remove the cgroup from the caches
+	if len(pids) == 0 || (len(pids) == 1 && pids[0] == deletedPid) {
+		cr.removeCgroup(cgroup)
+		return
+	}
+
+	// otherwise sync it with new values
+	pids = slices.DeleteFunc(pids, func(todel uint32) bool {
+		return todel == deletedPid
+	})
+	for _, pid := range pids {
+		cgroup.PIDs[pid] = true
+	}
+
+	// then, ensure those pids are not part of other cgroups
+	cr.cleanupPidsWithMultipleCgroups(pids, cgroup)
+}
+
+// currentCgroup already locked
+func (cr *Resolver) cleanupPidsWithMultipleCgroups(pids []uint32, currentCgroup *cgroupModel.CacheEntry) {
+	for _, cgroup := range cr.containerWorkloads.Values() {
+		if cgroup.CGroupFile == currentCgroup.CGroupFile {
+			continue
+		}
+		cgroup.Lock()
+		for _, pid := range pids {
+			delete(cgroup.PIDs, pid)
+		}
+		if len(cgroup.PIDs) == 0 {
+			// No double check here to ensure that the cgroup is REALLY empty,
+			// because we already are in such a double check for another cgroup.
+			// No need to introduce a recursion here.
+			cr.removeCgroup(cgroup)
+		}
+		cgroup.Unlock()
+	}
+
+	for _, cgroup := range cr.hostWorkloads.Values() {
+		if cgroup.CGroupFile == currentCgroup.CGroupFile {
+			continue
+		}
+		cgroup.Lock()
+		for _, pid := range pids {
+			delete(cgroup.PIDs, pid)
+		}
+		if len(cgroup.PIDs) == 0 {
+			// No double check here to ensure that the cgroup is REALLY empty,
+			// because we already are in such a double check for another cgroup.
+			// No need to introduce a recursion here.
+			cr.removeCgroup(cgroup)
+		}
+		cgroup.Unlock()
+	}
+}
+
+func (cr *Resolver) pushNewCacheEntry(process *model.ProcessCacheEntry) {
+	// create new entry now
+	newCGroup := cgroupModel.NewCacheEntry(process.ContainerID, &process.CGroup, process.Pid)
 	newCGroup.CreatedAt = uint64(process.ProcessContext.ExecTime.UnixNano())
 
 	// add the new CGroup to the cache
@@ -145,6 +197,46 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 	cr.NotifyListeners(CGroupCreated, newCGroup)
 }
 
+// AddPID update the cgroup cache to associates a cgroup and a pid
+func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
+	cr.Lock()
+	defer cr.Unlock()
+
+	found := false
+
+	for _, cgroup := range cr.hostWorkloads.Values() {
+		cgroup.Lock()
+		if cgroup.CGroupFile == process.CGroup.CGroupFile {
+			cgroup.PIDs[process.Pid] = true
+			found = true
+		} else if _, exist := cgroup.PIDs[process.Pid]; exist {
+			delete(cgroup.PIDs, process.Pid)
+			if len(cgroup.PIDs) == 0 {
+				cr.syncOrDeleteCgroup(cgroup, process.Pid)
+			}
+		}
+		cgroup.Unlock()
+	}
+
+	for _, cgroup := range cr.containerWorkloads.Values() {
+		cgroup.Lock()
+		if cgroup.CGroupFile == process.CGroup.CGroupFile {
+			cgroup.PIDs[process.Pid] = true
+			found = true
+		} else if _, exist := cgroup.PIDs[process.Pid]; exist {
+			delete(cgroup.PIDs, process.Pid)
+			if len(cgroup.PIDs) == 0 {
+				cr.syncOrDeleteCgroup(cgroup, process.Pid)
+			}
+		}
+		cgroup.Unlock()
+	}
+
+	if !found {
+		cr.pushNewCacheEntry(process)
+	}
+}
+
 // GetCGroupContext returns the cgroup context with the specified path key
 func (cr *Resolver) GetCGroupContext(cgroupPath model.PathKey) (*model.CGroupContext, bool) {
 	cr.Lock()
@@ -153,11 +245,17 @@ func (cr *Resolver) GetCGroupContext(cgroupPath model.PathKey) (*model.CGroupCon
 	return cr.cgroups.Get(cgroupPath)
 }
 
-// GetContainerWorkloads returns the container workloads
-func (cr *Resolver) GetContainerWorkloads() *simplelru.LRU[containerutils.ContainerID, *cgroupModel.CacheEntry] {
+// Iterate iterates on all cached cgroups
+func (cr *Resolver) Iterate(cb func(*cgroupModel.CacheEntry)) {
 	cr.Lock()
 	defer cr.Unlock()
-	return cr.containerWorkloads
+
+	for _, cgroup := range cr.hostWorkloads.Values() {
+		cb(cgroup)
+	}
+	for _, cgroup := range cr.containerWorkloads.Values() {
+		cb(cgroup)
+	}
 }
 
 // GetWorkload returns the workload referenced by the provided ID
@@ -187,20 +285,21 @@ func (cr *Resolver) DelPID(pid uint32) {
 }
 
 // deleteWorkloadPID removes a PID from a workload
-func (cr *Resolver) deleteWorkloadPID(pid uint32, workload *cgroupModel.CacheEntry) {
+func (cr *Resolver) deleteWorkloadPID(pid uint32, workload *cgroupModel.CacheEntry) bool {
 	workload.Lock()
 	defer workload.Unlock()
+
+	if _, exist := workload.PIDs[pid]; !exist {
+		return false
+	}
 
 	delete(workload.PIDs, pid)
 
 	// check if the workload should be deleted
-	if len(workload.PIDs) <= 0 {
-		cr.cgroups.Remove(workload.CGroupFile)
-		cr.hostWorkloads.Remove(workload.CGroupID)
-		if workload.ContainerID != "" {
-			cr.containerWorkloads.Remove(workload.ContainerID)
-		}
+	if len(workload.PIDs) == 0 {
+		cr.syncOrDeleteCgroup(workload, pid)
 	}
+	return true
 }
 
 // Len return the number of entries

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -579,7 +579,7 @@ func (p *EBPFResolver) RetrieveFileFieldsFromProcfs(filename string) (*model.Fil
 	return &fileFields, nil
 }
 
-func (p *EBPFResolver) insertEntry(entry *model.ProcessCacheEntry, source uint64) {
+func (p *EBPFResolver) insertEntry(entry *model.ProcessCacheEntry, source uint64, newPid bool) {
 	entry.Source = source
 
 	if prev := p.entryCache[entry.Pid]; prev != nil {
@@ -592,7 +592,7 @@ func (p *EBPFResolver) insertEntry(entry *model.ProcessCacheEntry, source uint64
 	// the count will be decremented once the entry is released
 	p.processCacheEntryCount.Inc()
 
-	if p.cgroupResolver != nil && entry.CGroup.CGroupID != "" {
+	if newPid && p.cgroupResolver != nil && entry.CGroup.CGroupID != "" {
 		// add the new PID in the right cgroup_resolver bucket
 		p.cgroupResolver.AddPID(entry)
 	}
@@ -635,7 +635,7 @@ func (p *EBPFResolver) insertForkEntry(entry *model.ProcessCacheEntry, inode uin
 		}
 	}
 
-	p.insertEntry(entry, source)
+	p.insertEntry(entry, source, true)
 }
 
 func (p *EBPFResolver) insertExecEntry(entry *model.ProcessCacheEntry, inode uint64, source uint64) {
@@ -660,7 +660,7 @@ func (p *EBPFResolver) insertExecEntry(entry *model.ProcessCacheEntry, inode uin
 		entry.IsParentMissing = true
 	}
 
-	p.insertEntry(entry, source)
+	p.insertEntry(entry, source, false)
 }
 
 func (p *EBPFResolver) deleteEntry(pid uint32, exitTime time.Time) {
@@ -1373,7 +1373,7 @@ func (p *EBPFResolver) newEntryFromProcfs(proc *process.Process, filledProc *uti
 		seclog.Debugf("unable to set the type of process, not pid 1, no parent in cache: %+v", entry)
 	}
 
-	p.insertEntry(entry, source)
+	p.insertEntry(entry, source, true)
 
 	seclog.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.FileEvent.PathnameStr, pid, entry.FileEvent.Inode)
 
@@ -1536,13 +1536,18 @@ func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *mod
 		return false
 	}
 
+	pce.Process.CGroup = *cgroupContext
+	pce.CGroup = *cgroupContext
+
 	if cgroupContext.CGroupID != "" {
 		pce.Process.ContainerID = containerutils.FindContainerID(cgroupContext.CGroupID)
 		pce.ContainerID = pce.Process.ContainerID
-	}
 
-	pce.Process.CGroup = *cgroupContext
-	pce.CGroup = *cgroupContext
+		// update the PID in the right cgroup_resolver bucket
+		if p.cgroupResolver != nil {
+			p.cgroupResolver.AddPID(pce)
+		}
+	}
 
 	return true
 }

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -830,7 +830,7 @@ func TestIsExecExecSnapshot(t *testing.T) {
 	child3 := newFakeExecEvent(3, 4, 769, resolver)
 
 	// X(pid:3)
-	resolver.insertEntry(parent.ProcessCacheEntry, model.ProcessCacheEntryFromSnapshot)
+	resolver.insertEntry(parent.ProcessCacheEntry, model.ProcessCacheEntryFromSnapshot, true)
 	assert.Equal(t, parent.ProcessCacheEntry, resolver.entryCache[parent.ProcessCacheEntry.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 
@@ -838,7 +838,7 @@ func TestIsExecExecSnapshot(t *testing.T) {
 	//    |
 	// X(pid:4)
 	resolver.setAncestor(child.ProcessCacheEntry)
-	resolver.insertEntry(child.ProcessCacheEntry, model.ProcessCacheEntryFromSnapshot)
+	resolver.insertEntry(child.ProcessCacheEntry, model.ProcessCacheEntryFromSnapshot, true)
 	assert.Equal(t, child.ProcessCacheEntry, resolver.entryCache[child.ProcessCacheEntry.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent.ProcessCacheEntry, child.ProcessCacheEntry.Ancestor)
@@ -874,7 +874,7 @@ func TestCGroupContext(t *testing.T) {
 
 	t.Run("unknown-container-runtime", func(t *testing.T) {
 		node := newFakeForkEvent(0, 3, 123, resolver)
-		resolver.insertEntry(node.ProcessCacheEntry, model.ProcessCacheEntryFromEvent)
+		resolver.insertEntry(node.ProcessCacheEntry, model.ProcessCacheEntryFromEvent, true)
 
 		const (
 			containerID = containerutils.ContainerID("09d3f62464b8761e9106350bacc609deb0dc639403888bdf2112033cb30e1bf6")

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -35,10 +35,10 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 
 			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) {
 				cgce.RLock()
+				defer cgce.RUnlock()
 				if cgce.ContainerContext.ContainerID == "" {
 					return
 				}
-				defer cgce.RUnlock()
 
 				event := e.probe.PlatformProbe.NewEvent()
 				event.ContainerContext = &cgce.ContainerContext

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
@@ -31,13 +32,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				continue
 			}
 			cgr := ebpfProbe.Resolvers.CGroupResolver
-			containerWorkloads := cgr.GetContainerWorkloads()
-			if containerWorkloads == nil {
-				continue
-			}
 
-			for _, cgce := range containerWorkloads.Values() {
+			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) {
 				cgce.RLock()
+				if cgce.ContainerContext.ContainerID == "" {
+					return
+				}
 				defer cgce.RUnlock()
 
 				event := e.probe.PlatformProbe.NewEvent()
@@ -46,7 +46,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				scopedName := fmt.Sprintf("%s.%s", name, cgce.ContainerContext.ContainerID)
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
-					continue
+					return
 				}
 
 				scopedValue := fmt.Sprintf("%v", value)
@@ -54,17 +54,12 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					Name:  scopedName,
 					Value: scopedValue,
 				}
-			}
+			})
 		} else if strings.HasPrefix(name, "cgroup.") {
 			scopedVariable := value.(eval.ScopedVariable)
 
 			cgr := e.probe.PlatformProbe.(*probe.EBPFProbe).Resolvers.CGroupResolver
-			containerWorkloads := cgr.GetContainerWorkloads()
-			if containerWorkloads == nil {
-				continue
-			}
-
-			for _, cgce := range containerWorkloads.Values() {
+			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) {
 				cgce.RLock()
 				defer cgce.RUnlock()
 
@@ -74,7 +69,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 				scopedName := fmt.Sprintf("%s.%s", name, cgce.CGroupID)
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
-					continue
+					return
 				}
 
 				scopedValue := fmt.Sprintf("%v", value)
@@ -82,7 +77,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					Name:  scopedName,
 					Value: scopedValue,
 				}
-			}
+			})
 		}
 	}
 	return seclVariables

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -300,7 +300,7 @@ func (m *Manager) linkProfileMap(profile *profile.Profile, workload *tags.Worklo
 		seclog.Errorf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}
-	seclog.Infof("workload %s (selector: %s) successfully linked to profile %s", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name)
+	seclog.Infof("workload %s (selector: %s, key: %v) successfully linked to profile %s", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name)
 }
 
 // linkProfile applies a profile to the provided workload
@@ -335,7 +335,7 @@ func (m *Manager) unlinkProfileMap(profile *profile.Profile, workload *tags.Work
 		seclog.Errorf("couldn't unlink workload %s (selector: %s, key: %v) with profile %s: %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}
-	seclog.Infof("workload %s (selector: %s) successfully unlinked from profile %s", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name)
+	seclog.Infof("workload %s (selector: %s, key: %v) successfully unlinked from profile %s", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name)
 }
 
 // unlinkProfile removes the link between a workload and a profile

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -287,6 +287,7 @@ func (m *Manager) unloadProfileMap(profile *profile.Profile) {
 	// remove kernel space filters
 	if err := m.securityProfileSyscallsMap.Delete(profile.GetProfileCookie()); err != nil {
 		seclog.Errorf("couldn't remove syscalls filter: %v", err)
+		return
 	}
 
 	// TODO: delete all kernel space programs
@@ -332,6 +333,7 @@ func (m *Manager) unlinkProfileMap(profile *profile.Profile, workload *tags.Work
 
 	if err := m.securityProfileMap.Delete(workload.CGroupFile); err != nil {
 		seclog.Errorf("couldn't unlink workload %s (selector: %s) with profile %s: %v", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name, err)
+		return
 	}
 	seclog.Infof("workload %s (selector: %s) successfully unlinked from profile %s", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name)
 }

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -297,7 +297,7 @@ func (m *Manager) unloadProfileMap(profile *profile.Profile) {
 // linkProfile (thread unsafe) updates the kernel space mapping between a workload and its profile
 func (m *Manager) linkProfileMap(profile *profile.Profile, workload *tags.Workload) {
 	if err := m.securityProfileMap.Put(workload.CGroupFile, profile.GetProfileCookie()); err != nil {
-		seclog.Errorf("couldn't link workload %s (selector: %s) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name, err)
+		seclog.Errorf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}
 	seclog.Infof("workload %s (selector: %s) successfully linked to profile %s", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name)
@@ -332,7 +332,7 @@ func (m *Manager) unlinkProfileMap(profile *profile.Profile, workload *tags.Work
 	}
 
 	if err := m.securityProfileMap.Delete(workload.CGroupFile); err != nil {
-		seclog.Errorf("couldn't unlink workload %s (selector: %s) with profile %s: %v", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name, err)
+		seclog.Errorf("couldn't unlink workload %s (selector: %s, key: %v) with profile %s: %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}
 	seclog.Infof("workload %s (selector: %s) successfully unlinked from profile %s", workload.ContainerID, workload.Selector.String(), profile.Metadata.Name)

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -158,7 +158,7 @@ type CGroupContext struct {
 }
 
 var defaultCGroupMountpoints = []string{
-	"/sys/fs/cgroup/unified", // must stay first for cgroupv1
+	"/sys/fs/cgroup/systemd", // must stay first for cgroupv1
 	"/sys/fs/cgroup",
 }
 

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -158,8 +158,8 @@ type CGroupContext struct {
 }
 
 var defaultCGroupMountpoints = []string{
+	"/sys/fs/cgroup/unified", // must stay first for cgroupv1
 	"/sys/fs/cgroup",
-	"/sys/fs/cgroup/unified",
 }
 
 // ErrNoCGroupMountpoint is returned when no cgroup mount point is found
@@ -197,6 +197,15 @@ func newCGroupFS() *CGroupFS {
 	cfs.detectCurrentCgroupPath(Getpid(), uint32(os.Getpid()))
 
 	return cfs
+}
+
+func (cfs *CGroupFS) removeMountPointFromCGroupPath(cpath string) string {
+	for _, mount := range cfs.cGroupMountPoints {
+		if strings.HasPrefix(cpath, mount) {
+			return cpath[len(mount):]
+		}
+	}
+	return cpath
 }
 
 // FindCGroupContext returns the container ID, cgroup context and sysfs cgroup path the process belongs to.
@@ -237,7 +246,7 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 			}
 
 			if exists, err = checkPidExists(cgroupPath, pid); err == nil && exists {
-				cgroupID := containerutils.CGroupID(cgroupPath)
+				cgroupID := containerutils.CGroupID(cfs.removeMountPointFromCGroupPath(cgroupPath))
 				ctrID := containerutils.FindContainerID(cgroupID)
 				cgroupContext.CGroupID = cgroupID
 				containerID = ctrID
@@ -288,6 +297,35 @@ func checkPidExists(sysFScGroupPath string, expectedPid uint32) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// GetCgroupPids returns the list of PIDs attached to the given cgroup name
+func (cfs *CGroupFS) GetCgroupPids(cgroupName string) ([]uint32, error) {
+	var data []byte
+	var err error
+	for _, cgroupMountPoint := range cfs.cGroupMountPoints {
+		data, err = os.ReadFile(filepath.Join(cgroupMountPoint, cgroupName, "cgroup.procs"))
+		if err != nil {
+			// the cgroup is in threaded mode, and in that case, reading cgroup.procs returns ENOTSUP.
+			// see https://github.com/opencontainers/runc/issues/3821
+			if errors.Is(err, unix.ENOTSUP) {
+				if data, err = os.ReadFile(filepath.Join(cgroupMountPoint, cgroupName, "cgroup.threads")); err != nil {
+					continue
+				}
+			} else {
+				continue
+			}
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		res := []uint32{}
+		for scanner.Scan() {
+			if pid, err := strconv.Atoi(strings.TrimSpace(scanner.Text())); err == nil {
+				res = append(res, uint32(pid))
+			}
+		}
+		return res, nil
+	}
+	return []uint32{}, err
 }
 
 // GetCgroup2MountPoint checks if cgroup v2 is available and returns its mount point

--- a/pkg/security/utils/cgroup_test.go
+++ b/pkg/security/utils/cgroup_test.go
@@ -342,13 +342,14 @@ func TestCGroupFS(t *testing.T) {
 		})
 
 		t.Run("find-cgroup-context-ok", func(t *testing.T) {
-			expectedCgroupPath := filepath.Join(tempDir, "sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf099a5b1_192b_4df6_b6d2_aa0b366fc2f1.slice/cri-containerd-b82e1003daa43c88a8f2ee5369e1a6905db37e28d29d61e189d176aea52b2b17.scope")
+			expectedCgroupPath := "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf099a5b1_192b_4df6_b6d2_aa0b366fc2f1.slice/cri-containerd-b82e1003daa43c88a8f2ee5369e1a6905db37e28d29d61e189d176aea52b2b17.scope"
+			expectedFullCgroupPath := filepath.Join(tempDir, "/sys/fs/cgroup", expectedCgroupPath)
 
 			containerID, cgroupContext, cgroupPath, err := cfs.FindCGroupContext(600894, 600894)
 			assert.Equal(t, containerutils.CGroupID(expectedCgroupPath), cgroupContext.CGroupID)
 			assert.Equal(t, containerutils.ContainerID("b82e1003daa43c88a8f2ee5369e1a6905db37e28d29d61e189d176aea52b2b17"), containerID)
 			assert.NoError(t, err)
-			assert.Equal(t, expectedCgroupPath, cgroupPath)
+			assert.Equal(t, expectedFullCgroupPath, cgroupPath)
 		})
 	})
 
@@ -375,13 +376,14 @@ func TestCGroupFS(t *testing.T) {
 		})
 
 		t.Run("find-cgroup-context-ok", func(t *testing.T) {
-			expectedCgroupPath := filepath.Join(tempDir, "sys/fs/cgroup/pids/docker/d308fe417b11e128c3b42d910f3b3df6f778439edba9ab600e62dfeb5631a46f")
+			expectedCgroupPath := "/pids/docker/d308fe417b11e128c3b42d910f3b3df6f778439edba9ab600e62dfeb5631a46f"
+			expectedFullCgroupPath := filepath.Join(tempDir, "/sys/fs/cgroup", expectedCgroupPath)
 
 			containerID, cgroupContext, cgroupPath, err := cfs.FindCGroupContext(18865, 18865)
 			assert.Equal(t, containerutils.CGroupID(expectedCgroupPath), cgroupContext.CGroupID)
 			assert.Equal(t, containerutils.ContainerID("d308fe417b11e128c3b42d910f3b3df6f778439edba9ab600e62dfeb5631a46f"), containerID)
 			assert.NoError(t, err)
-			assert.Equal(t, expectedCgroupPath, cgroupPath)
+			assert.Equal(t, expectedFullCgroupPath, cgroupPath)
 		})
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix some cgroups issues we found with our resolver cache:
* On cgroup_write events the cgroup cache was not updated accordingly (which led to a state where we spammed cgroup created/deleted notifications)
* The `CGroupID` path was inconsistent and contained the cgroupfs mount path if resolved during the snapshot
* PIDs can be assigned in multiple cgroups

This PR fixes those issues and add fallbacks and guards to ensure the cache consistency. From my tests I know that we really need those because we still miss (or run into a race?) some pid cgroup transitions.

It also fixes the cgroup scope for variables.

TODO:
* see if we can remove the `containersWorkload` cache to keep only one and simplify this way the code.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->