### PR TITLE
Add authentication helper tasks

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -11,6 +11,7 @@ from tasks import (
     agent,
     agent_ci_api,
     ami,
+    auth,
     bench,
     buildimages,
     cluster_agent,
@@ -167,6 +168,7 @@ ns.add_task(build_and_upload_fuzz)
 ns.add_task(lint_go)
 
 # add namespaced tasks to the root
+ns.add_collection(auth)
 ns.add_collection(agent)
 ns.add_collection(ami)
 ns.add_collection(agent_ci_api)

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -7,7 +7,7 @@ import subprocess
 import requests
 from invoke import task
 
-from tasks.auth import datadog_infra
+from tasks.libs.common.auth import datadog_infra_token
 
 
 def get_datacenter(env):
@@ -97,7 +97,7 @@ def run(
 
     token = ''
     if not is_local:
-        token = datadog_infra(ctx, audience="rapid-agent-devx", datacenter=dc)
+        token = datadog_infra_token(ctx, audience="rapid-agent-devx", datacenter=dc)
     origin_header = os.environ["CI_JOB_ID"] if from_ci else "curl-authanywhere"
     url = (
         f"http://localhost:{localport}/{prefix}{endpoint}"

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -7,6 +7,8 @@ import subprocess
 import requests
 from invoke import task
 
+from tasks.auth import datadog_infra
+
 
 def get_datacenter(env):
     if env == 'prod':
@@ -95,16 +97,7 @@ def run(
 
     token = ''
     if not is_local:
-        token = (
-            ctx.run(
-                'authanywhere --audience rapid-agent-devx'
-                if from_ci
-                else f'ddtool auth token rapid-agent-devx --datacenter {dc} --http-header',
-                hide=True,
-            )
-            .stdout.strip()
-            .removeprefix('Authorization: ')
-        )
+        token = datadog_infra(ctx, audience="rapid-agent-devx", datacenter=dc)
     origin_header = os.environ["CI_JOB_ID"] if from_ci else "curl-authanywhere"
     url = (
         f"http://localhost:{localport}/{prefix}{endpoint}"

--- a/tasks/auth.py
+++ b/tasks/auth.py
@@ -1,6 +1,5 @@
 """Manages authentication to services."""
 
-import requests
 from invoke import task
 
 from tasks.libs.common.utils import running_in_ci
@@ -20,26 +19,6 @@ def datadog_infra(ctx, audience, datacenter="us1.ddbuild.io", verbose=False):
         .stdout.strip()
         .removeprefix('Authorization: ')
     )
-
-    if verbose:
-        print(token)
-
-    return token
-
-
-@task
-def gitlab(ctx, repo='datadog-agent', verbose=False):
-    """Get a gitlab token."""
-
-    infra_token = datadog_infra(ctx, audience="sdm")
-    url = f"https://bti-ci-api.us1.ddbuild.io/internal/ci/gitlab/token?owner=DataDog&repository={repo}"
-
-    res = requests.get(url, headers={'Authorization': infra_token}, timeout=10)
-
-    if not res.ok:
-        raise RuntimeError(f'Failed to retrieve Gitlab token, request failed with code {res.status_code}:\n{res.text}')
-
-    token = res.json()['token']
 
     if verbose:
         print(token)

--- a/tasks/auth.py
+++ b/tasks/auth.py
@@ -2,25 +2,13 @@
 
 from invoke import task
 
-from tasks.libs.common.utils import running_in_ci
+from tasks.libs.common.auth import datadog_infra_token
 
 
 @task
-def datadog_infra(ctx, audience, datacenter="us1.ddbuild.io", verbose=False):
+def datadog_infra(ctx, audience, datacenter="us1.ddbuild.io"):
     """Returns the http token for the given audience."""
 
-    token = (
-        ctx.run(
-            f'authanywhere --audience {audience}'
-            if running_in_ci()
-            else f'ddtool auth token {audience} --datacenter "{datacenter}" --http-header',
-            hide=True,
-        )
-        .stdout.strip()
-        .removeprefix('Authorization: ')
-    )
+    token = datadog_infra_token(ctx, audience, datacenter)
 
-    if verbose:
-        print(token)
-
-    return token
+    print(token)

--- a/tasks/auth.py
+++ b/tasks/auth.py
@@ -1,0 +1,47 @@
+"""Manages authentication to services."""
+
+import requests
+from invoke import task
+
+from tasks.libs.common.utils import running_in_ci
+
+
+@task
+def datadog_infra(ctx, audience, datacenter="us1.ddbuild.io", verbose=False):
+    """Returns the http token for the given audience."""
+
+    token = (
+        ctx.run(
+            f'authanywhere --audience {audience}'
+            if running_in_ci()
+            else f'ddtool auth token {audience} --datacenter "{datacenter}" --http-header',
+            hide=True,
+        )
+        .stdout.strip()
+        .removeprefix('Authorization: ')
+    )
+
+    if verbose:
+        print(token)
+
+    return token
+
+
+@task
+def gitlab(ctx, repo='datadog-agent', verbose=False):
+    """Get a gitlab token."""
+
+    infra_token = datadog_infra(ctx, audience="sdm")
+    url = f"https://bti-ci-api.us1.ddbuild.io/internal/ci/gitlab/token?owner=DataDog&repository={repo}"
+
+    res = requests.get(url, headers={'Authorization': infra_token}, timeout=10)
+
+    if not res.ok:
+        raise RuntimeError(f'Failed to retrieve Gitlab token, request failed with code {res.status_code}:\n{res.text}')
+
+    token = res.json()['token']
+
+    if verbose:
+        print(token)
+
+    return token

--- a/tasks/libs/common/auth.py
+++ b/tasks/libs/common/auth.py
@@ -1,0 +1,18 @@
+from tasks.libs.common.utils import running_in_ci
+
+
+def datadog_infra_token(ctx, audience, datacenter="us1.ddbuild.io"):
+    """Returns the http token for the given audience to access Datadog infrastructure services."""
+
+    token = (
+        ctx.run(
+            f'authanywhere --audience {audience}'
+            if running_in_ci()
+            else f'ddtool auth token {audience} --datacenter "{datacenter}" --http-header',
+            hide=True,
+        )
+        .stdout.strip()
+        .removeprefix('Authorization: ')
+    )
+
+    return token


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This prepares the future tasks to handle short live gitlab / github tokens. Every token generator will be moved here and they will rely on this newly defined function.

You can test with:

```sh
dda inv auth.datadog-infra sdm
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->