### PR TITLE
[ACIX-939] Add a job to deploy macos artifacts on testing bucket

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -82,7 +82,7 @@ deploy_deb_testing*                  @DataDog/agent-delivery
 deploy_rpm_testing*                  @DataDog/agent-delivery
 deploy_suse_rpm_testing*             @DataDog/agent-delivery
 deploy_windows_testing*              @DataDog/agent-delivery
-deploy_macos_testing*                @DataDog/agent-delivery
+deploy_dmg_testing*                @DataDog/agent-delivery
 
 # Image build
 docker_build*                        @DataDog/agent-build

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -82,6 +82,7 @@ deploy_deb_testing*                  @DataDog/agent-delivery
 deploy_rpm_testing*                  @DataDog/agent-delivery
 deploy_suse_rpm_testing*             @DataDog/agent-delivery
 deploy_windows_testing*              @DataDog/agent-delivery
+deploy_macos_testing*                @DataDog/agent-delivery
 
 # Image build
 docker_build*                        @DataDog/agent-build

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -268,9 +268,11 @@ export_testing_public_key:
 
 .deploy_dmg_testing-a7:
   rules:
-    - !reference [.except_no_tests_no_deploy]
-    - !reference [.except_mergequeue]
-    - when: on_success
+     - !reference [.on_macos_gui_change]
+     - !reference [.on_packaging_change]
+     - !reference [.on_main_or_release_branch]
+     - !reference [.on_all_builds]
+     - !reference [.manual]
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -295,4 +295,4 @@ deploy_macos_testing_x64-a7:
       fi
       dmg_src=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null)
       echo "Found single DMG file: $dmg_src"
-      $S3_CP_CMD "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID/datadog-agent-7-latest.dmg"
+      $S3_CP_CMD --acl public-read "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID/datadog-agent-7-latest.dmg"

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -265,3 +265,34 @@ export_testing_public_key:
     paths:
       - gpg-testing-public-key.asc
     expire_in: 1 day
+
+deploy_macos_testing_x64-a7:
+  rules:
+    - !reference [.except_no_tests_no_deploy]
+    - !reference [.except_mergequeue]
+    - when: on_success
+  stage: e2e_deploy
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
+  tags: ["arch:amd64"]
+  needs:
+    ["agent_dmg-x64-a7"]
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  script:
+    - |
+      echo "Listing all datadog-agent-7.*.dmg files in $OMNIBUS_PACKAGE_DIR:"
+      ls -la "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null || echo "No datadog-agent-7.*.dmg files found"
+      
+      count=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null | wc -l || true)
+      if [ "$count" -eq 0 ]; then
+        echo "No DMG found in $OMNIBUS_PACKAGE_DIR matching datadog-agent-7.*.dmg" >&2
+        exit 1
+      fi
+      if [ "$count" -gt 1 ]; then
+        echo "Multiple DMGs found for datadog-agent-7.*.dmg pattern:" >&2
+        ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg >&2
+        exit 1
+      fi
+      dmg_src=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null)
+      echo "Found single DMG file: $dmg_src"
+      $S3_CP_CMD "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID/datadog-agent-7-latest.dmg"

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -266,7 +266,7 @@ export_testing_public_key:
       - gpg-testing-public-key.asc
     expire_in: 1 day
 
-deploy_dmg_testing-a7_x64:
+.deploy_dmg_testing-a7:
   rules:
     - !reference [.except_no_tests_no_deploy]
     - !reference [.except_mergequeue]
@@ -274,8 +274,6 @@ deploy_dmg_testing-a7_x64:
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64"]
-  needs:
-    ["agent_dmg-x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
@@ -295,4 +293,18 @@ deploy_dmg_testing-a7_x64:
       fi
       dmg_src=$(ls -1 "$OMNIBUS_PACKAGE_DIR"/datadog-agent-7.*.dmg 2>/dev/null)
       echo "Found single DMG file: $dmg_src"
-      $S3_CP_CMD --acl public-read "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID/datadog-agent-7-latest.dmg"
+      $S3_CP_CMD --acl public-read "$dmg_src" "s3://$MACOS_S3_BUCKET/ci/datadog-agent/pipeline-$CI_PIPELINE_ID-$ARCH/datadog-agent-7-latest.dmg"
+
+
+deploy_dmg_testing-a7_arm64:
+  extends: .deploy_dmg_testing-a7
+  needs: ["agent_dmg-arm64-a7"]
+  variables:
+    ARCH: "arm64"
+
+
+deploy_dmg_testing-a7_x64:
+  extends: .deploy_dmg_testing-a7
+  needs: ["agent_dmg-x64-a7"]
+  variables:
+    ARCH: "x64"

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -266,7 +266,7 @@ export_testing_public_key:
       - gpg-testing-public-key.asc
     expire_in: 1 day
 
-deploy_macos_testing_x64-a7:
+deploy_dmg_testing-a7_x64:
   rules:
     - !reference [.except_no_tests_no_deploy]
     - !reference [.except_mergequeue]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add two jobs to deploy the MacOS build on a testing bucket.
These jobs are deployed in `dd-agent-macostesting/ci/datadog-agent/pipeline-<pipeline-id>-<arch>/datadog-agent-7-latest.dmg`
Naming the file that way allows us to reuse the install script after just changing the `DD_REPO_URL` environment variable to target the correct folder.

The runner permissions have been updated to allow pusing on that specific path, and a lifecycle was added to the bucket to make sure that these artifacts are cleaned up after 1 month
https://github.com/DataDog/cloud-inventory/pull/40520


### Motivation

Deploy DMG build so that we can use them in automated tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->