### PR TITLE
[VULN-11394]Upgrading JMXFetch to 0.50.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,8 +3,8 @@
     "current_milestone": "7.71.0",
     "dependencies": {
         "OMNIBUS_RUBY_VERSION": "c760785c93689c06da59e5f38875cdeda39438c4",
-        "JMXFETCH_VERSION": "0.49.9",
-        "JMXFETCH_HASH": "0f33f0f0d95ba9286bb1c02ee39955ab6709c5b7f923d318a796a71ef2e6b706",
+        "JMXFETCH_VERSION": "0.50.0",
+        "JMXFETCH_HASH": "4a426b206132114484d6af06297ad520f77bd143daa7d946092929bb0a776b2e",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.9.0",
         "WINDOWS_DDNPM_SHASUM": "5830a4618b8aaa6b07f337801a21c48e63dd0341d860f13007b702f759e6e097",

--- a/releasenotes/notes/jmxfetch-0.50.0-4d0552859a8b6fd6.yaml
+++ b/releasenotes/notes/jmxfetch-0.50.0-4d0552859a8b6fd6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    JMXFetch upgrade to `0.50.0 <https://github.com/DataDog/jmxfetch/releases/0.50.0>` to mitigate against CVE-2025-52999.


### PR DESCRIPTION
### What does this PR do?

Upgrades JMXFetch to `0.50.0`, https://github.com/DataDog/jmxfetch/releases/tag/0.50.0.

### Motivation

This was done as version `0.50.0` removes Jackson from JMXFetch, mitigating the [CVE-2025-52999](https://nvd.nist.gov/vuln/detail/CVE-2025-52999).

### Describe how you validated your changes

The end2end tests cover JMXFetch updates.

### Possible Drawbacks / Trade-offs

Replacing Jackson with a new JSON parser may cause issues with some customer configurations.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->