### PR TITLE
[APM] CSS: Split aggregation and flushing goroutines

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -589,7 +589,7 @@ func New() *AgentConfig {
 		TraceWriter:              new(WriterConfig),
 		ConnectionResetInterval:  0, // disabled
 		MaxSenderRetries:         4,
-		ClientStatsFlushInterval: 1 * time.Second,
+		ClientStatsFlushInterval: 2 * time.Second, // bucket duration (2s)
 
 		StatsdHost:    "localhost",
 		StatsdPort:    8125,

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -6,6 +6,7 @@
 package stats
 
 import (
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/version"
@@ -57,6 +58,9 @@ type ClientStatsAggregator struct {
 	exit chan struct{}
 	done chan struct{}
 
+	exitWG sync.WaitGroup
+	mu     sync.Mutex
+
 	statsd statsd.ClientInterface
 }
 
@@ -85,17 +89,33 @@ func NewClientStatsAggregator(conf *config.AgentConfig, writer Writer, statsd st
 
 // Start starts the aggregator.
 func (a *ClientStatsAggregator) Start() {
+	// 2 goroutines: aggregation and flushing
+	a.exitWG.Add(2)
+
+	// aggregation goroutine
 	go func() {
 		defer watchdog.LogOnPanic(a.statsd)
+		defer a.exitWG.Done()
+		for {
+			select {
+			case input := <-a.In:
+				a.add(time.Now(), input)
+			case <-a.exit:
+				return
+			}
+		}
+	}()
+
+	// flushing goroutine
+	go func() {
+		defer watchdog.LogOnPanic(a.statsd)
+		defer a.exitWG.Done()
 		for {
 			select {
 			case t := <-a.flushTicker.C:
 				a.flushOnTime(t)
-			case input := <-a.In:
-				a.add(time.Now(), input)
 			case <-a.exit:
 				a.flushAll()
-				close(a.done)
 				return
 			}
 		}
@@ -106,25 +126,34 @@ func (a *ClientStatsAggregator) Start() {
 func (a *ClientStatsAggregator) Stop() {
 	close(a.exit)
 	a.flushTicker.Stop()
-	<-a.done
+	a.exitWG.Wait()
 }
 
 // flushOnTime flushes all buckets up to flushTs, except the last one.
 func (a *ClientStatsAggregator) flushOnTime(now time.Time) {
-	flushTs := alignAggTs(now.Add(bucketDuration - oldestBucketStart))
-	for t := a.oldestTs; t.Before(flushTs); t = t.Add(bucketDuration) {
-		if b, ok := a.buckets[t.Unix()]; ok {
-			a.flush(b.aggregationToPayloads())
-			delete(a.buckets, t.Unix())
-		}
-	}
-	a.oldestTs = flushTs
+	a.flush(now, false)
 }
 
+// flushAll flushes all buckets, typically called on agent shutdown.
 func (a *ClientStatsAggregator) flushAll() {
-	for _, b := range a.buckets {
-		a.flush(b.aggregationToPayloads())
+	a.flush(time.Now(), true)
+}
+
+func (a *ClientStatsAggregator) flush(now time.Time, force bool) {
+	flushTs := alignAggTs(now.Add(bucketDuration - oldestBucketStart))
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for ts, b := range a.buckets {
+		if !force && !flushTs.After(b.ts) {
+			continue
+		}
+		log.Debugf("css aggregator: flushing bucket %d", ts)
+		a.flushPayloads(b.aggregationToPayloads())
+		delete(a.buckets, ts)
 	}
+	a.oldestTs = flushTs
 }
 
 // getAggregationBucketTime returns unix time at which we aggregate the bucket.
@@ -148,6 +177,10 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 	// compute the PayloadAggregationKey, common for all buckets within the payload
 	payloadAggKey := newPayloadAggregationKey(p.Env, p.Hostname, p.Version, p.ContainerID, p.GitCommitSha, p.ImageTag, p.Lang, p.ProcessTagsHash)
 
+	// acquire lock over shared data
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	for _, clientBucket := range p.Stats {
 		clientBucketStart := time.Unix(0, int64(clientBucket.Start))
 		ts := a.getAggregationBucketTime(now, clientBucketStart)
@@ -165,7 +198,7 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 	}
 }
 
-func (a *ClientStatsAggregator) flush(p []*pb.ClientStatsPayload) {
+func (a *ClientStatsAggregator) flushPayloads(p []*pb.ClientStatsPayload) {
 	if len(p) == 0 {
 		return
 	}

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -67,8 +67,8 @@ type ClientStatsAggregator struct {
 // NewClientStatsAggregator initializes a new aggregator ready to be started
 func NewClientStatsAggregator(conf *config.AgentConfig, writer Writer, statsd statsd.ClientInterface) *ClientStatsAggregator {
 	flushInterval := conf.ClientStatsFlushInterval
-	if flushInterval == 0 { // default to 1s if not set to ensure users of this outside the agent aren't broken by this change
-		flushInterval = 1 * time.Second
+	if flushInterval == 0 { // default to 2s if not set to ensure users of this outside the agent aren't broken by this change
+		flushInterval = 2 // bucketDuration
 	}
 	c := &ClientStatsAggregator{
 		flushTicker:   time.NewTicker(flushInterval),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Work for https://datadoghq.atlassian.net/browse/APMSP-2210

Split the CSS aggregator goroutine into 2: one for aggregation, another one for flushing. This split further prevents a potential highjacking of the goroutine from the flushing ticker, which can take over the `select` block when flushing takes longer than `ticker` internal.

Additionally, the ticker interval is set to 2s, which is the internal bucket duration. This way, each tick will attempt to flush 1 bucket (having 1s ticker essentially does nothing half of the time). This is similar to how the Stats Concentrator works (albeit with 10s bucket durations).

### Motivation

See above.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->