### PR TITLE
fix(invoke-unit-tests): Do not use the regular CODEOWNERS file

### DIFF
--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -48,14 +48,14 @@ class TestSplitJUnitXML(unittest.TestCase):
 
     def test_without_split(self):
         xml_file = Path("./tasks/unit_tests/testdata/secret.tar.gz/bedroom-rspec-win2016-azure-x86_64.xml")
-        owners = read_owners(".github/CODEOWNERS")
+        owners = read_owners("./tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS")
         self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, {}, {}), 1)
         generated_folder = xml_file.parent / "windows-products_base"
         self.assertTrue(generated_folder.exists())
 
     def test_with_split(self):
         xml_file = Path("./tasks/unit_tests/testdata/secret.tar.gz/-go-src-datadog-agent-junit-out-base.xml")
-        owners = read_owners(".github/CODEOWNERS")
+        owners = read_owners("./tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS")
         self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, {}, {}), 27)
 
 
@@ -120,6 +120,7 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
         junit.junit_upload_from_tgz(
             "tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz",
             "tasks/unit_tests/testdata/test_output_no_failure.json",
+            "tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS",
         )
         mock_check_call.assert_called()
         self.assertEqual(mock_check_call.call_count, 29)
@@ -130,7 +131,7 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
             for k in tmp_dir_vars:
                 self.assertIn(k, env)
             last_tmp_dir = env[tmp_dir_vars[-1]]
-            self.assertDictEqual({k: env[k] for k in tmp_dir_vars}, {k: last_tmp_dir for k in tmp_dir_vars})
+            self.assertDictEqual({k: env[k] for k in tmp_dir_vars}, dict.fromkeys(tmp_dir_vars, last_tmp_dir))
             self.assertNotIn(last_tmp_dir, seen_tmp_dirs)
             self.assertFalse(Path(last_tmp_dir).exists())
             seen_tmp_dirs.add(last_tmp_dir)
@@ -150,6 +151,7 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
             junit.junit_upload_from_tgz(
                 "tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz",
                 "tasks/unit_tests/testdata/test_output_no_failure.json",
+                "tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS",
             )
         mock_check_call.assert_called()
         self.assertEqual(mock_check_call.call_count, 29)

