### PR TITLE
Change go deps diff metric type to gauge

### DIFF
--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -13,7 +13,7 @@ from tasks.flavor import AgentFlavor
 from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
 from tasks.go import version as dot_go_version
 from tasks.libs.common.color import color_message
-from tasks.libs.common.datadog_api import create_count, create_gauge, send_metrics
+from tasks.libs.common.datadog_api import create_gauge, send_metrics
 from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_current_branch
 from tasks.release import _get_release_json_value
 
@@ -83,7 +83,7 @@ BINARIES: dict[str, dict] = {
     },
 }
 
-METRIC_GO_DEPS_DIFF = "datadog.agent.go_dependencies.diff"
+METRIC_GO_DEPS_DIFF = "datadog.agent.go_dependencies.difference"
 
 
 @task
@@ -212,7 +212,7 @@ def diff(
                         if git_ref:
                             tags.append(f"git_ref:{git_ref}")
 
-                        dependency_diff = create_count(METRIC_GO_DEPS_DIFF, timestamp, (add - remove), tags)
+                        dependency_diff = create_gauge(METRIC_GO_DEPS_DIFF, timestamp, (add - remove), tags)
                         send_metrics([dependency_diff])
 
                     color_add = color_message(f"+{add}", "green")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Change go deps diff metric type to gauge.
Also change the name to avoid messing up old data. This is only used by one monitor internally so it won't break anyone.

### Motivation
We want to use the last value of the metric for a given branch, but we can only sum with a count.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->