### PR TITLE
Fix README check example to work with new check API

### DIFF
--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -61,6 +61,10 @@ inherits from `AgentCheck` and implements the `check` method:
 from datadog_checks.checks import AgentCheck
 
 class MyCheck(AgentCheck):
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
+        # Read config, set up instances, initialize checks
+        # ...
     def check(self, instance):
         # Collect metrics, emit events, submit service checks,
         # ...
@@ -135,11 +139,21 @@ checks code.
 Scenario: You have implemented a custom check called `hello_world` and you would
 like to run this with a local Agent build.
 
+Example contents of `hello_world.yaml`:
+```yaml
+instances:
+  - only_one_instance: true
+```
+
+The contents of the instance item are not important, but if an instance is not present the agent will not run the check.
+
 Example contents of `hello_world.py`:
 ```python
 from datadog_checks.checks import AgentCheck
 
 class MyCheck(AgentCheck):
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
     def check(self, instance):
         self.gauge('hello.world', 1.23, tags=['foo:bar'])
 ```


### PR DESCRIPTION
The "hello world" custom check example in the documentation does not actually work, as there are two main problems:

* The check class requires a constructor, which must in turn call the constructor for the AgentCheck class
* The YAML config for the new custom check needs an `instances` section which defines at least one instance

### What does this PR do?
Fix some documentation.

### Motivation
Our documentation should lead users down a path that works.

### Describe how you validated your changes
I followed the steps in the existing documentation. They did not work. I iterated until I got something working, then modified the documentation to match what I did to make it work.

### Possible Drawbacks / Trade-offs

### Additional Notes
