### PR TITLE
fix(chainguard): Use the correct workflow reference

### DIFF
--- a/.github/chainguard/self.create-rc-pr.create-pr.sts.yaml
+++ b/.github/chainguard/self.create-rc-pr.create-pr.sts.yaml
@@ -1,12 +1,11 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:DataDog/datadog-agent:ref:refs/heads/main
+subject: repo:DataDog/datadog-agent:environment:main
 
 claim_pattern:
   event_name: (workflow_dispatch|schedule)
-  ref: refs/heads/main
-  ref_protected: "true"
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/create_rc_pr\.yml@refs/heads/main
+  ref: (refs/heads/main|refs/heads/test_release/.*)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/create_rc_pr\.yml@refs/heads/(main|test_release/.*)
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?
The create_rc_pr is triggered with an environment. As such the workflow reference is `repo:DataDog/datadog-agent:environment:main` and not `repo:DataDog/datadog-agent:ref:refs/heads/main`. 

### Motivation
See https://github.com/DataDog/datadog-agent/actions/runs/17207937624/job/48812626220, detected because of #40193 

### Describe how you validated your changes
Locally tested with [this claim](https://github.com/DataDog/datadog-agent/actions/runs/17207510552/job/48811304932#step:6:13)
```
 DDOCTOSTS_ID_TOKEN=$(cat claims.json) dd-octo-sts check --scope DataDog/datadog-agent --policy self.create-rc-pr.create-pr
🔍 Checking repository and policy location...
Assuming repository path "/Users/nicolas.schweitzer/go/src/github.com/DataDog/datadog-agent"
  Tip: Use --repo/-r to override.
✅ Policy is in a valid location.
   Location: .github/chainguard/self.create-rc-pr.create-pr.sts.yaml

🔍 Checking policy file...
✅ Policy is valid
   Permissions:
   - contents: write
✅ Policy is valid
   Permissions:
   - pull_requests: write

🔍 Checking token...
⚠️ Fabricating a token out of claims.
   This token will not work in production, but is suitable for testing.
✅ Supplied token is valid for policy
   Matching claims:
   - ref: refs/heads/test_release/token
   - ref_protected: false
   - event_name: workflow_dispatch
   - job_workflow_ref: DataDog/datadog-agent/.github/workflows/create_rc_pr.yml@refs/heads/test_release/token
```
Valid as well replacing `test_release/*` by `main` with a protected ref.

### Possible Drawbacks / Trade-offs

### Additional Notes
Relates to https://datadoghq.atlassian.net/browse/SINT-3833, https://github.com/DataDog/datadog-agent/pull/39488 and https://github.com/DataDog/datadog-agent/pull/39662
