### PR TITLE
[USMON-1456] Use MapCleaner on demand API

### DIFF
--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"time"
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -439,6 +440,13 @@ var opensslSpec = &protocols.ProtocolSpec{
 	},
 }
 
+var (
+	// The interval of the periodic scan for terminated processes. Increasing the interval, might cause larger spikes in cpu
+	// and lowering it might cause constant cpu usage.
+	// Defined as a var to allow tests to override it.
+	nativeTLSScanTerminatedProcessesInterval = 30 * time.Second
+)
+
 type sslProgram struct {
 	cfg         *config.Config
 	attacher    *uprobes.UprobeAttacher
@@ -491,6 +499,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 		PerformInitialScan:             true,
 		EnablePeriodicScanNewProcesses: true,
 		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetCrypto},
+		ScanProcessesInterval:          nativeTLSScanTerminatedProcessesInterval,
 		EnableDetailedLogging:          false,
 		OnSyncCallback:                 o.cleanupDeadPids,
 	}

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -479,6 +479,10 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 			LibraryNameRegex: regexp.MustCompile(`libgnutls.so`),
 		},
 	}
+	o := &sslProgram{
+		cfg:         c,
+		ebpfManager: m,
+	}
 	attacherConfig := uprobes.AttacherConfig{
 		ProcRoot:                       procRoot,
 		Rules:                          rules,
@@ -488,15 +492,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 		EnablePeriodicScanNewProcesses: true,
 		SharedLibsLibsets:              []sharedlibraries.Libset{sharedlibraries.LibsetCrypto},
 		EnableDetailedLogging:          false,
-	}
-
-	o := &sslProgram{
-		cfg:         c,
-		ebpfManager: m,
-	}
-
-	if features.HaveProgramType(ebpf.RawTracepoint) != nil {
-		attacherConfig.OnSyncCallback = o.cleanupDeadPids
+		OnSyncCallback:                 o.cleanupDeadPids,
 	}
 
 	var err error

