### PR TITLE
fix(create_rc): Add a missing GITHUB_TOKEN in env

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -94,12 +94,7 @@ jobs:
           MATRIX: ${{ matrix.value }}
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
-          if [ -n "${{ needs.find_release_branches.outputs.warning }}" ]; then
-            dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING"
-          else
-            dda inv -- -e release.check-for-changes -r "$MATRIX"
-          fi
-          if [ $? -ne 0 ]; then
+          if [ $(dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING") -ne 0 ]; then
             echo "CHANGES=true" >> $GITHUB_OUTPUT
           else
             echo "CHANGES=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -41,6 +41,7 @@ jobs:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           dda inv -- -e release.check-previous-agent6-rc
 

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -94,7 +94,7 @@ jobs:
           MATRIX: ${{ matrix.value }}
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
-          if [ $(dda inv -- -e release.check-for-changes -r "$MATRIX" $WARNING) -ne 0 ]; then
+          if ! dda inv -- -e release.check-for-changes -r "$MATRIX" $WARNING; then
             echo "CHANGES=true" >> $GITHUB_OUTPUT
           else
             echo "CHANGES=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -75,10 +75,17 @@ jobs:
         value: ${{fromJSON(needs.find_release_branches.outputs.branches)}}
       fail-fast: false
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.create-rc-pr.create-pr
+
       - name: Checkout the main branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: true
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Install dda
         uses: ./.github/actions/install-dda
@@ -110,12 +117,6 @@ jobs:
           if [[ "$is_qualification" == "true" && "${{ steps.check_for_changes.outputs.CHANGES }}" == "false" ]]; then
             dda inv -- -e release.alert-ci-on-call -r 6.53.x
           fi
-
-      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/datadog-agent
-          policy: self.create-rc-pr.create-pr
 
       - name: Create RC PR
         if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false') }}

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -94,7 +94,7 @@ jobs:
           MATRIX: ${{ matrix.value }}
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
-          if [ $(dda inv -- -e release.check-for-changes -r "$MATRIX" "$WARNING") -ne 0 ]; then
+          if [ $(dda inv -- -e release.check-for-changes -r "$MATRIX" $WARNING) -ne 0 ]; then
             echo "CHANGES=true" >> $GITHUB_OUTPUT
           else
             echo "CHANGES=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### What does this PR do?
- Add a missing env variable the `find-release-branch` job `Check previous agent6 status` step.
- Update the shell part to prevent unexpected failure because of the new return value introduced by #40104 

### Motivation
The workflow was modified in the scope of https://datadoghq.atlassian.net/browse/SINT-3833 by #39488 and #39662. At [execution](https://github.com/DataDog/datadog-agent/actions/runs/17204317107/job/48801454867) it still requires the GITHUB_TOKEN in the above mentioned step

### Describe how you validated your changes
[Manual trigger of the workflow](https://github.com/DataDog/datadog-agent/actions/runs/17268857870/job/49007822877) passed and called the RC creation as expected.

### Additional note
Depends on #40210
