### PR TITLE
APM: Retry Info calls to avoid flakes in MacOS CI runners

### DIFF
--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +127,33 @@ func testServerError(t *testing.T) *httptest.Server {
 	return server
 }
 
-// run this at the beginning of each test, this is because we *really*
+// retryInfoCall attempts to call Info with retry logic for CI overload handling
+func retryInfoCall(t *testing.T, conf *config.AgentConfig) (string, error) {
+	var buf bytes.Buffer
+	var info string
+
+	// Retry with 1 second delay to handle CI overload on MacOS runners
+	maxRetries := 2
+	for attempt := range maxRetries {
+		buf.Reset()
+		err := Info(&buf, conf)
+		if err != nil {
+			if attempt < maxRetries-1 {
+				t.Logf("Info call failed (attempt %d/%d), retrying in 1 second: %v", attempt+1, maxRetries, err)
+				time.Sleep(time.Second)
+			} else {
+				return "", err
+			}
+			continue
+		}
+		info = buf.String()
+		break
+	}
+
+	return info, nil
+}
+
+// testInit runs at the beginning of each test, this is because we *really*
 // need to have InitInfo be called before doing anything
 func testInit(t *testing.T, serverConfig *tls.Config) *config.AgentConfig {
 	assert := assert.New(t)
@@ -178,10 +205,8 @@ func TestInfo(t *testing.T) {
 	assert.NoError(err)
 	conf.DebugServerPort = port
 
-	var buf bytes.Buffer
-	err = Info(&buf, conf)
+	info, err := retryInfoCall(t, conf)
 	assert.NoError(err)
-	info := buf.String()
 	assert.NotEmpty(info)
 	t.Logf("Info:\n%s\n", info)
 	expectedInfo, err := os.ReadFile("./testdata/okay.info")
@@ -210,10 +235,8 @@ func TestProbabilisticSampler(t *testing.T) {
 	assert.NoError(err)
 	conf.DebugServerPort = port
 
-	var buf bytes.Buffer
-	err = Info(&buf, conf)
+	info, err := retryInfoCall(t, conf)
 	assert.NoError(err)
-	info := buf.String()
 	assert.NotEmpty(info)
 	t.Logf("Info:\n%s\n", info)
 	expectedInfo, err := os.ReadFile("./testdata/psp.info")
@@ -255,10 +278,8 @@ func TestWarning(t *testing.T) {
 	assert.NoError(err)
 	conf.DebugServerPort = port
 
-	var buf bytes.Buffer
-	err = Info(&buf, conf)
+	info, err := retryInfoCall(t, conf)
 	assert.NoError(err)
-	info := buf.String()
 
 	expectedWarning, err := os.ReadFile("./testdata/warning.info")
 	re := regexp.MustCompile(`\r\n`)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add retries for these unit tests as the MacOS runners flake on these calls sometimes due to too many parallel test servers / being overwhelmed

### Motivation
Flaky tests are bad

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
For MacOS this will extend the runtime a bit, but seems a worthy tradeoff for reduced flakes. If this doesn't work at all I have another idea to refactor this and force all these Info tests to run sequentially, but this seemed like a good first approach.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->