### PR TITLE
Allow older Ubuntu versions to be used as base for building ddot-byoc

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -148,7 +148,7 @@ trigger_distribution*         @DataDog/agent-delivery
 integration_tests_windows*    @DataDog/windows-products
 integration_tests_otel        @DataDog/opentelemetry-agent
 docker_image_build_otel       @DataDog/opentelemetry-agent
-ddot_byoc_package_*           @DataDog/opentelemetry-agent
+ddot_byoc_*                   @DataDog/opentelemetry-agent
 datadog_otel_components_ocb_build  @DataDog/opentelemetry-agent
 docker_integration_tests      @DataDog/container-integrations
 trace_agent_integration_tests @DataDog/agent-apm

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -121,3 +121,47 @@ ddot_byoc_package_build_test_deb:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
+
+ddot_byoc_binary_build_test_ubuntu2004:
+  stage: integration_test
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
+  needs: ["integration_tests_otel"]
+  tags: ["docker-in-docker:amd64"]
+  before_script:
+    - !reference [docker_image_build_otel, before_script]
+  script:
+    - !reference [.login_to_docker_readonly]
+    - AGENT_VERSION=$(dda inv -- agent.version --no-include-git --no-include-pre)
+    - |
+      docker build \
+        --target artifact \
+        --output type=local,dest=./ \
+        --build-arg AGENT_BRANCH=$CI_COMMIT_REF_NAME \
+        --build-arg AGENT_VERSION=$AGENT_VERSION \
+        --build-arg UBUNTU_VERSION=20.04 \
+        -f /tmp/otel-ci/Dockerfile.agent-otel /tmp/otel-ci
+    - |
+      BIN_PATH=ddot-byoc/otel-agent
+      if [ ! -f "$BIN_PATH" ]; then
+        echo "ERROR: Expected otel-agent binary not found in output directory!" >&2
+        exit 1
+      fi
+    # Check GLIBC compatibility (must be <= 2.31, given we built with Ubuntu 20.04)
+    - |
+      ALLOWED_GLIBC=2.31
+      REQUIRED_GLIBC=$(objdump -T "$BIN_PATH" 2>/dev/null | grep -o 'GLIBC_[0-9][0-9.]*' | sed 's/[^0-9.]//g' | sort -V | tail -1)
+      echo "Detected required GLIBC version: ${REQUIRED_GLIBC:-unknown} (allowed max: $ALLOWED_GLIBC)"
+      if [ -z "$REQUIRED_GLIBC" ]; then
+        echo "WARNING: Could not detect GLIBC requirement from binary; proceeding without hard failure." >&2
+      else
+        # This amounts to reporting an error when $REQUIRED_GLIBC > $ALLOWED_GLIBC
+        highest_version=$(printf '%s\n%s\n' "$REQUIRED_GLIBC" "$ALLOWED_GLIBC" | sort -V | tail -1)
+        if [[ "$REQUIRED_GLIBC" != "$ALLOWED_GLIBC" && "$highest_version" == "$REQUIRED_GLIBC" ]]; then
+          echo "ERROR: otel-agent requires GLIBC_$REQUIRED_GLIBC which exceeds expected GLIBC_$ALLOWED_GLIBC" >&2
+          objdump -T "$BIN_PATH" | grep 'GLIBC'
+          exit 1
+        fi
+      fi
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -1,8 +1,9 @@
 ARG AGENT_REPO=datadog/agent-dev
 ARG AGENT_VERSION=nightly-full-main-jmx
 ARG AGENT_BRANCH=main
+ARG UBUNTU_VERSION=24.04
 # Use the Ubuntu Slim AMD64 base image
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:${UBUNTU_VERSION} AS builder
 
 # Set environment variables
 ARG AGENT_REPO
@@ -21,9 +22,6 @@ RUN apt-get update && \
     software-properties-common \
     build-essential \
     git \
-    python3 \
-    python3-pip \
-    python3-venv \
     rpm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -58,24 +56,28 @@ ENV GOPATH=/go
 
 # Verify installations
 RUN go version && \
-    python3 --version && \
     curl --version
 
-# Create and activate virtual environment, then install requirements
-RUN python3 -m venv venv && \
-    . venv/bin/activate && \
-    pip install --upgrade pip && \
-    pip install dda && \
+ENV DDA_INTERACTIVE=false
+# Install prebuilt dda and sync tasks
+RUN ARCH=$(dpkg --print-architecture) && \
+    DDA_VERSION=v0.25.0 && \
+    if [ "$ARCH" = "amd64" ]; then DDA_ARCH="x86_64"; \
+    elif [ "$ARCH" = "arm64" ]; then DDA_ARCH="aarch64"; fi && \
+    curl -fsSL "https://github.com/DataDog/datadog-agent-dev/releases/download/${DDA_VERSION}/dda-${DDA_ARCH}-unknown-linux-gnu.tar.gz" \
+    | tar -xzf - -C /usr/local/bin && \
+    chmod +x /usr/local/bin/dda && \
     dda self dep sync -f legacy-tasks
+
 
 # Copy the manifest file
 COPY manifest.yaml /workspace/datadog-agent-${AGENT_BRANCH}/comp/otelcol/collector-contrib/impl/manifest.yaml
 
 # Generate the files
-RUN . venv/bin/activate && dda inv collector.generate
+RUN dda inv collector.generate
 
 # Build the OTel agent
-RUN . venv/bin/activate && dda inv otel-agent.build --byoc
+RUN dda inv otel-agent.build --byoc
 
 # Install nfpm if package type is specified
 ARG PACKAGE_TYPE

--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -84,8 +84,7 @@ ARG PACKAGE_TYPE
 RUN if [ -n "$PACKAGE_TYPE" ]; then \
     ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then ARCH="x86_64"; fi && \
-    curl -sL -o /usr/local/bin/nfpm https://github.com/goreleaser/nfpm/releases/download/v2.43.0/nfpm_2.43.0_linux_${ARCH}.tar.gz && \
-    tar -xzf /usr/local/bin/nfpm -C /usr/local/bin/ && \
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v2.43.0/nfpm_2.43.0_linux_${ARCH}.tar.gz" | tar -xzf - -C /usr/local/bin/ && \
     chmod +x /usr/local/bin/nfpm; \
     fi
 


### PR DESCRIPTION
### What does this PR do?

It makes it possible to build custom ddot (byoc) targeting a broader compatibility base (defined by available version of glibc on the OS), by allowing the choice of the base version of Ubuntu used, via `--build-arg UBUNTU_VERSION=xx.xx`.

### Motivation

Allow more users to benefit from the ddot byoc workflow.

### Describe how you validated your changes

Added a job to the pipeline which runs the build on Ubuntu 20.04 and checks that the maximum glibc version required by the binary doesn't exceed what would be expected for that version of Ubuntu.

### Possible Drawbacks / Trade-offs

- Not very user-friendly, but provides a quick way to provide this compatibility.

### Additional Notes

This pins the `dda` version in use and switches to its "standalone" version such that we don't need to worry about the python version or python env management.

In practice, by dropping to Ubuntu 20.04, we currently already see the glibc requirement drop to 2.17 max, which makes it at least as compatible as the regular Agent.

We eventually plan to package our C/C++ toolchains that target the compatibility that the Agent supports, which would probably give us a better way to provide the necessary compatibility without the need to change the base image like done here.