### PR TITLE
Adjust Omnibus env variable pass-through logic

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -73,6 +73,12 @@ OS_SPECIFIC_ENV_PASSTHROUGH = {
         'VSTUDIO_ROOT': 'For symbol inspector',
         'WINDIR': 'Windows operating system directory',
         'WINDOWS_BUILDER': 'Used to decide whether to assume a role for S3 access',
+        'WINDOWS_DDNPM_DRIVER': 'Windows Network Driver',
+        'WINDOWS_DDNPM_VERSION': 'Windows Network Driver Version',
+        'WINDOWS_DDNPM_SHASUM': 'Windows Network Driver Checksum',
+        'WINDOWS_DDPROCMON_DRIVER': 'Windows Kernel Procmon Driver',
+        'WINDOWS_DDPROCMON_VERSION': 'Windows Kernel Procmon Driver Version',
+        'WINDOWS_DDPROCMON_SHASUM': 'Windows Kernel Procmon Driver Checksum',
     },
     'linux': {
         'DEB_GPG_KEY': 'Used to sign packages',

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -90,27 +90,19 @@ def get_omnibus_env(
 ):
     env = load_dependencies(ctx)
 
-    windows_only_vars = [
-        'WINDOWS_DDNPM_DRIVER',
-        'WINDOWS_DDNPM_VERSION',
-        'WINDOWS_DDNPM_SHASUM',
-        'WINDOWS_DDPROCMON_DRIVER',
-        'WINDOWS_DDPROCMON_VERSION',
-        'WINDOWS_DDPROCMON_SHASUM',
-    ]
-    # Discard windows variables when not on Windows
+    # Discard windows variables when not on Windows (so that they're not used in the cache key either)
     if sys.platform != 'win32':
+        windows_only_vars = [
+            'WINDOWS_DDNPM_DRIVER',
+            'WINDOWS_DDNPM_VERSION',
+            'WINDOWS_DDNPM_SHASUM',
+            'WINDOWS_DDPROCMON_DRIVER',
+            'WINDOWS_DDPROCMON_VERSION',
+            'WINDOWS_DDPROCMON_SHASUM',
+        ]
         for var in windows_only_vars:
             if var in env:
                 del env[var]
-
-    else:
-        # if any of windows vars set in env keep them
-        for key in windows_only_vars:
-            value = os.environ.get(key)
-            # Only overrides the env var if the value is a non-empty string.
-            if value:
-                env[key] = value
 
     # If the host has a GOMODCACHE set, try to reuse it
     if not go_mod_cache and os.environ.get('GOMODCACHE'):


### PR DESCRIPTION
### What does this PR do?

- Reuse existing logic for overriding windows driver variables if present in the environment.
- ~~Skip empty variables from the environment on the pass-through logic.~~ (can't be done, as we rely on [this](https://github.com/DataDog/datadog-agent-buildimages/blob/475a6a2b0bbb2e09d01b8e36fafcb63bc5b1a666/linux/Dockerfile#L218) empty `PKG_CONFIG_LIBDIR` variable).

### Motivation

Follow-up to #39946.

### Describe how you validated your changes

CI (and a look at the logs) should be enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->