### PR TITLE
fix(invoke-unit-tests): Do not run the invoke unit tests on source_tests

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -19,9 +19,8 @@ include:
     - dda inv -- -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH
     - FAST_TESTS_FLAG=""
     - if [[ "$FAST_TESTS" == "true" ]]; then FAST_TESTS_FLAG="--only-impacted-packages"; fi
+    - dda inv -- -e agent.build
     - dda inv -- -e test --rerun-fails=2 --race --profile --cpus 12 --result-json $TEST_OUTPUT_FILE --junit-tar "junit-${CI_JOB_NAME}.tgz" $FAST_TESTS_FLAG --test-washer --coverage
-    - dda self dep sync -f legacy-kernel-matrix-testing
-    - dda inv --feat legacy-kernel-matrix-testing -- -e invoke-unit-tests
   after_script:
     - !reference [.vault_login]
     - !reference [.install_python_dependencies]


### PR DESCRIPTION
### What does this PR do?
- Prevent running the "basic" `invoke-unit-test.run` on go source tests. They are launched during the `tooling_unit_test` job and are not platform specific.
- Run an `agent.build` instead, like it's done on other platforms.

### Motivation
Prevent unexpected failure of invoke unit tests [during the agent go tests](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1095803050).

### Describe how you validated your changes
UT in the CI are green
