### PR TITLE
Add safety check before calculating memory working set

### DIFF
--- a/pkg/util/containers/metrics/containerd/collector_cgroupv1.go
+++ b/pkg/util/containers/metrics/containerd/collector_cgroupv1.go
@@ -67,8 +67,12 @@ func getMemoryStatsCgroupV1(memStat *v1.MemoryStat) *provider.ContainerMemStats 
 
 	if memStat.Usage != nil {
 		res.UsageTotal = pointer.Ptr(float64(memStat.Usage.Usage))
-		res.WorkingSet = pointer.Ptr(float64(memStat.Usage.Usage - memStat.InactiveFile))
 		res.Limit = pointer.Ptr(float64(memStat.Usage.Limit))
+
+		// guard against buffer overflows
+		if memStat.InactiveFile < memStat.Usage.Usage {
+			res.WorkingSet = pointer.Ptr(float64(memStat.Usage.Usage - memStat.InactiveFile))
+		}
 	}
 
 	if memStat.Kernel != nil {

--- a/pkg/util/containers/metrics/containerd/collector_cgroupv2.go
+++ b/pkg/util/containers/metrics/containerd/collector_cgroupv2.go
@@ -54,7 +54,6 @@ func getMemoryStatsCgroupV2(memStat *v2.MemoryStat, memEvents *v2.MemoryEvents) 
 
 	res := provider.ContainerMemStats{
 		UsageTotal:   pointer.Ptr(float64(memStat.Usage)),
-		WorkingSet:   pointer.Ptr(float64(memStat.Usage - memStat.InactiveFile)),
 		RSS:          pointer.Ptr(float64(memStat.Anon)),
 		Cache:        pointer.Ptr(float64(memStat.File)),
 		KernelMemory: pointer.Ptr(float64(memStat.Slab + memStat.KernelStack)),
@@ -63,6 +62,11 @@ func getMemoryStatsCgroupV2(memStat *v2.MemoryStat, memEvents *v2.MemoryEvents) 
 		Pgfault:      pointer.Ptr(float64(memStat.Pgfault)),
 		Pgmajfault:   pointer.Ptr(float64(memStat.Pgmajfault)),
 		Peak:         pointer.Ptr(float64(memStat.MaxUsage)),
+	}
+
+	// guard against buffer overflows
+	if memStat.InactiveFile < memStat.Usage {
+		res.WorkingSet = pointer.Ptr(float64(memStat.Usage - memStat.InactiveFile))
 	}
 
 	if memEvents != nil {

--- a/releasenotes/notes/container-memory-working-set-bug-fix-dcfcd3a81dc8108a.yaml
+++ b/releasenotes/notes/container-memory-working-set-bug-fix-dcfcd3a81dc8108a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add a safety check before calculating the container.memory.working_set
+    metric to prevent an inflated, incorrect result (16 EiB).


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
`container.memory.working_set` is the result of `(memory.usage - memory.inactive_file)`

This PR adds a safety check to ensure that inactive file is less than usage before proceeding with the subtraction.

### Motivation
Resolve inflated metric values in response to customer escalations.

### Describe how you validated your changes
N/A

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->