--- a/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
+++ b/tasks/unit_tests/testdata/TEST_JUNIT_CODEOWNERS
@@ -1,0 +1,777 @@
+# Package code owners
+
+# The listed owners will be automatically added as reviewers for PRs,
+# to ensure code quality and consistency of the package, and identify
+# possible side effects.
+# PRs should still be peer-reviewed by the team opening the PR
+
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another the rest of the directory.
+
+# When adding a new team to this file, don't forget to assign it
+# a slack channel in tasks/libs/pipeline_notifications.py
+
+# Config files for various CI systems / tasks
+/.*                                     @DataDog/agent-devx
+# changing the config of mockery will regenerate the mocks, so owners will have to review anyway
+/.mockery.yaml                          # do not notify anyone
+/.go-version                            @DataDog/agent-runtimes @DataDog/agent-build
+# Go linters and pre-commit config
+/.golangci.yml                          @DataDog/agent-devx
+/.custom-gcl.yml                        @DataDog/agent-devx
+/.pre-commit-config.yaml                @DataDog/agent-devx
+/.vscode/                               @DataDog/agent-devx
+
+# Bazel configuration
+/.bazel*                                @DataDog/agent-build
+/bazel/                                 @DataDog/agent-build
+/MODULE.bazel*                          @DataDog/agent-build
+# Temporary during Bazel migration
+/**/BUILD.bazel                         @DataDog/agent-build
+
+/CHANGELOG.rst                          @DataDog/agent-delivery
+/CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
+/CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery @DataDog/agent-onboarding
+
+/*.md                                   @DataDog/agent-devx
+/NOTICE                                 @DataDog/agent-delivery
+
+/LICENSE*                               # do not notify anyone
+
+/mkdocs.yml                             @DataDog/agent-devx
+/release.json                           @DataDog/agent-build @DataDog/agent-delivery @DataDog/agent-integrations
+/renovate.json                          @DataDog/agent-devx
+/pyproject.toml                         @DataDog/agent-devx
+/repository.datadog.yml                 @DataDog/agent-devx
+/generate_tools.go                      @DataDog/agent-devx
+/service.datadog.yaml                   @DataDog/agent-delivery @DataDog/agent-devx
+/static-analysis.datadog.yml            @DataDog/agent-devx
+
+/modules.yml                            @DataDog/agent-runtimes
+# if go.work changes then either .go-version or modules.yml changed too, so ASC might as well own it
+/go.work                                @DataDog/agent-runtimes
+
+/.github/CODEOWNERS                                  # do not notify anyone
+/.github/*_TEMPLATE.md                               @DataDog/agent-devx
+/.github/dependabot.yaml                             @DataDog/agent-devx
+/.github/workflows/serverless-benchmarks.yml         @DataDog/serverless @Datadog/serverless-aws
+/.github/workflows/serverless-binary-size.yml        @DataDog/serverless @Datadog/serverless-aws
+/.github/workflows/serverless-integration.yml        @DataDog/serverless @Datadog/serverless-aws
+/.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security
+/.github/workflows/gohai.yml                         @DataDog/agent-configuration
+/.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes
+/.github/workflows/update_dependencies.yml           @DataDog/agent-runtimes
+/.github/workflows/buildimages-update.yml            @DataDog/agent-build @DataDog/agent-runtimes
+/.github/workflows/collector-generate-and-update.yml @DataDog/opentelemetry-agent
+
+/.github/chainguard/self.buildimages-update.*            @DataDog/agent-build @DataDog/agent-runtimes
+/.github/chainguard/self.collector-generate-and-update.* @DataDog/opentelemetry-agent
+/.github/chainguard/self.cws-btfhub-sync*               @DataDog/agent-security
+/.github/chainguard/*                             @DataDog/agent-devx @DataDog/agent-build
+
+/.run                                                @DataDog/agent-devx
+/.run/docker/                                        @DataDog/container-integrations @DataDog/container-platform
+
+/skaffold.yaml                                       @DataDog/agent-devx @DataDog/container-platform
+/.run/skaffold/                                      @DataDog/agent-devx @DataDog/container-platform
+
+# Gitlab files
+# Files containing job contents are owned by teams in charge of the jobs + agent-devx or agent-delivery or agent-build
+# Files that only describe structure (eg. includes, rules) are owned by agent-devx
+
+/.gitlab/.ci-linters.yml                             @DataDog/agent-devx
+/.gitlab/.pre/*                                      @DataDog/agent-devx
+/.gitlab/check_deploy/*                              @DataDog/agent-delivery
+/.gitlab/check_merge/*                               @DataDog/agent-devx
+/.gitlab/deploy*/*                                   @DataDog/agent-delivery
+/.gitlab/deps_fetch/*                                @DataDog/agent-devx
+/.gitlab/e2e/*                                       @DataDog/agent-devx
+/.gitlab/e2e_testing_deploy/*                        @DataDog/agent-devx
+/.gitlab/e2e_install_packages/*                      @DataDog/agent-onboarding
+/.gitlab/e2e_pre_test/*                              @DataDog/agent-devx
+/.gitlab/kernel_matrix_testing/*                     @DataDog/agent-devx @DataDog/ebpf-platform
+/.gitlab/lint/*                                      @DataDog/agent-devx
+/.gitlab/maintenance_jobs/*                          @DataDog/agent-devx
+/.gitlab/notify/*                                    @DataDog/agent-devx
+/.gitlab/pkg_metrics/*                               @DataDog/agent-devx
+/.gitlab/post_rc_build/*                             @DataDog/agent-devx
+/.gitlab/setup/*                                     @DataDog/agent-devx
+/.gitlab/trigger_distribution/*                      @DataDog/agent-delivery
+/.gitlab/trigger_release/*                           @DataDog/agent-devx @DataDog/agent-delivery
+
+/.gitlab/binary_build/cws_instrumentation.yml        @DataDog/agent-devx @DataDog/agent-security
+/.gitlab/binary_build/include.yml                    @DataDog/agent-devx
+/.gitlab/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-build
+/.gitlab/functional_test/include.yml                 @DataDog/agent-devx
+/.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-build
+/.gitlab/install_script_testing/install_script_testing.yml          @DataDog/agent-build @DataDog/agent-onboarding
+/.gitlab/integration_test/dogstatsd.yml              @DataDog/agent-devx @DataDog/agent-metric-pipelines
+/.gitlab/integration_test/include.yml                @DataDog/agent-devx
+/.gitlab/integration_test/linux.yml                  @DataDog/agent-devx
+/.gitlab/integration_test/otel.yml                   @DataDog/agent-devx @DataDog/opentelemetry-agent
+/.gitlab/internal_image_deploy/internal_image_deploy.yml            @DataDog/agent-delivery
+/.gitlab/internal_kubernetes_deploy/include.yml                     @DataDog/agent-devx
+/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml  @DataDog/agent-delivery
+/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml        @DataDog/agent-delivery
+/.gitlab/package_deps_build/package_deps_build.yml   @DataDog/agent-devx @DataDog/ebpf-platform
+/.gitlab/source_test/golang_deps_diff.yml            @DataDog/agent-devx
+/.gitlab/source_test/*                               @DataDog/agent-devx
+/.gitlab/source_test/linux.yml                       @DataDog/agent-devx
+/.gitlab/source_test/macos.yml                       @DataDog/agent-devx
+/.gitlab/source_test/notify.yml                      @DataDog/agent-devx
+/.gitlab/source_test/slack.yml                       @DataDog/agent-devx
+/.gitlab/source_test/tooling_unit_tests.yml          @DataDog/agent-devx
+
+/.gitlab/binary_build/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-build
+/.gitlab/binary_build/cluster_agent.yml              @DataDog/container-integrations @DataDog/agent-build
+/.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-devx
+/.gitlab/binary_build/serverless.yml                 @DataDog/serverless @Datadog/serverless-aws @DataDog/agent-build
+/.gitlab/binary_build/otel_agent.yml                 @DataDog/opentelemetry-agent @DataDog/agent-build
+/.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-build
+/.gitlab/binary_build/windows.yml                    @DataDog/agent-build @DataDog/windows-products
+
+/.gitlab/source_test/codeql_scan.yml                 @DataDog/sdlc-security
+
+/.gitlab/benchmarks/                                 @DataDog/agent-devx @DataDog/apm-ecosystems-performance @DataDog/agent-apm
+
+/.gitlab/deploy_containers/                          @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/deploy_dca/                                 @DataDog/container-integrations @DataDog/agent-delivery
+
+/.gitlab/deploy_packages/                               @DataDog/agent-delivery
+/.gitlab/deploy_packages/oci.yml                        @DataDog/agent-delivery @DataDog/fleet
+/.gitlab/deploy_packages/windows.yml                    @DataDog/agent-delivery @DataDog/windows-products
+/.gitlab/deploy_packages/winget.yml                     @DataDog/agent-delivery @DataDog/windows-products
+/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-devx
+/.gitlab/deploy_packages/e2e.yml                        @DataDog/agent-devx @DataDog/agent-e2e-testing @DataDog/fleet
+
+/.gitlab/deps_build/                                 @DataDog/ebpf-platform @DataDog/agent-build @DataDog/windows-products
+
+/.gitlab/e2e_install_packages/windows.yml            @DataDog/agent-onboarding @DataDog/windows-products
+
+/.gitlab/common/                                     @DataDog/agent-devx
+/.gitlab/common/test_infra_version.yml               @DataDog/agent-devx
+
+/.gitlab/e2e/e2e.yml                                 @DataDog/container-integrations @DataDog/agent-devx
+/.gitlab/container_build/fakeintake.yml              @DataDog/agent-e2e-testing @DataDog/agent-devx
+/.gitlab/binary_build/fakeintake.yml                 @DataDog/agent-e2e-testing @DataDog/agent-devx
+
+/.gitlab/functional_test/oracle.yml                  @DataDog/agent-devx @DataDog/database-monitoring
+
+/.gitlab/choco_build/choco_build.yml                 @DataDog/agent-build @DataDog/windows-products
+
+/.gitlab/integration_test/windows.yml                @DataDog/agent-devx @DataDog/windows-products
+
+/.gitlab/kernel_matrix_testing                       @DataDog/ebpf-platform
+/.gitlab/kernel_matrix_testing/security_agent.yml    @DataDog/agent-security
+
+/.gitlab/common/container_publish_job_templates.yml  @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/container_build/                            @DataDog/container-integrations @DataDog/agent-build
+/.gitlab/container_build/include.yml                 @DataDog/container-integrations @DataDog/agent-build
+/.gitlab/container_build/docker_windows*             @DataDog/agent-build @DataDog/windows-products
+
+/.gitlab/dev_container_deploy/                       @DataDog/container-integrations @DataDog/agent-delivery
+/.gitlab/dev_container_deploy/fakeintake.yml         @DataDog/agent-devx
+/.gitlab/dev_container_deploy/e2e.yml                @DataDog/agent-devx @DataDog/agent-e2e-testing
+/.gitlab/dev_container_deploy/docker_windows.yml     @DataDog/agent-delivery @DataDog/windows-products
+
+/.gitlab/container_scan/container_scan.yml           @DataDog/container-integrations @DataDog/agent-delivery
+
+
+/.gitlab/maintenance_jobs/docker.yml                 @DataDog/container-integrations @DataDog/agent-delivery
+
+/.gitlab/source_test/ebpf.yml                        @DataDog/ebpf-platform @DataDog/agent-devx
+/.gitlab/source_test/windows.yml                     @DataDog/agent-devx @DataDog/windows-products
+/.gitlab/source_test/go_generate_check.yml           @DataDog/agent-security
+
+/.gitlab/package_build/                              @DataDog/agent-build
+/.gitlab/package_build/windows.yml                   @DataDog/agent-build @DataDog/windows-products
+/.gitlab/package_build/installer.yml                 @DataDog/agent-build @DataDog/fleet
+/.gitlab/packaging/                                  @DataDog/agent-build
+
+/.gitlab/benchmarks/benchmarks.yml                   @DataDog/agent-apm
+
+/.gitlab/functional_test/regression_detector.yml     @DataDog/single-machine-performance
+
+
+
+/chocolatey/                            @DataDog/windows-products
+
+/cmd/                                   @DataDog/agent-configuration
+/cmd/trace-agent/                       @DataDog/agent-apm
+/cmd/agent/subcommands/controlsvc       @DataDog/windows-products
+/cmd/agent/subcommands/check            @DataDog/agent-runtimes @DataDog/agent-integrations
+/cmd/agent/subcommands/dogstatsd*       @DataDog/agent-metric-pipelines
+/cmd/agent/subcommands/integrations     @DataDog/agent-integrations @DataDog/agent-runtimes
+/cmd/agent/subcommands/hostname         @DataDog/agent-runtimes
+/cmd/agent/subcommands/version          @DataDog/agent-runtimes
+/cmd/agent/subcommands/remoteconfig     @Datadog/remote-config
+/cmd/agent/subcommands/snmp             @DataDog/ndm-core
+/cmd/agent/subcommands/streamlogs       @DataDog/agent-log-pipelines
+/cmd/agent/subcommands/analyzelogs      @DataDog/agent-log-pipelines
+/cmd/agent/subcommands/streamep         @DataDog/container-integrations
+/cmd/agent/subcommands/taggerlist       @DataDog/container-platform
+/cmd/agent/subcommands/workloadlist     @DataDog/container-platform
+/cmd/agent/subcommands/run/internal/clcrunnerapi/       @DataDog/container-platform
+/cmd/agent/windows                      @DataDog/windows-products
+/cmd/agent/windows_resources            @DataDog/windows-products
+/cmd/agent/dist/conf.d/container.d/     @DataDog/container-integrations
+/cmd/agent/dist/conf.d/containerd.d/    @DataDog/container-integrations
+/cmd/agent/dist/conf.d/container_image.d/      @DataDog/container-integrations
+/cmd/agent/dist/conf.d/container_lifecycle.d/  @DataDog/container-integrations
+/cmd/agent/dist/conf.d/discovery.d/          @DataDog/agent-discovery
+/cmd/agent/dist/conf.d/jetson.d/        @DataDog/agent-devx
+/cmd/agent/dist/conf.d/oracle.d/    @DataDog/database-monitoring
+/cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
+/cmd/agent/dist/conf.d/network_path.d/ @DataDog/cloud-network-monitoring
+/cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
+/cmd/agent/dist/conf.d/service_discovery.d/          @DataDog/agent-discovery
+/cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
+/cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
+/cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
+/cmd/agent/installer.go                 @DataDog/fleet
+/cmd/agent/install*.sh                  @DataDog/agent-onboarding @DataDog/agent-build
+/cmd/cluster-agent/                     @DataDog/container-platform
+/cmd/cluster-agent/subcommands/autoscalerlist   @DataDog/container-autoscaling @DataDog/container-integrations
+/cmd/cluster-agent-cloudfoundry/        @DataDog/agent-integrations
+/cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/agent-integrations
+/cmd/cws-instrumentation/               @DataDog/agent-security
+/cmd/dogstatsd/                         @DataDog/agent-metric-pipelines
+/cmd/otel-agent/                        @DataDog/opentelemetry-agent
+/cmd/process-agent/                     @DataDog/container-experiences
+/cmd/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/cmd/serverless-init/                   @DataDog/serverless
+/cmd/sbomgen/                           @DataDog/agent-security
+/cmd/system-probe/                      @DataDog/ebpf-platform
+/cmd/system-probe/modules/usm*          @DataDog/universal-service-monitoring
+/cmd/system-probe/modules/network_tracer*  @DataDog/cloud-network-monitoring
+/cmd/system-probe/modules/oom_kill_probe*   @DataDog/container-integrations
+/cmd/system-probe/modules/process*      @DataDog/container-experiences
+/cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
+/cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
+/cmd/system-probe/modules/traceroute*  @DataDog/cloud-network-monitoring
+/cmd/system-probe/modules/ping*         @DataDog/ndm-core
+/cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
+/cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
+/cmd/system-probe/windows_resources/    @DataDog/windows-products
+/cmd/system-probe/main_windows*.go      @DataDog/windows-products
+/cmd/system-probe/subcommands/runtime/  @DataDog/agent-security
+/cmd/systray/                           @DataDog/windows-products
+/cmd/security-agent/                    @DataDog/agent-security
+/cmd/installer/                         @DataDog/fleet @DataDog/windows-products
+
+/dev/                                   @DataDog/agent-devx
+/devenv/                                @DataDog/agent-devx
+
+/Dockerfiles/                            @DataDog/agent-build
+/Dockerfiles/agent/entrypoint.d.windows/ @DataDog/agent-build @DataDog/windows-products
+/Dockerfiles/agent/entrypoint.ps1        @DataDog/agent-build @DataDog/windows-products
+/Dockerfiles/agent/windows/              @DataDog/agent-build @DataDog/windows-products
+/Dockerfiles/agent-ddot                  @DataDog/opentelemetry-agent
+/Dockerfiles/agent/bouncycastle-fips     @DataDog/agent-metric-pipelines
+
+/docs/                                  @DataDog/agent-devx
+/docs/dev/checks/                       @DataDog/agent-runtimes
+/docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
+
+/docs/public/components/                                     @DataDog/agent-runtimes
+/docs/public/hostname/                                       @DataDog/agent-runtimes
+/docs/public/architecture/dogstatsd/                         @DataDog/agent-metric-pipelines
+/docs/public/guidelines/deprecated-components-documentation/ @DataDog/agent-runtimes
+
+# These files are owned by all teams, but assigning them to @DataDog/agent-all causes a lot of spam
+# Assigning them to a group that doesn't exist means nobody will receive notifications for them, but
+# that should be fine since rarely we make PRs that only change those files alone.
+/go.mod                                 # do not notify anyone
+/go.sum                                 # do not notify anyone
+
+/omnibus/                               @DataDog/agent-build
+/omnibus/package-scripts/agent-rpm/     @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/agent-deb/     @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/installer-deb/ @DataDog/agent-build @DataDog/fleet
+/omnibus/package-scripts/installer-rpm/ @DataDog/agent-build @DataDog/fleet
+/omnibus/python-scripts/                @DataDog/agent-integrations @DataDog/windows-products
+/omnibus/config/patches/openscap/                         @DataDog/agent-cspm
+/omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
+/omnibus/config/software/datadog-security-agent*.rb       @Datadog/agent-security @DataDog/agent-build
+/omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
+/omnibus/config/software/snmp-traps.rb                    @DataDog/ndm-core
+/omnibus/config/templates/init-scripts-agent/             @DataDog/agent-build @DataDog/fleet
+/omnibus/resources/*/msi/                                 @DataDog/windows-products
+
+# The following is managed by `dda inv lint-components` -- DO NOT EDIT
+# BEGIN COMPONENTS
+/comp @DataDog/agent-runtimes
+/comp/agent @DataDog/agent-runtimes
+/comp/aggregator @DataDog/agent-metric-pipelines
+/comp/api @DataDog/agent-runtimes
+/comp/checks @DataDog/agent-runtimes
+/comp/collector @DataDog/agent-runtimes
+/comp/core @DataDog/agent-runtimes
+/comp/dogstatsd @DataDog/agent-metric-pipelines
+/comp/forwarder @DataDog/agent-metric-pipelines
+/comp/logs @DataDog/agent-log-pipelines
+/comp/metadata @DataDog/agent-configuration
+/comp/ndmtmp @DataDog/ndm-core
+/comp/netflow @DataDog/ndm-integrations
+/comp/networkpath @DataDog/cloud-network-monitoring
+/comp/otelcol @DataDog/opentelemetry-agent
+/comp/process @DataDog/container-experiences
+/comp/remote-config @DataDog/remote-config
+/comp/snmptraps @DataDog/ndm-core
+/comp/systray @DataDog/windows-products
+/comp/trace @DataDog/agent-apm
+/comp/updater @DataDog/fleet @DataDog/windows-products
+/comp/agent/cloudfoundrycontainer @DataDog/agent-integrations
+/comp/agent/jmxlogger @DataDog/agent-metric-pipelines
+/comp/aggregator/diagnosesendermanager @DataDog/agent-configuration
+/comp/checks/agentcrashdetect @DataDog/windows-products
+/comp/checks/windowseventlog @DataDog/windows-products
+/comp/checks/winregistry @DataDog/windows-products
+/comp/core/autodiscovery @DataDog/container-platform
+/comp/core/config @DataDog/agent-configuration
+/comp/core/configsync @DataDog/agent-configuration
+/comp/core/flare @DataDog/agent-configuration
+/comp/core/gui @DataDog/agent-configuration
+/comp/core/profiler @DataDog/agent-configuration
+/comp/core/secrets @DataDog/agent-configuration
+/comp/core/settings @DataDog/agent-configuration
+/comp/core/status @DataDog/agent-configuration
+/comp/core/sysprobeconfig @DataDog/ebpf-platform
+/comp/core/tagger @DataDog/container-platform
+/comp/core/workloadfilter @DataDog/container-platform
+/comp/core/workloadmeta @DataDog/container-platform
+/comp/forwarder/eventplatform @DataDog/agent-log-pipelines
+/comp/forwarder/eventplatformreceiver @DataDog/agent-log-pipelines
+/comp/forwarder/orchestrator @DataDog/container-app
+/comp/metadata/clusteragent @DataDog/container-platform
+/comp/metadata/haagent @DataDog/ndm-core
+/comp/metadata/hostgpu @DataDog/ebpf-platform
+/comp/metadata/packagesigning @DataDog/agent-delivery
+/comp/metadata/softwareinventory @DataDog/windows-products
+/comp/trace/etwtracer @DataDog/windows-products
+/comp/updater/daemonchecker @DataDog/fleet
+/comp/updater/ssistatus @DataDog/fleet
+/comp/autoscaling/datadogclient @DataDog/container-integrations
+/comp/connectivitychecker @DataDog/fleet
+/comp/etw @DataDog/windows-products
+/comp/fleetstatus @DataDog/fleet
+/comp/haagent @DataDog/ndm-core
+/comp/languagedetection/client @DataDog/container-platform
+/comp/networkdeviceconfig @DataDog/network-device-monitoring
+/comp/rdnsquerier @DataDog/ndm-integrations
+/comp/serializer/logscompression @DataDog/agent-log-pipelines
+/comp/serializer/metricscompression @DataDog/agent-metric-pipelines
+/comp/snmpscan @DataDog/ndm-core
+# END COMPONENTS
+
+# Additional notification to  @iglendd about Agent Telemetry changes for optional approval and governance acknowledgement
+/comp/core/agenttelemetry               @DataDog/agent-runtimes @iglendd
+
+# trace-agent logging implementation should also notify agent-apm
+/comp/core/log/impl-trace @DataDog/agent-apm
+
+# pkg
+/pkg/                                   @DataDog/agent-runtimes
+/pkg/api/                               @DataDog/agent-runtimes
+/pkg/aggregator/                        @DataDog/agent-metric-pipelines
+/pkg/collector/                         @DataDog/agent-runtimes
+/pkg/commonchecks/                      @DataDog/agent-runtimes
+/pkg/cli/                               @DataDog/agent-configuration
+/pkg/cli/subcommands/check              @DataDog/agent-runtimes @DataDog/agent-integrations
+/pkg/cli/subcommands/version            @DataDog/agent-runtimes
+/pkg/cli/subcommands/clusterchecks      @DataDog/container-platform
+/pkg/cli/subcommands/autoscalerlist     @DataDog/container-autoscaling @DataDog/container-integrations
+/pkg/discovery/                         @DataDog/agent-discovery
+/pkg/errors/                            @DataDog/agent-runtimes
+/pkg/fips                               @DataDog/agent-runtimes
+/pkg/gohai                              @DataDog/agent-configuration
+/pkg/gpu/                               @DataDog/ebpf-platform
+/pkg/hosttags/                          @DataDog/agent-runtimes
+/pkg/jmxfetch/                          @DataDog/agent-metric-pipelines
+/pkg/metrics/                           @DataDog/agent-metric-pipelines
+/pkg/metrics/metricsource.go            @DataDog/agent-metric-pipelines @DataDog/agent-integrations
+/pkg/serializer/                        @DataDog/agent-metric-pipelines
+/pkg/serializer/internal/metrics/origin_mapping.go  @DataDog/agent-metric-pipelines @DataDog/agent-integrations
+/pkg/serverless/                        @DataDog/serverless @Datadog/serverless-aws
+/pkg/serverless/appsec/                 @DataDog/asm-go
+/pkg/status/                            @DataDog/agent-configuration
+/pkg/status/health                      @DataDog/agent-runtimes
+/pkg/status/collector                   @DataDog/agent-runtimes
+/pkg/status/clusteragent                @DataDog/container-platform
+/pkg/telemetry/                         @DataDog/agent-runtimes
+/pkg/telemetry/stat_gauge_wrapper.go    @DataDog/ebpf-platform
+/pkg/telemetry/stat_counter_wrapper.go  @DataDog/ebpf-platform
+/pkg/template/                          @DataDog/agent-runtimes
+/pkg/version/                           @DataDog/agent-runtimes
+/pkg/obfuscate/                         @DataDog/agent-apm
+/pkg/trace/                             @DataDog/agent-apm
+/pkg/trace/api/otlp*.go                 @DataDog/opentelemetry-agent
+/pkg/trace/traceutil/otel*.go           @DataDog/opentelemetry-agent
+/pkg/trace/stats/                       @DataDog/agent-apm @DataDog/opentelemetry-agent
+/pkg/trace/telemetry/                   @DataDog/apm-trace-storage
+/pkg/trace/transform/                   @DataDog/opentelemetry-agent
+/comp/core/autodiscovery/listeners/           @DataDog/container-platform
+/comp/core/autodiscovery/listeners/cloudfoundry*.go  @DataDog/agent-integrations
+/comp/core/autodiscovery/listeners/snmp*.go   @DataDog/ndm-core
+/comp/core/autodiscovery/providers/           @DataDog/container-platform
+/comp/core/autodiscovery/providers/file*.go   @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/config_reader*.go @DataDog/container-platform @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/cloudfoundry*.go  @DataDog/agent-integrations
+/comp/core/autodiscovery/providers/process_log*.go @DataDog/agent-discovery @DataDog/agent-log-pipelines
+/comp/core/autodiscovery/providers/remote_config*.go  @DataDog/remote-config
+/comp/core/autodiscovery/providers/datastreams @DataDog/data-streams-monitoring
+/pkg/cloudfoundry                       @Datadog/agent-integrations
+/pkg/clusteragent/                      @DataDog/container-platform
+/pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling @DataDog/container-integrations
+/pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
+/pkg/clusteragent/admission/mutate/autoinstrumentation/ @DataDog/container-platform @DataDog/injection-platform
+/pkg/clusteragent/admission/mutate/cwsinstrumentation    @Datadog/agent-security
+/pkg/clusteragent/orchestrator/         @DataDog/container-app
+/pkg/clusteragent/telemetry/            @DataDog/apm-trace-storage
+/pkg/collector/                         @DataDog/agent-runtimes
+/pkg/collector/corechecks/cluster/      @DataDog/container-integrations
+/pkg/collector/corechecks/cluster/orchestrator  @DataDog/container-app
+/pkg/collector/corechecks/containers/   @DataDog/container-integrations
+/pkg/collector/corechecks/containerimage/       @DataDog/container-integrations
+/pkg/collector/corechecks/containerlifecycle/   @DataDog/container-integrations
+/pkg/collector/corechecks/discovery/ @DataDog/agent-discovery
+/pkg/collector/corechecks/ebpf/                       @DataDog/container-integrations
+/pkg/collector/corechecks/ebpf/ebpf*                  @DataDog/ebpf-platform
+/pkg/collector/corechecks/ebpf/probe/ebpfcheck/       @DataDog/ebpf-platform
+/pkg/collector/corechecks/ebpf/c/runtime/ebpf*        @DataDog/ebpf-platform
+/pkg/collector/corechecks/embed/                   @Datadog/agent-delivery
+/pkg/collector/corechecks/embed/apm/               @DataDog/agent-apm
+/pkg/collector/corechecks/embed/process/           @DataDog/container-experiences
+/pkg/collector/corechecks/gpu/                     @DataDog/ebpf-platform
+/pkg/collector/corechecks/network-devices/         @DataDog/ndm-integrations
+/pkg/collector/corechecks/orchestrator/   @DataDog/container-app
+/pkg/collector/corechecks/net/          @DataDog/agent-runtimes
+/pkg/collector/corechecks/net/wlan/     @DataDog/windows-products
+/pkg/collector/corechecks/oracle        @DataDog/database-monitoring
+/pkg/collector/corechecks/sbom/         @DataDog/agent-security @DataDog/container-integrations
+/pkg/collector/corechecks/servicediscovery/ @DataDog/agent-discovery
+/pkg/collector/corechecks/snmp/         @DataDog/ndm-core
+/pkg/collector/corechecks/system/                 @DataDog/agent-runtimes
+/pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-runtimes @DataDog/windows-products
+/pkg/collector/corechecks/system/wincrashdetect/  @DataDog/windows-products
+/pkg/collector/corechecks/system/windowscertificate/ @DataDog/windows-products
+/pkg/collector/corechecks/system/winkmem/         @DataDog/windows-products
+/pkg/collector/corechecks/system/winproc/         @DataDog/windows-products
+/pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
+/pkg/collector/corechecks/nvidia/       @DataDog/agent-runtimes
+/pkg/config/                            @DataDog/agent-configuration
+/pkg/config/config_template.yaml        @DataDog/agent-configuration @DataDog/documentation
+/pkg/config/setup/apm.go                @DataDog/agent-apm @DataDog/agent-configuration
+/pkg/config/autodiscovery/              @DataDog/container-integrations @DataDog/container-platform @DataDog/agent-configuration
+/pkg/config/env                         @DataDog/container-integrations @DataDog/container-platform @DataDog/agent-configuration
+/pkg/config/setup                            @DataDog/agent-configuration
+/pkg/config/setup/process*.go                 @DataDog/container-experiences @DataDog/agent-configuration
+/pkg/config/setup/system_probe.go               @DataDog/ebpf-platform @DataDog/agent-configuration
+/pkg/config/setup/system_probe_cws.go           @DataDog/agent-security @DataDog/agent-configuration
+/pkg/config/setup/system_probe_cws_notwin.go    @DataDog/agent-security @DataDog/agent-configuration
+/pkg/config/setup/system_probe_cws_windows.go   @DataDog/windows-products @DataDog/agent-configuration
+/pkg/config/setup/security_agent.go             @DataDog/agent-security @DataDog/agent-configuration
+/pkg/config/remote/                     @DataDog/remote-config
+/pkg/config/remote/meta/                @DataDog/remote-config @DataDog/sdlc-security
+/pkg/containerlifecycle/                @Datadog/container-integrations
+/pkg/diagnose/                          @Datadog/container-platform
+/pkg/diagnose/connectivity/             @DataDog/agent-configuration
+/pkg/diagnose/firewallscanner/          @DataDog/ndm-core
+/pkg/diagnose/ports/                    @DataDog/agent-configuration
+/pkg/diagnose/ports/*windows*.go        @DataDog/windows-products
+/pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
+/pkg/dyninst/                           @DataDog/debugger-go
+/pkg/flare/                             @DataDog/agent-configuration
+/pkg/flare/clusteragent/manifests.go    @DataDog/agent-onboarding @DataDog/agent-configuration
+/pkg/flare/*_win.go                     @Datadog/windows-products @DataDog/agent-configuration
+/pkg/flare/*_windows.go                 @Datadog/windows-products @DataDog/agent-configuration
+/pkg/flare/*_windows_test.go            @Datadog/windows-products @DataDog/agent-configuration
+/pkg/fleet/                             @DataDog/fleet @DataDog/windows-products
+/pkg/fleet/installer/setup/djm/         @DataDog/fleet @DataDog/data-jobs-monitoring
+/pkg/inventory/                         @DataDog/windows-products
+/pkg/inventory/software/                @DataDog/windows-products
+/pkg/opentelemetry-mapping-go           @DataDog/opentelemetry-agent
+/pkg/pidfile/                           @DataDog/agent-runtimes
+/pkg/persistentcache/                   @DataDog/agent-runtimes
+/pkg/proto/                             @DataDog/agent-runtimes
+/pkg/proto/datadog/languagedetection    @DataDog/container-experiences
+/pkg/proto/datadog/process              @DataDog/container-experiences
+/pkg/proto/datadog/trace                @DataDog/agent-apm
+/pkg/proto/datadog/workloadmeta         @DataDog/container-platform
+/pkg/remoteconfig/                      @DataDog/remote-config
+/pkg/runtime/                           @DataDog/agent-runtimes
+/pkg/system-probe/                      @DataDog/ebpf-platform
+/pkg/system-probe/api/client/client_windows.go      @DataDog/windows-products
+/pkg/system-probe/api/server/listener_windows.go    @DataDog/windows-products
+/pkg/system-probe/config/adjust_npm.go  @DataDog/ebpf-platform @DataDog/cloud-network-monitoring
+/pkg/system-probe/config/adjust_usm.go  @DataDog/ebpf-platform @DataDog/universal-service-monitoring
+/pkg/system-probe/config/adjust_security.go  @DataDog/ebpf-platform @DataDog/agent-security
+/pkg/tagset/                            @DataDog/agent-runtimes
+/pkg/util/                              @DataDog/agent-runtimes
+/pkg/util/aggregatingqueue              @DataDog/container-integrations @DataDog/container-platform
+/pkg/util/cloudproviders/cloudfoundry/  @DataDog/agent-integrations
+/pkg/util/clusteragent/                 @DataDog/container-platform
+/pkg/util/containerd/                   @DataDog/container-integrations
+/pkg/util/containers/                   @DataDog/container-integrations
+/pkg/util/crio/                         @DataDog/container-integrations
+/pkg/util/docker/                       @DataDog/container-integrations
+/pkg/util/ecs/                          @DataDog/container-integrations
+/pkg/util/encoding/                     @DataDog/ebpf-platform
+/pkg/util/funcs/                        @DataDog/ebpf-platform
+/pkg/util/gpu/                          @DataDog/container-platform
+/pkg/util/installinfo/                  @DataDog/agent-configuration
+/pkg/util/kernel/                       @DataDog/ebpf-platform
+/pkg/util/safeelf/                      @DataDog/ebpf-platform
+/pkg/util/slices/                       @DataDog/ebpf-platform
+/pkg/util/ktime                         @DataDog/agent-security
+/pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-platform @DataDog/container-app
+/pkg/util/podman/                       @DataDog/container-integrations
+/pkg/util/port/                         @DataDog/agent-runtimes
+/pkg/util/port/portlist/*windows*.go    @DataDog/windows-products
+/pkg/util/prometheus                    @DataDog/container-integrations
+/pkg/util/quantile/                     @DataDog/opentelemetry-agent
+/pkg/util/tags/                         @DataDog/container-platform
+/pkg/util/trivy/                        @DataDog/agent-security @DataDog/container-integrations
+/pkg/util/uuid/                         @DataDog/agent-runtimes
+/pkg/util/cgroups/                      @DataDog/container-integrations
+/pkg/util/retry/                        @DataDog/container-platform
+/pkg/util/intern/                       @DataDog/ebpf-platform
+/pkg/util/crashreport/                  @DataDog/windows-products
+/pkg/util/pdhutil/                      @DataDog/windows-products
+/pkg/util/winutil/                      @DataDog/windows-products
+/pkg/util/testutil/flake                @DataDog/agent-devx
+/pkg/util/testutil/patternscanner.go    @DataDog/universal-service-monitoring @DataDog/ebpf-platform
+/pkg/util/testutil/docker               @DataDog/universal-service-monitoring @DataDog/ebpf-platform
+/pkg/util/trie                          @DataDog/container-integrations
+/pkg/languagedetection                  @DataDog/container-experiences @DataDog/agent-discovery
+/pkg/linters/                           @DataDog/agent-devx
+/pkg/linters/components/                @DataDog/agent-runtimes
+/pkg/linters/components/pkgconfigusage  @DataDog/agent-configuration
+/pkg/logs/                              @DataDog/agent-log-pipelines
+/pkg/logs/launchers/container           @DataDog/agent-log-pipelines @DataDog/container-integrations
+/pkg/logs/tailers/container             @DataDog/agent-log-pipelines @DataDog/container-integrations
+/pkg/logs/launchers/windowsevent        @DataDog/agent-log-pipelines @DataDog/windows-products
+/pkg/logs/tailers/windowsevent          @DataDog/agent-log-pipelines @DataDog/windows-products
+/pkg/logs/util/windowsevent             @DataDog/agent-log-pipelines @DataDog/windows-products
+/pkg/logs/client                        @DataDog/agent-log-pipelines
+/pkg/logs/diagnostic                    @DataDog/agent-log-pipelines
+/pkg/logs/message                       @DataDog/agent-log-pipelines
+/pkg/logs/pipeline                      @DataDog/agent-log-pipelines
+/pkg/logs/processor                     @DataDog/agent-log-pipelines
+/pkg/logs/sds                           @DataDog/agent-log-pipelines
+/pkg/logs/sender                        @DataDog/agent-log-pipelines
+/pkg/process/                           @DataDog/container-experiences
+/pkg/process/util/address*.go           @DataDog/cloud-network-monitoring
+/pkg/process/checks/net*.go             @DataDog/cloud-network-monitoring
+/pkg/process/metadata/parser/           @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring
+/pkg/process/metadata/parser/*windows*  @DataDog/universal-service-monitoring @DataDog/container-experiences @DataDog/cloud-network-monitoring @DataDog/windows-products
+/pkg/process/monitor/                   @DataDog/universal-service-monitoring
+/pkg/process/net/                       @DataDog/universal-service-monitoring @DataDog/cloud-network-monitoring
+/pkg/proto/datadog/remoteconfig/        @DataDog/remote-config
+/pkg/proto/pbgo/                        # do not notify anyone
+/pkg/proto/pbgo/trace                   @DataDog/agent-apm
+/pkg/proto/pbgo/languagedetection       @DataDog/agent-apm
+/pkg/proto/pbgo/process                 @DataDog/container-experiences
+/pkg/proto/pbgo/core                    @DataDog/agent-runtimes
+/pkg/proto/pbgo/core/remoteconfig.pb.go       @DataDog/remote-config
+/pkg/proto/pbgo/core/remoteconfig_gen.go      @DataDog/remote-config
+/pkg/proto/pbgo/core/remoteconfig_gen_test.go @DataDog/remote-config
+/pkg/proto/pbgo/core/workloadmeta.pb.go       @DataDog/container-platform
+/pkg/proto/pbgo/mocks/core              @DataDog/agent-runtimes
+/pkg/orchestrator/                      @DataDog/container-app
+/pkg/network/                           @DataDog/cloud-network-monitoring
+/pkg/network/*usm*                      @DataDog/universal-service-monitoring
+/pkg/network/*_windows*.go              @DataDog/windows-products
+/pkg/network/config/config_test.go      @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring @DataDog/windows-products
+/pkg/network/driver_*.go                @DataDog/windows-products
+/pkg/network/dns/*_windows*.go          @DataDog/windows-products
+/pkg/network/driver/                    @DataDog/windows-products
+/pkg/network/ebpf/c/prebuilt/usm*      @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/runtime/usm*       @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/prebuilt/shared-libraries*  @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/runtime/shared-libraries*   @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/shared-libraries/           @DataDog/universal-service-monitoring
+/pkg/network/ebpf/c/protocols/          @DataDog/universal-service-monitoring
+/pkg/network/encoding/marshal/*usm*     @DataDog/universal-service-monitoring
+/pkg/network/encoding/marshal/*_windows*.go  @DataDog/windows-products
+/pkg/network/go/                        @DataDog/universal-service-monitoring
+/pkg/network/protocols/                 @DataDog/universal-service-monitoring
+/pkg/network/protocols/http/driver_*.go         @DataDog/windows-products
+/pkg/network/protocols/http/etw*.go             @DataDog/windows-products
+/pkg/network/protocols/http/*_windows*.go       @DataDog/windows-products
+/pkg/network/tracer/testutil/proxy/              @DataDog/universal-service-monitoring
+/pkg/network/tracer/*_windows*.go               @DataDog/windows-products
+/pkg/network/usm/                       @DataDog/universal-service-monitoring
+/pkg/network/usm/tests/*_windows*.go    @DataDog/windows-products
+/pkg/ebpf/                              @DataDog/ebpf-platform
+/pkg/ebpf/map_cleaner*.go               @DataDog/universal-service-monitoring
+/pkg/compliance/                        @DataDog/agent-cspm
+/pkg/databasemonitoring                 @DataDog/database-monitoring
+/pkg/kubestatemetrics                   @DataDog/container-integrations
+/pkg/security/                          @DataDog/agent-security
+/pkg/networkdevice/                     @DataDog/ndm-core
+/pkg/snmp/                              @DataDog/ndm-core
+/pkg/tagger/                            @DataDog/container-platform
+/pkg/windowsdriver/                     @DataDog/windows-products
+/comp/core/workloadmeta/collectors/internal/cloudfoundry  @DataDog/agent-integrations
+/comp/core/workloadmeta/collectors/internal/containerd    @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/crio          @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/docker        @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/ecs           @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/ecsfargate    @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/kubeapiserver @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/kubelet       @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/kubemetadata  @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/nvml          @DataDog/ebpf-platform
+/comp/core/workloadmeta/collectors/internal/podman        @DataDog/container-platform @DataDog/container-integrations
+/comp/core/workloadmeta/collectors/internal/process       @DataDog/container-experiences @DataDog/container-platform
+/comp/core/tagger/collectors            @DataDog/container-platform @DataDog/container-integrations
+/pkg/sbom/                              @DataDog/agent-security @DataDog/container-integrations
+/pkg/networkpath/                       @DataDog/cloud-network-monitoring
+/pkg/networkpath/traceroute/            @DataDog/cloud-network-monitoring @DataDog/windows-products
+/pkg/collector/corechecks/networkpath/  @DataDog/cloud-network-monitoring
+
+/releasenotes/                          @DataDog/documentation
+/releasenotes-dca/                      @DataDog/documentation
+
+/rtloader/                              @DataDog/agent-runtimes
+
+/tasks/                                 @DataDog/agent-devx
+/tasks/msi.py                           @DataDog/windows-products
+/tasks/agent.py                         @DataDog/agent-runtimes
+/tasks/go_deps.py                       @DataDog/agent-runtimes
+/tasks/dogstatsd.py                     @DataDog/agent-metric-pipelines
+/tasks/update_go.py                     @DataDog/agent-runtimes
+/tasks/unit_tests/update_go_tests.py    @DataDog/agent-runtimes
+/tasks/pkg_template.py                  @DataDog/agent-runtimes
+/tasks/cluster_agent_cloudfoundry.py    @DataDog/agent-integrations
+/tasks/devcontainer.py                  @DataDog/agent-devx @DataDog/container-platform
+/tasks/skaffold.py                      @DataDog/agent-devx @DataDog/container-platform
+/tasks/new_e2e_tests.py                 @DataDog/agent-e2e-testing @DataDog/agent-devx
+/tasks/process_agent.py                 @DataDog/container-experiences
+/tasks/system_probe.py                  @DataDog/ebpf-platform
+/tasks/ebpf.py                          @DataDog/ebpf-platform
+/tasks/kmt.py                           @DataDog/ebpf-platform
+/tasks/kernel_matrix_testing/           @DataDog/ebpf-platform
+/tasks/ebpf_verifier/                   @DataDog/ebpf-platform
+/tasks/trace_agent.py                   @DataDog/agent-apm
+/tasks/quality_gates.py                 @DataDog/agent-build
+/tasks/static_quality_gates/            @DataDog/agent-build
+/tasks/rtloader.py                      @DataDog/agent-runtimes
+/tasks/security_agent.py                @DataDog/agent-security
+/tasks/sbomgen.py                       @DataDog/agent-security
+/tasks/libs/cws/                        @DataDog/agent-security
+/tasks/sds.py                           @DataDog/agent-log-pipelines
+/tasks/systray.py                       @DataDog/windows-products
+/tasks/winbuildscripts/                 @DataDog/windows-products
+/tasks/winbuild.py                      @DataDog/windows-products
+/tasks/windows_resources.py             @DataDog/windows-products
+/tasks/collector.py                     @DataDog/opentelemetry-agent
+/tasks/components.py                    @DataDog/agent-runtimes
+/tasks/components_templates             @DataDog/agent-runtimes
+/tasks/libs/ciproviders/                @DataDog/agent-devx
+/tasks/libs/common/omnibus.py           @DataDog/agent-build
+/tasks/omnibus.py                       @DataDog/agent-build
+/tasks/release.py                       @DataDog/agent-delivery
+/tasks/release_metrics/                 @DataDog/agent-delivery
+/tasks/libs/releasing/                  @DataDog/agent-delivery
+/tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
+/tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
+/tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes
+/tasks/installer.py                     @DataDog/fleet
+/test/                                  @DataDog/agent-devx
+/test/benchmarks/                       @DataDog/agent-metric-pipelines
+/test/benchmarks/kubernetes_state/      @DataDog/container-integrations
+/test/integration/                      @DataDog/serverless @Datadog/serverless-aws
+/test/integration/docker/               @DataDog/opentelemetry-agent
+/test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
+/test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core
+/test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/ndm-core
+/test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
+/test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
+/test/fakeintake/aggregator/servicediscovery* @DataDog/agent-discovery
+/test/new-e2e/                                @DataDog/agent-e2e-testing @DataDog/agent-devx
+/test/new-e2e/pkg/components/datadog-installer @DataDog/windows-products
+/test/new-e2e/pkg/testcommon/check            @DataDog/agent-runtimes
+/test/new-e2e/test-infra-definition           @DataDog/agent-devx
+/test/new-e2e/system-probe                    @DataDog/ebpf-platform
+/test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
+/test/new-e2e/tests/agent-platform            @DataDog/agent-onboarding @DataDog/agent-delivery @DataDog/agent-devx
+/test/new-e2e/tests/agent-platform/common/agent_integration.go @DataDog/agent-integrations
+/test/new-e2e/tests/agent-runtimes            @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-configuration       @DataDog/agent-configuration
+/test/new-e2e/tests/agent-metric-pipelines    @DataDog/agent-metric-pipelines
+/test/new-e2e/tests/agent-subcommands             @DataDog/agent-configuration
+/test/new-e2e/tests/agent-subcommands/check       @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/health      @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/hostname    @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/configcheck @DataDog/agent-runtimes @DataDog/agent-integrations
+/test/new-e2e/tests/agent-subcommands/run         @DataDog/agent-runtimes
+/test/new-e2e/tests/agent-subcommands/config      @DataDog/agent-configuration
+/test/new-e2e/tests/agent-subcommands/diagnose    @DataDog/agent-configuration
+/test/new-e2e/tests/agent-subcommands/flare       @DataDog/agent-configuration
+/test/new-e2e/tests/agent-subcommands/secret      @DataDog/agent-configuration
+/test/new-e2e/tests/agent-subcommands/status      @DataDog/agent-configuration
+/test/new-e2e/tests/containers                @DataDog/container-integrations @DataDog/container-platform
+/test/new-e2e/tests/discovery                 @DataDog/agent-discovery
+/test/new-e2e/tests/fips-compliance           @DataDog/agent-runtimes
+/test/new-e2e/tests/ha-agent                  @DataDog/ndm-core
+/test/new-e2e/tests/language-detection        @DataDog/container-experiences
+/test/new-e2e/tests/ndm                       @DataDog/ndm-core
+/test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
+/test/new-e2e/tests/netpath                   @DataDog/cloud-network-monitoring @DataDog/windows-products
+/test/new-e2e/tests/npm                       @DataDog/cloud-network-monitoring
+/test/new-e2e/tests/npm/ec2_1host_wkit_test.go @DataDog/cloud-network-monitoring @DataDog/windows-products
+/test/new-e2e/tests/orchestrator              @DataDog/container-app
+/test/new-e2e/tests/otel                      @DataDog/opentelemetry-agent
+/test/new-e2e/tests/process                   @DataDog/container-experiences
+/test/new-e2e/tests/sysprobe-functional     @DataDog/windows-products
+/test/new-e2e/tests/security-agent-functional     @DataDog/windows-products @DataDog/agent-security
+/test/new-e2e/tests/cws                       @DataDog/agent-security
+/test/new-e2e/tests/agent-log-pipelines       @DataDog/agent-log-pipelines
+/test/new-e2e/tests/windows                   @DataDog/windows-products @DataDog/windows-products
+/test/new-e2e/tests/apm                       @DataDog/agent-apm
+/test/new-e2e/tests/remote-config             @DataDog/remote-config
+/test/new-e2e/tests/installer                 @DataDog/fleet @DataDog/windows-products
+/test/new-e2e/tests/installer/script          @DataDog/fleet @DataDog/data-jobs-monitoring
+/test/new-e2e/tests/gpu                       @Datadog/ebpf-platform
+/test/otel/                                   @DataDog/opentelemetry-agent
+/test/static/                                 @DataDog/agent-build
+/test/system/                                 @DataDog/agent-runtimes
+/test/system/dogstatsd/                       @DataDog/agent-metric-pipelines
+/test/benchmarks/apm_scripts/                 @DataDog/agent-apm
+/test/regression/                             @DataDog/single-machine-performance
+/test/regression/cases/docker_containers*     @DataDog/single-machine-performance @DataDog/container-integrations
+
+/tools/                                 @DataDog/agent-devx
+/tools/ci                               @DataDog/agent-devx
+/tools/ebpf/                            @DataDog/ebpf-platform
+/tools/gdb/                             @DataDog/agent-runtimes
+/tools/go-update/                       @DataDog/agent-runtimes
+/tools/NamedPipeCmd/                    @DataDog/windows-products
+/tools/retry_file_dump/                 @DataDog/agent-metric-pipelines
+/tools/windows/                         @DataDog/windows-products
+/tools/windows/DatadogAgentInstaller/WixSetup/localization-en-us.wxl @DataDog/windows-products @DataDog/documentation
+/tools/agent_QA/                        @DataDog/agent-devx
+
+/internal/tools/                        @DataDog/agent-devx
+/internal/third_party/client-go         @DataDog/container-platform
+/internal/third_party/kubernetes        @DataDog/container-integrations
+/internal/third_party/golang/           @DataDog/container-integrations
+
+# With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
+# Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.
+# Each team can individually decide to update CODEOWNERS to be requested for a review on each modification of their go.mod/sum
+/**/go.mod                              # do not notify anyone
+/**/go.sum                              # do not notify anyone
+
+# Add here modules that need explicit review from the team owning them
+/internal/tools/**/go.mod                @DataDog/agent-devx
+/internal/tools/**/go.sum                @DataDog/agent-devx
+
+/pkg/fleet/installer/go.mod              @DataDog/fleet
+/pkg/fleet/installer/go.sum              @DataDog/fleet
+
+/pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
+/pkg/util/scrubber/go.sum                @DataDog/agent-runtimes


### PR DESCRIPTION
### What does this PR do?
Prevent the `invoke-unit-tests` from relying on the regular CODEOWNERS file

### Motivation
Whenever an owner is changed, [it can have an impact on the UT](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1095803050). We don't want to create failures on tests on such changes.

### Describe how you validated your changes
- The tests are covered by UT, and each method can import its own CODEOWNER file.
- Will prevent the failure raised by https://github.com/DataDog/datadog-agent/pull/39898