--- a/pkg/network/usm/ebpf_ssl_test.go
+++ b/pkg/network/usm/ebpf_ssl_test.go
@@ -9,11 +9,13 @@ package usm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	nethttp "net/http"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 	"unsafe"
@@ -34,6 +36,15 @@ import (
 const (
 	addressOfHTTPPythonServer = "127.0.0.1:8001"
 )
+
+// setNativeTLSPeriodicTerminatedProcessesScanInterval sets the interval for the periodic scan of terminated processes in GoTLS.
+func setNativeTLSPeriodicTerminatedProcessesScanInterval(tb testing.TB, interval time.Duration) {
+	originalValue := nativeTLSScanTerminatedProcessesInterval
+	tb.Cleanup(func() {
+		nativeTLSScanTerminatedProcessesInterval = originalValue
+	})
+	nativeTLSScanTerminatedProcessesInterval = interval
+}
 
 func testArch(t *testing.T, arch string) {
 	cfg := utils.NewUSMEmptyConfig()
@@ -69,9 +80,26 @@ func TestArchArm64(t *testing.T) {
 	testArch(t, "arm64")
 }
 
+// findNonExistingPid finds a PID that doesn't exist on the system
+func findNonExistingPid(t *testing.T) int {
+	// Start from a high number to avoid common system PIDs
+	for pid := 100000; pid < 1000000; pid++ {
+		// On Linux, kill(pid, 0) returns 0 if process exists, -1 if it doesn't
+		if err := syscall.Kill(pid, 0); err != nil {
+			if errors.Is(err, syscall.ESRCH) { // No such process
+				return pid
+			}
+		}
+	}
+	t.Log("Failed to find a non-existing PID")
+	t.FailNow()
+	return 0
+}
+
 // TestSSLMapsCleaner verifies that SSL-related kernel maps are cleared correctly.
 // the map entry is deleted when the thread exits, also periodic map cleaner removes dead threads.
 func TestSSLMapsCleaner(t *testing.T) {
+	setNativeTLSPeriodicTerminatedProcessesScanInterval(t, time.Second)
 	// setup monitor
 	cfg := utils.NewUSMEmptyConfig()
 	cfg.EnableNativeTLSMonitoring = true
@@ -87,17 +115,19 @@ func TestSSLMapsCleaner(t *testing.T) {
 	cleanProtocolMaps(t, bioNewSocketArgsMap, monitor.ebpfProgram.Manager.Manager)
 
 	// find maps by names
+	sslPidKeyMaps := []string{sslReadArgsMap, sslReadExArgsMap, sslWriteArgsMap, sslWriteExArgsMap, bioNewSocketArgsMap}
 	maps := getMaps(t, monitor.ebpfProgram.Manager.Manager, sslPidKeyMaps)
 	require.Equal(t, len(maps), len(sslPidKeyMaps))
 
 	// add random pid to the maps
-	pid := 100
+	pid := findNonExistingPid(t)
 	addPidEntryToMaps(t, maps, pid)
 	checkPidExistsInMaps(t, monitor.ebpfProgram.Manager.Manager, maps, pid)
 
 	// verify that map is empty after cleaning up terminated processes
-	cleanDeadPidsInSslMaps(t, monitor.ebpfProgram.Manager.Manager)
-	checkPidNotFoundInMaps(t, monitor.ebpfProgram.Manager.Manager, maps, pid)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		checkPidNotFoundInMaps(t, ct, monitor.ebpfProgram.Manager.Manager, maps, pid)
+	}, 10*time.Second, 1*time.Second, "pid was not removed from the maps after process exit")
 
 	// start dummy program and add its pid to the map
 	cmd, cancel := startDummyProgram(t)
@@ -107,7 +137,7 @@ func TestSSLMapsCleaner(t *testing.T) {
 	// verify exit of process cleans the map
 	cancel()
 	_ = cmd.Wait()
-	checkPidNotFoundInMaps(t, monitor.ebpfProgram.Manager.Manager, maps, cmd.Process.Pid)
+	checkPidNotFoundInMaps(t, t, monitor.ebpfProgram.Manager.Manager, maps, cmd.Process.Pid)
 }
 
 // getMaps returns eBPF maps searched by names.
@@ -157,7 +187,7 @@ func checkPidExistsInMaps(t *testing.T, manager *manager.Manager, maps []*ebpf.M
 }
 
 // checkPidNotFoundInMaps checks that pid does not exist in all provided maps.
-func checkPidNotFoundInMaps(t *testing.T, manager *manager.Manager, maps []*ebpf.Map, pid int) {
+func checkPidNotFoundInMaps(originalT *testing.T, t require.TestingT, manager *manager.Manager, maps []*ebpf.Map, pid int) {
 	// make the key for single thread process when pid and tgid are the same
 	key := uint64(pid)<<32 | uint64(pid)
 
@@ -167,8 +197,8 @@ func checkPidNotFoundInMaps(t *testing.T, manager *manager.Manager, maps []*ebpf
 		require.NoError(t, err)
 
 		if findKeyInMap[uint64](m, key) {
-			t.Logf("pid '%d' was found in the map %q", pid, mapInfo.Name)
-			ebpftest.DumpMapsTestHelper(t, manager.DumpMaps, mapInfo.Name)
+			originalT.Logf("pid '%d' was found in the map %q", pid, mapInfo.Name)
+			ebpftest.DumpMapsTestHelper(originalT, manager.DumpMaps, mapInfo.Name)
 			t.FailNow()
 		}
 	}
@@ -190,14 +220,6 @@ func startDummyProgram(t *testing.T) (*exec.Cmd, context.CancelFunc) {
 	require.NoError(t, err)
 
 	return cmd, cancel
-}
-
-// cleanDeadPidsInSslMap delete terminated pid entries in the SSL maps.
-func cleanDeadPidsInSslMaps(t *testing.T, manager *manager.Manager) {
-	for _, mapName := range sslPidKeyMaps {
-		err := deleteDeadPidsInMap(manager, mapName, nil)
-		require.NoError(t, err)
-	}
 }
 
 // TestSSLMapsCleanup verifies that the eBPF cleanup mechanism


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Always enable user-mode map cleaner for SSL maps
* Replaces manual cleanup of the maps with MapCleaner on demand calls

### Motivation

* MapCleaner is more performent, as it uses BatchAPI whenever possible
* Adding another layer to clean maps, and prevent leaks.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->