### PR TITLE
[CWS] introduce concept of user facing event type category

### DIFF
--- a/pkg/security/probe/eventstream/monitor.go
+++ b/pkg/security/probe/eventstream/monitor.go
@@ -612,7 +612,7 @@ func (pbm *Monitor) collectAndSendKernelStats(client statsd.ClientInterface) err
 			// retrieve event type from key
 			evtType := model.EventType(id % uint32(model.MaxKernelEventType))
 			tags[2] = fmt.Sprintf("event_type:%s", evtType)
-			tags[3] = fmt.Sprintf("category:%s", model.GetEventTypeCategory(evtType.String()))
+			tags[3] = fmt.Sprintf("category:%s", model.GetEventTypeCategoryUserFacing(evtType.String()))
 
 			// loop over each cpu entry
 			for cpu, stats := range perCPUMapStats {

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -13,18 +13,32 @@ import (
 )
 
 // EventCategory category type
-type EventCategory = string
+type EventCategory int
 
 // Event categories
 const (
 	// FIMCategory FIM events
-	FIMCategory EventCategory = "File Activity"
+	FIMCategory EventCategory = iota
 	// ProcessCategory process events
-	ProcessCategory EventCategory = "Process Activity"
+	ProcessCategory
 	// KernelCategory Kernel events
-	KernelCategory EventCategory = "Kernel Activity"
+	KernelCategory
 	// NetworkCategory network events
-	NetworkCategory EventCategory = "Network Activity"
+	NetworkCategory
+)
+
+// EventCategoryUserFacing user facing category type
+type EventCategoryUserFacing string
+
+const (
+	// FIMCategoryUserFacing FIM events
+	FIMCategoryUserFacing EventCategoryUserFacing = "File Activity"
+	// ProcessCategoryUserFacing process events
+	ProcessCategoryUserFacing EventCategoryUserFacing = "Process Activity"
+	// KernelCategoryUserFacing Kernel events
+	KernelCategoryUserFacing EventCategoryUserFacing = "Kernel Activity"
+	// NetworkCategoryUserFacing network events
+	NetworkCategoryUserFacing EventCategoryUserFacing = "Network Activity"
 )
 
 // GetAllCategories returns all categories
@@ -75,6 +89,29 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 	}
 
 	return FIMCategory
+}
+
+// GetEventTypeCategoryUserFacing returns the category for the given event type
+func GetEventTypeCategoryUserFacing(eventType eval.EventType) EventCategoryUserFacing {
+	switch eventType {
+	case
+		BindEventType.String(),
+		ConnectEventType.String():
+		return NetworkCategoryUserFacing
+	}
+
+	switch GetEventTypeCategory(eventType) {
+	case FIMCategory:
+		return FIMCategoryUserFacing
+	case ProcessCategory:
+		return ProcessCategoryUserFacing
+	case KernelCategory:
+		return KernelCategoryUserFacing
+	case NetworkCategory:
+		return NetworkCategoryUserFacing
+	}
+
+	panic("unknown category for given event type")
 }
 
 // GetEventTypePerCategory returns the event types per category

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -509,7 +509,7 @@ func (rs *RuleSet) WithExcludedRuleFromDiscarders(excludedRuleFromDiscarders map
 }
 
 // AddRule creates the rule evaluator and adds it to the bucket of its events
-func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule) (model.EventCategory, error) {
+func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule) (model.EventCategoryUserFacing, error) {
 	if pRule.Def.Disabled {
 		return "", nil
 	}
@@ -530,7 +530,7 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule
 
 	expandedRules := expandFim(pRule.Def.ID, pRule.Def.GroupID, pRule.Def.Expression)
 
-	categories := make([]model.EventCategory, 0)
+	categories := make([]model.EventCategoryUserFacing, 0)
 	for _, er := range expandedRules {
 		category, err := rs.innerAddExpandedRule(parsingContext, pRule, er, tags)
 		if err != nil {
@@ -545,7 +545,7 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule
 	return categories[0], nil
 }
 
-func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRule *PolicyRule, exRule expandedRule, tags []string) (model.EventCategory, error) {
+func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRule *PolicyRule, exRule expandedRule, tags []string) (model.EventCategoryUserFacing, error) {
 	evalRule, err := eval.NewRule(exRule.id, exRule.expr, parsingContext, rs.evalOpts, tags...)
 	if err != nil {
 		return "", &ErrRuleLoad{Rule: pRule, Err: &ErrRuleSyntax{Err: err}}
@@ -641,7 +641,7 @@ func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRul
 
 	rs.rules[pRule.Def.ID] = rule
 
-	return model.GetEventTypeCategory(eventType), nil
+	return model.GetEventTypeCategoryUserFacing(eventType), nil
 }
 
 // NotifyRuleMatch notifies all the ruleset listeners that an event matched a rule

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -448,7 +448,7 @@ func NewBaseEventSerializer(event *model.Event, rule *rules.Rule) *BaseEventSeri
 		}
 	}
 
-	s.Category = model.GetEventTypeCategory(eventType.String())
+	s.Category = string(model.GetEventTypeCategoryUserFacing(eventType.String()))
 
 	switch eventType {
 	case model.ExitEventType:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We currently have one event category type that is being use for 2 different orthogonal goals:
- extract a user facing event category ("Kernel Activity", "File Activity", etc)
- use it for probe selection: especially the Network category that we use to enable the network specific TC probes

This causes an issue because we have some events that are network from a user point of view (connect and bind) but that are kernel from the point of view of the probe (since they use regular kprobes and not the TC stuff).

This PR fixes this by splitting the event category into 2 types, each matching one use case.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->