### PR TITLE
[APM] Add timeout to Stats handler

### DIFF
--- a/cmd/trace-agent/test/agent.go
+++ b/cmd/trace-agent/test/agent.go
@@ -170,9 +170,9 @@ func (s *agentRunner) Run(conf []byte) error {
 		case <-timeout:
 			return fmt.Errorf("agent: timed out waiting for start, log:\n%s", s.Log())
 		default:
-			if strings.Contains(s.log.String(), "Listening for traces at") {
+			if strings.Contains(s.log.String(), "trace-agent running...") {
 				if s.verbose {
-					log.Print("agent: Listening for traces")
+					log.Print("agent: trace-agent running...")
 				}
 				return nil
 			}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -222,6 +222,7 @@ func (a *Agent) Run() {
 		go a.work()
 	}
 
+	log.Infof("trace-agent running...")
 	a.loop()
 }
 

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -595,8 +595,13 @@ func mergeDuplicates(s *pb.ClientStatsBucket) {
 }
 
 // ProcessStats processes incoming client stats in from the given tracer.
-func (a *Agent) ProcessStats(in *pb.ClientStatsPayload, lang, tracerVersion, containerID, obfuscationVersion string) {
-	a.ClientStatsAggregator.In <- a.processStats(in, lang, tracerVersion, containerID, obfuscationVersion)
+func (a *Agent) ProcessStats(ctx context.Context, in *pb.ClientStatsPayload, lang, tracerVersion, containerID, obfuscationVersion string) error {
+	select {
+	case a.ClientStatsAggregator.In <- a.processStats(in, lang, tracerVersion, containerID, obfuscationVersion):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // sample performs all sampling on the processedTrace modifying it as needed and returning if the trace should be kept

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -542,9 +542,9 @@ func (r *HTTPReceiver) replyOK(req *http.Request, v Version, w http.ResponseWrit
 
 // StatsProcessor implementations are able to process incoming client stats.
 type StatsProcessor interface {
-	// ProcessStats takes a stats payload and consumes it. It is considered to be originating
-	// from the given lang.
-	ProcessStats(p *pb.ClientStatsPayload, lang, tracerVersion, containerID, obfuscationVersion string)
+	// ProcessStats takes a stats payload and consumes it. It is considered to be originating from the given lang.
+	// Context should be used to control processing timeouts, allowing the receiver to return the error response.
+	ProcessStats(ctx context.Context, p *pb.ClientStatsPayload, lang, tracerVersion, containerID, obfuscationVersion string) error
 }
 
 // handleStats handles incoming stats payloads.
@@ -556,6 +556,8 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	in := &pb.ClientStatsPayload{}
 	if err := msgp.Decode(rd, in); err != nil {
 		log.Errorf("Error decoding pb.ClientStatsPayload: %v", err)
+		tags := append(r.tagStats(V06, req.Header, "").AsTags(), fmt.Sprintf("reason:decode"))
+		_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload_rejected", 1, tags, 1)
 		httpDecodingError(err, []string{"handler:stats", "codec:msgpack", "v:v0.6"}, w, r.statsd)
 		return
 	}
@@ -577,7 +579,15 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	tracerVersion := req.Header.Get(header.TracerVersion)
 	obfuscationVersion := req.Header.Get(header.TracerObfuscationVersion)
 	containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)
-	r.statsProcessor.ProcessStats(in, lang, tracerVersion, containerID, obfuscationVersion)
+
+	ctx, cancel := context.WithTimeout(req.Context(), time.Duration(r.conf.ReceiverTimeout)*time.Second)
+	defer cancel()
+	if err := r.statsProcessor.ProcessStats(ctx, in, lang, tracerVersion, containerID, obfuscationVersion); err != nil {
+		log.Errorf("Error processing pb.ClientStatsPayload: %v", err)
+		tags := append(ts.AsTags(), fmt.Sprintf("reason:timeout"))
+		_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload_rejected", 1, tags, 1)
+		httpDecodingError(err, []string{"handler:stats", "codec:msgpack", "v:v0.6"}, w, r.statsd)
+	}
 }
 
 // handleTraces knows how to handle a bunch of traces

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -556,7 +556,7 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	in := &pb.ClientStatsPayload{}
 	if err := msgp.Decode(rd, in); err != nil {
 		log.Errorf("Error decoding pb.ClientStatsPayload: %v", err)
-		tags := append(r.tagStats(V06, req.Header, "").AsTags(), fmt.Sprintf("reason:decode"))
+		tags := append(r.tagStats(V06, req.Header, "").AsTags(), "reason:decode")
 		_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload_rejected", 1, tags, 1)
 		httpDecodingError(err, []string{"handler:stats", "codec:msgpack", "v:v0.6"}, w, r.statsd)
 		return
@@ -584,7 +584,7 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	defer cancel()
 	if err := r.statsProcessor.ProcessStats(ctx, in, lang, tracerVersion, containerID, obfuscationVersion); err != nil {
 		log.Errorf("Error processing pb.ClientStatsPayload: %v", err)
-		tags := append(ts.AsTags(), fmt.Sprintf("reason:timeout"))
+		tags := append(ts.AsTags(), "reason:timeout")
 		_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload_rejected", 1, tags, 1)
 		httpDecodingError(err, []string{"handler:stats", "codec:msgpack", "v:v0.6"}, w, r.statsd)
 	}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -580,7 +580,8 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	obfuscationVersion := req.Header.Get(header.TracerObfuscationVersion)
 	containerID := r.containerIDProvider.GetContainerID(req.Context(), req.Header)
 
-	ctx, cancel := context.WithTimeout(req.Context(), time.Duration(r.conf.ReceiverTimeout)*time.Second)
+	timeout := getConfiguredRequestTimeoutDuration(r.conf)
+	ctx, cancel := context.WithTimeout(req.Context(), timeout)
 	defer cancel()
 	if err := r.statsProcessor.ProcessStats(ctx, in, lang, tracerVersion, containerID, obfuscationVersion); err != nil {
 		log.Errorf("Error processing pb.ClientStatsPayload: %v", err)

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -832,6 +832,7 @@ func TestHandleStats(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer resp.Body.Close()
 
 		assert.Equal(t, resp.StatusCode, http.StatusRequestTimeout)
 	})

--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -6,6 +6,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,6 +54,10 @@ func httpDecodingError(err error, tags []string, w http.ResponseWriter, statsd s
 		msg = errtag
 	case io.EOF, io.ErrUnexpectedEOF:
 		errtag = "unexpected-eof"
+		msg = errtag
+	case context.DeadlineExceeded:
+		status = http.StatusRequestTimeout
+		errtag = "timeout"
 		msg = errtag
 	}
 	if err, ok := err.(net.Error); ok && err.Timeout() {


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Work for https://datadoghq.atlassian.net/browse/APMSP-2209

Reuse receiver timeout configuration (used for traces endpoint) on the stats endpoint, which currently waits indefinitely until the payload can be processed.

This timeout ensures the correct status code and error is returned to the client.

Additional telemetry is added:
`datadog.trace_agent.receiver.stats_payload_rejected`, with the appropriate "reason" tag.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are added, will be followed up with e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->