### PR TITLE
Forbid calling SetWithoutSource with a struct, or outside test code

### DIFF
--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -58,7 +58,7 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKey
 	}
 	h, _ := hostname.Get(context.Background())
 	config := pkgconfigsetup.Datadog()
-	config.SetWithoutSource("serializer_compressor_kind", "none")
+	config.Set("serializer_compressor_kind", model.SourceAgentRuntime)
 	serializer := serializer.NewSerializer(forwarder, nil, selector.FromConfig(config), pkgconfigsetup.Datadog(), logger, h)
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize, utils.IsTelemetryEnabled(pkgconfigsetup.Datadog()))
 	tagsStore := tags.NewStore(pkgconfigsetup.Datadog().GetBool("aggregator_use_tags_store"), "timesampler")

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -15,6 +15,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	forwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/hosttags"
@@ -58,7 +59,7 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]utils.APIKey
 	}
 	h, _ := hostname.Get(context.Background())
 	config := pkgconfigsetup.Datadog()
-	config.Set("serializer_compressor_kind", model.SourceAgentRuntime)
+	config.Set("serializer_compressor_kind", "none", model.SourceAgentRuntime)
 	serializer := serializer.NewSerializer(forwarder, nil, selector.FromConfig(config), pkgconfigsetup.Datadog(), logger, h)
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize, utils.IsTelemetryEnabled(pkgconfigsetup.Datadog()))
 	tagsStore := tags.NewStore(pkgconfigsetup.Datadog().GetBool("aggregator_use_tags_store"), "timesampler")

--- a/pkg/config/nodetreemodel/assert.go
+++ b/pkg/config/nodetreemodel/assert.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !test
+
+package nodetreemodel
+
+import (
+	"fmt"
+)
+
+func (c *ntmConfig) assertIsTest(methodName string) {
+	panic(fmt.Errorf("assertion failed: can only call %s from test code", methodName))
+}

--- a/pkg/config/nodetreemodel/assert_testonly.go
+++ b/pkg/config/nodetreemodel/assert_testonly.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package nodetreemodel
+
+func (c *ntmConfig) assertIsTest(_ string) {
+	// nothing to do, it's okay to call this method from a test
+}

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -268,11 +268,15 @@ func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 
 }
 
-// SetWithoutSource assigns the value to the given key using source Unknown
+// SetWithoutSource assigns the value to the given key using source Unknown, may only be called from tests
 func (c *ntmConfig) SetWithoutSource(key string, value interface{}) {
+	c.assertIsTest("SetWithoutSource")
 	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
 	if v.Kind() == reflect.Struct {
-		panic("You cannot set a struct as a value")
+		panic("SetWithoutSource cannot assign struct to a setting")
 	}
 	c.Set(key, value, model.SourceUnknown)
 	keySet := make(map[string]struct{}, len(c.allSettings))

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -260,7 +260,9 @@ func TestProxy(t *testing.T) {
 		{
 			name: "from configuration",
 			setup: func(_ *testing.T, config pkgconfigmodel.Config) {
-				config.SetWithoutSource("proxy", expectedProxy)
+				config.SetWithoutSource("proxy.http", expectedProxy.HTTP)
+				config.SetWithoutSource("proxy.https", expectedProxy.HTTPS)
+				config.SetWithoutSource("proxy.no_proxy", expectedProxy.NoProxy)
 			},
 			tests: func(t *testing.T, config pkgconfigmodel.Config) {
 				assert.Equal(t, expectedProxy, config.GetProxies())

--- a/pkg/config/viperconfig/assert.go
+++ b/pkg/config/viperconfig/assert.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !test
+
+package viperconfig
+
+import (
+	"fmt"
+)
+
+func (c *safeConfig) assertIsTest(methodName string) {
+	panic(fmt.Errorf("assertion failed: can only call %s from test code", methodName))
+}

--- a/pkg/config/viperconfig/assert_testonly.go
+++ b/pkg/config/viperconfig/assert_testonly.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package viperconfig
+
+func (c *safeConfig) assertIsTest(_ string) {
+	// nothing to do, it's okay to call this method from a test
+}

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -130,8 +130,16 @@ func (c *safeConfig) Set(key string, newValue interface{}, source model.Source) 
 	c.sendNotification(key, source, oldValue, latestValue, c.sequenceID)
 }
 
-// SetWithoutSource sets the given value using source Unknown
+// SetWithoutSource sets the given value using source Unknown, may only be called from tests
 func (c *safeConfig) SetWithoutSource(key string, value interface{}) {
+	c.assertIsTest("SetWithoutSource")
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Struct {
+		panic("SetWithoutSource cannot assign struct to a setting")
+	}
 	c.Set(key, value, model.SourceUnknown)
 }
 

--- a/pkg/process/runner/collector_api_test.go
+++ b/pkg/process/runner/collector_api_test.go
@@ -38,7 +38,7 @@ func setProcessEndpointsForTest(config pkgconfigmodel.Config, eps ...apicfg.Endp
 	for i, ep := range eps {
 		if i == 0 {
 			config.SetWithoutSource("api_key", ep.APIKey)
-			config.SetWithoutSource("process_config.process_dd_url", ep.Endpoint)
+			config.SetWithoutSource("process_config.process_dd_url", ep.Endpoint.String())
 		} else {
 			additionalEps[ep.Endpoint.String()] = append(additionalEps[ep.Endpoint.String()], ep.APIKey)
 		}
@@ -51,7 +51,7 @@ func setProcessEventsEndpointsForTest(config pkgconfigmodel.Config, eps ...apicf
 	for i, ep := range eps {
 		if i == 0 {
 			config.SetWithoutSource("api_key", ep.APIKey)
-			config.SetWithoutSource("process_config.events_dd_url", ep.Endpoint)
+			config.SetWithoutSource("process_config.events_dd_url", ep.Endpoint.String())
 		} else {
 			additionalEps[ep.Endpoint.String()] = append(additionalEps[ep.Endpoint.String()], ep.APIKey)
 		}


### PR DESCRIPTION
### What does this PR do?

Disallow calling SetWithoutSource unless in test code. This method should only be called from tests.

Disallow calling SetWithoutSource with a struct shaped parameter. Only plain data types, those that can be obtained by parsing yaml, should be assigned to the config's data model.

### Motivation

Stop relying on viper's implicit conversion of types. The in-memory config should have a consistent data model.

### Describe how you validated your changes

Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
