### PR TITLE
feat(ssi): add memory limit buffer for emptyDir

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -105,6 +105,26 @@ func (i initContainer) mutatePod(pod *corev1.Pod) error {
 	return nil
 }
 
+type sleepContainer struct {
+	corev1.Container
+	Prepend bool
+}
+
+var _ podMutator = (*sleepContainer)(nil)
+
+func (s sleepContainer) mutatePod(pod *corev1.Pod) error {
+	container := s.Container
+	for idx, c := range pod.Spec.Containers {
+		if c.Name == container.Name {
+			pod.Spec.Containers[idx] = container
+			return nil
+		}
+	}
+
+	pod.Spec.Containers = appendOrPrepend(container, pod.Spec.Containers, s.Prepend)
+	return nil
+}
+
 // volume is a podMutator which adds the volume to a pod.
 //
 // It will only add the volume one time based on the volume name.

--- a/releasenotes-dca/notes/add-memory-limit-buffer-482a6fbb7cf14ebc.yaml
+++ b/releasenotes-dca/notes/add-memory-limit-buffer-482a6fbb7cf14ebc.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    When the Single Step Instrumentation webhook is configured to use a library storage limit, we now add a buffer
+    container to the Pod to request the amount of memory needed for the emptyDir. This will allow Kubernetes to properly
+    account for the emptyDir usage in the Pod's memory limit.

--- a/releasenotes-dca/notes/add-memory-limit-buffer-482a6fbb7cf14ebc.yaml
+++ b/releasenotes-dca/notes/add-memory-limit-buffer-482a6fbb7cf14ebc.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    When the Single Step Instrumentation webhook is configured to use a library storage limit, we now add a buffer
-    container to the Pod to request the amount of memory needed for the emptyDir. This will allow Kubernetes to properly
-    account for the emptyDir usage in the Pod's memory limit.
+    When the Single Step Instrumentation webhook is configured with a library storage limit, the Pod now includes a
+    buffer container that requests memory for the `emptyDir`. This will allow Kubernetes to properly
+    account for the `emptyDir` usage in the Pod's memory limit.


### PR DESCRIPTION
**⚠️ Note - this change is being merged to a feature branch that we don't expect to merge into main ⚠️**

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This change adds a buffer container that requests the additional memory required for the `emptyDir` when the limit is set.

### Motivation
We are building a feature for a customer that allows them to use a memory backed `emptyDir`. As part of that change, we have added the ability to set the limit to control the size of the `emptyDir`. The problem is, the additional memory used for the tmpfs is not accounted for anywhere in the pod resources. With this change, we will account for the additional memory used by the tmpfs so that the pod will not be OOMKilled.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I've been using injector-dev:
```bash
injector-dev apply -f storage-constraints.yaml --build
```

<details>
  <summary>storage-constraints.yaml</summary>

```yaml
operator:
  apps:
  - name: python
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      image:
        repository: registry.ddbuild.io/ci/injector-dev/python
        tag: 2cd78ded
      podLabels:
        language: python
        tags.datadoghq.com/env: local
      service:
        port: "8080"
  versions:
    operator: 1.17.0
    cluster_agent:
      build: {}
    agent: 7.69.1
    injector: 0.44.0
  config:
    apiVersion: datadoghq.com/v2alpha1
    kind: DatadogAgent
    metadata:
      name: datadog
    spec:
      override:
        clusterAgent:
          # image:
          #   name: "datadog/cluster-agent-dev:mark-spicer-inplat-772-add-library-storage-medium"
          env:
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_MEDIUM"
              value: "memory"
            - name: "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_VOLUME_EMPTY_DIR_STORAGE_LIMIT"
              value: "100Mi"
      features:
        apm:
          instrumentation:
            enabled: true
            targets:
            - ddTraceVersions:
                python: default
              name: python
              podSelector:
                matchLabels:
                  language: python
```

</details>


I tested that with the storage limit, we get the buffer container with limits set. Without the storage limit, we don't get the buffer container. I also tested with multiple SDKs to ensure that only one container was added.

### Possible Drawbacks / Trade-offs
I technically am not checking the type of storage before setting the limit. I set `10m` for CPU request/limits to ensure there is a QoS class associated, but with 100 pods on a node, that would account for an additional core. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I've chosen to use the injector for the image. That feels safe given they will already need that image to be available.