### PR TITLE
Add debugger/v2/intake endpoint

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -600,13 +600,13 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.DebuggerProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
 	}
 	if k := "apm_config.debugger_diagnostics_dd_url"; core.IsSet(k) {
-		c.DebuggerDiagnosticsProxy.DDURL = core.GetString(k)
+		c.DebuggerIntakeProxy.DDURL = core.GetString(k)
 	}
 	if k := "apm_config.debugger_diagnostics_api_key"; core.IsSet(k) {
-		c.DebuggerDiagnosticsProxy.APIKey = core.GetString(k)
+		c.DebuggerIntakeProxy.APIKey = core.GetString(k)
 	}
 	if k := "apm_config.debugger_diagnostics_additional_endpoints"; core.IsSet(k) {
-		c.DebuggerDiagnosticsProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
+		c.DebuggerIntakeProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
 	}
 	if k := "apm_config.symdb_dd_url"; core.IsSet(k) {
 		c.SymDBProxy.DDURL = core.GetString(k)

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -23,8 +23,8 @@ const (
 	// logsIntakeURLTemplate is the template for building the logs intake URL for each site.
 	logsIntakeURLTemplate = "https://http-intake.logs.%s/api/v2/logs"
 
-	// debuggerDiagnosticsURLTemplate is the template for building the debugger intake URL for each site.
-	debuggerDiagnosticsURLTemplate = "https://debugger-intake.%s/api/v2/debugger"
+	// debuggerIntakeURLTemplate specifies the template for obtaining the intake URL along with the site.
+	debuggerIntakeURLTemplate = "https://debugger-intake.%s/api/v2/debugger"
 
 	// ddTagsQueryStringMaxLen is the maximum number of characters we send as ddtags in the intake query string.
 	// This limit is not imposed by the event platform intake, it's a safeguard we've added to guarantee an upper
@@ -41,7 +41,13 @@ func (r *HTTPReceiver) debuggerLogsProxyHandler() http.Handler {
 // debuggerDiagnosticsProxyHandler returns an http.Handler proxying Dynamic Instrumentation diagnostic messages
 // to the debugger intake.
 func (r *HTTPReceiver) debuggerDiagnosticsProxyHandler() http.Handler {
-	return r.debuggerProxyHandler(debuggerDiagnosticsURLTemplate, r.conf.DebuggerDiagnosticsProxy)
+	return r.debuggerProxyHandler(debuggerIntakeURLTemplate, r.conf.DebuggerIntakeProxy)
+}
+
+// debuggerV2IntakeProxyHandler returns an http.Handler proxying Dynamic Instrumentation messages
+// to the debugger intake (DEBUGGER track, not logs track).
+func (r *HTTPReceiver) debuggerV2IntakeProxyHandler() http.Handler {
+	return r.debuggerProxyHandler(debuggerIntakeURLTemplate, r.conf.DebuggerIntakeProxy)
 }
 
 // debuggerProxyHandler returns an http.Handler proxying requests to the configured intake. If the intake url cannot be

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -147,6 +147,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerDiagnosticsProxyHandler() },
 	},
 	{
+		Pattern: "/debugger/v2/input",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.debuggerV2IntakeProxyHandler() },
+	},
+	{
 		Pattern: "/symdb/v1/input",
 		Handler: func(r *HTTPReceiver) http.Handler { return r.symDBProxyHandler() },
 	},

--- a/pkg/trace/api/symdb.go
+++ b/pkg/trace/api/symdb.go
@@ -20,11 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
-const (
-	// debuggerIntakeURLTemplate specifies the template for obtaining the intake URL along with the site.
-	debuggerIntakeURLTemplate = "https://debugger-intake.%s/api/v2/debugger"
-)
-
 // symDBProxyHandler returns an http.Handler proxying requests to the logs intake. If the logs intake url cannot be
 // parsed, the returned handler will always return http.StatusInternalServerError with a clarifying message.
 func (r *HTTPReceiver) symDBProxyHandler() http.Handler {
@@ -32,7 +27,7 @@ func (r *HTTPReceiver) symDBProxyHandler() http.Handler {
 	if orch := r.conf.FargateOrchestrator; orch != config.OrchestratorUnknown {
 		hostTags = hostTags + ",orchestrator:fargate_" + strings.ToLower(string(orch))
 	}
-	intake := fmt.Sprintf(debuggerIntakeURLTemplate, r.conf.Site)
+	intake := fmt.Sprintf(debuggerIntakeURLTemplate, r.conf.Site) // debuggerIntakeURLTemplate comes from debugger.go
 	if v := r.conf.SymDBProxy.DDURL; v != "" {
 		intake = v
 	} else if site := r.conf.Site; site != "" {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -478,8 +478,8 @@ type AgentConfig struct {
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
 
-	// DebuggerDiagnosticsProxy contains the settings for the Live Debugger diagnostics proxy.
-	DebuggerDiagnosticsProxy DebuggerProxyConfig
+	// DebuggerIntakeProxy contains the settings for the Live Debugger intake proxy.
+	DebuggerIntakeProxy DebuggerProxyConfig
 
 	// SymDBProxy contains the settings for the Symbol Database proxy.
 	SymDBProxy SymDBProxyConfig

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -462,8 +462,8 @@ func TestInfoConfig(t *testing.T) {
 	conf.EVPProxy.ApplicationKey = ""
 	assert.Equal("", confCopy.DebuggerProxy.APIKey, "Debugger Proxy API Key should *NEVER* be exported")
 	conf.DebuggerProxy.APIKey = ""
-	assert.Equal("", confCopy.DebuggerDiagnosticsProxy.APIKey, "Debugger Diagnostics Proxy API Key should *NEVER* be exported")
-	conf.DebuggerDiagnosticsProxy.APIKey = ""
+	assert.Equal("", confCopy.DebuggerIntakeProxy.APIKey, "Debugger Intake Proxy API Key should *NEVER* be exported")
+	conf.DebuggerIntakeProxy.APIKey = ""
 	// IPC Auth data should not be exposed
 	conf.AuthToken = ""
 	conf.IPCTLSClientConfig = nil

--- a/releasenotes/notes/add-debugger-v2-intake-proxy-a9fee7975b4274ec.yaml
+++ b/releasenotes/notes/add-debugger-v2-intake-proxy-a9fee7975b4274ec.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add debugger v2 intake proxy.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add another endpoint for debugger input that forwards to the debugger intake instead of logs.

### Motivation

We want to do additional processing on the events.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Start trace-agent locally with go run
1. Send request to debugger/v2/input, debugger/v1/input, debugger/v1/diagnostics as well as symdb/v1/input
1. Confirm messages are received as expected
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->