### PR TITLE
maintain existing span.Meta on error

### DIFF
--- a/pkg/fleet/installer/telemetry/span.go
+++ b/pkg/fleet/installer/telemetry/span.go
@@ -67,11 +67,9 @@ func (s *Span) Finish(err error) {
 	s.span.Duration = time.Now().UnixNano() - s.span.Start
 	if err != nil {
 		s.span.Error = 1
-		s.span.Meta = map[string]string{
-			"error.message": err.Error(),
-			"error.stack":   string(debug.Stack()),
-			"error.type":    getRootErrorType(err),
-		}
+		s.setTag("error.message", err.Error())
+		s.setTag("error.stack", string(debug.Stack()))
+		s.setTag("error.type", getRootErrorType(err))
 	}
 	globalTracer.finishSpan(s)
 }
@@ -98,6 +96,11 @@ func (s *Span) SetTag(key string, value interface{}) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.setTag(key, value)
+}
+
+// setTag sets the span on the tag, requires s.mu lock to be held
+func (s *Span) setTag(key string, value interface{}) {
 	if value == nil {
 		s.span.Meta[key] = "nil"
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
maintain existing `span.Meta` on error

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1744
don't lose previously set tags

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
look at `msiexec` error spans from this `@git.commit.sha` and ensure the `params` fields are present

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
similar code from [dd-trace-go](https://github.com/DataDog/dd-trace-go/blob/c72fe0ba259fb29cd685fde13fb68c4ae497576d/ddtrace/tracer/span.go#L427-L449) sets the fields individually