### PR TITLE
[EBPF-802] gpu: add libndj4cuda.so as a library target

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -107,7 +107,8 @@ func (r *AttachRule) MatchesLibrary(path string) bool {
 	return r.canTarget(AttachToSharedLibraries) && r.LibraryNameRegex != nil && r.LibraryNameRegex.MatchString(path)
 }
 
-func (r *AttachRule) matchesExecutable(path string, procInfo *ProcInfo) bool {
+// MatchesExecutable returns true if the rule matches the given executable path
+func (r *AttachRule) MatchesExecutable(path string, procInfo *ProcInfo) bool {
 	return r.canTarget(AttachToExecutable) && (r.ExecutableFilter == nil || r.ExecutableFilter(path, procInfo))
 }
 
@@ -716,7 +717,7 @@ func (ua *UprobeAttacher) getRulesForExecutable(path string, procInfo *ProcInfo)
 	var matchedRules []*AttachRule
 
 	for _, rule := range ua.config.Rules {
-		if rule.matchesExecutable(path, procInfo) {
+		if rule.MatchesExecutable(path, procInfo) {
 			matchedRules = append(matchedRules, rule)
 		}
 	}

--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -102,7 +102,8 @@ func (r *AttachRule) canTarget(target AttachTarget) bool {
 	return r.Targets&target != 0
 }
 
-func (r *AttachRule) matchesLibrary(path string) bool {
+// MatchesLibrary returns true if the rule matches the given library path
+func (r *AttachRule) MatchesLibrary(path string) bool {
 	return r.canTarget(AttachToSharedLibraries) && r.LibraryNameRegex != nil && r.LibraryNameRegex.MatchString(path)
 }
 
@@ -703,7 +704,7 @@ func (ua *UprobeAttacher) getRulesForLibrary(path string) []*AttachRule {
 	var matchedRules []*AttachRule
 
 	for _, rule := range ua.config.Rules {
-		if rule.matchesLibrary(path) {
+		if rule.MatchesLibrary(path) {
 			matchedRules = append(matchedRules, rule)
 		}
 	}

--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -349,16 +349,16 @@ func TestRuleMatches(t *testing.T) {
 			LibraryNameRegex: regexp.MustCompile(`libssl.so`),
 			Targets:          AttachToSharedLibraries,
 		}
-		require.True(tt, rule.matchesLibrary("pkg/network/usm/testdata/site-packages/dd-trace/libssl.so.arm64"))
-		require.False(tt, rule.matchesExecutable("pkg/network/usm/testdata/site-packages/dd-trace/libssl.so.arm64", nil))
+		require.True(tt, rule.MatchesLibrary("pkg/network/usm/testdata/site-packages/dd-trace/libssl.so.arm64"))
+		require.False(tt, rule.MatchesExecutable("pkg/network/usm/testdata/site-packages/dd-trace/libssl.so.arm64", nil))
 	})
 
 	t.Run("Executable", func(tt *testing.T) {
 		rule := AttachRule{
 			Targets: AttachToExecutable,
 		}
-		require.False(tt, rule.matchesLibrary("/bin/bash"))
-		require.True(tt, rule.matchesExecutable("/bin/bash", nil))
+		require.False(tt, rule.MatchesLibrary("/bin/bash"))
+		require.True(tt, rule.MatchesExecutable("/bin/bash", nil))
 	})
 
 	t.Run("ExecutableWithFuncFilter", func(tt *testing.T) {
@@ -368,9 +368,9 @@ func TestRuleMatches(t *testing.T) {
 				return strings.Contains(path, "bash")
 			},
 		}
-		require.False(tt, rule.matchesLibrary("/bin/bash"))
-		require.True(tt, rule.matchesExecutable("/bin/bash", nil))
-		require.False(tt, rule.matchesExecutable("/bin/thing", nil))
+		require.False(tt, rule.MatchesLibrary("/bin/bash"))
+		require.True(tt, rule.MatchesExecutable("/bin/bash", nil))
+		require.False(tt, rule.MatchesExecutable("/bin/thing", nil))
 	})
 }
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -363,46 +363,58 @@ func (p *Probe) CollectConsumedEvents(ctx context.Context, count int) ([][]byte,
 	return p.consumer.debugCollector.wait(ctx)
 }
 
+// getCudaLibraryAttacherRule returns the attach rule for the CUDA libraries
+// split in a separate function to make it easier to test
+func getCudaLibraryAttacherRule() *uprobes.AttachRule {
+	return &uprobes.AttachRule{
+		LibraryNameRegex: regexp.MustCompile(`lib(cudart|nd4jcuda)\.so`),
+		Targets:          uprobes.AttachToExecutable | uprobes.AttachToSharedLibraries,
+		ProbesSelector: []manager.ProbesSelector{
+			&manager.AllOf{
+				Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaLaunchKernelProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMallocProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMallocRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaStreamSyncProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaStreamSyncRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaFreeProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventDestroyProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyRetProbe}},
+				},
+			},
+		},
+	}
+}
+
+// getLibcAttacherRule returns the attach rule for the libc library
+// split in a separate function to make it easier to test
+func getLibcAttacherRule() *uprobes.AttachRule {
+	return &uprobes.AttachRule{
+		LibraryNameRegex: regexp.MustCompile(`libc\.so`),
+		Targets:          uprobes.AttachToSharedLibraries | uprobes.AttachToExecutable,
+		ProbesSelector: []manager.ProbesSelector{
+			&manager.AllOf{
+				Selectors: []manager.ProbesSelector{
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: setenvProbe}},
+				},
+			},
+		},
+	}
+}
+
 func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 	return uprobes.AttacherConfig{
 		Rules: []*uprobes.AttachRule{
-			{
-				LibraryNameRegex: regexp.MustCompile(`lib(cudart|nd4jcuda)\.so`),
-				Targets:          uprobes.AttachToExecutable | uprobes.AttachToSharedLibraries,
-				ProbesSelector: []manager.ProbesSelector{
-					&manager.AllOf{
-						Selectors: []manager.ProbesSelector{
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaLaunchKernelProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMallocProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMallocRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaStreamSyncProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaStreamSyncRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaFreeProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeRetProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventDestroyProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyProbe}},
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyRetProbe}},
-						},
-					},
-				},
-			},
-			{
-				LibraryNameRegex: regexp.MustCompile(`libc\.so`),
-				Targets:          uprobes.AttachToSharedLibraries | uprobes.AttachToExecutable,
-				ProbesSelector: []manager.ProbesSelector{
-					&manager.AllOf{
-						Selectors: []manager.ProbesSelector{
-							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: setenvProbe}},
-						},
-					},
-				},
-			},
+			getCudaLibraryAttacherRule(),
+			getLibcAttacherRule(),
 		},
 		EbpfConfig:                     &cfg.Config,
 		PerformInitialScan:             cfg.InitialProcessSync,

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -367,7 +367,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 	return uprobes.AttacherConfig{
 		Rules: []*uprobes.AttachRule{
 			{
-				LibraryNameRegex: regexp.MustCompile(`libcudart\.so`),
+				LibraryNameRegex: regexp.MustCompile(`lib(cudart|nd4jcuda)\.so`),
 				Targets:          uprobes.AttachToExecutable | uprobes.AttachToSharedLibraries,
 				ProbesSelector: []manager.ProbesSelector{
 					&manager.AllOf{

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -273,11 +273,11 @@ func TestCudaLibraryAttacherRule(t *testing.T) {
 		t.Run(library, func(t *testing.T) {
 			require.True(t, rule.MatchesLibrary(library))
 			// Test with a suffix too
-			require.True(t, rule.MatchesLibrary(library + ".10-2"))
+			require.True(t, rule.MatchesLibrary(library+".10-2"))
 
 			// And test with a path before the library name
-			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/" + library))
-			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/" + library + ".10-2"))
+			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/"+library))
+			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/"+library+".10-2"))
 		})
 	}
 }

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -260,3 +260,24 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	require.Greater(t, pidStats.UsedCores, 0.0) // core usage depends on the time this took to run, so it's not deterministic
 	require.Equal(t, pidStats.Memory.MaxBytes, uint64(110))
 }
+
+func TestCudaLibraryAttacherRule(t *testing.T) {
+	rule := getCudaLibraryAttacherRule()
+
+	expectedLibraries := []string{
+		"libcudart.so",
+		"libnd4jcuda.so",
+	}
+
+	for _, library := range expectedLibraries {
+		t.Run(library, func(t *testing.T) {
+			require.True(t, rule.MatchesLibrary(library))
+			// Test with a suffix too
+			require.True(t, rule.MatchesLibrary(library + ".10-2"))
+
+			// And test with a path before the library name
+			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/" + library))
+			require.True(t, rule.MatchesLibrary("/usr/lib/x86_64-linux-gnu/" + library + ".10-2"))
+		})
+	}
+}

--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -89,7 +89,7 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     u64 gpu_libset_enabled = 0;
     LOAD_CONSTANT("gpu_libset_enabled", gpu_libset_enabled);
 
-    if (gpu_libset_enabled && (match6chars(0, 'c', 'u', 'd', 'a', 'r', 't'))) {
+    if (gpu_libset_enabled && (match6chars(0, 'c', 'u', 'd', 'a', 'r', 't') || match6chars(0, '4', 'j', 'c', 'u', 'd', 'a'))) {
         bpf_perf_event_output(ctx, &gpu_shared_libraries, BPF_F_CURRENT_CPU, path, sizeof(lib_path_t));
     }
 

--- a/pkg/network/usm/sharedlibraries/ebpf_test.go
+++ b/pkg/network/usm/sharedlibraries/ebpf_test.go
@@ -44,6 +44,76 @@ func TestEbpfProgram(t *testing.T) {
 	})
 }
 
+func (s *EbpfProgramSuite) TestExpectedLibrariesAreDetected() {
+	t := s.T()
+
+	cfg := ebpf.NewConfig()
+	require.NotNil(t, cfg)
+
+	libsetToSampleLibraries := map[Libset][]string{
+		LibsetCrypto: {
+			"libssl.so",
+			"libcrypto.so",
+		},
+		LibsetLibc: {
+			"libc.so",
+		},
+		LibsetGPU: {
+			"libcudart.so",
+			"libnd4jcuda.so",
+		},
+	}
+
+	for libset, libraries := range libsetToSampleLibraries {
+		t.Run(string(libset), func(t *testing.T) {
+			cfg := ebpf.NewConfig()
+			require.NotNil(t, cfg)
+
+			prog := GetEBPFProgram(cfg)
+			require.NotNil(t, prog)
+			t.Cleanup(prog.Stop)
+
+			require.NoError(t, prog.InitWithLibsets(libset))
+
+			for _, library := range libraries {
+				t.Run(library, func(t *testing.T) {
+					// Add foo prefix to ensure we only get opens from our test file
+					filename := "foo-" + library
+					tempFile, _ := createTempTestFile(t, filename)
+
+					var receivedEventMutex sync.Mutex
+					var receivedEvent *LibPath
+					unsub, err := prog.Subscribe(func(path LibPath) {
+						receivedEventMutex.Lock()
+						defer receivedEventMutex.Unlock()
+						if strings.Contains(path.String(), filename) {
+							receivedEvent = &path
+						}
+					}, libset)
+					require.NoError(t, err)
+					t.Cleanup(unsub)
+
+					command, err := fileopener.OpenFromAnotherProcess(t, tempFile)
+					require.NoError(t, err)
+					require.NotNil(t, command.Process)
+					t.Cleanup(func() {
+						command.Process.Kill()
+					})
+
+					require.Eventually(t, func() bool {
+						receivedEventMutex.Lock()
+						defer receivedEventMutex.Unlock()
+						return receivedEvent != nil
+					}, 1*time.Second, 10*time.Millisecond)
+
+					require.Equal(t, tempFile, receivedEvent.String())
+					require.Equal(t, command.Process.Pid, int(receivedEvent.Pid))
+			})
+			}
+		})
+	}
+}
+
 func (s *EbpfProgramSuite) TestCanInstantiateMultipleTimes() {
 	t := s.T()
 	cfg := ebpf.NewConfig()

--- a/pkg/network/usm/sharedlibraries/ebpf_test.go
+++ b/pkg/network/usm/sharedlibraries/ebpf_test.go
@@ -108,7 +108,7 @@ func (s *EbpfProgramSuite) TestExpectedLibrariesAreDetected() {
 
 					require.Equal(t, tempFile, receivedEvent.String())
 					require.Equal(t, command.Process.Pid, int(receivedEvent.Pid))
-			})
+				})
 			}
 		})
 	}

--- a/releasenotes/notes/gpu-libndj4cuda-7ad832f59478f2e0.yaml
+++ b/releasenotes/notes/gpu-libndj4cuda-7ad832f59478f2e0.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    gpu: Java programs using deeplearning4j are now properly detected and monitored
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.

--- a/releasenotes/notes/gpu-libndj4cuda-7ad832f59478f2e0.yaml
+++ b/releasenotes/notes/gpu-libndj4cuda-7ad832f59478f2e0.yaml
@@ -9,8 +9,3 @@
 fixes:
   - |
     gpu: Java programs using deeplearning4j are now properly detected and monitored
-other:
-  - |
-    Add here every other information you want in the CHANGELOG that
-    don't fit in any other section. This section should rarely be
-    used.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

This PR adds the `libndj4cuda.so` library as a target for the GPU probe attacher. It also changes some functions to allow better testing.

### Motivation

Ensure that Java programs that use the deeplearning4j library are probed correctly, as they use this library instead of `libcudart.so`.

### Describe how you validated your changes

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added unit tests to ensure attachment works as expected, and manually validated with a program running the Java library that we got the expected results.

### Possible Drawbacks / Trade-offs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->