### PR TITLE
Inject non-empty release overrides earlier

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -57,7 +57,7 @@ def build(
 
     if policies_version is None:
         print("Loading dependencies from release.json")
-        env = load_overridden_dependencies(ctx)
+        env = load_overridden_dependencies()
         if "SECURITY_AGENT_POLICIES_VERSION" in env:
             policies_version = env["SECURITY_AGENT_POLICIES_VERSION"]
             print(f"Security Agent polices: {policies_version}")

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_default_build_tags
 from tasks.cluster_agent_helpers import build_common, clean_common, refresh_assets_common, version_common
 from tasks.cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
-from tasks.libs.releasing.version import load_overridden_dependencies
+from tasks.libs.dependencies import load_overridden_dependencies
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_default_build_tags
 from tasks.cluster_agent_helpers import build_common, clean_common, refresh_assets_common, version_common
 from tasks.cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
-from tasks.libs.dependencies import load_overridden_dependencies
+from tasks.libs.dependencies import get_effective_dependencies_env
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
@@ -57,7 +57,7 @@ def build(
 
     if policies_version is None:
         print("Loading dependencies from release.json")
-        env = load_overridden_dependencies()
+        env = get_effective_dependencies_env()
         if "SECURITY_AGENT_POLICIES_VERSION" in env:
             policies_version = env["SECURITY_AGENT_POLICIES_VERSION"]
             print(f"Security Agent polices: {policies_version}")

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_default_build_tags
 from tasks.cluster_agent_helpers import build_common, clean_common, refresh_assets_common, version_common
 from tasks.cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
-from tasks.libs.releasing.version import load_dependencies
+from tasks.libs.releasing.version import load_overridden_dependencies
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
@@ -57,7 +57,7 @@ def build(
 
     if policies_version is None:
         print("Loading dependencies from release.json")
-        env = load_dependencies(ctx)
+        env = load_overridden_dependencies(ctx)
         if "SECURITY_AGENT_POLICIES_VERSION" in env:
             policies_version = env["SECURITY_AGENT_POLICIES_VERSION"]
             print(f"Security Agent polices: {policies_version}")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -63,6 +63,7 @@ from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.git import get_current_branch
 from tasks.libs.common.utils import get_build_flags
 from tasks.libs.pipeline.tools import GitlabJobStatus, loop_status
+from tasks.libs.releasing.json import load_release_json
 from tasks.libs.releasing.version import VERSION_RE, check_version
 from tasks.libs.types.arch import Arch, KMTArchName
 from tasks.libs.types.types import JobDependency
@@ -2385,8 +2386,7 @@ def install_ddagent(
     if version is not None:
         check_version(ctx, version)
     else:
-        with open("release.json") as f:
-            release = json.load(f)
+        release = load_release_json()
         version = release["last_stable"]["7"]
 
     if version is None:

--- a/tasks/libs/dependencies.py
+++ b/tasks/libs/dependencies.py
@@ -7,7 +7,7 @@ from tasks.libs.releasing.json import load_release_json
 from tasks.libs.releasing.version import RELEASE_JSON_DEPENDENCIES
 
 
-def load_overridden_dependencies():
+def get_effective_dependencies_env():
     """
     Load dependency versions from release.json with environment variable overrides.
     WINDOWS_* dependencies are skipped on non-Windows platforms.
@@ -16,10 +16,10 @@ def load_overridden_dependencies():
         dict: Environment dictionary with dependency versions as strings.
     """
     release = load_release_json()
-    if not (dependencies := release.get(RELEASE_JSON_DEPENDENCIES)):
+    if not (release_dependencies := release.get(RELEASE_JSON_DEPENDENCIES)):
         raise Exit(f"Could not find {RELEASE_JSON_DEPENDENCIES!r} in release.json")
-    env = {}
-    for key, value in dependencies.items():
+    effective_dependencies_env = {}
+    for key, value in release_dependencies.items():
         if key.startswith("WINDOWS_") and sys.platform != "win32":
             print(f"Ignoring {key!r} on {sys.platform}", file=sys.stderr)
             continue
@@ -27,5 +27,5 @@ def load_overridden_dependencies():
             print(f"Overriding {key!r}: {value!r} -> {override!r}", file=sys.stderr)
             value = override
         # windows runners don't accept anything else than strings in the environment when running a subprocess.
-        env[key] = str(value)
-    return env
+        effective_dependencies_env[key] = str(value)
+    return effective_dependencies_env

--- a/tasks/libs/dependencies.py
+++ b/tasks/libs/dependencies.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+from invoke import Exit
+
+from tasks.libs.releasing.json import load_release_json
+from tasks.libs.releasing.version import RELEASE_JSON_DEPENDENCIES
+
+
+def load_overridden_dependencies():
+    """
+    Load dependency versions from release.json with environment variable overrides.
+    WINDOWS_* dependencies are skipped on non-Windows platforms.
+
+    Returns:
+        dict: Environment dictionary with dependency versions as strings.
+    """
+    release = load_release_json()
+    if not (dependencies := release.get(RELEASE_JSON_DEPENDENCIES)):
+        raise Exit(f"Could not find {RELEASE_JSON_DEPENDENCIES!r} in release.json")
+    env = {}
+    for key, value in dependencies.items():
+        if key.startswith("WINDOWS_") and sys.platform != "win32":
+            print(f"Ignoring {key!r} on {sys.platform}", file=sys.stderr)
+            continue
+        if override := os.getenv(key):
+            print(f"Overriding {key!r}: {value!r} -> {override!r}", file=sys.stderr)
+            value = override
+        # windows runners don't accept anything else than strings in the environment when running a subprocess.
+        env[key] = str(value)
+    return env

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -371,6 +371,13 @@ def get_version_numeric_only(ctx, major_version='7'):
 
 
 def load_overridden_dependencies(_):
+    """
+    Load dependency versions from release.json with environment variable overrides.
+    WINDOWS_* dependencies are skipped on non-Windows platforms.
+
+    Returns:
+        dict: Environment dictionary with dependency versions as strings.
+    """
     from tasks.libs.releasing.json import load_release_json  # delayed to avoid circular imports
 
     release = load_release_json()

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -370,32 +370,6 @@ def get_version_numeric_only(ctx, major_version='7'):
     return version
 
 
-def load_overridden_dependencies():
-    """
-    Load dependency versions from release.json with environment variable overrides.
-    WINDOWS_* dependencies are skipped on non-Windows platforms.
-
-    Returns:
-        dict: Environment dictionary with dependency versions as strings.
-    """
-    from tasks.libs.releasing.json import load_release_json  # delayed to avoid circular imports
-
-    release = load_release_json()
-    if not (dependencies := release.get(RELEASE_JSON_DEPENDENCIES)):
-        raise Exit(f"Could not find {RELEASE_JSON_DEPENDENCIES!r} in release.json")
-    env = {}
-    for key, value in dependencies.items():
-        if key.startswith("WINDOWS_") and sys.platform != "win32":
-            print(f"Ignoring {key!r} on {sys.platform}", file=sys.stderr)
-            continue
-        if override := os.getenv(key):
-            print(f"Overriding {key!r}: {value!r} -> {override!r}", file=sys.stderr)
-            value = override
-        # windows runners don't accept anything else than strings in the environment when running a subprocess.
-        env[key] = str(value)
-    return env
-
-
 def create_version_json(ctx, git_sha_length=7):
     """
     Generate a json cache file containing all needed variables used by get_version.

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -370,7 +370,7 @@ def get_version_numeric_only(ctx, major_version='7'):
     return version
 
 
-def load_overridden_dependencies(_):
+def load_overridden_dependencies():
     """
     Load dependency versions from release.json with environment variable overrides.
     WINDOWS_* dependencies are skipped on non-Windows platforms.

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -83,7 +83,7 @@ def _get_vs_build_command(cmd, vstudio_root=None):
 
 
 def _get_env(ctx, flavor=None):
-    env = load_overridden_dependencies(ctx)
+    env = load_overridden_dependencies()
 
     if flavor is None:
         flavor = os.getenv("AGENT_FLAVOR", "")
@@ -502,7 +502,7 @@ def get_msm_info(ctx):
     """
     Get the merge module info from the release.json
     """
-    env = load_overridden_dependencies(ctx)
+    env = load_overridden_dependencies()
     base_url = "https://s3.amazonaws.com/dd-windowsfilter/builds"
     msm_info = {}
     if 'WINDOWS_DDNPM_VERSION' in env:

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -18,7 +18,12 @@ from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.utils import download_to_tempfile, timed
-from tasks.libs.releasing.version import VERSION_RE, _create_version_from_match, get_version, load_dependencies
+from tasks.libs.releasing.version import (
+    VERSION_RE,
+    _create_version_from_match,
+    get_version,
+    load_overridden_dependencies,
+)
 
 # Windows only import
 try:
@@ -78,7 +83,7 @@ def _get_vs_build_command(cmd, vstudio_root=None):
 
 
 def _get_env(ctx, flavor=None):
-    env = load_dependencies(ctx)
+    env = load_overridden_dependencies(ctx)
 
     if flavor is None:
         flavor = os.getenv("AGENT_FLAVOR", "")
@@ -497,7 +502,7 @@ def get_msm_info(ctx):
     """
     Get the merge module info from the release.json
     """
-    env = load_dependencies(ctx)
+    env = load_overridden_dependencies(ctx)
     base_url = "https://s3.amazonaws.com/dd-windowsfilter/builds"
     msm_info = {}
     if 'WINDOWS_DDNPM_VERSION' in env:

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -18,7 +18,7 @@ from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.utils import download_to_tempfile, timed
-from tasks.libs.dependencies import load_overridden_dependencies
+from tasks.libs.dependencies import get_effective_dependencies_env
 from tasks.libs.releasing.version import VERSION_RE, _create_version_from_match, get_version
 
 # Windows only import
@@ -79,7 +79,7 @@ def _get_vs_build_command(cmd, vstudio_root=None):
 
 
 def _get_env(ctx, flavor=None):
-    env = load_overridden_dependencies()
+    env = get_effective_dependencies_env()
 
     if flavor is None:
         flavor = os.getenv("AGENT_FLAVOR", "")
@@ -498,7 +498,7 @@ def get_msm_info(ctx):
     """
     Get the merge module info from the release.json
     """
-    env = load_overridden_dependencies()
+    env = get_effective_dependencies_env()
     base_url = "https://s3.amazonaws.com/dd-windowsfilter/builds"
     msm_info = {}
     if 'WINDOWS_DDNPM_VERSION' in env:

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -18,12 +18,8 @@ from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.utils import download_to_tempfile, timed
-from tasks.libs.releasing.version import (
-    VERSION_RE,
-    _create_version_from_match,
-    get_version,
-    load_overridden_dependencies,
-)
+from tasks.libs.dependencies import load_overridden_dependencies
+from tasks.libs.releasing.version import VERSION_RE, _create_version_from_match, get_version
 
 # Windows only import
 try:

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -28,7 +28,7 @@ from tasks.libs.common.omnibus import (
 )
 from tasks.libs.common.user_interactions import yes_no_question
 from tasks.libs.common.utils import gitlab_section, timed
-from tasks.libs.dependencies import load_overridden_dependencies
+from tasks.libs.dependencies import get_effective_dependencies_env
 from tasks.libs.releasing.version import get_version
 
 
@@ -91,7 +91,7 @@ def get_omnibus_env(
     custom_config_dir=None,
     fips_mode=False,
 ):
-    env = load_overridden_dependencies()
+    env = get_effective_dependencies_env()
 
     # If the host has a GOMODCACHE set, try to reuse it
     if not go_mod_cache and os.environ.get('GOMODCACHE'):

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -28,7 +28,8 @@ from tasks.libs.common.omnibus import (
 )
 from tasks.libs.common.user_interactions import yes_no_question
 from tasks.libs.common.utils import gitlab_section, timed
-from tasks.libs.releasing.version import get_version, load_overridden_dependencies
+from tasks.libs.dependencies import load_overridden_dependencies
+from tasks.libs.releasing.version import get_version
 
 
 def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info", host_distribution=None):

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -28,7 +28,7 @@ from tasks.libs.common.omnibus import (
 )
 from tasks.libs.common.user_interactions import yes_no_question
 from tasks.libs.common.utils import gitlab_section, timed
-from tasks.libs.releasing.version import get_version, load_dependencies
+from tasks.libs.releasing.version import get_version, load_overridden_dependencies
 
 
 def omnibus_run_task(ctx, task, target_project, base_dir, env, log_level="info", host_distribution=None):
@@ -90,21 +90,7 @@ def get_omnibus_env(
     custom_config_dir=None,
     fips_mode=False,
 ):
-    env = load_dependencies(ctx)
-
-    # Discard windows variables when not on Windows (so that they're not used in the cache key either)
-    if sys.platform != 'win32':
-        windows_only_vars = [
-            'WINDOWS_DDNPM_DRIVER',
-            'WINDOWS_DDNPM_VERSION',
-            'WINDOWS_DDNPM_SHASUM',
-            'WINDOWS_DDPROCMON_DRIVER',
-            'WINDOWS_DDPROCMON_VERSION',
-            'WINDOWS_DDPROCMON_SHASUM',
-        ]
-        for var in windows_only_vars:
-            if var in env:
-                del env[var]
+    env = load_overridden_dependencies(ctx)
 
     # If the host has a GOMODCACHE set, try to reuse it
     if not go_mod_cache and os.environ.get('GOMODCACHE'):
@@ -118,10 +104,6 @@ def get_omnibus_env(
         "OMNIBUS_RUBY_VERSION": "https://github.com/DataDog/omnibus-ruby.git",
     }
     for key, url in external_repos.items():
-        value = os.environ.get(key)
-        # Only overrides the env var if the value is a non-empty string.
-        if value:
-            env[key] = value
         ref = env[key]
         if not re.fullmatch(r"[0-9a-f]{4,40}", ref):  # resolve only "moving" refs, such as `own/branch`
             candidates = [

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -90,7 +90,7 @@ def get_omnibus_env(
     custom_config_dir=None,
     fips_mode=False,
 ):
-    env = load_overridden_dependencies(ctx)
+    env = load_overridden_dependencies()
 
     # If the host has a GOMODCACHE set, try to reuse it
     if not go_mod_cache and os.environ.get('GOMODCACHE'):


### PR DESCRIPTION
### Motivation
So that we don't need to think twice where/whether overridden versions were injected from environment variables.