### PR TITLE
networkv2: simplify ethtool stats call per interface

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -286,14 +286,8 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 		return nil
 	}
 
-	// Preparing the interface name and copy it into the request
-	iface := interfaceIO.Name
-	if len(iface) > 15 {
-		iface = iface[:15]
-	}
-
 	// Fetch driver information (ETHTOOL_GDRVINFO)
-	drvInfo, err := ethtoolObject.DriverInfo(iface)
+	drvInfo, err := ethtoolObject.DriverInfo(interfaceIO.Name)
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("driver info is not supported for interface: %s", interfaceIO.Name)
@@ -307,7 +301,7 @@ func handleEthtoolStats(sender sender.Sender, ethtoolObject ethtoolInterface, in
 	driverVersion := replacer.Replace(drvInfo.Version)
 
 	// Fetch ethtool stats values (ETHTOOL_GSTATS)
-	statsMap, err := ethtoolObject.Stats(iface)
+	statsMap, err := ethtoolObject.Stats(interfaceIO.Name)
 	if err != nil {
 		if err == unix.ENOTTY || err == unix.EOPNOTSUPP {
 			log.Debugf("ethtool stats are not supported for interface: %s", interfaceIO.Name)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the ethtool calls `Stats` and `DriverInfo` done with the interface name to match the expected length. Basically there is no need to slice the interface name to len 15, because the ethtool lib is already doing it internally: https://github.com/safchain/ethtool/blob/v0.6.1/ethtool.go#L672. Also the max size is IFNAMSIZ=16, not 15 which is a bug fixed by this PR.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->